### PR TITLE
lcb: Handle signed and unsigned const mat #129

### DIFF
--- a/vadl/main/resources/templates/lcb/llvm/lib/Target/MCTargetDesc/TargetConstMatInt.cpp
+++ b/vadl/main/resources/templates/lcb/llvm/lib/Target/MCTargetDesc/TargetConstMatInt.cpp
@@ -12,13 +12,21 @@ using namespace llvm;
 
 namespace llvm::[(${namespace})]MatInt {
   InstSeq generateInstSeqImpl(int64_t Val, [(${namespace})]MatInt::InstSeq &Res ) {
+    uint64_t uVal = Val;
 
     [# th:each="cons : ${constantSequences}" ]
+    [# th:if="${cons.isSigned == false}" ]
+    if(uVal >= [(${cons.lowestValue})] && uVal <= [(${cons.highestValue})]) {
+      Res.emplace_back([(${namespace})]::[(${cons.instruction})], uVal);
+      return Res;
+    }
+    [/]
+    [# th:if="${cons.isSigned == true}" ]
     if(Val >= [(${cons.lowestValue})] && Val <= [(${cons.highestValue})]) {
       Res.emplace_back([(${namespace})]::[(${cons.instruction})], Val);
       return Res;
     }
-    [/]
+    [/]    [/]
 
     llvm_unreachable("not supported immediate");
   }

--- a/vadl/main/resources/templates/lcb/llvm/lib/Target/MCTargetDesc/TargetConstMatInt.h
+++ b/vadl/main/resources/templates/lcb/llvm/lib/Target/MCTargetDesc/TargetConstMatInt.h
@@ -21,7 +21,7 @@ class APInt;
 namespace [(${namespace})]MatInt {
   class Inst {
     unsigned Opc;
-    int32_t Imm; // The largest value we need to store is 20 bits.
+    int64_t Imm; // The largest value we need to store is 20 bits.
 
   public:
     Inst(unsigned Opc, int64_t I) : Opc(Opc), Imm(I) {


### PR DESCRIPTION
The header class was copied from RISCV. The difference is that upstream is only storing machine instructions which have smaller bit widths in the instructions. We store pseudo instructions which hold the whole immediate. Therefore, the type change in the header.

Everything is a signed integer. Even though, it is not. So if no signed constant sequences fits then try the unsigned constant sequences.