### PR TITLE
ci: Build multiplatform images using different runners

### DIFF
--- a/.github/workflows/build-llvm17.yml
+++ b/.github/workflows/build-llvm17.yml
@@ -9,31 +9,22 @@ permissions:
 
 jobs:
   build:
-    # The build crashed on MacOS arm64, so we only use x64 runners to build the images.
-    # This also avoids the need of exposing the macOS user password as secret to the CI.
-    runs-on: self-hosted-x64
+    uses: ./.github/workflows/reusable-image-build.yml
+    strategy:
+      matrix:
+        target:
+          - platform: linux/arm64
+            runner: self-hosted-arm64
+          - platform: linux/amd64
+            runner: self-hosted-x64
+    with:
+      image: ghcr.io/openvadl/llvm17-base
+      context: vadl/test/resources/images/llvm_riscv/llvm17_base_image
+      platform: ${{ matrix.target.platform }}
+      runner: ${{ matrix.target.runner }}
 
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: vadl/test/resources/images/llvm_riscv/llvm17_base_image
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ghcr.io/openvadl/llvm17-base:latest
+  merge:
+    needs: build
+    uses: ./.github/workflows/reusable-image-merge.yml
+    with:
+      image: ghcr.io/openvadl/llvm17-base

--- a/.github/workflows/build-qemu.yml
+++ b/.github/workflows/build-qemu.yml
@@ -9,31 +9,22 @@ permissions:
 
 jobs:
   build:
-    # The build crashed on MacOS arm64, so we only use x64 runners to build the images.
-    # This also avoids the need of exposing the macOS user password as secret to the CI.
-    runs-on: self-hosted-x64
+    uses: ./.github/workflows/reusable-image-build.yml
+    strategy:
+      matrix:
+        target:
+          - platform: linux/arm64
+            runner: self-hosted-arm64
+          - platform: linux/amd64
+            runner: self-hosted-x64
+    with:
+      image: ghcr.io/openvadl/qemu-base
+      context: docker/iss/qemu
+      platform: ${{ matrix.target.platform }}
+      runner: ${{ matrix.target.runner }}
 
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: docker/iss/qemu
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ghcr.io/openvadl/qemu-base:latest
+  merge:
+    needs: build
+    uses: ./.github/workflows/reusable-image-merge.yml
+    with:
+      image: ghcr.io/openvadl/qemu-base

--- a/.github/workflows/build-riscv-toolchain.yml
+++ b/.github/workflows/build-riscv-toolchain.yml
@@ -9,31 +9,25 @@ permissions:
 
 jobs:
   build:
-    # The build crashed on MacOS arm64, so we only use x64 runners to build the images.
-    # This also avoids the need of exposing the macOS user password as secret to the CI.
-    runs-on: self-hosted-x64
+    uses: ./.github/workflows/reusable-image-build.yml
+    strategy:
+      matrix:
+        target:
+          - platform: linux/arm64
+            runner: self-hosted-arm64
+          - platform: linux/amd64
+            runner: self-hosted-x64
+    with:
+      image: ghcr.io/openvadl/riscv-toolchain
+      context: docker/iss/riscv-toolchain
+      platform: ${{ matrix.target.platform }}
+      runner: ${{ matrix.target.runner }}
+      tags: |
+        latest
+        medany-rv32i-rv32im-rv32impriv-rv64i-rv64im-rv64impriv
 
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: docker/iss/riscv-toolchain
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ghcr.io/openvadl/riscv-toolchain:medany-rv32i-rv32im-rv32impriv-rv64i-rv64im-rv64impriv
+  merge:
+    needs: build
+    uses: ./.github/workflows/reusable-image-merge.yml
+    with:
+      image: ghcr.io/openvadl/riscv-toolchain

--- a/.github/workflows/build-spike-rv32im.yml
+++ b/.github/workflows/build-spike-rv32im.yml
@@ -9,31 +9,22 @@ permissions:
 
 jobs:
   build:
