### PR TITLE
gcb: Extend labeling with types

### DIFF
--- a/vadl/main/vadl/gcb/passes/MachineInstructionCtx.java
+++ b/vadl/main/vadl/gcb/passes/MachineInstructionCtx.java
@@ -16,19 +16,27 @@
 
 package vadl.gcb.passes;
 
+import java.util.Optional;
+import vadl.types.BitsType;
+import vadl.types.DataType;
 import vadl.viam.Definition;
 import vadl.viam.DefinitionExtension;
 import vadl.viam.Instruction;
 
 /**
  * An extension for the {@link Instruction}. It will be used
- * label the instruction with a {@link MachineInstructionLabel}.
+ * label the instruction with a {@link MachineInstructionLabel}. The {@code type} indicates on
+ * what type the instruction operates. It can be {@link Optional#empty()} when they are
+ * multiple writes or reads with different sizes.
  */
 public class MachineInstructionCtx extends DefinitionExtension<Instruction> {
   private final MachineInstructionLabel label;
+  private final Optional<BitsType> type;
 
-  public MachineInstructionCtx(MachineInstructionLabel label) {
+  public MachineInstructionCtx(MachineInstructionLabel label,
+                               Optional<BitsType> type) {
     this.label = label;
+    this.type = type;
   }
 
   @Override
@@ -38,5 +46,9 @@ public class MachineInstructionCtx extends DefinitionExtension<Instruction> {
 
   public MachineInstructionLabel label() {
     return label;
+  }
+
+  public Optional<BitsType> type() {
+    return type;
   }
 }

--- a/vadl/test/vadl/lcb/riscv/riscv64/IsaMachineInstructionMatchingRiscv64PassTest.java
+++ b/vadl/test/vadl/lcb/riscv/riscv64/IsaMachineInstructionMatchingRiscv64PassTest.java
@@ -14,67 +14,98 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-package vadl.lcb.passes;
+package vadl.lcb.riscv.riscv64;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import vadl.gcb.passes.IsaMachineInstructionMatchingPass;
+import vadl.gcb.passes.MachineInstructionCtx;
 import vadl.gcb.passes.MachineInstructionLabel;
 import vadl.lcb.AbstractLcbTest;
 import vadl.pass.PassOrders;
 import vadl.pass.exception.DuplicatedPassKeyException;
+import vadl.types.BitsType;
+import vadl.types.DataType;
 import vadl.viam.Definition;
 
 public class IsaMachineInstructionMatchingRiscv64PassTest extends AbstractLcbTest {
 
   private static Stream<Arguments> getExpectedMatchings() {
     return Stream.of(
-        Arguments.of(List.of("ADD"), MachineInstructionLabel.ADD_64),
-        Arguments.of(List.of("ADDI"), MachineInstructionLabel.ADDI_64),
-        Arguments.of(List.of("BEQ"), MachineInstructionLabel.BEQ),
-        Arguments.of(List.of("BNE"), MachineInstructionLabel.BNEQ),
-        Arguments.of(List.of("BGE"), MachineInstructionLabel.BSGEQ),
-        Arguments.of(List.of("BGEU"), MachineInstructionLabel.BUGEQ),
-        Arguments.of(List.of("BLT"), MachineInstructionLabel.BSLTH),
-        Arguments.of(List.of("BLTU"), MachineInstructionLabel.BULTH),
-        Arguments.of(List.of("AND", "ANDI"), MachineInstructionLabel.AND),
-        Arguments.of(List.of("SUB", "SUBW"), MachineInstructionLabel.SUB),
-        Arguments.of(List.of("OR"), MachineInstructionLabel.OR),
-        Arguments.of(List.of("ORI"), MachineInstructionLabel.ORI),
-        Arguments.of(List.of("XOR"), MachineInstructionLabel.XOR),
-        Arguments.of(List.of("XORI"), MachineInstructionLabel.XORI),
-        Arguments.of(List.of("MUL", "MULW"), MachineInstructionLabel.MUL),
-        Arguments.of(List.of("MULHU"), MachineInstructionLabel.MULHU),
-        Arguments.of(List.of("MULH"), MachineInstructionLabel.MULHS),
-        Arguments.of(List.of("DIV", "DIVW"), MachineInstructionLabel.SDIV),
-        Arguments.of(List.of("DIVU", "DIVUW"), MachineInstructionLabel.UDIV),
-        Arguments.of(List.of("REMU", "REMUW"), MachineInstructionLabel.UMOD),
-        Arguments.of(List.of("REM", "REMW"), MachineInstructionLabel.SMOD),
-        Arguments.of(List.of("SLL", "SLLW"), MachineInstructionLabel.SLL),
-        Arguments.of(List.of("SLLI"), MachineInstructionLabel.SLLI),
-        Arguments.of(List.of("SRL", "SRLW"), MachineInstructionLabel.SRL),
-        Arguments.of(List.of("SLT"), MachineInstructionLabel.LTS),
-        Arguments.of(List.of("SLTU"), MachineInstructionLabel.LTU),
-        Arguments.of(List.of("SLTI"), MachineInstructionLabel.LTI),
-        Arguments.of(List.of("SLTIU"), MachineInstructionLabel.LTIU),
+        Arguments.of(List.of("ADD"), MachineInstructionLabel.ADD_64,
+            Optional.of(DataType.bits(64))),
+        Arguments.of(List.of("ADDI"), MachineInstructionLabel.ADDI_64,
+            Optional.of(DataType.bits(64))),
+        Arguments.of(List.of("BEQ"), MachineInstructionLabel.BEQ, Optional.empty()),
+        Arguments.of(List.of("BNE"), MachineInstructionLabel.BNEQ, Optional.empty()),
+        Arguments.of(List.of("BGE"), MachineInstructionLabel.BSGEQ, Optional.empty()),
+        Arguments.of(List.of("BGEU"), MachineInstructionLabel.BUGEQ, Optional.empty()),
+        Arguments.of(List.of("BLT"), MachineInstructionLabel.BSLTH, Optional.empty()),
+        Arguments.of(List.of("BLTU"), MachineInstructionLabel.BULTH, Optional.empty()),
+        Arguments.of(List.of("AND", "ANDI"), MachineInstructionLabel.AND,
+            Optional.of(DataType.bits(64))),
+        Arguments.of(List.of("SUB", "SUBW"), MachineInstructionLabel.SUB,
+            Optional.of(DataType.bits(64))),
+        Arguments.of(List.of("OR"), MachineInstructionLabel.OR,
+            Optional.of(DataType.bits(64))),
+        Arguments.of(List.of("ORI"), MachineInstructionLabel.ORI,
+            Optional.of(DataType.bits(64))),
+        Arguments.of(List.of("XOR"), MachineInstructionLabel.XOR,
+            Optional.of(DataType.bits(64))),
+        Arguments.of(List.of("XORI"), MachineInstructionLabel.XORI,
+            Optional.of(DataType.bits(64))),
+        Arguments.of(List.of("MUL", "MULW"), MachineInstructionLabel.MUL,
+            Optional.of(DataType.bits(64))),
+        Arguments.of(List.of("MULHU"), MachineInstructionLabel.MULHU,
+            Optional.of(DataType.bits(64))),
+        Arguments.of(List.of("MULH"), MachineInstructionLabel.MULHS,
+            Optional.of(DataType.bits(64))),
+        Arguments.of(List.of("DIV", "DIVW"), MachineInstructionLabel.SDIV,
+            Optional.of(DataType.bits(64))),
+        Arguments.of(List.of("DIVU", "DIVUW"), MachineInstructionLabel.UDIV,
+            Optional.of(DataType.bits(64))),
+        Arguments.of(List.of("REMU", "REMUW"), MachineInstructionLabel.UMOD,
+            Optional.of(DataType.bits(64))),
+        Arguments.of(List.of("REM", "REMW"), MachineInstructionLabel.SMOD,
+            Optional.of(DataType.bits(64))),
+        Arguments.of(List.of("SLL", "SLLW"), MachineInstructionLabel.SLL,
+            Optional.of(DataType.bits(64))),
+        Arguments.of(List.of("SLLI"), MachineInstructionLabel.SLLI,
+            Optional.of(DataType.bits(64))),
+        Arguments.of(List.of("SRL", "SRLW"), MachineInstructionLabel.SRL,
+            Optional.of(DataType.bits(64))),
+        Arguments.of(List.of("SLT"), MachineInstructionLabel.LTS,
+            Optional.of(DataType.bits(64))),
+        Arguments.of(List.of("SLTU"), MachineInstructionLabel.LTU,
+            Optional.of(DataType.bits(64))),
+        Arguments.of(List.of("SLTI"), MachineInstructionLabel.LTI,
+            Optional.of(DataType.bits(64))),
+        Arguments.of(List.of("SLTIU"), MachineInstructionLabel.LTIU,
+            Optional.of(DataType.bits(64))),
         Arguments.of(List.of("LB", "LBU", "LD", "LH", "LHU", "LW", "LWU"),
-            MachineInstructionLabel.LOAD_MEM),
-        Arguments.of(List.of("SB", "SD", "SH", "SW"), MachineInstructionLabel.STORE_MEM),
-        Arguments.of(List.of("JALR"), MachineInstructionLabel.JALR),
-        Arguments.of(List.of("JAL"), MachineInstructionLabel.JAL)
+            MachineInstructionLabel.LOAD_MEM, Optional.of(DataType.bits(64))),
+        Arguments.of(List.of("SB", "SD", "SH", "SW"), MachineInstructionLabel.STORE_MEM,
+            Optional.of(DataType.bits(64))),
+        Arguments.of(List.of("JALR"), MachineInstructionLabel.JALR,
+            Optional.of(DataType.bits(64))),
+        Arguments.of(List.of("JAL"), MachineInstructionLabel.JAL,
+            Optional.of(DataType.bits(64)))
     );
   }
 
   @ParameterizedTest
   @MethodSource("getExpectedMatchings")
-  void shouldFindMatchings(List<String> expectedInstructionName, MachineInstructionLabel label)
+  void shouldFindMatchings(List<String> expectedInstructionName,
+                           MachineInstructionLabel label,
+                           Optional<BitsType> dataType)
       throws IOException, DuplicatedPassKeyException {
     // Given
     var config = getConfiguration(false);
@@ -96,5 +127,40 @@ public class IsaMachineInstructionMatchingRiscv64PassTest extends AbstractLcbTes
     Assertions.assertNotNull(matchings.get(label));
     var result = matchings.get(label).stream().map(Definition::simpleName).sorted().toList();
     assertEquals(expectedInstructionName.stream().sorted().toList(), result);
+  }
+
+
+  @ParameterizedTest
+  @MethodSource("getExpectedMatchings")
+  void shouldFindMatchingsByExtension(List<String> expectedInstructionName,
+                                      MachineInstructionLabel label,
+                                      Optional<BitsType> dataType)
+      throws IOException, DuplicatedPassKeyException {
+    // Given
+    var config = getConfiguration(false);
+    var setup = setupPassManagerAndRunSpec(
+        "sys/risc-v/rv64im.vadl",
+        PassOrders.lcb(config)
+            .untilFirst(IsaMachineInstructionMatchingPass.class)
+    );
+
+    // When
+    for (var instructionName : expectedInstructionName) {
+      var instruction = setup.specification().isa().get().ownInstructions()
+          .stream().filter(x -> x.identifier.simpleName().equals(instructionName))
+          .findFirst()
+          .get();
+
+      var ctx = instruction.extension(MachineInstructionCtx.class);
+
+      // Then
+      Assertions.assertNotNull(ctx);
+      Assertions.assertEquals(label, ctx.label());
+      if (dataType.isPresent()) {
+        Assertions.assertEquals(dataType.get(), ctx.type().get());
+      } else {
+        Assertions.assertTrue(ctx.type().isEmpty());
+      }
+    }
   }
 }

--- a/vadl/test/vadl/lcb/riscv/riscv64/IsaPseudoInstructionMatchingRiscv64PassTest.java
+++ b/vadl/test/vadl/lcb/riscv/riscv64/IsaPseudoInstructionMatchingRiscv64PassTest.java
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-package vadl.lcb.passes;
+package vadl.lcb.riscv.riscv64;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 


### PR DESCRIPTION
This PR tries to capture the type of the instruction. This is required for later when we try to generate the `setOperationAction`. The `setOperationAction` defines which operation are legal, illegal and have to be supplied by LLVM.