### PR TITLE
dump: Add border bottom border to graph

### DIFF
--- a/vadl/main/vadl/dump/InfoUtils.java
+++ b/vadl/main/vadl/dump/InfoUtils.java
@@ -186,7 +186,7 @@ public class InfoUtils {
     // add the body with the empty graph container and the dot graph script
     info.body = """
         <div class="flex flex-col h-full">
-            <div id="graph-%s" class="graph-container flex-grow rounded-md flex items-center justify-center">
+            <div id="graph-%s" class="graph-container flex-grow rounded-md flex items-center justify-center border-b">
                 <!-- Graph will render here -->
             </div>
             <div class="flex px-4 pt-4 justify-between">

--- a/vadl/main/vadl/viam/graph/visualize/DotGraphVisualizer.java
+++ b/vadl/main/vadl/viam/graph/visualize/DotGraphVisualizer.java
@@ -69,7 +69,7 @@ public class DotGraphVisualizer implements GraphVisualizer<String, Graph> {
     Objects.requireNonNull(graph);
 
     StringBuilder dotBuilder = new StringBuilder();
-    dotBuilder.append("digraph G {\n");
+    dotBuilder.append("digraph {\n");
     dotBuilder.append("    label=%s\n".formatted(wrapStr(name)));
     dotBuilder.append("\n");
 


### PR DESCRIPTION
I initially tried playing around with the HTML dump to improve performance but so far I could only shrink the output for `closedaarch64.vadl` by a couple of megabytes (down to ~25MB from the original 32MB) which overall didn't impact the generation performance nor the rendering performance in the browser.

However, while I got more familiar with the code I also tweaked the usability which is all this PR is.
Maybe I will still have a better idea on performance improvements in the future that are more fruitful ;)