### PR TITLE
chore: Tooling Java Minimum Major Version Check

### DIFF
--- a/gradlew
+++ b/gradlew
@@ -141,8 +141,8 @@ location of your Java installation."
 fi
 
 # Add minimum Java major version check, see: https://github.com/OpenVADL/openvadl/pull/162
-JAVA_VERSION_STRING=$("$JAVACMD" -version 2>&1)
-JAVA_VERSION_MAJOR=$(echo "$JAVA_VERSION_STRING" | sed -n 's/.* version "\(1\.\|\)\([0-9]*\).*/\2/p')
+JAVA_VERSION_STRING=$("$JAVACMD" -version 2>&1 | grep 'version' | head -n 1 | cut -d '"' -f2)
+JAVA_VERSION_MAJOR=$(echo "$JAVA_VERSION_STRING" | cut -d '.' -f1)
 if [ "$JAVA_VERSION_MAJOR" -lt 17 ]; then
     echo "ERROR: Java 17 or higher is required. Found Java version $JAVA_VERSION_STRING."
     exit 1

--- a/gradlew
+++ b/gradlew
@@ -140,6 +140,14 @@ location of your Java installation."
     fi
 fi
 
+# Add minimum Java major version check, see: https://github.com/OpenVADL/openvadl/pull/162
+JAVA_VERSION_STRING=$("$JAVACMD" -version 2>&1)
+JAVA_VERSION_MAJOR=$(echo "$JAVA_VERSION_STRING" | sed -n 's/.* version "\(1\.\|\)\([0-9]*\).*/\2/p')
+if [ "$JAVA_VERSION_MAJOR" -lt 17 ]; then
+    echo "ERROR: Java 17 or higher is required. Found Java version $JAVA_VERSION_STRING."
+    exit 1
+fi
+
 # Increase the maximum file descriptors if we can.
 if ! "$cygwin" && ! "$darwin" && ! "$nonstop" ; then
     case $MAX_FD in #(

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -70,6 +70,16 @@ goto fail
 
 set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
 
+rem Add minimum Java major version check, see: https://github.com/OpenVADL/openvadl/pull/162
+for /f "tokens=2 delims==" %%v in ('"%JAVA_EXE%" -version 2^>^&1 ^| findstr /i "version"') do (
+set "JAVA_VERSION_STRING=%%~v"
+)
+for /f "tokens=1 delims=." %%m in ("%JAVA_VERSION_STRING%") do (
+set /a JAVA_VERSION_MAJOR=%%m
+)
+if %JAVA_VERSION_MAJOR% lss 17 (
+echo ERROR: Java 17 or higher is required. Found Java version %JAVA_VERSION_STRING%.
+exit /b 1
 
 @rem Execute Gradle
 "%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %*


### PR DESCRIPTION
This PR introduces the following changes:

* set minimum required Java 17 major version fix in Gradle setup (relates to docs changed in a905882a450cc9ee53d4b7a42e98e2d2c30b8083)
