### PR TITLE
cli: Add timings printout

### DIFF
--- a/vadl/main/vadl/ast/Ast.java
+++ b/vadl/main/vadl/ast/Ast.java
@@ -31,10 +31,20 @@ import vadl.utils.WithSourceLocation;
 public class Ast {
   List<Definition> definitions = new ArrayList<>();
   URI fileUri = SourceLocation.INVALID_SOURCE_LOCATION.uri();
-  List<VadlParser.PassTimings> passTimings = new ArrayList<>();
+  public List<PassTimings> passTimings = new ArrayList<>();
+
 
   @Nullable
   SymbolTable rootSymbolTable;
+
+  /**
+   * A simple record to hold the timings of passes in the frontend.
+   *
+   * @param description of the pass.
+   * @param durationMS  of the pass.
+   */
+  public record PassTimings(String description, long durationMS) {
+  }
 
   SymbolTable rootSymbolTable() {
     return Objects.requireNonNull(rootSymbolTable, "Symbol collector has not been applied");

--- a/vadl/main/vadl/ast/ModelRemover.java
+++ b/vadl/main/vadl/ast/ModelRemover.java
@@ -24,9 +24,17 @@ package vadl.ast;
  */
 public class ModelRemover implements DefinitionVisitor<Definition> {
 
+  /**
+   * Remove all models in the ast.
+   *
+   * @param ast to be modified.
+   */
   public void removeModels(Ast ast) {
+    var startTime = System.nanoTime();
     ast.definitions.removeIf(this::shouldRemove);
     ast.definitions.replaceAll(definition -> definition.accept(this));
+    ast.passTimings.add(
+        new Ast.PassTimings("Model Removing", (System.nanoTime() - startTime) / 1_000_000));
   }
 
   @Override

--- a/vadl/main/vadl/ast/SymbolTable.java
+++ b/vadl/main/vadl/ast/SymbolTable.java
@@ -856,10 +856,12 @@ class SymbolTable {
    */
   static class ResolutionPass {
     static List<Diagnostic> resolveSymbols(Ast ast) {
+      var resolveStartTime = System.nanoTime();
       for (Definition definition : ast.definitions) {
         resolveSymbols(definition);
       }
-      ast.passTimings.add(new VadlParser.PassTimings(System.nanoTime(), "Symbol resolution"));
+      ast.passTimings.add(new Ast.PassTimings("Symbol resolution",
+          (System.nanoTime() - resolveStartTime) / 1000_000));
       return Objects.requireNonNull(ast.rootSymbolTable).errors;
     }
 

--- a/vadl/main/vadl/ast/TypeChecker.java
+++ b/vadl/main/vadl/ast/TypeChecker.java
@@ -136,7 +136,10 @@ public class TypeChecker
    * @throws Diagnostic if the program isn't well typed
    */
   public void verify(Ast ast) {
+    var startTime = System.nanoTime();
     ast.definitions.forEach(this::check);
+    ast.passTimings.add(
+        new Ast.PassTimings("Type Checking", (System.nanoTime() - startTime) / 1_000_000));
   }
 
   private void throwUnimplemented(Node node) {

--- a/vadl/main/vadl/ast/Ungrouper.java
+++ b/vadl/main/vadl/ast/Ungrouper.java
@@ -31,8 +31,16 @@ package vadl.ast;
 public class Ungrouper
     implements ExprVisitor<Expr>, DefinitionVisitor<Void>, StatementVisitor<Void> {
 
+  /**
+   * Remove all unneeded group expressions in the AST.
+   *
+   * @param ast to be modified.
+   */
   public void ungroup(Ast ast) {
+    var startTime = System.nanoTime();
     ast.definitions.forEach(def -> def.accept(this));
+    ast.passTimings.add(
+        new Ast.PassTimings("Ungrouping", (System.nanoTime() - startTime) / 1_000_000));
   }
 
   @Override

--- a/vadl/main/vadl/ast/ViamLowering.java
+++ b/vadl/main/vadl/ast/ViamLowering.java
@@ -120,6 +120,7 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
    * @throws Diagnostic if something goes wrong.
    */
   public vadl.viam.Specification generate(Ast ast) {
+    var startTime = System.nanoTime();
     var spec = new Specification(
         new vadl.viam.Identifier(ParserUtils.baseName(ast.fileUri),
             SourceLocation.INVALID_SOURCE_LOCATION));
@@ -129,6 +130,9 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
         .map(this::fetch)
         .flatMap(Optional::stream)
         .collect(Collectors.toList()));
+
+    ast.passTimings.add(
+        new Ast.PassTimings("Lowering to VIAM", (System.nanoTime() - startTime) / 1_000_000));
     return spec;
   }
 


### PR DESCRIPTION
Timings will now be printed like:

```
Timings:
	- Symbol resolution:                           0ms
	- Parsing:                                   131ms
	- Ungrouping:                                  0ms
	- Model Removing:                              0ms
	- Type Checking:                              20ms
	- Lowering to VIAM:                           47ms
	- VIAM Creation (pseudo pass):                 0ms
	- Collect Behavior Dot Graphs:                23ms
	- HTML Dump at phase VIAM Creation:         1208ms
	- ViamVerificationPass:                        4ms
	- Total:                                    1505ms
```

Somewhere it feels like we are _loosing_ some time (because the total) is larger than it's sums but I will investigate this in another PR, for now this already can help us discover large gaps and get a rough overview, but obviously this cannot replace proper profiling.