-    # The build crashed on MacOS arm64, so we only use x64 runners to build the images.
-    # This also avoids the need of exposing the macOS user password as secret to the CI.
-    runs-on: self-hosted-x64
+    uses: ./.github/workflows/reusable-image-build.yml
+    strategy:
+      matrix:
+        target:
+          - platform: linux/arm64
+            runner: self-hosted-arm64
+          - platform: linux/amd64
+            runner: self-hosted-x64
+    with:
+      image: ghcr.io/openvadl/spike-rv32im-base-image
+      context: vadl/test/resources/images/spike_rv32im/base_image
+      platform: ${{ matrix.target.platform }}
+      runner: ${{ matrix.target.runner }}
 
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: vadl/test/resources/images/spike_rv32im/base_image
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ghcr.io/openvadl/spike-rv32im-base-image:latest
+  merge:
+    needs: build
+    uses: ./.github/workflows/reusable-image-merge.yml
+    with:
+      image: ghcr.io/openvadl/spike-rv32im-base-image

--- a/.github/workflows/build-spike-rv64im.yml
+++ b/.github/workflows/build-spike-rv64im.yml
@@ -9,31 +9,22 @@ permissions:
 
 jobs:
   build:
-    # The build crashed on MacOS arm64, so we only use x64 runners to build the images.
-    # This also avoids the need of exposing the macOS user password as secret to the CI.
-    runs-on: self-hosted-x64
+    uses: ./.github/workflows/reusable-image-build.yml
+    strategy:
+      matrix:
+        target:
+          - platform: linux/arm64
+            runner: self-hosted-arm64
+          - platform: linux/amd64
+            runner: self-hosted-x64
+    with:
+      image: ghcr.io/openvadl/spike-rv64im-base-image
+      context: vadl/test/resources/images/spike_rv64im/base_image
+      platform: ${{ matrix.target.platform }}
+      runner: ${{ matrix.target.runner }}
 
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: vadl/test/resources/images/spike_rv64im/base_image
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ghcr.io/openvadl/spike-rv64im-base-image:latest
+  merge:
+    needs: build
+    uses: ./.github/workflows/reusable-image-merge.yml
+    with:
+      image: ghcr.io/openvadl/spike-rv64im-base-image

--- a/.github/workflows/reusable-image-build.yml
+++ b/.github/workflows/reusable-image-build.yml
@@ -1,0 +1,95 @@
+# A callable workflow that encapsulates the process of
+# building and pushing docker images.
+# It is especially useful for multiplatform builds that need to be built on
+# different runners (one per platform) and later merged with the
+# reusable-image-merge workflow.
+
+name: Reusable Image Build Workflow
+
+on:
+  workflow_call:
+    inputs:
+      image:
+        description: 'The image name: ghcr.io/<org>/<image>'
+        required: true
+        type: string
+      platform:
+        description: 'The docker build platform (linux/arm64 or linux/amd64)'
+        required: true
+        type: string
+      runner:
+        description: 'Runs-on property'
+        required: true
+        type: string
+      context:
+        description: 'Path to docker build context'
+        required: true
+        type: string
+      tags:
+        description: 'Tags in metadata-action format'
+        required: false
+        type: string
+        default: latest
+
+jobs:
+  build-and-push:
+    name: ${{ inputs.platform }}
+    runs-on: ${{ inputs.runner }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Prepare
+        run: |
+          platform=${{ inputs.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ inputs.image }}
+          tags: ${{ inputs.tags }}
+
+      - name: Unlock Keychain
+        if: ${{ runner.os == 'macOS' }}
+        env:
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        run: |
+          security -v unlock-keychain -p "$KEYCHAIN_PASSWORD" ~/Library/Keychains/login.keychain-db
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ inputs.context }}
+          platforms: ${{ inputs.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ inputs.image }}
+          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: List temp directory contents
+        run: ls -al ${{ runner.temp }}/digests
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/reusable-image-merge.yml
+++ b/.github/workflows/reusable-image-merge.yml
@@ -1,0 +1,61 @@
+# A callable workflow that merges multiplatform images to a single digest image.
+# Those images must have been built with the reusable-image-build workflow.
+
+name: Reusable Image Merge Workflow
+
+on:
+  workflow_call:
+    inputs:
+      image:
+        description: 'The name of the image'
+        required: true
+        type: string
+
+jobs:
+  merge:
+    runs-on: self-hosted
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Unlock Keychain
+        if: ${{ runner.os == 'macOS' }}
+        env:
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        run: |
+          security -v unlock-keychain -p "$KEYCHAIN_PASSWORD" ~/Library/Keychains/login.keychain-db
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ inputs.image }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ inputs.image }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ inputs.image }}:${{ steps.meta.outputs.version }}


### PR DESCRIPTION
This dramatically speeds up building big images for multiplatform, as it does not require QEMU to cross-build images.
