### PR TITLE
ci: Added manual workflow to build llvm17

### DIFF
--- a/.github/workflows/build-llvm17.yml
+++ b/.github/workflows/build-llvm17.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
It should be possible to build the test images in OpenVADL from the CI. Currently, the images belong to me in DockerHub. So all changes have to be done by me.