### PR TITLE
lcb: Implemented automatic deriving of setOperationAction

### DIFF
--- a/vadl/main/resources/templates/lcb/llvm/lib/Target/ISelLowering.cpp
+++ b/vadl/main/resources/templates/lcb/llvm/lib/Target/ISelLowering.cpp
@@ -52,15 +52,13 @@ void [(${namespace})]TargetLowering::anchor() {}
         setOperationAction(ISD::SIGN_EXTEND_INREG, VT, Expand);
     }
     setOperationAction(ISD::BR_JT, MVT::Other, Expand);
-    setOperationAction(ISD::ROTR, MVT::i32, Expand);
-    setOperationAction(ISD::SHL_PARTS, MVT::i32, Expand);
-    setOperationAction(ISD::SRL_PARTS, MVT::i32, Expand);
-    setOperationAction(ISD::SRA_PARTS, MVT::i32, Expand);
-    setOperationAction(ISD::BSWAP, MVT::i32, Expand);
     setOperationAction(ISD::DYNAMIC_STACKALLOC, MVT::i32, Expand);
     setOperationAction(ISD::STACKSAVE, MVT::Other, Expand);
     setOperationAction(ISD::STACKRESTORE, MVT::Other, Expand);
-    setOperationAction({ISD::ROTL, ISD::ROTR}, MVT::[(${stackPointerType})], Expand);
+
+    [# th:each="x : ${expandableDagNodes}" ]
+    setOperationAction(ISD::[(${x.isdName})], MVT::[(${x.mvt.value})], Expand);
+    [/]
 
     for (auto N : {ISD::EXTLOAD, ISD::SEXTLOAD, ISD::ZEXTLOAD}) {
         setLoadExtAction(N, MVT::[(${stackPointerType})], MVT::i1, Promote);

--- a/vadl/main/vadl/lcb/passes/llvmLowering/ISelLoweringOperationActionPass.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/ISelLoweringOperationActionPass.java
@@ -1,0 +1,150 @@
+// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.lcb.passes.llvmLowering;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.annotation.Nullable;
+import vadl.configuration.GeneralConfiguration;
+import vadl.lcb.passes.llvmLowering.domain.MachineValueType;
+import vadl.lcb.passes.llvmLowering.domain.SelectionDagToISDNameMapper;
+import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmBSwapSD;
+import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmRotlSD;
+import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmRotrSD;
+import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmShlPartsSD;
+import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmSraPartsSD;
+import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmSrlPartsSD;
+import vadl.lcb.passes.llvmLowering.tablegen.model.TableGenMachineInstruction;
+import vadl.lcb.passes.llvmLowering.tablegen.model.TableGenPattern;
+import vadl.pass.Pass;
+import vadl.pass.PassName;
+import vadl.pass.PassResults;
+import vadl.template.Renderable;
+import vadl.viam.Abi;
+import vadl.viam.Instruction;
+import vadl.viam.InstructionSetArchitecture;
+import vadl.viam.Specification;
+import vadl.viam.graph.dependency.DependencyNode;
+
+/**
+ * An {@link InstructionSetArchitecture} will not provide all {@link Instruction} which is
+ * required for LLVM. LLVM supports default implementations to replace selection dag nodes by
+ * other nodes. This passes computes the nodes which need to be expanded.
+ */
+public class ISelLoweringOperationActionPass extends Pass {
+  public static final Set<Class<?>> expandableSelectionDagNodes = new HashSet<>();
+
+  static {
+    expandableSelectionDagNodes.add(LlvmRotlSD.class);
+    expandableSelectionDagNodes.add(LlvmRotrSD.class);
+    expandableSelectionDagNodes.add(LlvmShlPartsSD.class);
+    expandableSelectionDagNodes.add(LlvmSrlPartsSD.class);
+    expandableSelectionDagNodes.add(LlvmSraPartsSD.class);
+    expandableSelectionDagNodes.add(LlvmBSwapSD.class);
+  }
+
+  public ISelLoweringOperationActionPass(GeneralConfiguration configuration) {
+    super(configuration);
+  }
+
+  @Override
+  public PassName getName() {
+    return new PassName("ISelLoweringOperationActionPass");
+  }
+
+  record Coverage(Instruction instruction, DependencyNode node) {
+
+  }
+
+  /**
+   * Container for selection dag nodes which need to be expanded.
+   */
+  public record NoCoverage(Class<DependencyNode> node,
+                           String llvmDagName, /* ISD Name in LLVM */
+                           MachineValueType mvt) implements Renderable {
+
+    @Override
+    public Map<String, Object> renderObj() {
+      return Map.of("isdName", llvmDagName,
+          "mvt", mvt);
+    }
+  }
+
+  /**
+   * Output record for this pass. It contains the nodes which should be covered by the patterns.
+   * And also the classes of the nodes which need to be expanded.
+   */
+  public record CoverageSummary(List<Coverage> coveredSelectionDagNodes,
+                                List<NoCoverage> notCoveredSelectionDagNodes) {
+  }
+
+  @Nullable
+  @Override
+  public Object execute(PassResults passResults, Specification viam) throws IOException {
+    var abi = viam.abi().orElseThrow();
+    var tableGenMachineInstructions = (List<TableGenMachineInstruction>) passResults.lastResultOf(
+        GenerateTableGenMachineInstructionRecordPass.class);
+
+    // First, we collect the root nodes of the patterns.
+    // Then we check which selection dag nodes need to be expanded.
+    var covered = coverage(tableGenMachineInstructions);
+    var notCovered = noCoverage(abi, covered);
+
+    return new CoverageSummary(covered, notCovered);
+  }
+
+  private List<NoCoverage> noCoverage(Abi abi, List<Coverage> covered) {
+    var result = new ArrayList<NoCoverage>();
+    var mapped =
+        covered.stream().map(x -> x.node.getClass()).collect(Collectors.toSet());
+
+    for (var needle : expandableSelectionDagNodes) {
+      if (!mapped.contains(needle)) {
+        result.add(new NoCoverage((Class<DependencyNode>) needle, SelectionDagToISDNameMapper.map(
+            (Class<LlvmNodeLowerable>) needle),
+            MachineValueType.from(abi.stackPointer().registerFile().resultType())));
+      }
+    }
+
+    return result;
+  }
+
+  private List<Coverage> coverage(
+      List<TableGenMachineInstruction> tableGenMachineInstructions) {
+    return tableGenMachineInstructions
+        .stream()
+        .flatMap(
+            tableGenMachineInstruction -> tableGenMachineInstruction.llvmLoweringRecord().patterns()
+                .stream().flatMap(
+                    coverageCandidate(tableGenMachineInstruction)))
+        .toList();
+  }
+
+  private static Function<TableGenPattern, Stream<? extends Coverage>> coverageCandidate(
+      TableGenMachineInstruction tableGenMachineInstruction) {
+    return tableGenPattern -> tableGenPattern.selector().getDataflowRoots().stream()
+        .map(rootNode -> new Coverage(tableGenMachineInstruction.instruction(),
+            rootNode));
+  }
+}

--- a/vadl/main/vadl/lcb/passes/llvmLowering/domain/MachineValueType.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/domain/MachineValueType.java
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.lcb.passes.llvmLowering.domain;
+
+import java.util.Map;
+import vadl.error.Diagnostic;
+import vadl.template.Renderable;
+import vadl.types.DataType;
+import vadl.utils.SourceLocation;
+
+enum MachineValueTypeEnum {
+  I32,
+  I64
+}
+
+/**
+ * Machine Value Type in LLVM.
+ */
+public record MachineValueType(MachineValueTypeEnum value) implements Renderable {
+  /**
+   * Get {@link MachineValueType} from {@link DataType} based on the bitwidth.
+   */
+  public static MachineValueType from(DataType dataType) {
+    if (dataType.bitWidth() == 32) {
+      return new MachineValueType(MachineValueTypeEnum.I32);
+    } else if (dataType.bitWidth() == 64) {
+      return new MachineValueType(MachineValueTypeEnum.I64);
+    }
+
+    throw Diagnostic.error("Cannot lower MVT", SourceLocation.INVALID_SOURCE_LOCATION)
+        .build();
+  }
+
+  @Override
+  public Map<String, Object> renderObj() {
+    return Map.of("value", value.name().toLowerCase());
+  }
+}

--- a/vadl/main/vadl/lcb/passes/llvmLowering/domain/SelectionDagToISDNameMapper.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/domain/SelectionDagToISDNameMapper.java
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.lcb.passes.llvmLowering.domain;
+
+import vadl.error.Diagnostic;
+import vadl.lcb.passes.llvmLowering.LlvmNodeLowerable;
+import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmBSwapSD;
+import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmRotlSD;
+import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmRotrSD;
+import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmShlPartsSD;
+import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmSraPartsSD;
+import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmSrlPartsSD;
+import vadl.utils.SourceLocation;
+
+/**
+ * This class maps {@link LlvmNodeLowerable} to their LLVM ISD node name.
+ */
+public class SelectionDagToISDNameMapper {
+  /**
+   * Map a class in our domain model to an ISD in LLVM.
+   *
+   * <pre>
+   *     setOperationAction(ISD::ROTR, MVT::i32, Expand);
+   * </pre>
+   */
+  public static String map(Class<LlvmNodeLowerable> nodeLowerable) {
+    if (nodeLowerable.isAssignableFrom(LlvmRotlSD.class)) {
+      return "ROTL";
+    } else if (nodeLowerable.isAssignableFrom(LlvmRotrSD.class)) {
+      return "ROTR";
+    } else if (nodeLowerable.isAssignableFrom(LlvmBSwapSD.class)) {
+      return "BSWAP";
+    } else if (nodeLowerable.isAssignableFrom(LlvmShlPartsSD.class)) {
+      return "SHL_PARTS";
+    } else if (nodeLowerable.isAssignableFrom(LlvmSrlPartsSD.class)) {
+      return "SRL_PARTS";
+    } else if (nodeLowerable.isAssignableFrom(LlvmSraPartsSD.class)) {
+      return "SRA_PARTS";
+    }
+
+    throw Diagnostic.error("Cannot map to class name", SourceLocation.INVALID_SOURCE_LOCATION)
+        .build();
+  }
+}

--- a/vadl/main/vadl/lcb/passes/llvmLowering/domain/selectionDag/LlvmBSwapSD.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/domain/selectionDag/LlvmBSwapSD.java
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.lcb.passes.llvmLowering.domain.selectionDag;
+
+import vadl.lcb.passes.llvmLowering.LlvmNodeLowerable;
+import vadl.lcb.passes.llvmLowering.strategies.visitors.TableGenMachineInstructionVisitor;
+import vadl.lcb.passes.llvmLowering.strategies.visitors.TableGenNodeVisitor;
+import vadl.types.BuiltInTable;
+import vadl.types.Type;
+import vadl.viam.graph.GraphNodeVisitor;
+import vadl.viam.graph.Node;
+import vadl.viam.graph.NodeList;
+import vadl.viam.graph.dependency.BuiltInCall;
+import vadl.viam.graph.dependency.ExpressionNode;
+
+/**
+ * LLVM Node for swap.
+ */
+public class LlvmBSwapSD extends BuiltInCall implements LlvmNodeLowerable {
+
+  public LlvmBSwapSD(NodeList<ExpressionNode> args,
+                     Type type) {
+    super(BuiltInTable.ADD, args, type);
+  }
+
+  @Override
+  public String lower() {
+    return "bswap";
+  }
+
+  @Override
+  public void accept(GraphNodeVisitor visitor) {
+    if (visitor instanceof TableGenMachineInstructionVisitor v) {
+      v.visit(this);
+    } else if (visitor instanceof TableGenNodeVisitor v) {
+      v.visit(this);
+    } else {
+      visitor.visit(this);
+    }
+  }
+
+  @Override
+  public ExpressionNode copy() {
+    return new LlvmBSwapSD(
+        new NodeList<>(args.stream().map(x -> (ExpressionNode) x.copy()).toList()),
+        type());
+  }
+
+  @Override
+  public Node shallowCopy() {
+    return new LlvmBSwapSD(args, type());
+  }
+}

--- a/vadl/main/vadl/lcb/passes/llvmLowering/domain/selectionDag/LlvmRotrSD.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/domain/selectionDag/LlvmRotrSD.java
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.lcb.passes.llvmLowering.domain.selectionDag;
+
+import vadl.lcb.passes.llvmLowering.LlvmNodeLowerable;
+import vadl.lcb.passes.llvmLowering.strategies.visitors.TableGenMachineInstructionVisitor;
+import vadl.lcb.passes.llvmLowering.strategies.visitors.TableGenNodeVisitor;
+import vadl.types.BuiltInTable;
+import vadl.types.Type;
+import vadl.viam.graph.GraphNodeVisitor;
+import vadl.viam.graph.Node;
+import vadl.viam.graph.NodeList;
+import vadl.viam.graph.dependency.BuiltInCall;
+import vadl.viam.graph.dependency.ExpressionNode;
+
+/**
+ * Logical node for rotate right.
+ */
+public class LlvmRotrSD extends BuiltInCall implements LlvmNodeLowerable {
+  public LlvmRotrSD(NodeList<ExpressionNode> args,
+                    Type type) {
+    super(BuiltInTable.ROL, args, type);
+  }
+
+  @Override
+  public String lower() {
+    return "right";
+  }
+
+  @Override
+  public void accept(GraphNodeVisitor visitor) {
+    if (visitor instanceof TableGenMachineInstructionVisitor v) {
+      v.visit(this);
+    } else if (visitor instanceof TableGenNodeVisitor v) {
+      v.visit(this);
+    } else {
+      visitor.visit(this);
+    }
+  }
+
+  @Override
+  public ExpressionNode copy() {
+    return new LlvmRotrSD(
+        new NodeList<>(args.stream().map(x -> (ExpressionNode) x.copy()).toList()),
+        type());
+  }
+
+  @Override
+  public Node shallowCopy() {
+    return new LlvmRotrSD(args, type());
+  }
+}

--- a/vadl/main/vadl/lcb/passes/llvmLowering/domain/selectionDag/LlvmShlPartsSD.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/domain/selectionDag/LlvmShlPartsSD.java
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.lcb.passes.llvmLowering.domain.selectionDag;
+
+import vadl.lcb.passes.llvmLowering.LlvmNodeLowerable;
+import vadl.lcb.passes.llvmLowering.strategies.visitors.TableGenMachineInstructionVisitor;
+import vadl.lcb.passes.llvmLowering.strategies.visitors.TableGenNodeVisitor;
+import vadl.types.BuiltInTable;
+import vadl.types.Type;
+import vadl.viam.graph.GraphNodeVisitor;
+import vadl.viam.graph.Node;
+import vadl.viam.graph.NodeList;
+import vadl.viam.graph.dependency.BuiltInCall;
+import vadl.viam.graph.dependency.ExpressionNode;
+
+/**
+ * LLVM Node for XXX.
+ */
+public class LlvmShlPartsSD extends BuiltInCall implements LlvmNodeLowerable {
+
+  public LlvmShlPartsSD(NodeList<ExpressionNode> args,
+                        Type type) {
+    super(BuiltInTable.ADD, args, type);
+  }
+
+  @Override
+  public String lower() {
+    return "shl_parts";
+  }
+
+  @Override
+  public void accept(GraphNodeVisitor visitor) {
+    if (visitor instanceof TableGenMachineInstructionVisitor v) {
+      v.visit(this);
+    } else if (visitor instanceof TableGenNodeVisitor v) {
+      v.visit(this);
+    } else {
+      visitor.visit(this);
+    }
+  }
+
+  @Override
+  public ExpressionNode copy() {
+    return new LlvmShlPartsSD(
+        new NodeList<>(args.stream().map(x -> (ExpressionNode) x.copy()).toList()),
+        type());
+  }
+
+  @Override
+  public Node shallowCopy() {
+    return new LlvmShlPartsSD(args, type());
+  }
+}

--- a/vadl/main/vadl/lcb/passes/llvmLowering/domain/selectionDag/LlvmSraPartsSD.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/domain/selectionDag/LlvmSraPartsSD.java
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.lcb.passes.llvmLowering.domain.selectionDag;
+
+import vadl.lcb.passes.llvmLowering.LlvmNodeLowerable;
+import vadl.lcb.passes.llvmLowering.strategies.visitors.TableGenMachineInstructionVisitor;
+import vadl.lcb.passes.llvmLowering.strategies.visitors.TableGenNodeVisitor;
+import vadl.types.BuiltInTable;
+import vadl.types.Type;
+import vadl.viam.graph.GraphNodeVisitor;
+import vadl.viam.graph.Node;
+import vadl.viam.graph.NodeList;
+import vadl.viam.graph.dependency.BuiltInCall;
+import vadl.viam.graph.dependency.ExpressionNode;
+
+/**
+ * LLVM Node for XXX.
+ */
+public class LlvmSraPartsSD extends BuiltInCall implements LlvmNodeLowerable {
+
+  public LlvmSraPartsSD(NodeList<ExpressionNode> args,
+                        Type type) {
+    super(BuiltInTable.ADD, args, type);
+  }
+
+  @Override
+  public String lower() {
+    return "sra_parts";
+  }
+
+  @Override
+  public void accept(GraphNodeVisitor visitor) {
+    if (visitor instanceof TableGenMachineInstructionVisitor v) {
+      v.visit(this);
+    } else if (visitor instanceof TableGenNodeVisitor v) {
+      v.visit(this);
+    } else {
+      visitor.visit(this);
+    }
+  }
+
+  @Override
+  public ExpressionNode copy() {
+    return new LlvmSraPartsSD(
+        new NodeList<>(args.stream().map(x -> (ExpressionNode) x.copy()).toList()),
+        type());
+  }
+
+  @Override
+  public Node shallowCopy() {
+    return new LlvmSraPartsSD(args, type());
+  }
+}

--- a/vadl/main/vadl/lcb/passes/llvmLowering/domain/selectionDag/LlvmSrlPartsSD.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/domain/selectionDag/LlvmSrlPartsSD.java
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.lcb.passes.llvmLowering.domain.selectionDag;
+
+import vadl.lcb.passes.llvmLowering.LlvmNodeLowerable;
+import vadl.lcb.passes.llvmLowering.strategies.visitors.TableGenMachineInstructionVisitor;
+import vadl.lcb.passes.llvmLowering.strategies.visitors.TableGenNodeVisitor;
+import vadl.types.BuiltInTable;
+import vadl.types.Type;
+import vadl.viam.graph.GraphNodeVisitor;
+import vadl.viam.graph.Node;
+import vadl.viam.graph.NodeList;
+import vadl.viam.graph.dependency.BuiltInCall;
+import vadl.viam.graph.dependency.ExpressionNode;
+
+/**
+ * LLVM Node for XXX.
+ */
+public class LlvmSrlPartsSD extends BuiltInCall implements LlvmNodeLowerable {
+
+  public LlvmSrlPartsSD(NodeList<ExpressionNode> args,
+                        Type type) {
+    super(BuiltInTable.ADD, args, type);
+  }
+
+  @Override
+  public String lower() {
+    return "shr_parts";
+  }
+
+  @Override
+  public void accept(GraphNodeVisitor visitor) {
+    if (visitor instanceof TableGenMachineInstructionVisitor v) {
+      v.visit(this);
+    } else if (visitor instanceof TableGenNodeVisitor v) {
+      v.visit(this);
+    } else {
+      visitor.visit(this);
+    }
+  }
+
+  @Override
+  public ExpressionNode copy() {
+    return new LlvmSrlPartsSD(
+        new NodeList<>(args.stream().map(x -> (ExpressionNode) x.copy()).toList()),
+        type());
+  }
+
+  @Override
+  public Node shallowCopy() {
+    return new LlvmSrlPartsSD(args, type());
+  }
+}

--- a/vadl/main/vadl/lcb/template/lib/Target/EmitISelLoweringCppFilePass.java
+++ b/vadl/main/vadl/lcb/template/lib/Target/EmitISelLoweringCppFilePass.java
@@ -40,6 +40,7 @@ import vadl.lcb.codegen.model.llvm.ValueType;
 import vadl.lcb.passes.isaMatching.database.Database;
 import vadl.lcb.passes.isaMatching.database.Query;
 import vadl.lcb.passes.llvmLowering.GenerateTableGenRegistersPass;
+import vadl.lcb.passes.llvmLowering.ISelLoweringOperationActionPass;
 import vadl.lcb.passes.llvmLowering.domain.LlvmMachineInstructionUtil;
 import vadl.lcb.passes.llvmLowering.tablegen.model.register.TableGenRegisterClass;
 import vadl.lcb.passes.relocation.GenerateLinkerComponentsPass;
@@ -106,6 +107,9 @@ public class EmitISelLoweringCppFilePass extends LcbTemplateRenderingPass {
         () -> Diagnostic.error("Cannot find semantics of the instructions",
             specification.sourceLocation()))
         .labels();
+    var coverageSummary =
+        (ISelLoweringOperationActionPass.CoverageSummary) passResults.lastResultOf(
+            ISelLoweringOperationActionPass.class);
     var hasCMove32 = labelledMachineInstructions.containsKey(MachineInstructionLabel.CMOVE_32);
     var hasCMove64 = labelledMachineInstructions.containsKey(MachineInstructionLabel.CMOVE_64);
     var conditionalMove = getConditionalMove(hasCMove32, hasCMove64, labelledMachineInstructions);
@@ -140,6 +144,7 @@ public class EmitISelLoweringCppFilePass extends LcbTemplateRenderingPass {
         findHighModifier(addi, linkerInformation, fieldUsages).value());
     map.put("addImmediateLowModifier",
         findLowModifier(addi, linkerInformation, fieldUsages).value());
+    map.put("expandableDagNodes", coverageSummary.notCoveredSelectionDagNodes());
     return map;
   }
 

--- a/vadl/main/vadl/pass/PassOrders.java
+++ b/vadl/main/vadl/pass/PassOrders.java
@@ -75,6 +75,7 @@ import vadl.lcb.passes.llvmLowering.GenerateTableGenAbiSequenceInstructionRecord
 import vadl.lcb.passes.llvmLowering.GenerateTableGenMachineInstructionRecordPass;
 import vadl.lcb.passes.llvmLowering.GenerateTableGenPseudoInstructionRecordPass;
 import vadl.lcb.passes.llvmLowering.GenerateTableGenRegistersPass;
+import vadl.lcb.passes.llvmLowering.ISelLoweringOperationActionPass;
 import vadl.lcb.passes.llvmLowering.LlvmLoweringPass;
 import vadl.lcb.passes.llvmLowering.compensation.CompensationPatternPass;
 import vadl.lcb.passes.llvmLowering.immediates.GenerateTableGenImmediateRecordPass;
@@ -219,6 +220,7 @@ public class PassOrders {
     order.add(new GenerateTableGenAbiSequenceInstructionRecordPass(configuration));
     order.add(new GenerateTableGenImmediateRecordPass(configuration));
     order.add(new CompensationPatternPass(configuration));
+    order.add(new ISelLoweringOperationActionPass(configuration));
     order.add(new GenerateLinkerComponentsPass(configuration));
 
     addHtmlDump(order, configuration,

--- a/vadl/test/vadl/lcb/passes/llvmLowering/domain/SelectionDagToISDNameMapperTest.java
+++ b/vadl/test/vadl/lcb/passes/llvmLowering/domain/SelectionDagToISDNameMapperTest.java
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.lcb.passes.llvmLowering.domain;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import vadl.lcb.passes.llvmLowering.ISelLoweringOperationActionPass;
+import vadl.lcb.passes.llvmLowering.LlvmNodeLowerable;
+
+class SelectionDagToISDNameMapperTest {
+  private static Stream<Arguments> expandableSelectionDagNodes() {
+    return ISelLoweringOperationActionPass.expandableSelectionDagNodes
+        .stream().map(Arguments::of);
+  }
+
+  @ParameterizedTest
+  @MethodSource("expandableSelectionDagNodes")
+  void checkIfEverythingIsMapped(Class<?> clazz) {
+    Assertions.assertDoesNotThrow(() -> {
+      SelectionDagToISDNameMapper.map((Class<LlvmNodeLowerable>) clazz);
+    });
+  }
+}


### PR DESCRIPTION
A compiler backend does not always provide all the required machine instructions as mapping for the ISel. LLVM provides functionality for legalization and expansion to ease the development. So far, the calls to `setOperationAction` have been hardcoded. This PR creates a new pass which checks which DAG nodes are covered by patterns (only root nodes) and constructs a list which has to be expanded by other DAG nodes by LLVM in `ISelLoweringOperationActionPass`. 

At the moment, we can only check the following classes to be expanded automatically. However, this list can be easily extended. Additionally, note that we only extend with the stack pointer type.

```
public static final Set<Class<?>> expandableSelectionDagNodes = new HashSet<>();

  static {
    expandableSelectionDagNodes.add(LlvmRotlSD.class);
    expandableSelectionDagNodes.add(LlvmRotrSD.class);
    expandableSelectionDagNodes.add(LlvmShlPartsSD.class);
    expandableSelectionDagNodes.add(LlvmSrlPartsSD.class);
    expandableSelectionDagNodes.add(LlvmSraPartsSD.class);
    expandableSelectionDagNodes.add(LlvmBSwapSD.class);
  }
```