### PR TITLE
ast: Fixed error message when pseudo instruction was not found

### DIFF
--- a/vadl/main/vadl/ast/ViamLowering.java
+++ b/vadl/main/vadl/ast/ViamLowering.java
@@ -100,9 +100,6 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
 
   private static final String RELATIVE = "relative";
   private static final String GLOBAL_OFFSET_TABLE = "globalOffset";
-  private static final String
-      MAYBE_CHECK_IF_THIS_INSTRUCTION_REALLY_EXISTS_OR_WAS_SPELLED_INCORRECTLY =
-      "Maybe check if this instruction really exists or was spelled incorrectly?";
   private final ConstantEvaluator constantEvaluator = new ConstantEvaluator();
 
   private final IdentityHashMap<Definition, Optional<vadl.viam.Definition>> definitionCache =
@@ -376,11 +373,11 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
 
     var pseudoRet = (PseudoInstruction) fetch(pseudoRetInstrDef).orElseThrow(() ->
         Diagnostic.error("Cannot find the pseudo return instruction", definition.sourceLocation())
-            .help(MAYBE_CHECK_IF_THIS_INSTRUCTION_REALLY_EXISTS_OR_WAS_SPELLED_INCORRECTLY)
+            .help("Maybe check if this instruction really exists or was spelled incorrectly?")
             .build());
     var pseudoCall = (PseudoInstruction) fetch(pseudoCallInstrDef).orElseThrow(() ->
         Diagnostic.error("Cannot find the pseudo call instruction", definition.sourceLocation())
-            .help(MAYBE_CHECK_IF_THIS_INSTRUCTION_REALLY_EXISTS_OR_WAS_SPELLED_INCORRECTLY)
+            .help("Maybe check if this instruction really exists or was spelled incorrectly?")
             .build());
     var pseudoLocalAddressLoad = fetch(pseudoLocalAddressLoadDef).map(x -> (PseudoInstruction) x);
     var pseudoGlobalAddressLoad = fetch(pseudoGlobalAddressLoadDef).map(x -> (PseudoInstruction) x);

--- a/vadl/main/vadl/ast/ViamLowering.java
+++ b/vadl/main/vadl/ast/ViamLowering.java
@@ -100,6 +100,9 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
 
   private static final String RELATIVE = "relative";
   private static final String GLOBAL_OFFSET_TABLE = "globalOffset";
+  private static final String
+      MAYBE_CHECK_IF_THIS_INSTRUCTION_REALLY_EXISTS_OR_WAS_SPELLED_INCORRECTLY =
+      "Maybe check if this instruction really exists or was spelled incorrectly?";
   private final ConstantEvaluator constantEvaluator = new ConstantEvaluator();
 
   private final IdentityHashMap<Definition, Optional<vadl.viam.Definition>> definitionCache =
@@ -371,8 +374,14 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
     var pseudoGlobalAddressLoadDef = getAbiPseudoInstruction(definition.definitions,
         AbiPseudoInstructionDefinition.Kind.GLOBAL_ADDRESS_LOAD);
 
-    var pseudoRet = (PseudoInstruction) fetch(pseudoRetInstrDef).orElseThrow();
-    var pseudoCall = (PseudoInstruction) fetch(pseudoCallInstrDef).orElseThrow();
+    var pseudoRet = (PseudoInstruction) fetch(pseudoRetInstrDef).orElseThrow(() ->
+        Diagnostic.error("Cannot find the pseudo return instruction", definition.sourceLocation())
+            .help(MAYBE_CHECK_IF_THIS_INSTRUCTION_REALLY_EXISTS_OR_WAS_SPELLED_INCORRECTLY)
+            .build());
+    var pseudoCall = (PseudoInstruction) fetch(pseudoCallInstrDef).orElseThrow(() ->
+        Diagnostic.error("Cannot find the pseudo call instruction", definition.sourceLocation())
+            .help(MAYBE_CHECK_IF_THIS_INSTRUCTION_REALLY_EXISTS_OR_WAS_SPELLED_INCORRECTLY)
+            .build());
     var pseudoLocalAddressLoad = fetch(pseudoLocalAddressLoadDef).map(x -> (PseudoInstruction) x);
     var pseudoGlobalAddressLoad = fetch(pseudoGlobalAddressLoadDef).map(x -> (PseudoInstruction) x);
     var pseudoAbsoluteAddressLoad =

