### PR TITLE
setup: Fail fast for generator tests

### DIFF
--- a/vadl/build.gradle.kts
+++ b/vadl/build.gradle.kts
@@ -116,6 +116,8 @@ val generators = listOf("iss", "lcb")
 
 for (gen in generators) {
     tasks.register<Test>("test-$gen") {
+        // fail fast, so we don't try to rebuild all failing images over and over
+        failFast = true
         val pkg = "vadl.$gen"
         description = "Runs tests for the $pkg package"
         filter {


### PR DESCRIPTION
Otherwise, a failing image build will try to rebuild every test and fail every test, causing long CI times.