### PR TITLE
iss: Add exception support

### DIFF
--- a/vadl/main/resources/templates/iss/target/gen-arch/cpu-bits.h
+++ b/vadl/main/resources/templates/iss/target/gen-arch/cpu-bits.h
@@ -1,31 +1,12 @@
 #ifndef [(${gen_arch_upper})]_CPU_BITS_H
 #define [(${gen_arch_upper})]_CPU_BITS_H
 
-#define get_field(reg, mask) (((reg) & \
-(uint64_t)(mask)) / ((mask) & ~((mask) << 1)))
-#define set_field(reg, mask, val) (((reg) & ~(uint64_t)(mask)) | \
-(((uint64_t)(val) * ((mask) & ~((mask) << 1))) & \
-(uint64_t)(mask)))
-
-#define PRIV_M 0
-
-/* Control and Status Registers */
-
-#define CSR_MTVEC 0x305
-
-/* mstatus CSR bits */
-#define MSTATUS_MIE         0x00000008
-#define MSTATUS_MPIE        0x00000080
-#define MSTATUS_MPP         0x00001800
-
 /* Exception causes */
 typedef enum [(${gen_arch_upper})]Exception {
   [(${gen_arch_upper})]_EXCP_NONE = -1,
-  [(${gen_arch_upper})]_EXCP_M_ECALL = 0xb,
+  [# th:each="exc, iterState : ${exc_info.exceptions}"]
+  [[${exc.enum_name}]],
+  [/]
 } [(${gen_arch_upper})]Exception;
-
-
-#define [(${gen_arch_upper})]_EXCP_INT_FLAG                0x80000000
-#define [(${gen_arch_upper})]_EXCP_INT_MASK                0x7fffffff
 
 #endif //[(${gen_arch_upper})]_CPU_BITS_H

--- a/vadl/main/resources/templates/iss/target/gen-arch/cpu.h
+++ b/vadl/main/resources/templates/iss/target/gen-arch/cpu.h
@@ -4,6 +4,7 @@
 #include "cpu-qom.h"
 #include "exec/cpu-defs.h"
 #include "qemu/typedefs.h"
+#include "cpu-bits.h"
 
 #define CPU_RESOLVING_TYPE TYPE_[(${gen_arch_upper})]_CPU
 
@@ -27,24 +28,18 @@ typedef struct CPUArchState {
   [# th:each="reg_file, iterState : ${register_files}"] // CPU register file(s)
   [(${reg_file.value_c_type})] [(${reg_file.name_lower})][[${'[' + gen_arch_upper + '_REG_FILE_' + reg_file.name_upper + '_SIZE' + ']'}]];
   [/]
-  [# th:each="reg, iterState : ${registers}"] // CPU registers
+  // CPU registers
+  [# th:each="reg, iterState : ${registers}"]
   [(${reg.c_type})] [(${reg.name_lower})];
-  [/]
-  [# th:if="${insn_count}"]
-  uint64_t insn_count;
   [/]
 
   // pc reset vector
   uint64_t reset_vec;
 
-  // hardcoded CSR and Privilege registers
-  target_ulong priv;
-
-  uint64_t mstatus;
-  target_ulong mtvec;
-  target_ulong mcause;
-  target_ulong mepc;
-  target_ulong mtval;
+  // Exception arguments (intermediate store during exception handling)
+  [# th:each="exc : ${exc_info.exceptions}"] [# th:each="p : ${exc.params}"]
+  [(${p.c_type})] [(${p.name_in_cpu})];
+  [/][/]
 } CPU[(${gen_arch_upper})]State;
 
 

--- a/vadl/main/resources/templates/iss/target/gen-arch/do_exception.c.inc
+++ b/vadl/main/resources/templates/iss/target/gen-arch/do_exception.c.inc
@@ -1,0 +1,4 @@
+
+[# th:each="func : ${do_exc_funcs}"]
+[(${func})]
+[/]

--- a/vadl/main/resources/templates/iss/target/gen-arch/helper.h
+++ b/vadl/main/resources/templates/iss/target/gen-arch/helper.h
@@ -1,8 +1,8 @@
 
-// helper that raises an exception when called
-DEF_HELPER_2(raise_exception, noreturn, env, i32)
+// helpers that raise an exception when called
 
 DEF_HELPER_1(unsupported, noreturn, env)
 
-DEF_HELPER_3(csrrw, tl, env, int, tl)
-
+[# th:each="exc : ${exc_info.exceptions}"]
+[(${exc.helper_def})]
+[/]

--- a/vadl/main/vadl/ast/Definition.java
+++ b/vadl/main/vadl/ast/Definition.java
@@ -2419,7 +2419,8 @@ final class ExceptionDefinition extends Definition implements IdentifiableNode {
     var that = (ExceptionDefinition) o;
     return Objects.equals(annotations, that.annotations)
         && Objects.equals(id, that.id)
-        && Objects.equals(statement, that.statement);
+        && Objects.equals(statement, that.statement)
+        && Objects.equals(params, that.params);
   }
 
   @Override
@@ -2427,6 +2428,7 @@ final class ExceptionDefinition extends Definition implements IdentifiableNode {
     int result = Objects.hashCode(annotations);
     result = 31 * result + Objects.hashCode(id);
     result = 31 * result + Objects.hashCode(statement);
+    result = 31 * result + Objects.hashCode(params);
     return result;
   }
 }

--- a/vadl/main/vadl/ast/SymbolTable.java
+++ b/vadl/main/vadl/ast/SymbolTable.java
@@ -360,6 +360,13 @@ class SymbolTable {
         .build());
   }
 
+  private void reportAlreadyDefined(String error, SourceLocation location,
+                                    SourceLocation firstOccurence) {
+    errors.add(Diagnostic.error(error, location)
+        .locationNote(firstOccurence, "Already defined here.")
+        .build());
+  }
+
   /**
    * Distributes "SymbolTable" instances across the nodes in the AST.
    * For "let" expressions and statements, symbols for the declared variables are created here.
@@ -949,10 +956,10 @@ class SymbolTable {
             assembly.instructionNodes.add(pseudoInstr);
             assembly.symbolTable().extendBy(pseudoInstr.symbolTable());
             if (pseudoInstr.assemblyDefinition != null) {
-              assembly.symbolTable().reportError(
-                  "Encoding for %s pseudo instruction is already defined".formatted(
+              assembly.symbolTable().reportAlreadyDefined(
+                  "Assembly for %s pseudo instruction is already defined".formatted(
                       identifier),
-                  identifier.location());
+                  identifier.location(), pseudoInstr.assemblyDefinition.location());
             }
             pseudoInstr.assemblyDefinition = assembly;
           } else {
@@ -962,10 +969,10 @@ class SymbolTable {
               assembly.instructionNodes.add(instr);
 
               if (instr.assemblyDefinition != null) {
-                assembly.symbolTable().reportError(
-                    "Encoding for %s instruction is already defined".formatted(
+                assembly.symbolTable().reportAlreadyDefined(
+                    "Assembly for %s instruction is already defined".formatted(
                         identifier),
-                    identifier.location());
+                    identifier.location(), instr.assemblyDefinition.location());
               }
               instr.assemblyDefinition = assembly;
             }
@@ -981,9 +988,9 @@ class SymbolTable {
             encoding.symbolTable().requireAs(encoding.identifier(), InstructionDefinition.class);
         if (inst != null) {
           if (inst.encodingDefinition != null) {
-            encoding.symbolTable().reportError(
+            encoding.symbolTable().reportAlreadyDefined(
                 "Encoding for %s instruction is already defined".formatted(encoding.identifier()),
-                encoding.location());
+                encoding.location(), inst.encodingDefinition.location());
           } else {
             inst.encodingDefinition = encoding;
           }

--- a/vadl/main/vadl/ast/ViamLowering.java
+++ b/vadl/main/vadl/ast/ViamLowering.java
@@ -1110,6 +1110,7 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
     var formats = filterAndCastToInstance(allDefinitions, Format.class);
     var functions = filterAndCastToInstance(allDefinitions, Function.class);
     var relocations = filterAndCastToInstance(allDefinitions, Relocation.class);
+    // TODO: @flofriday include anonymous exceptions as definitions
     var exceptions = filterAndCastToInstance(allDefinitions, ExceptionDef.class);
     var instructions = filterAndCastToInstance(allDefinitions, Instruction.class);
     var pseudoInstructions = filterAndCastToInstance(allDefinitions, PseudoInstruction.class);

--- a/vadl/main/vadl/configuration/IssConfiguration.java
+++ b/vadl/main/vadl/configuration/IssConfiguration.java
@@ -46,7 +46,6 @@ public class IssConfiguration extends GeneralConfiguration {
 
   // is set by the IssConfigurationPass
   private String targetName;
-  private boolean insnCount;
   private String machineName;
   private Tcg_32_64 targetSize;
   private EnumSet<IssOptsToSkip> optsToSkip;
@@ -58,22 +57,12 @@ public class IssConfiguration extends GeneralConfiguration {
     super(generalConfig);
     targetName = "unknown";
     machineName = "unknown";
-    insnCount = false;
     targetSize = Tcg_32_64.i64;
     optsToSkip = EnumSet.noneOf(IssOptsToSkip.class);
   }
 
   public static IssConfiguration from(GeneralConfiguration generalConfig) {
     return new IssConfiguration(generalConfig);
-  }
-
-  /**
-   * Construct the configuration from a general configuration.
-   */
-  public static IssConfiguration from(GeneralConfiguration generalConfig, boolean insnCounting) {
-    var config = new IssConfiguration(generalConfig);
-    config.insnCount = insnCounting;
-    return config;
   }
 
   public String targetName() {
@@ -94,14 +83,6 @@ public class IssConfiguration extends GeneralConfiguration {
 
   public void setMachineName(String machineName) {
     this.machineName = machineName;
-  }
-
-  public boolean isInsnCounting() {
-    return insnCount;
-  }
-
-  public void setInsnCounting(boolean insnCounting) {
-    this.insnCount = insnCounting;
   }
 
   public void setTargetSize(Tcg_32_64 targetSize) {

--- a/vadl/main/vadl/cppCodeGen/mixins/CDefaultMixins.java
+++ b/vadl/main/vadl/cppCodeGen/mixins/CDefaultMixins.java
@@ -44,7 +44,6 @@ import vadl.viam.graph.dependency.BuiltInCall;
 import vadl.viam.graph.dependency.ConstantNode;
 import vadl.viam.graph.dependency.FuncCallNode;
 import vadl.viam.graph.dependency.FuncParamNode;
-import vadl.viam.graph.dependency.ProcCallNode;
 import vadl.viam.graph.dependency.SelectNode;
 import vadl.viam.graph.dependency.SignExtendNode;
 import vadl.viam.graph.dependency.SliceNode;
@@ -243,14 +242,7 @@ public interface CDefaultMixins {
   ///  DEPENDENCY HANDLERS ///
 
   @SuppressWarnings("MissingJavadocType")
-  interface AllDependencies extends AllExpressions, AllSideEffects {
-  }
-
-  ///  SIDE EFFECT HANDLERS ///
-
-  @SuppressWarnings("MissingJavadocType")
-  interface AllSideEffects extends ProcCall {
-
+  interface AllDependencies extends AllExpressions {
   }
 
   ///  EXPRESSION HANDLERS ///
@@ -364,24 +356,6 @@ public interface CDefaultMixins {
     @SuppressWarnings("MissingJavadocMethod")
     default void handle(CGenContext<Node> ctx, FuncCallNode toHandle) {
       ctx.wr(toHandle.function().simpleName())
-          .wr("(");
-      var first = true;
-      for (var arg : toHandle.arguments()) {
-        if (!first) {
-          ctx.wr(", ");
-        }
-        ctx.gen(arg);
-      }
-      ctx.wr(")");
-    }
-  }
-
-  @SuppressWarnings("MissingJavadocType")
-  interface ProcCall {
-    @Handler
-    @SuppressWarnings("MissingJavadocMethod")
-    default void handle(CGenContext<Node> ctx, ProcCallNode toHandle) {
-      ctx.wr(toHandle.procedure().simpleName())
           .wr("(");
       var first = true;
       for (var arg : toHandle.arguments()) {

--- a/vadl/main/vadl/cppCodeGen/mixins/CInvalidMixins.java
+++ b/vadl/main/vadl/cppCodeGen/mixins/CInvalidMixins.java
@@ -54,13 +54,17 @@ public interface CInvalidMixins {
   }
 
   @SuppressWarnings("MissingJavadocType")
+  interface AsmRelated extends AsmBuiltInC {
+  }
+
+  @SuppressWarnings("MissingJavadocType")
   interface ResourceReads extends ReadReg, ReadMem, ReadRegFile, ReadArtificialResource {
   }
 
   @SuppressWarnings("MissingJavadocType")
   interface WriteReg {
     @Handler
-    default void impl(CGenContext<Node> ctx, WriteRegNode node) {
+    default void handle(CGenContext<Node> ctx, WriteRegNode node) {
       throwNotAllowed(node, "Register writes");
     }
   }
@@ -68,7 +72,7 @@ public interface CInvalidMixins {
   @SuppressWarnings("MissingJavadocType")
   interface WriteRegFile {
     @Handler
-    default void impl(CGenContext<Node> ctx, WriteRegFileNode node) {
+    default void handle(CGenContext<Node> ctx, WriteRegFileNode node) {
       throwNotAllowed(node, "Register writes");
     }
   }
@@ -76,7 +80,7 @@ public interface CInvalidMixins {
   @SuppressWarnings("MissingJavadocType")
   interface WriteMem {
     @Handler
-    default void impl(CGenContext<Node> ctx, WriteMemNode node) {
+    default void handle(CGenContext<Node> ctx, WriteMemNode node) {
       throwNotAllowed(node, "Memory writes");
     }
   }
@@ -84,7 +88,7 @@ public interface CInvalidMixins {
   @SuppressWarnings("MissingJavadocType")
   interface WriteArtificialRes {
     @Handler
-    default void impl(CGenContext<Node> ctx, WriteArtificialResNode node) {
+    default void handle(CGenContext<Node> ctx, WriteArtificialResNode node) {
       throwNotAllowed(node, "Artificial resource writes");
     }
   }
@@ -92,7 +96,7 @@ public interface CInvalidMixins {
   @SuppressWarnings("MissingJavadocType")
   interface ProcCall {
     @Handler
-    default void impl(CGenContext<Node> ctx, ProcCallNode node) {
+    default void handle(CGenContext<Node> ctx, ProcCallNode node) {
       throwNotAllowed(node, "Procedure calls");
     }
   }
@@ -101,7 +105,7 @@ public interface CInvalidMixins {
   @SuppressWarnings("MissingJavadocType")
   interface ReadReg {
     @Handler
-    default void impl(CGenContext<Node> ctx, ReadRegNode node) {
+    default void handle(CGenContext<Node> ctx, ReadRegNode node) {
       throwNotAllowed(node, "Register reads");
     }
   }
@@ -109,7 +113,7 @@ public interface CInvalidMixins {
   @SuppressWarnings("MissingJavadocType")
   interface ReadRegFile {
     @Handler
-    default void impl(CGenContext<Node> ctx, ReadRegFileNode node) {
+    default void handle(CGenContext<Node> ctx, ReadRegFileNode node) {
       throwNotAllowed(node, "Register reads");
     }
   }
@@ -117,7 +121,7 @@ public interface CInvalidMixins {
   @SuppressWarnings("MissingJavadocType")
   interface ReadArtificialResource {
     @Handler
-    default void impl(CGenContext<Node> ctx, ReadArtificialResNode node) {
+    default void handle(CGenContext<Node> ctx, ReadArtificialResNode node) {
       throwNotAllowed(node, "Artificial reads");
     }
   }
@@ -125,7 +129,7 @@ public interface CInvalidMixins {
   @SuppressWarnings("MissingJavadocType")
   interface ReadMem {
     @Handler
-    default void impl(CGenContext<Node> ctx, ReadMemNode node) {
+    default void handle(CGenContext<Node> ctx, ReadMemNode node) {
       throwNotAllowed(node, "Memory reads");
     }
   }
@@ -133,7 +137,7 @@ public interface CInvalidMixins {
   @SuppressWarnings("MissingJavadocType")
   interface InstrCall {
     @Handler
-    default void impl(CGenContext<Node> ctx, InstrCallNode node) {
+    default void handle(CGenContext<Node> ctx, InstrCallNode node) {
       throwNotAllowed(node, "Instruction calls");
     }
   }
@@ -141,7 +145,7 @@ public interface CInvalidMixins {
   @SuppressWarnings("MissingJavadocType")
   interface AsmBuiltInC {
     @Handler
-    default void impl(CGenContext<Node> ctx, AsmBuiltInCall node) {
+    default void handle(CGenContext<Node> ctx, AsmBuiltInCall node) {
       throwNotAllowed(node, "Assembler built-in calls");
     }
   }
@@ -150,7 +154,7 @@ public interface CInvalidMixins {
   @SuppressWarnings("MissingJavadocType")
   interface WriteStageOutput {
     @Handler
-    default void impl(CGenContext<Node> ctx, WriteStageOutputNode node) {
+    default void handle(CGenContext<Node> ctx, WriteStageOutputNode node) {
       throwNotAllowed(node, "Write stage output");
     }
   }
@@ -158,7 +162,7 @@ public interface CInvalidMixins {
   @SuppressWarnings("MissingJavadocType")
   interface ReadStageOutput {
     @Handler
-    default void impl(CGenContext<Node> ctx, ReadStageOutputNode node) {
+    default void handle(CGenContext<Node> ctx, ReadStageOutputNode node) {
       throwNotAllowed(node, "Read stage output");
     }
   }

--- a/vadl/main/vadl/dump/HtmlDumpPass.java
+++ b/vadl/main/vadl/dump/HtmlDumpPass.java
@@ -187,7 +187,7 @@ public class HtmlDumpPass extends AbstractTemplateRenderingPass {
     // find last pass for the result
     lastPass = getLastPass(passResults);
 
-    log.debug("HTML dump of phase '{}' at {}dump/{}", config.phase,
+    log.info("HTML dump of phase '{}' at {}dump/{}", config.phase,
         config.outputPath().toUri(),
         getOutputPath());
     // collect suppliers

--- a/vadl/main/vadl/iss/codegen/IssCMixins.java
+++ b/vadl/main/vadl/iss/codegen/IssCMixins.java
@@ -49,8 +49,8 @@ public interface IssCMixins {
   interface IssExpr {
 
     @Handler
-    default void impl(CGenContext<Node> ctx,
-                      vadl.iss.passes.opDecomposition.nodes.IssExprNode node) {
+    default void handle(CGenContext<Node> ctx,
+                        vadl.iss.passes.opDecomposition.nodes.IssExprNode node) {
       throwNotAllowed(node, "IssExprNode");
     }
 
@@ -66,8 +66,8 @@ public interface IssCMixins {
      * Implements the C code representation of the {@link IssConstExtractNode}.
      */
     @Handler
-    default void impl(CGenContext<Node> ctx,
-                      IssConstExtractNode node) {
+    default void handle(CGenContext<Node> ctx,
+                        IssConstExtractNode node) {
       var sign = node.isSigned() ? "s" : "u";
       ctx.wr("VADL_" + sign + "extract(")
           .gen(node.value())

--- a/vadl/main/vadl/iss/codegen/IssExceptionHandlingCodeGenerator.java
+++ b/vadl/main/vadl/iss/codegen/IssExceptionHandlingCodeGenerator.java
@@ -1,0 +1,147 @@
+// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.iss.codegen;
+
+import static vadl.error.DiagUtils.throwNotAllowed;
+import static vadl.utils.GraphUtils.getSingleNode;
+
+import vadl.configuration.IssConfiguration;
+import vadl.cppCodeGen.context.CGenContext;
+import vadl.cppCodeGen.context.CNodeContext;
+import vadl.cppCodeGen.mixins.CDefaultMixins;
+import vadl.cppCodeGen.mixins.CInvalidMixins;
+import vadl.iss.passes.extensions.ExceptionInfo;
+import vadl.javaannotations.DispatchFor;
+import vadl.javaannotations.Handler;
+import vadl.viam.MicroProcessor;
+import vadl.viam.graph.Node;
+import vadl.viam.graph.control.InstrCallNode;
+import vadl.viam.graph.control.StartNode;
+import vadl.viam.graph.dependency.AsmBuiltInCall;
+import vadl.viam.graph.dependency.FieldAccessRefNode;
+import vadl.viam.graph.dependency.FieldRefNode;
+import vadl.viam.graph.dependency.FuncParamNode;
+import vadl.viam.graph.dependency.ReadRegNode;
+import vadl.viam.graph.dependency.WriteMemNode;
+import vadl.viam.graph.dependency.WriteRegNode;
+import vadl.viam.passes.sideEffectScheduling.nodes.InstrExitNode;
+
+@DispatchFor(
+    value = Node.class,
+    context = CNodeContext.class,
+    include = "vadl.viam"
+)
+public class IssExceptionHandlingCodeGenerator implements CDefaultMixins.All,
+    CInvalidMixins.ResourceReads, CInvalidMixins.SideEffect, CInvalidMixins.HardwareRelated {
+
+  private final ExceptionInfo.Entry excInfo;
+  private final IssConfiguration config;
+
+  private final CNodeContext ctx;
+  private final StringBuilder builder = new StringBuilder();
+
+
+  /**
+   * Constructs the firmware setup code generator.
+   */
+  public IssExceptionHandlingCodeGenerator(ExceptionInfo.Entry excInfo, IssConfiguration config) {
+    this.excInfo = excInfo;
+    this.config = config;
+    this.ctx = new CNodeContext(
+        builder::append,
+        (ctx, node)
+            -> IssExceptionHandlingCodeGeneratorDispatcher.dispatch(this, ctx, node)
+    );
+  }
+
+  /**
+   * Produces the {@code setup_rom_reset_vec()} function setup the ROM, which correspond
+   * to the {@link MicroProcessor#firmware()} definition in the specification.
+   *
+   * @return the full function code, including signature.
+   */
+  public String fetch() {
+    var targetUpper = config.targetName().toUpperCase();
+    ctx.ln("static void %s(CPU%sState *env) {", excInfo.handlingFuncName(), targetUpper)
+        .spacedIn();
+
+    var start = getSingleNode(excInfo.def.behavior(), StartNode.class);
+    var current = start.next();
+    ctx.gen(current);
+
+    ctx.spaceOut().ln("}");
+    return builder.toString();
+  }
+
+  @Override
+  public void handle(CGenContext<Node> ctx, FuncParamNode toHandle) {
+    var param = excInfo.params.get(toHandle.parameter());
+    toHandle.ensure(param != null, "Exception parameter unknown.");
+    ctx.wr("env->" + param.nameInCpuState());
+  }
+
+  @Override
+  public void impl(CGenContext<Node> ctx, WriteRegNode node) {
+    ctx.wr("env->" + node.register().simpleName().toLowerCase() + " = ")
+        .gen(node.value());
+  }
+
+  @Override
+  public void impl(CGenContext<Node> ctx, ReadRegNode node) {
+    ctx.wr("env->" + node.register().simpleName().toLowerCase());
+  }
+
+  @Handler
+  public void impl(CGenContext<Node> ctx, InstrExitNode.PcChange node) {
+    ctx.gen(node.cause())
+        .ln(";")
+        .gen(node.next());
+  }
+
+  ///  INVALID NODES  ///
+
+  @Handler
+  public void impl(CGenContext<Node> ctx, InstrExitNode.Raise node) {
+    throwNotAllowed(node, "Raising exceptions");
+  }
+
+  @Override
+  public void impl(CGenContext<Node> ctx, WriteMemNode node) {
+    throwNotAllowed(node, "Memory writes");
+  }
+
+  @Handler
+  void handle(CGenContext<Node> ctx, FieldRefNode toHandle) {
+    throwNotAllowed(toHandle, "Field references");
+  }
+
+  @Handler
+  void handle(CGenContext<Node> ctx, FieldAccessRefNode toHandle) {
+    throwNotAllowed(toHandle, "Field accesses");
+  }
+
+  @Handler
+  void handle(CGenContext<Node> ctx, InstrCallNode toHandle) {
+    throwNotAllowed(toHandle, "Instruction calls");
+  }
+
+  @Handler
+  void handle(CGenContext<Node> ctx, AsmBuiltInCall toHandle) {
+    throwNotAllowed(toHandle, "Assembler built-in calls");
+  }
+
+}

--- a/vadl/main/vadl/iss/codegen/IssFirmwareCodeGenerator.java
+++ b/vadl/main/vadl/iss/codegen/IssFirmwareCodeGenerator.java
@@ -107,7 +107,7 @@ public class IssFirmwareCodeGenerator implements CDefaultMixins.All,
   }
 
   @Override
-  public void impl(CGenContext<Node> ctx, WriteMemNode node) {
+  public void handle(CGenContext<Node> ctx, WriteMemNode node) {
     // we normalize the node to an offset.
     var addr = ((ConstantNode) node.address()).constant().asVal().unsignedInteger();
     var offset = addr.subtract(memoryInfo.firmwareStart);

--- a/vadl/main/vadl/iss/codegen/IssTranslateCodeGenerator.java
+++ b/vadl/main/vadl/iss/codegen/IssTranslateCodeGenerator.java
@@ -58,7 +58,6 @@ public class IssTranslateCodeGenerator implements
     CInvalidMixins.InstrCall, CInvalidMixins.HardwareRelated {
 
   private Instruction insn;
-  private boolean generateInsnCount;
   private StringBuilder builder;
   private CNodeContext ctx;
   private String targetName;
@@ -69,7 +68,6 @@ public class IssTranslateCodeGenerator implements
   public IssTranslateCodeGenerator(Instruction instr,
                                    IssConfiguration configuration) {
     this.insn = instr;
-    this.generateInsnCount = configuration.isInsnCounting();
     this.builder = new StringBuilder();
     this.targetName = configuration.targetName();
     this.ctx = new CNodeContext(
@@ -99,14 +97,7 @@ public class IssTranslateCodeGenerator implements
     ctx.wr(name);
     ctx.ln(" *a) {");
 
-    ctx.wr("trace_" + this.targetName.toLowerCase() + "_instr_trans(__func__);");
-
-    if (generateInsnCount) {
-      //Add separate add instruction after each that increments special cpu_insn_count flag in
-      //QEMU CPU state
-      //see resources/templates/iss/target/cpu.h/CPUArchState
-      ctx.ln("\ttcg_gen_addi_i64(cpu_insn_count, cpu_insn_count, 1);");
-    }
+    ctx.ln("trace_" + this.targetName.toLowerCase() + "_instr_trans(__func__);");
 
     var start = getSingleNode(insn.behavior(), StartNode.class);
     var current = start.next();

--- a/vadl/main/vadl/iss/passes/AbstractIssPass.java
+++ b/vadl/main/vadl/iss/passes/AbstractIssPass.java
@@ -26,7 +26,7 @@ import vadl.pass.Pass;
  */
 public abstract class AbstractIssPass extends Pass {
 
-  protected AbstractIssPass(IssConfiguration configuration) {
+  public AbstractIssPass(IssConfiguration configuration) {
     super(configuration);
   }
 

--- a/vadl/main/vadl/iss/passes/IssExceptionDetectionPass.java
+++ b/vadl/main/vadl/iss/passes/IssExceptionDetectionPass.java
@@ -24,6 +24,10 @@ import vadl.pass.PassName;
 import vadl.pass.PassResults;
 import vadl.viam.Specification;
 
+/**
+ * Collects information about exceptions that are raised by instructions in the ISA.
+ * It constructs a {@link ExceptionInfo} extension that is added to the ISA.
+ */
 public class IssExceptionDetectionPass extends AbstractIssPass {
   public IssExceptionDetectionPass(IssConfiguration configuration) {
     super(configuration);

--- a/vadl/main/vadl/iss/passes/IssExceptionDetectionPass.java
+++ b/vadl/main/vadl/iss/passes/IssExceptionDetectionPass.java
@@ -17,46 +17,36 @@
 package vadl.iss.passes;
 
 import java.io.IOException;
-import java.util.List;
-import java.util.function.Consumer;
 import javax.annotation.Nullable;
 import vadl.configuration.IssConfiguration;
+import vadl.iss.passes.extensions.ExceptionInfo;
 import vadl.pass.PassName;
 import vadl.pass.PassResults;
-import vadl.viam.Instruction;
 import vadl.viam.Specification;
 
-/**
- * This pass manipulates the VIAM with hardcoded elements.
- * E.g. it adds an exception generation to {@code ECALL} instruction because
- * this is not yet supported in the VADL specification.
- */
-public class IssHardcodedTcgAddOnPass extends AbstractIssPass {
-
-  public IssHardcodedTcgAddOnPass(IssConfiguration configuration) {
+public class IssExceptionDetectionPass extends AbstractIssPass {
+  public IssExceptionDetectionPass(IssConfiguration configuration) {
     super(configuration);
   }
 
   @Override
   public PassName getName() {
-    return PassName.of("ISS Hardcoded TCG Add-Ons");
+    return new PassName("ISS Exception Detection Pass");
   }
 
-  List<Consumer<Instruction>> instrAddOns = List.of(
-
-  );
-
+  @Nullable
   @Override
-  public @Nullable Object execute(PassResults passResults, Specification viam)
-      throws IOException {
+  public Object execute(PassResults passResults, Specification viam) throws IOException {
 
-    viam.isa().ifPresent(isa ->
-        isa.ownInstructions()
-            .forEach(i ->
-                instrAddOns.forEach(f -> f.accept(i))));
+    var isa = viam.mip().get().isa();
+
+    var info = new ExceptionInfo(configuration());
+    isa.attachExtension(info);
+
+    for (var exception : isa.exceptions()) {
+      info.addException(exception);
+    }
 
     return null;
   }
-
-
 }

--- a/vadl/main/vadl/iss/passes/extensions/ExceptionInfo.java
+++ b/vadl/main/vadl/iss/passes/extensions/ExceptionInfo.java
@@ -31,6 +31,17 @@ import vadl.viam.ExceptionDef;
 import vadl.viam.InstructionSetArchitecture;
 import vadl.viam.Parameter;
 
+/**
+ * A {@link InstructionSetArchitecture} extension that provides information about existing
+ * {@link ExceptionDef}s. It is added by the {@link vadl.iss.passes.IssExceptionDetectionPass}.
+ * It consists of a list of {@link Entry}s that hold the information of an individual
+ * exception.
+ *
+ * @see Entry
+ * @see vadl.iss.passes.IssExceptionDetectionPass
+ * @see vadl.iss.codegen.IssExceptionHandlingCodeGenerator
+ * @see vadl.iss.template.IssTemplateRenderingPass
+ */
 public class ExceptionInfo extends DefinitionExtension<InstructionSetArchitecture>
     implements Renderable {
 
@@ -61,12 +72,30 @@ public class ExceptionInfo extends DefinitionExtension<InstructionSetArchitectur
     );
   }
 
+  /**
+   * Holds the information of a single exception.
+   * It provides methods required during QEMU generation, such as the name in the
+   * exception enum in {@code cpu-bits.h}.
+   *
+   * <p>It also holds a parameter map, that is constructed on initialization
+   * which provides ISS specific information about parameters, using the
+   * {@link Param} class.</p>
+   *
+   * @see ExceptionInfo
+   * @see vadl.iss.codegen.IssExceptionHandlingCodeGenerator
+   */
   public class Entry implements Renderable {
     public String name;
     public ExceptionDef def;
     public Map<Parameter, Param> params;
 
 
+    /**
+     * Construct the exception entry and processes the {@link Parameter} to
+     * construct a map of {@link Param}s.
+     *
+     * @param def the VIAM exception definition
+     */
     public Entry(ExceptionDef def) {
       this.name = def.simpleName();
       this.params = new HashMap<>();
@@ -80,29 +109,60 @@ public class ExceptionInfo extends DefinitionExtension<InstructionSetArchitectur
       this.def = def;
     }
 
+    /**
+     * The name used in the exception enum in {@code cpu-bits.h}.
+     */
     public String enumName() {
       return configuration.targetName().toUpperCase() + "_EXCP_" + name.toUpperCase();
     }
 
+    /**
+     * The name of the handling function in the {@code do_exceptions.c.inc}.
+     * E.g. {@code rv64im_do_exc}.
+     *
+     * @see vadl.iss.template.target.EmitIssDoExcCIncPass
+     * @see vadl.iss.template.target.EmitIssCpuSourcePass
+     */
     public String handlingFuncName() {
       return configuration.targetName().toLowerCase() + "_do_" + name.toLowerCase();
     }
 
+    /**
+     * The helper definition emitted in {@code helper.h}.
+     * E.g. {@code DEF_HELPER_2(raise_exc, noreturn, env, i64)} which produces the
+     * signatures for {@code gen_helper_raise_exc()} and the {@code helper_raise_exc}
+     * declaration which is provided by the {@link #helperImpl()}.
+     */
     public String helperDef() {
       // 1. env, ... parameter
       var nrArgs = 1 + def.parameters().length;
       var argTypes = Arrays.stream(def.parameters())
-          .map(p -> Tcg_32_64.nextFitting(p.type().asDataType().bitWidth()))
+          // all parameters are passed as target_size containers
+          .map(p -> configuration.targetSize())
+          // .map(p -> Tcg_32_64.nextFitting(p.type().asDataType().bitWidth()))
           .map(Enum::toString)
           .collect(Collectors.joining(", "));
       return "DEF_HELPER_" + nrArgs + "(raise_" + name.toLowerCase() + ", noreturn, env, "
           + argTypes + ")";
     }
 
+    /**
+     * Provides the implementation of the helper function defined by {@link #helperDef()}
+     * and emitted in {@code helper.c}.
+     * It is called during instruction execution, and its only job is to set the
+     * arguments for the exception in the CPU state, and calling {@code raise_exception()}.
+     *
+     * <pre>{@code
+     * void helper_raise_exc(CPURV64IMZICSRState *env, uint64_t cause) {
+     *   env->arg_exc_cause = (uint32_t) cause;
+     *   rv64imzicsr_raise_exception(env, RV64IMZICSR_EXCP_EXC);
+     * }
+     * }</pre>
+     */
     public String helperImpl() {
-      // 1. env, 2. index, ... parameter
+      // 1. env, 2. index, ... parameter (in target size container)
       var params = this.params.values().stream()
-          .map(p -> p.cType() + " " + p.param.simpleName())
+          .map(p -> "uint" + configuration.targetSize().width + "_t " + p.param.simpleName())
           .collect(Collectors.joining(", "));
       var targetUpper = configuration.targetName().toUpperCase();
       var targetLower = configuration.targetName().toLowerCase();
@@ -111,7 +171,8 @@ public class ExceptionInfo extends DefinitionExtension<InstructionSetArchitectur
           .append("(CPU" + targetUpper + "State *env, " + params)
           .append(") {\n");
       for (Param p : this.params.values()) {
-        sb.append("\tenv->" + p.nameInCpuState + " = " + p.param.simpleName() + ";\n");
+        sb.append("\tenv->" + p.nameInCpuState + " = (" + p.cType() + ") " + p.param.simpleName()
+            + ";\n");
       }
       sb.append("\t" + targetLower + "_raise_exception(env, ")
           .append(enumName() + ");\n}");
@@ -131,12 +192,26 @@ public class ExceptionInfo extends DefinitionExtension<InstructionSetArchitectur
     }
   }
 
+  /**
+   * An ISS internal representation of exception parameters.
+   * The most important field is the {@link #nameInCpuState} which defines the field name
+   * used in the CPU state to hold the parameter.
+   * We need this, as the exception handling function is not directly called, but
+   * from the exception handling step in the QEMU main execution loop.
+   * So instead when the exception is raise, we store the arguments in the CPU state and
+   * in the exception handling function, we get them from the CPU state.
+   *
+   * @param param          the VIAM parameter this corresponds to
+   * @param tcgWidth       of the parameter
+   * @param nameInCpuState field name in the CPU state
+   */
   public record Param(
       Parameter param,
       Tcg_32_64 tcgWidth,
       String nameInCpuState
   ) implements Renderable {
 
+    @SuppressWarnings("MethodName")
     public String cType() {
       return "uint" + tcgWidth.width + "_t";
     }

--- a/vadl/main/vadl/iss/passes/extensions/ExceptionInfo.java
+++ b/vadl/main/vadl/iss/passes/extensions/ExceptionInfo.java
@@ -1,0 +1,156 @@
+// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.iss.passes.extensions;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import vadl.configuration.IssConfiguration;
+import vadl.iss.passes.tcgLowering.Tcg_32_64;
+import vadl.template.Renderable;
+import vadl.viam.Definition;
+import vadl.viam.DefinitionExtension;
+import vadl.viam.ExceptionDef;
+import vadl.viam.InstructionSetArchitecture;
+import vadl.viam.Parameter;
+
+public class ExceptionInfo extends DefinitionExtension<InstructionSetArchitecture>
+    implements Renderable {
+
+  private IssConfiguration configuration;
+  private List<Entry> exception = new ArrayList<>();
+
+  public ExceptionInfo(IssConfiguration configuration) {
+    this.configuration = configuration;
+  }
+
+  public List<Entry> entries() {
+    return exception;
+  }
+
+  public void addException(ExceptionDef def) {
+    exception.add(new Entry(def));
+  }
+
+  @Override
+  public Class<? extends Definition> extendsDefClass() {
+    return InstructionSetArchitecture.class;
+  }
+
+  @Override
+  public Map<String, Object> renderObj() {
+    return Map.of(
+        "exceptions", exception
+    );
+  }
+
+  public class Entry implements Renderable {
+    public String name;
+    public ExceptionDef def;
+    public Map<Parameter, Param> params;
+
+
+    public Entry(ExceptionDef def) {
+      this.name = def.simpleName();
+      this.params = new HashMap<>();
+      for (Parameter p : def.parameters()) {
+        params.put(p, new Param(
+            p,
+            Tcg_32_64.nextFitting(p.type().asDataType().bitWidth()),
+            "arg_" + this.name.toLowerCase() + "_" + p.simpleName()
+        ));
+      }
+      this.def = def;
+    }
+
+    public String enumName() {
+      return configuration.targetName().toUpperCase() + "_EXCP_" + name.toUpperCase();
+    }
+
+    public String handlingFuncName() {
+      return configuration.targetName().toLowerCase() + "_do_" + name.toLowerCase();
+    }
+
+    public String helperDef() {
+      // 1. env, ... parameter
+      var nrArgs = 1 + def.parameters().length;
+      var argTypes = Arrays.stream(def.parameters())
+          .map(p -> Tcg_32_64.nextFitting(p.type().asDataType().bitWidth()))
+          .map(Enum::toString)
+          .collect(Collectors.joining(", "));
+      return "DEF_HELPER_" + nrArgs + "(raise_" + name.toLowerCase() + ", noreturn, env, "
+          + argTypes + ")";
+    }
+
+    public String helperImpl() {
+      // 1. env, 2. index, ... parameter
+      var params = this.params.values().stream()
+          .map(p -> p.cType() + " " + p.param.simpleName())
+          .collect(Collectors.joining(", "));
+      var targetUpper = configuration.targetName().toUpperCase();
+      var targetLower = configuration.targetName().toLowerCase();
+      var sb = new StringBuilder();
+      sb.append("void helper_raise_" + name.toLowerCase())
+          .append("(CPU" + targetUpper + "State *env, " + params)
+          .append(") {\n");
+      for (Param p : this.params.values()) {
+        sb.append("\tenv->" + p.nameInCpuState + " = " + p.param.simpleName() + ";\n");
+      }
+      sb.append("\t" + targetLower + "_raise_exception(env, ")
+          .append(enumName() + ");\n}");
+      return sb.toString();
+    }
+
+    @Override
+    public Map<String, Object> renderObj() {
+      return Map.of(
+          "name_lower", name.toLowerCase(),
+          "helper_def", helperDef(),
+          "helper_impl", helperImpl(),
+          "enum_name", enumName(),
+          "params", params.values().stream().toList(),
+          "handling_func", handlingFuncName()
+      );
+    }
+  }
+
+  public record Param(
+      Parameter param,
+      Tcg_32_64 tcgWidth,
+      String nameInCpuState
+  ) implements Renderable {
+
+    public String cType() {
+      return "uint" + tcgWidth.width + "_t";
+    }
+
+    public int width() {
+      return tcgWidth.width;
+    }
+
+    @Override
+    public Map<String, Object> renderObj() {
+      return Map.of(
+          "name_in_cpu", nameInCpuState,
+          "c_type", cType()
+      );
+    }
+  }
+}

--- a/vadl/main/vadl/iss/passes/tcgLowering/nodes/TcgGenException.java
+++ b/vadl/main/vadl/iss/passes/tcgLowering/nodes/TcgGenException.java
@@ -51,7 +51,7 @@ public class TcgGenException extends TcgNode {
   public String cCode(Function<Node, String> nodeToCCode) {
     // update PC before leaving TB and generate
     return "gen_update_pc_diff(ctx, 0);\n\t"
-        + "gen_helper_raise_" + exception.simpleName().toLowerCase() + "(ctx, "
+        + "gen_helper_raise_" + exception.simpleName().toLowerCase() + "(tcg_env, "
         + args.stream().map(nodeToCCode).collect(Collectors.joining(", "))
         + ")";
   }

--- a/vadl/main/vadl/iss/template/target/EmitIssDoExcCIncPass.java
+++ b/vadl/main/vadl/iss/template/target/EmitIssDoExcCIncPass.java
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.iss.template.target;
+
+import java.util.List;
+import java.util.Map;
+import vadl.configuration.IssConfiguration;
+import vadl.iss.codegen.IssExceptionHandlingCodeGenerator;
+import vadl.iss.passes.extensions.ExceptionInfo;
+import vadl.iss.template.IssTemplateRenderingPass;
+import vadl.pass.PassResults;
+import vadl.viam.Specification;
+
+public class EmitIssDoExcCIncPass extends IssTemplateRenderingPass {
+  public EmitIssDoExcCIncPass(IssConfiguration configuration) {
+    super(configuration);
+  }
+
+  @Override
+  protected String issTemplatePath() {
+    return "target/gen-arch/do_exception.c.inc";
+  }
+
+  @Override
+  protected Map<String, Object> createVariables(PassResults passResults,
+                                                Specification specification) {
+    var vars = super.createVariables(passResults, specification);
+    vars.put("do_exc_funcs", doExcFuncs(specification));
+    return vars;
+  }
+
+  private List<String> doExcFuncs(Specification specification) {
+    var isa = specification.mip().get().isa();
+    var excInfo = isa.expectExtension(ExceptionInfo.class);
+
+    return excInfo.entries().stream()
+        .map(e -> new IssExceptionHandlingCodeGenerator(e, configuration()).fetch())
+        .toList();
+  }
+
+}

--- a/vadl/main/vadl/iss/template/target/EmitIssDoExcCIncPass.java
+++ b/vadl/main/vadl/iss/template/target/EmitIssDoExcCIncPass.java
@@ -25,6 +25,16 @@ import vadl.iss.template.IssTemplateRenderingPass;
 import vadl.pass.PassResults;
 import vadl.viam.Specification;
 
+/**
+ * Emits the {@code target/gen-arch/do_exception.c.inc} file which contains
+ * handling methods for each {@link vadl.viam.ExceptionDef}.
+ * They are called by the {@code do_interrupt()} in the {@code cpu.c} file.
+ *
+ * <p>The handling functions are generated from the {@link IssExceptionHandlingCodeGenerator}.</p>
+ *
+ * @see IssExceptionHandlingCodeGenerator
+ * @see ExceptionInfo
+ */
 public class EmitIssDoExcCIncPass extends IssTemplateRenderingPass {
   public EmitIssDoExcCIncPass(IssConfiguration configuration) {
     super(configuration);

--- a/vadl/main/vadl/iss/template/target/EmitIssTranslateCPass.java
+++ b/vadl/main/vadl/iss/template/target/EmitIssTranslateCPass.java
@@ -105,4 +105,5 @@ public class EmitIssTranslateCPass extends IssTemplateRenderingPass {
     };
   }
 
+
 }

--- a/vadl/main/vadl/viam/InstructionSetArchitecture.java
+++ b/vadl/main/vadl/viam/InstructionSetArchitecture.java
@@ -50,7 +50,7 @@ public class InstructionSetArchitecture extends Definition {
    *
    * @param identifier    the identifier of the ISA
    * @param specification the parent specification of the ISA
-   * @param registers     the registers in the ISA. This also includes sub-registers
+   * @param registers     the registers in the ISA
    * @param registerFiles the register files in the ISA
    * @param pc            the program counter of the ISA
    * @param formats       the list of formats associated with the ISA

--- a/vadl/main/vadl/viam/graph/control/DirectionalNode.java
+++ b/vadl/main/vadl/viam/graph/control/DirectionalNode.java
@@ -111,11 +111,12 @@ public abstract class DirectionalNode extends ControlNode {
    *
    * @param replacement The replacement of the current node
    */
-  public void replaceAndLink(DirectionalNode replacement) {
-    replace(replacement);
+  public DirectionalNode replaceAndLink(DirectionalNode replacement) {
+    var actual = replace(replacement);
     var next = this.next();
     setNext(null);
     replacement.setNext(next);
+    return actual;
   }
 
   public ControlNode next() {

--- a/vadl/main/vadl/viam/passes/sideEffectScheduling/SideEffectSchedulingPass.java
+++ b/vadl/main/vadl/viam/passes/sideEffectScheduling/SideEffectSchedulingPass.java
@@ -158,7 +158,7 @@ class SideEffectScheduler {
         // find side effects that cause instruction exits
         .collect(Collectors.partitioningBy(
             s ->
-                (s instanceof WriteResourceNode wRes && wRes.resourceDefinition().equals(pcReg))
+                (s instanceof WriteResourceNode write && write.resourceDefinition().equals(pcReg))
                     || (s instanceof ProcCallNode procCall && procCall.exceptionRaise())
         ));
 
@@ -175,8 +175,8 @@ class SideEffectScheduler {
     instrExitSideEffects.ifPresent(exitCause -> {
           if (exitCause instanceof ProcCallNode procCall) {
             endNode.addBefore(new InstrExitNode.Raise(procCall));
-          } else if (exitCause instanceof WriteResourceNode wRes) {
-            endNode.addBefore(new InstrExitNode.PcChange(wRes));
+          } else if (exitCause instanceof WriteResourceNode write) {
+            endNode.addBefore(new InstrExitNode.PcChange(write));
           } else {
             throw new IllegalStateException("Unexpected exit cause: " + exitCause);
           }

--- a/vadl/main/vadl/viam/passes/sideEffectScheduling/SideEffectSchedulingPass.java
+++ b/vadl/main/vadl/viam/passes/sideEffectScheduling/SideEffectSchedulingPass.java
@@ -42,6 +42,7 @@ import vadl.viam.graph.control.DirectionalNode;
 import vadl.viam.graph.control.MergeNode;
 import vadl.viam.graph.control.ScheduledNode;
 import vadl.viam.graph.control.StartNode;
+import vadl.viam.graph.dependency.ProcCallNode;
 import vadl.viam.graph.dependency.WriteResourceNode;
 import vadl.viam.passes.sideEffectScheduling.nodes.InstrExitNode;
 
@@ -154,13 +155,15 @@ class SideEffectScheduler {
 
     var pcReg = pc != null ? pc.registerRef() : null;
     var partitionedEffects = endNode.sideEffects().stream()
-        .map(WriteResourceNode.class::cast)
+        // find side effects that cause instruction exits
         .collect(Collectors.partitioningBy(
-            s -> s.resourceDefinition().equals(pcReg)
+            s ->
+                (s instanceof WriteResourceNode wRes && wRes.resourceDefinition().equals(pcReg))
+                    || (s instanceof ProcCallNode procCall && procCall.exceptionRaise())
         ));
 
     var nonPcUpdateEffects = partitionedEffects.getOrDefault(false, List.of());
-    var pcSideEffect = partitionedEffects.getOrDefault(true, List.of())
+    var instrExitSideEffects = partitionedEffects.getOrDefault(true, List.of())
         .stream().findFirst();
 
     // All non-PC updates should be inserted directly at the beginning of the branch
@@ -169,8 +172,16 @@ class SideEffectScheduler {
     }
 
     // Add PC update directly in front of branch end
-    pcSideEffect.ifPresent(pcUpdate ->
-        endNode.addBefore(new InstrExitNode((WriteResourceNode) pcUpdate))
+    instrExitSideEffects.ifPresent(exitCause -> {
+          if (exitCause instanceof ProcCallNode procCall) {
+            endNode.addBefore(new InstrExitNode.Raise(procCall));
+          } else if (exitCause instanceof WriteResourceNode wRes) {
+            endNode.addBefore(new InstrExitNode.PcChange(wRes));
+          } else {
+            throw new IllegalStateException("Unexpected exit cause: " + exitCause);
+          }
+        }
+
     );
 
     return endNode;

--- a/vadl/main/vadl/viam/passes/sideEffectScheduling/nodes/InstrExitNode.java
+++ b/vadl/main/vadl/viam/passes/sideEffectScheduling/nodes/InstrExitNode.java
@@ -29,11 +29,23 @@ import vadl.viam.graph.dependency.WriteResourceNode;
 /**
  * Represents the exit point of an instruction in the side-effect scheduling pass.
  * This node is a {@link DirectionalNode} that signifies the completion of an instruction,
- * specifically handling the write to the program counter (PC).
+ * specifically handling the write to the program counter (PC) or raise of an exception.
+ *
+ * @see PcChange
+ * @see Raise
+ * @see vadl.viam.passes.sideEffectScheduling.SideEffectSchedulingPass
+ * @see vadl.iss.passes.IssPcAccessConversionPass
+ * @see vadl.iss.passes.tcgLowering.TcgOpLoweringPass
  */
 public abstract sealed class InstrExitNode extends DirectionalNode permits InstrExitNode.PcChange,
     InstrExitNode.Raise {
 
+  /**
+   * An instruction exit that is caused by e PC change.
+   * If the PC is modified in an instruction, it means a jump from a QEMU perspective.
+   *
+   * @see InstrExitNode
+   */
   public static final class PcChange extends InstrExitNode {
 
     /**
@@ -86,6 +98,11 @@ public abstract sealed class InstrExitNode extends DirectionalNode permits Instr
     }
   }
 
+  /**
+   * An instruction exit that is caused by an exception raise.
+   *
+   * @see InstrExitNode
+   */
   public static final class Raise extends InstrExitNode {
 
     /**

--- a/vadl/test/resources/testSource/sys/risc-v/rv3264im.vadl
+++ b/vadl/test/resources/testSource/sys/risc-v/rv3264im.vadl
@@ -251,7 +251,7 @@
                                        funct3 = 0b000 ; ("(", register(rs1), ")"))
 
   $ECallInstr (ECALL ; 0)                              // environment (sys) call
-  $ECallInstr (EBREAK; 1)                              // environment (sys) break
+//   $ECallInstr (EBREAK; 1)                              // environment (sys) break
 
 $Arch3264 ( // ((((((((((((((((((((((((((((((((((((((((
 

--- a/vadl/test/resources/testSource/sys/risc-v/rv3264im.vadl
+++ b/vadl/test/resources/testSource/sys/risc-v/rv3264im.vadl
@@ -251,7 +251,7 @@
                                        funct3 = 0b000 ; ("(", register(rs1), ")"))
 
   $ECallInstr (ECALL ; 0)                              // environment (sys) call
-//   $ECallInstr (EBREAK; 1)                              // environment (sys) break
+  $ECallInstr (EBREAK; 1)                              // environment (sys) break
 
 $Arch3264 ( // ((((((((((((((((((((((((((((((((((((((((
 

--- a/vadl/test/vadl/iss/IssLoweringTest.java
+++ b/vadl/test/vadl/iss/IssLoweringTest.java
@@ -46,7 +46,7 @@ public class IssLoweringTest extends AbstractTest {
     var config =
         new IssConfiguration(new GeneralConfiguration(Path.of("build/test-output"), true));
 
-    setupPassManagerAndRunSpec("sys/risc-v/rv64zicsr_mini.vadl",
+    setupPassManagerAndRunSpec("sys/risc-v/rv64im.vadl",
         PassOrders.iss(config)
     );
 

--- a/vadl/test/vadl/iss/IssLoweringTest.java
+++ b/vadl/test/vadl/iss/IssLoweringTest.java
@@ -16,15 +16,17 @@
 
 package vadl.iss;
 
+import ch.qos.logback.classic.Level;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.EnumSet;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import vadl.AbstractTest;
 import vadl.configuration.GeneralConfiguration;
 import vadl.configuration.IssConfiguration;
+import vadl.dump.HtmlDumpPass;
 import vadl.pass.PassOrders;
 import vadl.pass.exception.DuplicatedPassKeyException;
 
@@ -32,21 +34,19 @@ public class IssLoweringTest extends AbstractTest {
 
   private static final Logger log = LoggerFactory.getLogger(IssLoweringTest.class);
 
+  @BeforeEach
+  void setUp() {
+    var logger = (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(HtmlDumpPass.class);
+    logger.setLevel(Level.DEBUG);
+  }
+
   // TODO: Remove this (it is just for testing purposes)
   @Test
   void issLoweringTest() throws IOException, DuplicatedPassKeyException {
     var config =
         new IssConfiguration(new GeneralConfiguration(Path.of("build/test-output"), true));
-    // skip allocation
-    config.setOptsToSkip(EnumSet.of(
-//        IssConfiguration.IssOptsToSkip.OPT_JMP_SLOTS,
-//        IssConfiguration.IssOptsToSkip.OPT_CTRL_FLOW,
-//        IssConfiguration.IssOptsToSkip.OPT_VAR_ALLOC,
-        IssConfiguration.IssOptsToSkip.OPT_ARGS
-//        IssConfiguration.IssOptsToSkip.OPT_BUILT_INS
-    ));
 
-    setupPassManagerAndRunSpec("sys/risc-v/rv64im.vadl",
+    setupPassManagerAndRunSpec("sys/risc-v/rv64zicsr_mini.vadl",
         PassOrders.iss(config)
     );
 


### PR DESCRIPTION
This PR adds support for exceptions to the ISS.
For each exception in the VIAM, a new handler function is generated in the `do_execution.c.inc`. Using generated helper functions, raise statements in the VIAM are now triggered by setting the exception index and leaving the TB.

Things to do: 
- tests are missing, as we don't have the necessary RISC-V spec yet
- anonymous raise exceptions aren’t supported, as they aren’t yet part of the VIAM