### PR TITLE
ci: Copy filecheck.sh to container

### DIFF
--- a/vadl/test/resources/images/spike_rv64im/base_image/Dockerfile
+++ b/vadl/test/resources/images/spike_rv64im/base_image/Dockerfile
@@ -46,3 +46,4 @@ COPY helper /helper
 COPY lcb_wrapper.sh .
 COPY llvm.sh .
 COPY spike.sh .
+COPY filecheck.sh .


### PR DESCRIPTION
We have forgot to add the `filecheck.sh` to the base image docker file for riscv64.