### PR TITLE
ci: Set self-hosted-x86 for benchmark lcb

### DIFF
--- a/.github/workflows/benchmark-lcb.yml
+++ b/.github/workflows/benchmark-lcb.yml
@@ -24,7 +24,7 @@ jobs:
         run: ./gradlew assemble testClasses -PFailOnWarnings
   benchmark:
     needs: build
-    runs-on: self-hosted
+    runs-on: self-hosted-x86 # The git push plugin requires linux
     steps:
       - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1


### PR DESCRIPTION
The git push plugin requires a linux system.