--- a/vadl/test/vadl/ast/ViamLoweringTest.java
+++ b/vadl/test/vadl/ast/ViamLoweringTest.java
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.ast;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import vadl.error.Diagnostic;
+
+public class ViamLoweringTest {
+
+  private final String base = """
+       instruction set architecture ISA = {
+        register file X : Bits<5> -> Bits<32>
+            
+        pseudo instruction NOP( symbol: Bits<5>) = {
+        }
+        assembly NOP = (mnemonic)
+      }
+            
+      """;
+
+  private String inputWrappedByValidAbi(String input) {
+    return """
+          %s
+                
+          application binary interface ABI for ISA = {
+            %s
+          }
+        """.formatted(base, input);
+  }
+
+  @Test
+  void shouldThrow_whenPseudoReturnInstructionMissing() {
+    var prog = """
+          pseudo return instruction = DOESNOTEXIST
+          pseudo call instruction = NOP
+          pseudo local address load instruction = NOP
+          pseudo absolute address load instruction = NOP
+          alias register zero = X(0)
+          stack pointer = zero
+          return address = zero
+          global pointer = zero
+          frame pointer = zero
+          thread pointer = zero
+          return value = zero
+          function argument = zero
+          caller saved = zero
+          callee saved = zero
+        """;
+    var ast = Assertions.assertDoesNotThrow(
+        () -> VadlParser.parse(inputWrappedByValidAbi(prog)), "Cannot parse input");
+    var typechecker = new TypeChecker();
+    typechecker.verify(ast);
+    var throwable =
+        Assertions.assertThrows(Diagnostic.class, () -> new ViamLowering().generate(ast));
+    Assertions.assertEquals(Diagnostic.Level.ERROR, throwable.level);
+    Assertions.assertEquals("Cannot find the pseudo return instruction", throwable.reason);
+  }
+
+  @Test
+  void shouldThrow_whenPseudoCallInstructionMissing() {
+    var prog = """
+          pseudo return instruction = NOP
+          pseudo call instruction = DOESNOTEXIST
+          pseudo local address load instruction = NOP
+          pseudo absolute address load instruction = NOP
+          alias register zero = X(0)
+          stack pointer = zero
+          return address = zero
+          global pointer = zero
+          frame pointer = zero
+          thread pointer = zero
+          return value = zero
+          function argument = zero
+          caller saved = zero
+          callee saved = zero
+        """;
+    var ast = Assertions.assertDoesNotThrow(
+        () -> VadlParser.parse(inputWrappedByValidAbi(prog)), "Cannot parse input");
+    var typechecker = new TypeChecker();
+    typechecker.verify(ast);
+    var throwable =
+        Assertions.assertThrows(Diagnostic.class, () -> new ViamLowering().generate(ast));
+    Assertions.assertEquals(Diagnostic.Level.ERROR, throwable.level);
+    Assertions.assertEquals("Cannot find the pseudo call instruction", throwable.reason);
+  }}

--- a/vadl/test/vadl/ast/ViamLoweringTest.java
+++ b/vadl/test/vadl/ast/ViamLoweringTest.java
@@ -97,4 +97,5 @@ public class ViamLoweringTest {
         Assertions.assertThrows(Diagnostic.class, () -> new ViamLowering().generate(ast));
     Assertions.assertEquals(Diagnostic.Level.ERROR, throwable.level);
     Assertions.assertEquals("Cannot find the pseudo call instruction", throwable.reason);
-  }}
+  }
+}


### PR DESCRIPTION
Fixes #165

The new error message is

```
> Task :vadl-cli:run FAILED
error: Cannot find the pseudo return instruction
     ╭──[test.vadl:6:1]
     │
   6 │> application binary interface ABI for ISA = {
   7 │>   alias register ra = X(0)
   8 │>   alias register gp = X(1)
    ⋮  13 lines omitted here...
  22 │>   pseudo return instruction = RET
  23 │>
  24 │> }
     │
     │
     help: Maybe check if this instruction really exists or was spelled incorrectly?
```