### PR TITLE
lcb: Fixed register renaming for pseudo instructions

### DIFF
--- a/vadl/test/resources/snapshots/rv64im/InstrInfoTableGen.td
+++ b/vadl/test/resources/snapshots/rv64im/InstrInfoTableGen.td
@@ -4143,23 +4143,23 @@ let Defs = [  ];
 
 
 
-def : InstAlias<"BEQZ $rs,$offset", (BEQ X:$rs1, X0, RV3264I_Btype_immAsLabel:$imm)>;
+def : InstAlias<"BEQZ $rs,$offset", (BEQ X:$rs, X0, RV3264I_Btype_immAsLabel:$imm)>;
 
-def : InstAlias<"BGEZ $rs,$offset", (BGE X:$rs1, X0, RV3264I_Btype_immAsLabel:$imm)>;
+def : InstAlias<"BGEZ $rs,$offset", (BGE X:$rs, X0, RV3264I_Btype_immAsLabel:$imm)>;
 
-def : InstAlias<"BGTZ $rs,$offset", (BLT X0, X:$rs2, RV3264I_Btype_immAsLabel:$imm)>;
+def : InstAlias<"BGTZ $rs,$offset", (BLT X0, X:$rs, RV3264I_Btype_immAsLabel:$imm)>;
 
-def : InstAlias<"BLEZ $rs,$offset", (BGE X0, X:$rs2, RV3264I_Btype_immAsLabel:$imm)>;
+def : InstAlias<"BLEZ $rs,$offset", (BGE X0, X:$rs, RV3264I_Btype_immAsLabel:$imm)>;
 
-def : InstAlias<"BLTZ $rs,$offset", (BLT X:$rs1, X0, RV3264I_Btype_immAsLabel:$imm)>;
+def : InstAlias<"BLTZ $rs,$offset", (BLT X:$rs, X0, RV3264I_Btype_immAsLabel:$imm)>;
 
-def : InstAlias<"BNEZ $rs,$offset", (BNE X:$rs1, X0, RV3264I_Btype_immAsLabel:$imm)>;
+def : InstAlias<"BNEZ $rs,$offset", (BNE X:$rs, X0, RV3264I_Btype_immAsLabel:$imm)>;
 
 def : InstAlias<"J $offset", (JAL X0, RV3264I_Jtype_immAsInt64:$imm)>;
 
 def : InstAlias<"MOV $rd,$rs1", (ADDI X:$rd, X:$rs1, 0)>;
 
-def : InstAlias<"NEG $rd,$rs1", (SUB X:$rd, X0, X:$rs2)>;
+def : InstAlias<"NEG $rd,$rs1", (SUB X:$rd, X0, X:$rs1)>;
 
 def : InstAlias<"NOP", (ADDI X0, X0, 0)>;
 
@@ -4167,11 +4167,11 @@ def : InstAlias<"NOT $rd,$rs1", (XORI X:$rd, X:$rs1, 4095)>;
 
 def : InstAlias<"RET", (JALR X1, X0, 0)>;
 
-def : InstAlias<"SGTZ $rd,$rs1", (SLT X:$rd, X0, X:$rs2)>;
+def : InstAlias<"SGTZ $rd,$rs1", (SLT X:$rd, X0, X:$rs1)>;
 
 def : InstAlias<"SLTZ $rd,$rs1", (SLT X:$rd, X:$rs1, X0)>;
 
-def : InstAlias<"SNEZ $rd,$rs1", (SLTU X:$rd, X0, X:$rs2)>;
+def : InstAlias<"SNEZ $rd,$rs1", (SLTU X:$rd, X0, X:$rs1)>;
 
 
 

--- a/vadl/test/vadl/lcb/riscv/riscv64/template/EmitInstrInfoTableGenFilePassTest.java
+++ b/vadl/test/vadl/lcb/riscv/riscv64/template/EmitInstrInfoTableGenFilePassTest.java
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-package vadl.lcb.template;
+package vadl.lcb.riscv.riscv64.template;
 
 import java.io.File;
 import java.io.IOException;


### PR DESCRIPTION
The PR [#432](https://ea.complang.tuwien.ac.at/vadl/open-vadl/pulls/432) introduced InstAlias which makes the lowering of pseudo instructions easier. However, when the parameter of the pseudo instruction does not match the field name in the underlying machine instruction, the pattern is wrong.
 def : InstAlias<"BNEZ $rs,$offset", (BNE X:$rs1, X0, RV3264I_Btype_immAsLabel:$imm)>;

Here the $rs and $rs1 should be the same.