### PR TITLE
lcb: Emit correct llvm relocations

### DIFF
--- a/vadl/main/resources/templates/lcb/lld/ELF/Arch/Target.cpp
+++ b/vadl/main/resources/templates/lcb/lld/ELF/Arch/Target.cpp
@@ -48,7 +48,7 @@ namespace lld
             case R_[(${namespace})]_64:
             [#th:block th:each="relocation: ${relocations}" ]
             case [(${relocation.elfRelocationName.value})]:
-                return [#th:block th:text="${relocation.kind == ABSOLUTE} ? 'R_ABS' : 'R_PC'" /];
+                return [(${relocation.llvmKind})];
             [/th:block]
             default:
                 error(getErrorLocation(loc) + "unknown relocation (" + Twine(type) +

--- a/vadl/main/vadl/gcb/passes/relocation/model/CompilerRelocation.java
+++ b/vadl/main/vadl/gcb/passes/relocation/model/CompilerRelocation.java
@@ -77,6 +77,28 @@ public abstract class CompilerRelocation implements Renderable {
         case GLOBAL_OFFSET_TABLE -> Relocation.Kind.GLOBAL_OFFSET_TABLE;
       };
     }
+
+    /**
+     * Get the {@link CompilerRelocation.Kind} from a {@link Relocation.Kind}.
+     */
+    public static Kind fromRelocationKind(Relocation.Kind kind) {
+      return switch (kind) {
+        case ABSOLUTE -> ABSOLUTE;
+        case RELATIVE -> RELATIVE;
+        case GLOBAL_OFFSET_TABLE -> GLOBAL_OFFSET_TABLE;
+      };
+    }
+
+    /**
+     * Maps a {@link CompilerRelocation.Kind} to a LLVM relocation kind.
+     */
+    public String llvmKind() {
+      return switch (this) {
+        case RELATIVE -> "R_PC";
+        case ABSOLUTE -> "R_ABS";
+        case GLOBAL_OFFSET_TABLE -> "R_GOT_PC";
+      };
+    }
   }
 
   /**
@@ -89,7 +111,7 @@ public abstract class CompilerRelocation implements Renderable {
       Relocation relocationRef
   ) {
     this(identifier,
-        relocationRef.isAbsolute() ? Kind.ABSOLUTE : Kind.RELATIVE,
+        Kind.fromRelocationKind(relocationRef.kind()),
         format,
         immediate,
         relocationRef);
@@ -143,7 +165,7 @@ public abstract class CompilerRelocation implements Renderable {
   @Override
   public Map<String, Object> renderObj() {
     var obj = new HashMap<String, Object>();
-    obj.put("kind", kind().name());
+    obj.put("llvmKind", kind.llvmKind());
     obj.put("elfRelocationName", elfRelocationName());
     obj.put("relocation", Map.of(
         "name", relocation().simpleName()

--- a/vadl/main/vadl/gcb/passes/relocation/model/UserSpecifiedRelocation.java
+++ b/vadl/main/vadl/gcb/passes/relocation/model/UserSpecifiedRelocation.java
@@ -40,7 +40,7 @@ public class UserSpecifiedRelocation extends CompilerRelocation {
       Relocation originalRelocation) {
     super(generateName(format,
             field,
-            originalRelocation.isAbsolute() ? Kind.ABSOLUTE : Kind.RELATIVE),
+            CompilerRelocation.Kind.fromRelocationKind(originalRelocation.kind())),
         format, field, originalRelocation);
     this.variantKind = new VariantKind(originalRelocation);
   }

--- a/vadl/main/vadl/viam/Relocation.java
+++ b/vadl/main/vadl/viam/Relocation.java
@@ -37,7 +37,7 @@ public class Relocation extends Function {
   public enum Kind {
     ABSOLUTE,
     RELATIVE,
-    GLOBAL_OFFSET_TABLE
+    GLOBAL_OFFSET_TABLE;
   }
 
   private final Kind kind;
@@ -65,6 +65,13 @@ public class Relocation extends Function {
   @Override
   public void accept(DefinitionVisitor visitor) {
     visitor.visit(this);
+  }
+
+  /**
+   * Returns the {@link Relocation.Kind} of this relocation.
+   */
+  public Kind kind() {
+    return kind;
   }
 
   /**

--- a/vadl/test/resources/testSource/sys/risc-v/rv32im.vadl
+++ b/vadl/test/resources/testSource/sys/risc-v/rv32im.vadl
@@ -245,20 +245,20 @@ assembly description ASM for ABI = {
     BranchPseudoInstruction @instruction :
       mnemonic = BranchPseudoIds @operand
       rs = Register @operand ","
-      offset = ImmediateOperand @operand
+      offset = ImmediateOperand
     ;
 
 
     LLAPseudoInstruction @instruction:
       mnemonic = "LLA" @operand
       rd = Register @operand ","
-      symbol = (Identifier @symbol) @operand
+      symbol = ImmediateOperand
     ;
 
     LIPseudoInstruction @instruction:
       mnemonic = "LI" @operand
       rd = Register @operand ","
-      symbol = (Identifier @symbol) @operand
+      symbol = ImmediateOperand
     ;
   }
 }

--- a/vadl/test/vadl/lcb/riscv/riscv64/template/lld/ELF/Arch/EmitLldTargetRelocationsHeaderFilePassTest.java
+++ b/vadl/test/vadl/lcb/riscv/riscv64/template/lld/ELF/Arch/EmitLldTargetRelocationsHeaderFilePassTest.java
@@ -216,25 +216,25 @@ public class EmitLldTargetRelocationsHeaderFilePassTest extends AbstractLcbTest 
         int64_t RV3264I_Ftype_RELATIVE_sft_pcrel_lo(uint32_t symbol) {
            return  VADL_sextract(VADL_uextract(symbol, 12), 12);
         }
-        int64_t RV3264I_Itype_RELATIVE_imm_got_hi(uint32_t symbol) {
+        int64_t RV3264I_Itype_GLOBAL_OFFSET_TABLE_imm_got_hi(uint32_t symbol) {
            return VADL_uextract(VADL_lsr(VADL_add(symbol, 32, ((uint32_t) 0x00000800 ), 32), 32, ((uint8_t) 0xc ), 4), 20);
         }
-        int64_t RV3264I_Utype_RELATIVE_imm_got_hi(uint32_t symbol) {
+        int64_t RV3264I_Utype_GLOBAL_OFFSET_TABLE_imm_got_hi(uint32_t symbol) {
            return VADL_uextract(VADL_lsr(VADL_add(symbol, 32, ((uint32_t) 0x00000800 ), 32), 32, ((uint8_t) 0xc ), 4), 20);
         }
-        int64_t RV3264I_Stype_RELATIVE_imm_got_hi(uint32_t symbol) {
+        int64_t RV3264I_Stype_GLOBAL_OFFSET_TABLE_imm_got_hi(uint32_t symbol) {
            return VADL_uextract(VADL_lsr(VADL_add(symbol, 32, ((uint32_t) 0x00000800 ), 32), 32, ((uint8_t) 0xc ), 4), 20);
         }
-        int64_t RV3264I_Btype_RELATIVE_imm_got_hi(uint32_t symbol) {
+        int64_t RV3264I_Btype_GLOBAL_OFFSET_TABLE_imm_got_hi(uint32_t symbol) {
            return VADL_uextract(VADL_lsr(VADL_add(symbol, 32, ((uint32_t) 0x00000800 ), 32), 32, ((uint8_t) 0xc ), 4), 20);
         }
-        int64_t RV3264I_Jtype_RELATIVE_imm_got_hi(uint32_t symbol) {
+        int64_t RV3264I_Jtype_GLOBAL_OFFSET_TABLE_imm_got_hi(uint32_t symbol) {
            return VADL_uextract(VADL_lsr(VADL_add(symbol, 32, ((uint32_t) 0x00000800 ), 32), 32, ((uint8_t) 0xc ), 4), 20);
         }
-        int64_t RV3264I_Rtype_RELATIVE_rs2_got_hi(uint32_t symbol) {
+        int64_t RV3264I_Rtype_GLOBAL_OFFSET_TABLE_rs2_got_hi(uint32_t symbol) {
            return VADL_uextract(VADL_lsr(VADL_add(symbol, 32, ((uint32_t) 0x00000800 ), 32), 32, ((uint8_t) 0xc ), 4), 20);
         }
-        int64_t RV3264I_Ftype_RELATIVE_sft_got_hi(uint32_t symbol) {
+        int64_t RV3264I_Ftype_GLOBAL_OFFSET_TABLE_sft_got_hi(uint32_t symbol) {
            return VADL_uextract(VADL_lsr(VADL_add(symbol, 32, ((uint32_t) 0x00000800 ), 32), 32, ((uint8_t) 0xc ), 4), 20);
         }
         int64_t RV3264I_Itype_ABSOLUTE_imm_Itype_ABSOLUTE_imm(int64_t input) {


### PR DESCRIPTION
This PR fixes the mapping from VADL relocations to generic LLVM relocations. Previously, all VADL relocations were mapped to the `R_PC` LLVM relocation. Now VADL relocations are mapped to one of `R_ABS`, `R_PC` or `R_GOT_PC`.