### PR TITLE
parser: Fix missing definitions in symbol resolution

### DIFF
--- a/vadl/main/vadl/ast/SymbolTable.java
+++ b/vadl/main/vadl/ast/SymbolTable.java
@@ -884,8 +884,37 @@ class SymbolTable {
           resolveSymbols(constant.typeLiteral);
         }
         resolveSymbols(constant.value);
+      } else if (definition instanceof CounterDefinition counterDefinition) {
+        resolveSymbols(counterDefinition.typeLiteral);
+      } else if (definition instanceof RegisterDefinition registerDefinition) {
+        resolveSymbols(registerDefinition.typeLiteral);
+      } else if (definition instanceof RegisterFileDefinition registerFile) {
+        for (var argType : registerFile.typeLiteral.argTypes()) {
+          resolveSymbols(argType);
+        }
+        resolveSymbols(registerFile.typeLiteral.resultType());
+      } else if (definition instanceof MemoryDefinition memory) {
+        resolveSymbols(memory.addressTypeLiteral);
+        resolveSymbols(memory.dataTypeLiteral);
+      } else if (definition instanceof UsingDefinition using) {
+        resolveSymbols(using.typeLiteral);
       } else if (definition instanceof FunctionDefinition function) {
         resolveSymbols(function.expr);
+      } else if (definition instanceof FormatDefinition format) {
+        resolveSymbols(format.typeLiteral);
+        for (FormatDefinition.FormatField field : format.fields) {
+          if (field instanceof FormatDefinition.RangeFormatField rangeField) {
+            if (rangeField.typeLiteral != null) {
+              resolveSymbols(rangeField.typeLiteral);
+            }
+          } else if (field instanceof FormatDefinition.TypedFormatField typedField) {
+            resolveSymbols(typedField.typeLiteral);
+          } else if (field instanceof FormatDefinition.DerivedFormatField dfField) {
+            resolveSymbols(dfField.expr);
+          } else {
+            throw new RuntimeException("Unknown class");
+          }
+        }
       } else if (definition instanceof InstructionDefinition instr) {
         var format = instr.symbolTable().requireAs(instr.typeIdentifier(), FormatDefinition.class);
         if (format != null) {

--- a/vadl/main/vadl/ast/vadl.ATG
+++ b/vadl/main/vadl/ast/vadl.ATG
@@ -396,10 +396,10 @@ PRODUCTIONS
   .
 
   formatField<out FormatDefinition.FormatField field> (. field = null; .)
-  = identifier<out Identifier id>       (. System.out.println("start field"); .)
-    ( formatFieldRange<out field, id>   (. System.out.println("range"); .)
-    | formatFieldType<out field, id>    (. System.out.println("type"); .)
-    | formatFieldDerived<out field, id> (. System.out.println("derived"); .)
+  = identifier<out Identifier id>
+    ( formatFieldRange<out field, id>
+    | formatFieldType<out field, id>
+    | formatFieldDerived<out field, id>
     )
   .
 

--- a/vadl/test/vadl/ast/NameResolutionTest.java
+++ b/vadl/test/vadl/ast/NameResolutionTest.java
@@ -256,4 +256,15 @@ public class NameResolutionTest {
     Assertions.assertThrows(DiagnosticList.class, () -> VadlParser.parse(prog),
         "Should reject typos");
   }
+
+  @Test
+  void invalidTypeNameInUsing() {
+    var prog = """
+        instruction set architecture ISA = {
+          using Word        = SInt<XSize>
+        }
+        """;
+    Assertions.assertThrows(DiagnosticList.class, () -> VadlParser.parse(prog),
+        "Should reject typos");
+  }
 }


### PR DESCRIPTION
@AndreasKrall found a crash with wrong types in `using` definitions.

```vadl
        instruction set architecture ISA = {
          using Word        = SInt<XSize>
        }
```

After a bit of investigation I found that the reason was that using definition (and five more) weren't resolved in the Symbol Resolver allowing the AST to be passed to the Typechecker that expects that all symbols exist and therefore crashes.

This however, now confirms my initial aversion to the long `if x instanceof y` chain used in the SymbolResolver over the more common visitor pattern used elsewhere. Because with the visitor pattern the compiler doesn't even allow you to compile the program if a case is missing.
I suspect that this will only become more and more of a problem with more authors and going open source in less than a week.