### PR TITLE
typechecker: Fix crash on unfound symbol

### DIFF
--- a/vadl/main/vadl/ast/SymbolTable.java
+++ b/vadl/main/vadl/ast/SymbolTable.java
@@ -899,6 +899,10 @@ class SymbolTable {
       } else if (definition instanceof UsingDefinition using) {
         resolveSymbols(using.typeLiteral);
       } else if (definition instanceof FunctionDefinition function) {
+        for (Parameter param : function.params) {
+          resolveSymbols(param.typeLiteral);
+        }
+        resolveSymbols(function.retType);
         resolveSymbols(function.expr);
       } else if (definition instanceof FormatDefinition format) {
         resolveSymbols(format.typeLiteral);

--- a/vadl/main/vadl/ast/TypeChecker.java
+++ b/vadl/main/vadl/ast/TypeChecker.java
@@ -1845,7 +1845,8 @@ public class TypeChecker
     }
 
     // The symbol resolver should have caught that
-    throw new IllegalStateException("Cannot find symbol %s".formatted(fullName));
+    throw new IllegalStateException(
+        "Cannot find symbol `%s` found at: %s".formatted(fullName, expr.location().toIDEString()));
   }
 
   @Override


### PR DESCRIPTION
The problem was again that the symbol resolver missed some cases. I'm more and more convinced that the manual iterating through the AST in each visitor is error prone and for passes that don't care to much about the order we should provide one default implementation.

But that's work for another commit, for now this commit fixes the missing children in the symbol resolver.