### PR TITLE
viam: Hardcoded setting label for LGA

### DIFF
--- a/vadl/main/resources/templates/lcb/llvm/lib/Target/AsmPrinter.cpp
+++ b/vadl/main/resources/templates/lcb/llvm/lib/Target/AsmPrinter.cpp
@@ -95,6 +95,9 @@ void [(${namespace})]AsmPrinter::emitInstruction( const MachineInstr *MI )
     {
         MCInstExpander.expand( TmpInst, [&](const MCInst &Inst) {
           emitToStreamer(*OutStreamer, Inst);
+        },
+        [&](MCSymbol* Symbol) {
+          OutStreamer->emitLabel(Symbol);
         });
     }
     else

--- a/vadl/main/resources/templates/lcb/llvm/lib/Target/AsmPrinter.cpp
+++ b/vadl/main/resources/templates/lcb/llvm/lib/Target/AsmPrinter.cpp
@@ -90,20 +90,16 @@ void [(${namespace})]AsmPrinter::emitInstruction( const MachineInstr *MI )
 
     MCInst TmpInst;
     MCInstLowering.Lower(MI, TmpInst);
-    std::vector<MCInst> resultVec;
 
     if( MCInstExpander.isExpandable( TmpInst ) )
     {
-        MCInstExpander.expand( TmpInst, resultVec );
+        MCInstExpander.expand( TmpInst, [&](const MCInst &Inst) {
+          emitToStreamer(*OutStreamer, Inst);
+        });
     }
     else
     {
-        resultVec.push_back( TmpInst );
-    }
-
-    for(auto it = std::begin(resultVec); it != std::end(resultVec); ++it)
-    {
-        emitToStreamer( *OutStreamer, *it );
+        emitToStreamer( *OutStreamer, TmpInst );
     }
 }
 

--- a/vadl/main/resources/templates/lcb/llvm/lib/Target/MCTargetDesc/TargetMCCodeEmitter.cpp
+++ b/vadl/main/resources/templates/lcb/llvm/lib/Target/MCTargetDesc/TargetMCCodeEmitter.cpp
@@ -132,18 +132,17 @@ void [(${namespace})]MCCodeEmitter::encodeInstruction(const MCInst &MCI, raw_ost
 
     if (MCInstExpander.isExpandable(MCI))
     {
-        MCInstExpander.expand(MCI, resultVec);
+        MCInstExpander.expand(MCI, [&](const MCInst &MI) {
+          encodeNonPseudoInstruction(MI, OS, Fixups, STI);
+          const MCInstrDesc &Desc = MCII.get(MI.getOpcode());
+          unsigned Size = Desc.getSize();
+          Offset += Size;
+        });
     }
     else
     {
-        resultVec.push_back(MCI);
-    }
-
-    for (auto it = std::begin(resultVec); it != std::end(resultVec); ++it)
-    {
-        MCInst MI = *it;
-        encodeNonPseudoInstruction(MI, OS, Fixups, STI);
-        const MCInstrDesc &Desc = MCII.get(MI.getOpcode());
+        encodeNonPseudoInstruction(MCI, OS, Fixups, STI);
+        const MCInstrDesc &Desc = MCII.get(MCI.getOpcode());
         unsigned Size = Desc.getSize();
         Offset += Size;
     }

--- a/vadl/main/resources/templates/lcb/llvm/lib/Target/MCTargetDesc/TargetMCCodeEmitter.cpp
+++ b/vadl/main/resources/templates/lcb/llvm/lib/Target/MCTargetDesc/TargetMCCodeEmitter.cpp
@@ -137,6 +137,8 @@ void [(${namespace})]MCCodeEmitter::encodeInstruction(const MCInst &MCI, raw_ost
           const MCInstrDesc &Desc = MCII.get(MI.getOpcode());
           unsigned Size = Desc.getSize();
           Offset += Size;
+        },
+        [&](MCSymbol* Symbol) {
         });
     }
     else

--- a/vadl/main/resources/templates/lcb/llvm/lib/Target/MCTargetDesc/TargetMCInstExpander.cpp
+++ b/vadl/main/resources/templates/lcb/llvm/lib/Target/MCTargetDesc/TargetMCInstExpander.cpp
@@ -7,6 +7,7 @@
 #include "llvm/MC/MCInst.h"
 #include "llvm/MC/MCExpr.h"
 #include "llvm/MC/MCContext.h"
+#include "llvm/MC/MCSymbol.h"
 
 #define DEBUG_TYPE "[(${namespace})]MCInstExpander"
 
@@ -55,7 +56,9 @@ bool [(${namespace})]MCInstExpander::isExpandable(const MCInst &MCI) const
     return false; // unreachable
 }
 
-bool [(${namespace})]MCInstExpander::expand(const MCInst &MCI, std::function<void(const MCInst &)> callback ) const
+bool [(${namespace})]MCInstExpander::expand(const MCInst &MCI,
+  std::function<void(const MCInst &)> callback,
+  std::function<void(MCSymbol*)> callbackSymbol  ) const
 {
     auto opcode = MCI.getOpcode();
     switch (opcode)
@@ -67,7 +70,7 @@ bool [(${namespace})]MCInstExpander::expand(const MCInst &MCI, std::function<voi
     [# th:each="instruction : ${compilerInstructions}" ]
       case [(${namespace})]::[(${instruction.compilerInstruction.name})]:
       {
-        [(${instruction.header})](MCI, callback );
+        [(${instruction.header})](MCI, callback, callbackSymbol );
         return true;
       }
     [/]

--- a/vadl/main/resources/templates/lcb/llvm/lib/Target/MCTargetDesc/TargetMCInstExpander.cpp
+++ b/vadl/main/resources/templates/lcb/llvm/lib/Target/MCTargetDesc/TargetMCInstExpander.cpp
@@ -55,7 +55,7 @@ bool [(${namespace})]MCInstExpander::isExpandable(const MCInst &MCI) const
     return false; // unreachable
 }
 
-bool [(${namespace})]MCInstExpander::expand(const MCInst &MCI, std::vector<MCInst> &MCIExpansion) const
+bool [(${namespace})]MCInstExpander::expand(const MCInst &MCI, std::function<void(const MCInst &)> callback ) const
 {
     auto opcode = MCI.getOpcode();
     switch (opcode)
@@ -67,7 +67,7 @@ bool [(${namespace})]MCInstExpander::expand(const MCInst &MCI, std::vector<MCIns
     [# th:each="instruction : ${compilerInstructions}" ]
       case [(${namespace})]::[(${instruction.compilerInstruction.name})]:
       {
-        MCIExpansion = [(${instruction.header})](MCI);
+        [(${instruction.header})](MCI, callback );
         return true;
       }
     [/]

--- a/vadl/main/resources/templates/lcb/llvm/lib/Target/MCTargetDesc/TargetMCInstExpander.h
+++ b/vadl/main/resources/templates/lcb/llvm/lib/Target/MCTargetDesc/TargetMCInstExpander.h
@@ -4,6 +4,7 @@
 #include <vector>
 #include <cstdint>
 #include <functional>
+#include "llvm/MC/MCSymbol.h"
 
 namespace llvm
 {
@@ -18,7 +19,7 @@ namespace llvm
         [(${namespace})]MCInstExpander(class MCContext & Ctx);
         bool needsExpansion(const MCInst &MCI) const;
         bool isExpandable(const MCInst &MCI) const;
-        bool expand(const MCInst &MCI, std::function<void(const MCInst &)> callback ) const;
+        bool expand(const MCInst &MCI, std::function<void(const MCInst &)> callback, std::function<void(MCSymbol* )> callbackSymbol ) const;
 
     private:
         MCContext & Ctx;
@@ -31,7 +32,9 @@ namespace llvm
         //
 
         [# th:each="instructionHeaders : ${compilerInstructionHeaders}" ]
-        std::vector<MCInst> [(${instructionHeaders})]( const MCInst& instruction, std::function<void(const MCInst &)> callback ) const;
+        std::vector<MCInst> [(${instructionHeaders})]( const MCInst& instruction,
+          std::function<void(const MCInst &)> callback,
+          std::function<void(MCSymbol*)> callbackSymbol ) const;
         [/]
     };
 }

--- a/vadl/main/resources/templates/lcb/llvm/lib/Target/MCTargetDesc/TargetMCInstExpander.h
+++ b/vadl/main/resources/templates/lcb/llvm/lib/Target/MCTargetDesc/TargetMCInstExpander.h
@@ -3,6 +3,7 @@
 
 #include <vector>
 #include <cstdint>
+#include <functional>
 
 namespace llvm
 {
@@ -17,7 +18,7 @@ namespace llvm
         [(${namespace})]MCInstExpander(class MCContext & Ctx);
         bool needsExpansion(const MCInst &MCI) const;
         bool isExpandable(const MCInst &MCI) const;
-        bool expand(const MCInst &MCI, std::vector<MCInst> &expansion) const;
+        bool expand(const MCInst &MCI, std::function<void(const MCInst &)> callback ) const;
 
     private:
         MCContext & Ctx;
@@ -30,7 +31,7 @@ namespace llvm
         //
 
         [# th:each="instructionHeaders : ${compilerInstructionHeaders}" ]
-        std::vector<MCInst> [(${instructionHeaders})]( const MCInst& instruction ) const;
+        std::vector<MCInst> [(${instructionHeaders})]( const MCInst& instruction, std::function<void(const MCInst &)> callback ) const;
         [/]
     };
 }

--- a/vadl/main/vadl/cppCodeGen/FunctionCodeGenerator.java
+++ b/vadl/main/vadl/cppCodeGen/FunctionCodeGenerator.java
@@ -26,6 +26,7 @@ import vadl.javaannotations.DispatchFor;
 import vadl.javaannotations.Handler;
 import vadl.viam.Function;
 import vadl.viam.graph.Node;
+import vadl.viam.graph.control.NewLabelNode;
 import vadl.viam.graph.control.ReturnNode;
 import vadl.viam.graph.dependency.AsmBuiltInCall;
 import vadl.viam.graph.dependency.ExpressionNode;

--- a/vadl/main/vadl/cppCodeGen/common/AccessFunctionCodeGenerator.java
+++ b/vadl/main/vadl/cppCodeGen/common/AccessFunctionCodeGenerator.java
@@ -25,6 +25,7 @@ import vadl.cppCodeGen.context.CGenContext;
 import vadl.viam.Format;
 import vadl.viam.Function;
 import vadl.viam.graph.Node;
+import vadl.viam.graph.control.NewLabelNode;
 import vadl.viam.graph.dependency.AsmBuiltInCall;
 import vadl.viam.graph.dependency.FieldAccessRefNode;
 import vadl.viam.graph.dependency.FieldRefNode;

--- a/vadl/main/vadl/cppCodeGen/common/AsmParserFunctionCodeGenerator.java
+++ b/vadl/main/vadl/cppCodeGen/common/AsmParserFunctionCodeGenerator.java
@@ -25,6 +25,7 @@ import vadl.types.BuiltInTable;
 import vadl.types.StringType;
 import vadl.viam.Function;
 import vadl.viam.graph.Node;
+import vadl.viam.graph.control.NewLabelNode;
 import vadl.viam.graph.dependency.AsmBuiltInCall;
 import vadl.viam.graph.dependency.ConstantNode;
 import vadl.viam.graph.dependency.FieldAccessRefNode;

--- a/vadl/main/vadl/cppCodeGen/common/PureFunctionCodeGenerator.java
+++ b/vadl/main/vadl/cppCodeGen/common/PureFunctionCodeGenerator.java
@@ -22,6 +22,7 @@ import vadl.cppCodeGen.FunctionCodeGenerator;
 import vadl.cppCodeGen.context.CGenContext;
 import vadl.viam.Function;
 import vadl.viam.graph.Node;
+import vadl.viam.graph.control.NewLabelNode;
 import vadl.viam.graph.dependency.AsmBuiltInCall;
 import vadl.viam.graph.dependency.FieldAccessRefNode;
 import vadl.viam.graph.dependency.FieldRefNode;

--- a/vadl/main/vadl/cppCodeGen/mixins/CDefaultMixins.java
+++ b/vadl/main/vadl/cppCodeGen/mixins/CDefaultMixins.java
@@ -36,6 +36,7 @@ import vadl.viam.graph.control.BranchEndNode;
 import vadl.viam.graph.control.IfNode;
 import vadl.viam.graph.control.InstrEndNode;
 import vadl.viam.graph.control.MergeNode;
+import vadl.viam.graph.control.NewLabelNode;
 import vadl.viam.graph.control.ProcEndNode;
 import vadl.viam.graph.control.ReturnNode;
 import vadl.viam.graph.control.ScheduledNode;
@@ -44,6 +45,7 @@ import vadl.viam.graph.dependency.BuiltInCall;
 import vadl.viam.graph.dependency.ConstantNode;
 import vadl.viam.graph.dependency.FuncCallNode;
 import vadl.viam.graph.dependency.FuncParamNode;
+import vadl.viam.graph.dependency.LabelNode;
 import vadl.viam.graph.dependency.SelectNode;
 import vadl.viam.graph.dependency.SignExtendNode;
 import vadl.viam.graph.dependency.SliceNode;
@@ -146,7 +148,7 @@ public interface CDefaultMixins {
   @SuppressWarnings("MissingJavadocType")
   interface AllControl
       extends Scheduled, InstrExit, IfElse, Begin, Start, Merge, BranchEnd, Return, InstrEnd,
-      ProcEnd {
+      ProcEnd, NewLabel {
 
   }
 
@@ -239,6 +241,14 @@ public interface CDefaultMixins {
     }
   }
 
+  @SuppressWarnings("MissingJavadocType")
+  interface NewLabel {
+    @Handler
+    default void handle(CGenContext<Node> ctx, NewLabelNode node) {
+      // nothing
+    }
+  }
+
   ///  DEPENDENCY HANDLERS ///
 
   @SuppressWarnings("MissingJavadocType")
@@ -250,7 +260,7 @@ public interface CDefaultMixins {
   @SuppressWarnings("MissingJavadocType")
   interface AllExpressions
       extends TypeCasts, Constant, FuncCall, BuiltIns, Slice, LetNode, Select, FuncParam,
-      TupleAccess {
+      TupleAccess, Label {
 
   }
 
@@ -408,4 +418,12 @@ public interface CDefaultMixins {
     }
   }
 
+  @SuppressWarnings("MissingJavadocType")
+  interface Label {
+    @Handler
+    @SuppressWarnings("MissingJavadocMethod")
+    default void handle(CGenContext<Node> ctx, LabelNode label) {
+      // nothing
+    }
+  }
 }

--- a/vadl/main/vadl/iss/passes/IssNormalizationPass.java
+++ b/vadl/main/vadl/iss/passes/IssNormalizationPass.java
@@ -50,6 +50,7 @@ import vadl.viam.graph.dependency.FieldAccessRefNode;
 import vadl.viam.graph.dependency.FieldRefNode;
 import vadl.viam.graph.dependency.FuncCallNode;
 import vadl.viam.graph.dependency.FuncParamNode;
+import vadl.viam.graph.dependency.LabelNode;
 import vadl.viam.graph.dependency.LetNode;
 import vadl.viam.graph.dependency.ReadArtificialResNode;
 import vadl.viam.graph.dependency.ReadMemNode;
@@ -228,6 +229,11 @@ class IssNormalizer implements VadlBuiltInNoStatusDispatcher<BuiltInCall> {
 
   @Handler
   void handle(IssStaticPcRegNode toHandle) {
+    // do nothing
+  }
+
+  @Handler
+  void handle(LabelNode toHandle) {
     // do nothing
   }
 

--- a/vadl/main/vadl/iss/passes/tcgLowering/TcgOpLoweringPass.java
+++ b/vadl/main/vadl/iss/passes/tcgLowering/TcgOpLoweringPass.java
@@ -85,6 +85,7 @@ import vadl.viam.graph.dependency.BuiltInCall;
 import vadl.viam.graph.dependency.ConstantNode;
 import vadl.viam.graph.dependency.DependencyNode;
 import vadl.viam.graph.dependency.FuncCallNode;
+import vadl.viam.graph.dependency.LabelNode;
 import vadl.viam.graph.dependency.LetNode;
 import vadl.viam.graph.dependency.ParamNode;
 import vadl.viam.graph.dependency.ProcCallNode;
@@ -806,6 +807,10 @@ class TcgOpLoweringExecutor implements CfgTraverser {
     throw failShouldNotHappen(toHandle);
   }
 
+  @Handler
+  void handle(LabelNode toHandle) {
+    throw failShouldNotHappen(toHandle);
+  }
 
   /**
    * Throws a {@link ViamGraphError} indicating that the node should not be handled.

--- a/vadl/main/vadl/lcb/codegen/expansion/CompilerInstructionExpansionCodeGenerator.java
+++ b/vadl/main/vadl/lcb/codegen/expansion/CompilerInstructionExpansionCodeGenerator.java
@@ -389,6 +389,7 @@ public class CompilerInstructionExpansionCodeGenerator extends FunctionCodeGener
         } else if (dir instanceof NewLabelNode newLabelNode) {
           var sym = symbolTable.getNextVariable();
           context.ln("MCSymbol *%s = Ctx.createTempSymbol();", sym);
+          context.ln("callbackSymbol(%s);", sym);
           labelSymbolNameLookup.put(newLabelNode, sym);
         }
 
@@ -478,6 +479,6 @@ public class CompilerInstructionExpansionCodeGenerator extends FunctionCodeGener
   public String genFunctionSignature() {
     return "std::vector<MCInst> %sMCInstExpander::%s_%s".formatted(targetName.value(),
         compilerInstruction.identifier.lower(), function.simpleName())
-        + "(const MCInst& instruction, std::function<void(const MCInst &)> callback ) const";
+        + "(const MCInst& instruction, std::function<void(const MCInst &)> callback, std::function<void(MCSymbol* )> callbackSymbol ) const";
   }
 }

--- a/vadl/main/vadl/lcb/codegen/expansion/CompilerInstructionExpansionCodeGenerator.java
+++ b/vadl/main/vadl/lcb/codegen/expansion/CompilerInstructionExpansionCodeGenerator.java
@@ -421,7 +421,7 @@ public class CompilerInstructionExpansionCodeGenerator extends FunctionCodeGener
           context.ln("result.push_back(%s);", sym);
         } else if (dir instanceof NewLabelNode newLabelNode) {
           var sym = symbolTable.getNextVariable();
-          context.ln("MCSymbol %s = Ctx.createTempSymbol();", sym);
+          context.ln("MCSymbol *%s = Ctx.createTempSymbol();", sym);
           labelSymbolNameLookup.put(newLabelNode, sym);
         }
 

--- a/vadl/main/vadl/lcb/codegen/expansion/CompilerInstructionExpansionCodeGenerator.java
+++ b/vadl/main/vadl/lcb/codegen/expansion/CompilerInstructionExpansionCodeGenerator.java
@@ -479,6 +479,7 @@ public class CompilerInstructionExpansionCodeGenerator extends FunctionCodeGener
   public String genFunctionSignature() {
     return "std::vector<MCInst> %sMCInstExpander::%s_%s".formatted(targetName.value(),
         compilerInstruction.identifier.lower(), function.simpleName())
-        + "(const MCInst& instruction, std::function<void(const MCInst &)> callback, std::function<void(MCSymbol* )> callbackSymbol ) const";
+        + "(const MCInst& instruction, std::function<void(const MCInst &)> callback, "
+        + "std::function<void(MCSymbol* )> callbackSymbol ) const";
   }
 }

--- a/vadl/main/vadl/lcb/codegen/expansion/CompilerInstructionExpansionCodeGenerator.java
+++ b/vadl/main/vadl/lcb/codegen/expansion/CompilerInstructionExpansionCodeGenerator.java
@@ -385,6 +385,7 @@ public class CompilerInstructionExpansionCodeGenerator extends FunctionCodeGener
                   instrCallNode.target().identifier.simpleName());
           writeInstructionCall(context, instrCallNode, sym);
           context.ln("result.push_back(%s);", sym);
+          context.ln("callback(%s);", sym);
         } else if (dir instanceof NewLabelNode newLabelNode) {
           var sym = symbolTable.getNextVariable();
           context.ln("MCSymbol *%s = Ctx.createTempSymbol();", sym);
@@ -477,6 +478,6 @@ public class CompilerInstructionExpansionCodeGenerator extends FunctionCodeGener
   public String genFunctionSignature() {
     return "std::vector<MCInst> %sMCInstExpander::%s_%s".formatted(targetName.value(),
         compilerInstruction.identifier.lower(), function.simpleName())
-        + "(const MCInst& instruction) const";
+        + "(const MCInst& instruction, std::function<void(const MCInst &)> callback ) const";
   }
 }

--- a/vadl/main/vadl/pass/PassOrders.java
+++ b/vadl/main/vadl/pass/PassOrders.java
@@ -99,6 +99,7 @@ import vadl.template.AbstractTemplateRenderingPass;
 import vadl.vdt.passes.VdtLoweringPass;
 import vadl.viam.Specification;
 import vadl.viam.passes.DuplicateWriteDetectionPass;
+import vadl.viam.passes.HardcodeLGALabelPass;
 import vadl.viam.passes.InstructionResourceAccessAnalysisPass;
 import vadl.viam.passes.algebraic_simplication.AlgebraicSimplificationPass;
 import vadl.viam.passes.behaviorRewrite.BehaviorRewritePass;
@@ -162,6 +163,9 @@ public class PassOrders {
     order.add(new AlgebraicSimplificationPass(configuration));
     order.add(new BehaviorRewritePass(configuration));
     order.add(new InstructionResourceAccessAnalysisPass(configuration));
+
+    // Hardcoded
+    order.add(new HardcodeLGALabelPass(configuration));
 
     // verification after viam optimizations
     order.add(new ViamVerificationPass(configuration));

--- a/vadl/main/vadl/viam/graph/Graph.java
+++ b/vadl/main/vadl/viam/graph/Graph.java
@@ -36,6 +36,7 @@ import vadl.viam.graph.control.AbstractEndNode;
 import vadl.viam.graph.control.ControlNode;
 import vadl.viam.graph.control.InstrCallNode;
 import vadl.viam.graph.control.InstrEndNode;
+import vadl.viam.graph.control.NewLabelNode;
 import vadl.viam.graph.control.ReturnNode;
 import vadl.viam.graph.control.StartNode;
 import vadl.viam.graph.dependency.DependencyNode;
@@ -304,6 +305,7 @@ public class Graph {
   public boolean isPseudoInstruction() {
     return getNodes(ControlNode.class).allMatch(
         e -> e instanceof InstrCallNode || e instanceof StartNode || e instanceof InstrEndNode
+            || e instanceof NewLabelNode
     ) && getNodes(ParamNode.class).allMatch(e -> e instanceof FuncParamNode);
   }
 

--- a/vadl/main/vadl/viam/graph/control/NewLabelNode.java
+++ b/vadl/main/vadl/viam/graph/control/NewLabelNode.java
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.viam.graph.control;
+
+import java.util.List;
+import vadl.javaannotations.viam.Input;
+import vadl.viam.PseudoInstruction;
+import vadl.viam.graph.GraphNodeVisitor;
+import vadl.viam.graph.GraphVisitor;
+import vadl.viam.graph.Node;
+import vadl.viam.graph.dependency.LabelNode;
+
+/**
+ * A node that indicates that a new temporary label has to be created. This is useful for
+ * {@link PseudoInstruction} where you need to implement addressing for relative addressing.
+ */
+public class NewLabelNode extends DirectionalNode {
+  @Input
+  private LabelNode label;
+
+  public NewLabelNode(LabelNode label) {
+    this.label = label;
+  }
+
+  @Override
+  public void collectInputs(List<Node> collection) {
+    super.collectInputs(collection);
+    collection.add(label);
+  }
+
+  @Override
+  public void applyOnInputsUnsafe(GraphVisitor.Applier<Node> visitor) {
+    super.applyOnInputsUnsafe(visitor);
+    label = visitor.apply(this, label, LabelNode.class);
+  }
+
+  @Override
+  public Node copy() {
+    return new NewLabelNode((LabelNode) label.copy());
+  }
+
+  @Override
+  public Node shallowCopy() {
+    return new NewLabelNode(label);
+  }
+
+  @Override
+  public <T extends GraphNodeVisitor> void accept(T visitor) {
+    visitor.visit(this);
+  }
+}

--- a/vadl/main/vadl/viam/graph/dependency/LabelNode.java
+++ b/vadl/main/vadl/viam/graph/dependency/LabelNode.java
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.viam.graph.dependency;
+
+import vadl.types.Type;
+import vadl.viam.graph.GraphNodeVisitor;
+import vadl.viam.graph.Node;
+import vadl.viam.graph.control.NewLabelNode;
+
+/**
+ * Given the user creates a label with {@link NewLabelNode} then the reference to this node is the
+ * {@link LabelNode}.
+ */
+public class LabelNode extends ExpressionNode {
+  public LabelNode(Type type) {
+    super(type);
+  }
+
+  @Override
+  public ExpressionNode copy() {
+    return new LabelNode(type());
+  }
+
+  @Override
+  public Node shallowCopy() {
+    return new LabelNode(type());
+  }
+
+  @Override
+  public <T extends GraphNodeVisitor> void accept(T visitor) {
+    visitor.visit(this);
+  }
+}

--- a/vadl/main/vadl/viam/passes/HardcodeLGALabelPass.java
+++ b/vadl/main/vadl/viam/passes/HardcodeLGALabelPass.java
@@ -27,6 +27,7 @@ import vadl.viam.Specification;
 import vadl.viam.graph.control.InstrCallNode;
 import vadl.viam.graph.control.NewLabelNode;
 import vadl.viam.graph.control.StartNode;
+import vadl.viam.graph.dependency.FuncCallNode;
 import vadl.viam.graph.dependency.LabelNode;
 
 /**
@@ -50,7 +51,7 @@ public class HardcodeLGALabelPass extends Pass {
         .ownPseudoInstructions()
         .stream().filter(instruction -> instruction.simpleName().equals("LGA_64"))
         .forEach(instruction -> {
-          var labelNode = new LabelNode(Type.signedInt(12));
+          var labelNode = new LabelNode(Type.signedInt(32));
           var startNode =
               instruction.behavior().getNodes(StartNode.class).findFirst().orElseThrow();
           var newlabelNode = new NewLabelNode(labelNode);
@@ -61,7 +62,8 @@ public class HardcodeLGALabelPass extends Pass {
               .findFirst()
               .orElseThrow();
 
-          ldInstruction.arguments().set(2, labelNode);
+          var pcrel = (FuncCallNode) ldInstruction.arguments().get(2);
+          pcrel.arguments().get(0).replaceAndDelete(labelNode);
         }));
 
     return null;

--- a/vadl/main/vadl/viam/passes/HardcodeLGALabelPass.java
+++ b/vadl/main/vadl/viam/passes/HardcodeLGALabelPass.java
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.viam.passes;
+
+import java.io.IOException;
+import javax.annotation.Nullable;
+import vadl.configuration.GeneralConfiguration;
+import vadl.pass.Pass;
+import vadl.pass.PassName;
+import vadl.pass.PassResults;
+import vadl.types.Type;
+import vadl.viam.Specification;
+import vadl.viam.graph.control.InstrCallNode;
+import vadl.viam.graph.control.NewLabelNode;
+import vadl.viam.graph.control.StartNode;
+import vadl.viam.graph.dependency.LabelNode;
+
+/**
+ * Temporary pass for inserting labels into a pseudo instruction.
+ * See {@code https://github.com/OpenVADL/openvadl/issues/148}.
+ */
+public class HardcodeLGALabelPass extends Pass {
+  public HardcodeLGALabelPass(GeneralConfiguration configuration) {
+    super(configuration);
+  }
+
+  @Override
+  public PassName getName() {
+    return new PassName("HardcodeLGALabelPass");
+  }
+
+  @Nullable
+  @Override
+  public Object execute(PassResults passResults, Specification viam) throws IOException {
+    viam.isa().ifPresent(isa -> isa
+        .ownPseudoInstructions()
+        .stream().filter(instruction -> instruction.simpleName().equals("LGA_64"))
+        .forEach(instruction -> {
+          var labelNode = new LabelNode(Type.signedInt(12));
+          var startNode =
+              instruction.behavior().getNodes(StartNode.class).findFirst().orElseThrow();
+          var newlabelNode = new NewLabelNode(labelNode);
+          startNode.addAfter(newlabelNode);
+
+          var ldInstruction = instruction.behavior().getNodes(InstrCallNode.class)
+              .filter(x -> x.target().simpleName().equals("LD"))
+              .findFirst()
+              .orElseThrow();
+
+          ldInstruction.arguments().set(2, labelNode);
+        }));
+
+    return null;
+  }
+}

--- a/vadl/main/vadl/viam/passes/HardcodeLGALabelPass.java
+++ b/vadl/main/vadl/viam/passes/HardcodeLGALabelPass.java
@@ -63,7 +63,8 @@ public class HardcodeLGALabelPass extends Pass {
               .orElseThrow();
 
           var pcrel = (FuncCallNode) ldInstruction.arguments().get(2);
-          pcrel.arguments().get(0).replaceAndDelete(labelNode);
+          var symbol = pcrel.arguments().getFirst();
+          pcrel.replaceInput(symbol, labelNode);
         }));
 
     return null;

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O0/pic.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O0/pic.ll
@@ -8,8 +8,9 @@
 define ptr @f1() nounwind {
 ; CHECK-LABEL: f1: # @f1
 ; CHECK-LABEL: # %bb.0: # %entry
+; CHECK-LABEL: .Ltmp0:
 ; CHECK-NEXT: AUIPC a0,%got_hi(external_var)
-; CHECK-NEXT: LD a0,%pcrel_lo(external_var)(a0)
+; CHECK-NEXT: LD a0,%pcrel_lo(.Ltmp0)(a0)
 ; CHECK-NEXT: JALR zero,0(ra)
 entry:
   ret ptr @external_var

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/pic.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/pic.ll
@@ -8,8 +8,9 @@
 define ptr @f1() nounwind {
 ; CHECK-LABEL: f1: # @f1
 ; CHECK-LABEL: # %bb.0: # %entry
+; CHECK-LABEL: .Ltmp0:
 ; CHECK-NEXT: AUIPC a0,%got_hi(external_var)
-; CHECK-NEXT: LD a0,%pcrel_lo(external_var)(a0)
+; CHECK-NEXT: LD a0,%pcrel_lo(.Ltmp0)(a0)
 ; CHECK-NEXT: JALR zero,0(ra)
 entry:
   ret ptr @external_var

--- a/vadl/test/vadl/lcb/riscv/riscv64/template/MCTargetDesc/EmitMCInstExpanderCppFilePassTest.java
+++ b/vadl/test/vadl/lcb/riscv/riscv64/template/MCTargetDesc/EmitMCInstExpanderCppFilePassTest.java
@@ -47,22 +47,23 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
 
     Assertions.assertLinesMatch("""
         #include "processornamevalueMCInstExpander.h"
-        
+                
         #include "MCTargetDesc/processornamevalueMCTargetDesc.h"
         #include "Utils/ImmediateUtils.h"
-        
+                
         #include "MCTargetDesc/processornamevalueMCExpr.h"
         #include "llvm/MC/MCInst.h"
         #include "llvm/MC/MCExpr.h"
         #include "llvm/MC/MCContext.h"
-        
+        #include "llvm/MC/MCSymbol.h"
+                
         #define DEBUG_TYPE "processornamevalueMCInstExpander"
-        
+                
         using namespace llvm;
-        
+                
         processornamevalueMCInstExpander::processornamevalueMCInstExpander(class MCContext &Ctx)
             : Ctx(Ctx) {}
-        
+                
         bool processornamevalueMCInstExpander::needsExpansion(const MCInst &MCI) const
         {
             auto opcode = MCI.getOpcode();
@@ -109,7 +110,7 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
             }
             return false; // unreachable
         }
-        
+                
         bool processornamevalueMCInstExpander::isExpandable(const MCInst &MCI) const
         {
             auto opcode = MCI.getOpcode();
@@ -156,8 +157,10 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
             }
             return false; // unreachable
         }
-        
-        bool processornamevalueMCInstExpander::expand(const MCInst &MCI, std::vector<MCInst> &MCIExpansion) const
+                
+        bool processornamevalueMCInstExpander::expand(const MCInst &MCI,
+          std::function<void(const MCInst &)> callback,
+          std::function<void(MCSymbol*)> callbackSymbol  ) const
         {
             auto opcode = MCI.getOpcode();
             switch (opcode)
@@ -165,146 +168,146 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
                 //
                 // instructions
                 //
-        
+                
            \s
               case processornamevalue::LGA_64:
               {
-                MCIExpansion = RV3264I_LGA_64_expand(MCI);
+                RV3264I_LGA_64_expand(MCI, callback, callbackSymbol );
                 return true;
               }
               case processornamevalue::CALL:
               {
-                MCIExpansion = RV3264I_CALL_expand(MCI);
+                RV3264I_CALL_expand(MCI, callback, callbackSymbol );
                 return true;
               }
               case processornamevalue::TAIL:
               {
-                MCIExpansion = RV3264I_TAIL_expand(MCI);
+                RV3264I_TAIL_expand(MCI, callback, callbackSymbol );
                 return true;
               }
               case processornamevalue::RET:
               {
-                MCIExpansion = RV3264I_RET_expand(MCI);
+                RV3264I_RET_expand(MCI, callback, callbackSymbol );
                 return true;
               }
               case processornamevalue::J:
               {
-                MCIExpansion = RV3264I_J_expand(MCI);
+                RV3264I_J_expand(MCI, callback, callbackSymbol );
                 return true;
               }
               case processornamevalue::NOP:
               {
-                MCIExpansion = RV3264I_NOP_expand(MCI);
+                RV3264I_NOP_expand(MCI, callback, callbackSymbol );
                 return true;
               }
               case processornamevalue::MV:
               {
-                MCIExpansion = RV3264I_MV_expand(MCI);
+                RV3264I_MV_expand(MCI, callback, callbackSymbol );
                 return true;
               }
               case processornamevalue::NOT:
               {
-                MCIExpansion = RV3264I_NOT_expand(MCI);
+                RV3264I_NOT_expand(MCI, callback, callbackSymbol );
                 return true;
               }
               case processornamevalue::NEG:
               {
-                MCIExpansion = RV3264I_NEG_expand(MCI);
+                RV3264I_NEG_expand(MCI, callback, callbackSymbol );
                 return true;
               }
               case processornamevalue::SNEZ:
               {
-                MCIExpansion = RV3264I_SNEZ_expand(MCI);
+                RV3264I_SNEZ_expand(MCI, callback, callbackSymbol );
                 return true;
               }
               case processornamevalue::SLTZ:
               {
-                MCIExpansion = RV3264I_SLTZ_expand(MCI);
+                RV3264I_SLTZ_expand(MCI, callback, callbackSymbol );
                 return true;
               }
               case processornamevalue::SGTZ:
               {
-                MCIExpansion = RV3264I_SGTZ_expand(MCI);
+                RV3264I_SGTZ_expand(MCI, callback, callbackSymbol );
                 return true;
               }
               case processornamevalue::BEQZ:
               {
-                MCIExpansion = RV3264I_BEQZ_expand(MCI);
+                RV3264I_BEQZ_expand(MCI, callback, callbackSymbol );
                 return true;
               }
               case processornamevalue::BNEZ:
               {
-                MCIExpansion = RV3264I_BNEZ_expand(MCI);
+                RV3264I_BNEZ_expand(MCI, callback, callbackSymbol );
                 return true;
               }
               case processornamevalue::BLEZ:
               {
-                MCIExpansion = RV3264I_BLEZ_expand(MCI);
+                RV3264I_BLEZ_expand(MCI, callback, callbackSymbol );
                 return true;
               }
               case processornamevalue::BGEZ:
               {
-                MCIExpansion = RV3264I_BGEZ_expand(MCI);
+                RV3264I_BGEZ_expand(MCI, callback, callbackSymbol );
                 return true;
               }
               case processornamevalue::BLTZ:
               {
-                MCIExpansion = RV3264I_BLTZ_expand(MCI);
+                RV3264I_BLTZ_expand(MCI, callback, callbackSymbol );
                 return true;
               }
               case processornamevalue::BGTZ:
               {
-                MCIExpansion = RV3264I_BGTZ_expand(MCI);
+                RV3264I_BGTZ_expand(MCI, callback, callbackSymbol );
                 return true;
               }
               case processornamevalue::LA:
               {
-                MCIExpansion = RV3264I_LA_expand(MCI);
+                RV3264I_LA_expand(MCI, callback, callbackSymbol );
                 return true;
               }
               case processornamevalue::LGA_32:
               {
-                MCIExpansion = RV3264I_LGA_32_expand(MCI);
+                RV3264I_LGA_32_expand(MCI, callback, callbackSymbol );
                 return true;
               }
               case processornamevalue::LLA:
               {
-                MCIExpansion = RV3264I_LLA_expand(MCI);
+                RV3264I_LLA_expand(MCI, callback, callbackSymbol );
                 return true;
               }
               case processornamevalue::LI:
               {
-                MCIExpansion = RV3264I_LI_expand(MCI);
+                RV3264I_LI_expand(MCI, callback, callbackSymbol );
                 return true;
               }
               case processornamevalue::constMat0:
               {
-                MCIExpansion = constMat0_expand(MCI);
+                constMat0_expand(MCI, callback, callbackSymbol );
                 return true;
               }
               case processornamevalue::constMat1:
               {
-                MCIExpansion = constMat1_expand(MCI);
+                constMat1_expand(MCI, callback, callbackSymbol );
                 return true;
               }
               case processornamevalue::constMat2:
               {
-                MCIExpansion = constMat2_expand(MCI);
+                constMat2_expand(MCI, callback, callbackSymbol );
                 return true;
               }
               case processornamevalue::constMat3:
               {
-                MCIExpansion = constMat3_expand(MCI);
+                constMat3_expand(MCI, callback, callbackSymbol );
                 return true;
               }
               case processornamevalue::constMat4:
               {
-                MCIExpansion = constMat4_expand(MCI);
+                constMat4_expand(MCI, callback, callbackSymbol );
                 return true;
               }
               case processornamevalue::registerAdjustment0:
               {
-                MCIExpansion = registerAdjustment0_expand(MCI);
+                registerAdjustment0_expand(MCI, callback, callbackSymbol );
                 return true;
               }
            \s
@@ -315,29 +318,29 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
             }
             return false; // unreachable
         }
-        
+                
         const MCExpr *processornamevalueMCInstExpander::MCOperandToMCExpr(const MCOperand &MCO) const
         {
             if (MCO.isImm())
             {
                 return MCConstantExpr::create(MCO.getImm(), Ctx);
             }
-        
+                
             if (MCO.isExpr())
             {
                 return MCO.getExpr();
             }
-        
+                
             llvm_unreachable("<unsupported mc operand type>");
         }
-        
+                
         const int64_t processornamevalueMCInstExpander::MCOperandToInt64(const MCOperand &MCO) const
         {
             if (MCO.isImm())
             {
                 return MCO.getImm();
             }
-        
+                
             if (MCO.isExpr())
             {
                 int64_t mcExprResult;
@@ -347,36 +350,40 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
                     return mcExprResult;
                 }
             }
-        
+                
             llvm_unreachable("<unsupported operand type or value>");
         }
-        
-        
-        
-        std::vector<MCInst> processorNameValueMCInstExpander::RV3264I_LGA_64_expand(const MCInst& instruction) const
+                
+                
+                
+        std::vector<MCInst> processorNameValueMCInstExpander::RV3264I_LGA_64_expand(const MCInst& instruction, std::function<void(const MCInst &)> callback, std::function<void(MCSymbol* )> callbackSymbol ) const
         {
            std::vector< MCInst > result;
-           MCInst a = MCInst();
-           a.setOpcode(processorNameValue::AUIPC);
-           a.addOperand(instruction.getOperand(0));
-           const MCExpr* b = MCOperandToMCExpr(instruction.getOperand(1));
-           MCOperand c = MCOperand::createExpr(processorNameValueMCExpr::create(b, processorNameValueMCExpr::VariantKind::VK_GOT_RV3264I_got_hi, Ctx));
-           a.addOperand(c);
-           result.push_back(a);
-           MCInst d = MCInst();
-           d.setOpcode(processorNameValue::LD);
-           d.addOperand(instruction.getOperand(0));
-           d.addOperand(instruction.getOperand(0));
-           const MCExpr* e = MCOperandToMCExpr(instruction.getOperand(1));
-           MCOperand f = MCOperand::createExpr(processorNameValueMCExpr::create(e, processorNameValueMCExpr::VariantKind::VK_PCREL_RV3264I_pcrel_lo, Ctx));
-           d.addOperand(f);
-           result.push_back(d);
+           MCSymbol *a = Ctx.createTempSymbol();
+           callbackSymbol(a);
+           MCInst b = MCInst();
+           b.setOpcode(processorNameValue::AUIPC);
+           b.addOperand(instruction.getOperand(0));
+           const MCExpr* c = MCOperandToMCExpr(instruction.getOperand(1));
+           MCOperand d = MCOperand::createExpr(processorNameValueMCExpr::create(c, processorNameValueMCExpr::VariantKind::VK_GOT_RV3264I_got_hi, Ctx));
+           b.addOperand(d);
+           result.push_back(b);
+           callback(b);
+           MCInst e = MCInst();
+           e.setOpcode(processorNameValue::LD);
+           e.addOperand(instruction.getOperand(0));
+           e.addOperand(instruction.getOperand(0));
+           const MCExpr* f = MCOperandToMCExpr(MCOperand::createExpr(MCSymbolRefExpr::create(a, Ctx)));
+           MCOperand g = MCOperand::createExpr(processorNameValueMCExpr::create(f, processorNameValueMCExpr::VariantKind::VK_PCREL_RV3264I_pcrel_lo, Ctx));
+           e.addOperand(g);
+           result.push_back(e);
+           callback(e);
            return result;
         }
-        
-        
-        
-        std::vector<MCInst> processorNameValueMCInstExpander::RV3264I_CALL_expand(const MCInst& instruction) const
+                
+                
+                
+        std::vector<MCInst> processorNameValueMCInstExpander::RV3264I_CALL_expand(const MCInst& instruction, std::function<void(const MCInst &)> callback, std::function<void(MCSymbol* )> callbackSymbol ) const
         {
            std::vector< MCInst > result;
            MCInst a = MCInst();
@@ -386,6 +393,7 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCOperand c = MCOperand::createExpr(processorNameValueMCExpr::create(b, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264I_hi, Ctx));
            a.addOperand(c);
            result.push_back(a);
+           callback(a);
            MCInst d = MCInst();
            d.setOpcode(processorNameValue::JALR);
            d.addOperand(MCOperand::createReg(processorNameValue::X1));
@@ -394,12 +402,13 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCOperand f = MCOperand::createExpr(processorNameValueMCExpr::create(e, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264I_lo, Ctx));
            d.addOperand(f);
            result.push_back(d);
+           callback(d);
            return result;
         }
-        
-        
-        
-        std::vector<MCInst> processorNameValueMCInstExpander::RV3264I_TAIL_expand(const MCInst& instruction) const
+                
+                
+                
+        std::vector<MCInst> processorNameValueMCInstExpander::RV3264I_TAIL_expand(const MCInst& instruction, std::function<void(const MCInst &)> callback, std::function<void(MCSymbol* )> callbackSymbol ) const
         {
            std::vector< MCInst > result;
            MCInst a = MCInst();
@@ -409,6 +418,7 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCOperand c = MCOperand::createExpr(processorNameValueMCExpr::create(b, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264I_hi, Ctx));
            a.addOperand(c);
            result.push_back(a);
+           callback(a);
            MCInst d = MCInst();
            d.setOpcode(processorNameValue::JALR);
            d.addOperand(MCOperand::createReg(processorNameValue::X0));
@@ -417,12 +427,13 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCOperand f = MCOperand::createExpr(processorNameValueMCExpr::create(e, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264I_lo, Ctx));
            d.addOperand(f);
            result.push_back(d);
+           callback(d);
            return result;
         }
-        
-        
-        
-        std::vector<MCInst> processorNameValueMCInstExpander::RV3264I_RET_expand(const MCInst& instruction) const
+                
+                
+                
+        std::vector<MCInst> processorNameValueMCInstExpander::RV3264I_RET_expand(const MCInst& instruction, std::function<void(const MCInst &)> callback, std::function<void(MCSymbol* )> callbackSymbol ) const
         {
            std::vector< MCInst > result;
            MCInst a = MCInst();
@@ -431,12 +442,13 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            a.addOperand(MCOperand::createReg(processorNameValue::X1));
            a.addOperand(MCOperand::createImm(RV3264I_Itype_immS_decode(0)));
            result.push_back(a);
+           callback(a);
            return result;
         }
-        
-        
-        
-        std::vector<MCInst> processorNameValueMCInstExpander::RV3264I_J_expand(const MCInst& instruction) const
+                
+                
+                
+        std::vector<MCInst> processorNameValueMCInstExpander::RV3264I_J_expand(const MCInst& instruction, std::function<void(const MCInst &)> callback, std::function<void(MCSymbol* )> callbackSymbol ) const
         {
            std::vector< MCInst > result;
            MCInst a = MCInst();
@@ -446,12 +458,13 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCOperand c = MCOperand::createExpr(processorNameValueMCExpr::create(b, processorNameValueMCExpr::VariantKind::VK_None, Ctx));
            a.addOperand(c);
            result.push_back(a);
+           callback(a);
            return result;
         }
-        
-        
-        
-        std::vector<MCInst> processorNameValueMCInstExpander::RV3264I_NOP_expand(const MCInst& instruction) const
+                
+                
+                
+        std::vector<MCInst> processorNameValueMCInstExpander::RV3264I_NOP_expand(const MCInst& instruction, std::function<void(const MCInst &)> callback, std::function<void(MCSymbol* )> callbackSymbol ) const
         {
            std::vector< MCInst > result;
            MCInst a = MCInst();
@@ -460,12 +473,13 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            a.addOperand(MCOperand::createReg(processorNameValue::X0));
            a.addOperand(MCOperand::createImm(RV3264I_Itype_immS_decode(0)));
            result.push_back(a);
+           callback(a);
            return result;
         }
-        
-        
-        
-        std::vector<MCInst> processorNameValueMCInstExpander::RV3264I_MV_expand(const MCInst& instruction) const
+                
+                
+                
+        std::vector<MCInst> processorNameValueMCInstExpander::RV3264I_MV_expand(const MCInst& instruction, std::function<void(const MCInst &)> callback, std::function<void(MCSymbol* )> callbackSymbol ) const
         {
            std::vector< MCInst > result;
            MCInst a = MCInst();
@@ -474,12 +488,13 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            a.addOperand(instruction.getOperand(1));
            a.addOperand(MCOperand::createImm(RV3264I_Itype_immS_decode(0)));
            result.push_back(a);
+           callback(a);
            return result;
         }
-        
-        
-        
-        std::vector<MCInst> processorNameValueMCInstExpander::RV3264I_NOT_expand(const MCInst& instruction) const
+                
+                
+                
+        std::vector<MCInst> processorNameValueMCInstExpander::RV3264I_NOT_expand(const MCInst& instruction, std::function<void(const MCInst &)> callback, std::function<void(MCSymbol* )> callbackSymbol ) const
         {
            std::vector< MCInst > result;
            MCInst a = MCInst();
@@ -488,12 +503,13 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            a.addOperand(instruction.getOperand(1));
            a.addOperand(MCOperand::createImm(RV3264I_Itype_immS_decode(4095)));
            result.push_back(a);
+           callback(a);
            return result;
         }
-        
-        
-        
-        std::vector<MCInst> processorNameValueMCInstExpander::RV3264I_NEG_expand(const MCInst& instruction) const
+                
+                
+                
+        std::vector<MCInst> processorNameValueMCInstExpander::RV3264I_NEG_expand(const MCInst& instruction, std::function<void(const MCInst &)> callback, std::function<void(MCSymbol* )> callbackSymbol ) const
         {
            std::vector< MCInst > result;
            MCInst a = MCInst();
@@ -502,12 +518,13 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            a.addOperand(MCOperand::createReg(processorNameValue::X0));
            a.addOperand(instruction.getOperand(1));
            result.push_back(a);
+           callback(a);
            return result;
         }
-        
-        
-        
-        std::vector<MCInst> processorNameValueMCInstExpander::RV3264I_SNEZ_expand(const MCInst& instruction) const
+                
+                
+                
+        std::vector<MCInst> processorNameValueMCInstExpander::RV3264I_SNEZ_expand(const MCInst& instruction, std::function<void(const MCInst &)> callback, std::function<void(MCSymbol* )> callbackSymbol ) const
         {
            std::vector< MCInst > result;
            MCInst a = MCInst();
@@ -516,12 +533,13 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            a.addOperand(MCOperand::createReg(processorNameValue::X0));
            a.addOperand(instruction.getOperand(1));
            result.push_back(a);
+           callback(a);
            return result;
         }
-        
-        
-        
-        std::vector<MCInst> processorNameValueMCInstExpander::RV3264I_SLTZ_expand(const MCInst& instruction) const
+                
+                
+                
+        std::vector<MCInst> processorNameValueMCInstExpander::RV3264I_SLTZ_expand(const MCInst& instruction, std::function<void(const MCInst &)> callback, std::function<void(MCSymbol* )> callbackSymbol ) const
         {
            std::vector< MCInst > result;
            MCInst a = MCInst();
@@ -530,12 +548,13 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            a.addOperand(instruction.getOperand(1));
            a.addOperand(MCOperand::createReg(processorNameValue::X0));
            result.push_back(a);
+           callback(a);
            return result;
         }
-        
-        
-        
-        std::vector<MCInst> processorNameValueMCInstExpander::RV3264I_SGTZ_expand(const MCInst& instruction) const
+                
+                
+                
+        std::vector<MCInst> processorNameValueMCInstExpander::RV3264I_SGTZ_expand(const MCInst& instruction, std::function<void(const MCInst &)> callback, std::function<void(MCSymbol* )> callbackSymbol ) const
         {
            std::vector< MCInst > result;
            MCInst a = MCInst();
@@ -544,12 +563,13 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            a.addOperand(MCOperand::createReg(processorNameValue::X0));
            a.addOperand(instruction.getOperand(1));
            result.push_back(a);
+           callback(a);
            return result;
         }
-        
-        
-        
-        std::vector<MCInst> processorNameValueMCInstExpander::RV3264I_BEQZ_expand(const MCInst& instruction) const
+                
+                
+                
+        std::vector<MCInst> processorNameValueMCInstExpander::RV3264I_BEQZ_expand(const MCInst& instruction, std::function<void(const MCInst &)> callback, std::function<void(MCSymbol* )> callbackSymbol ) const
         {
            std::vector< MCInst > result;
            MCInst a = MCInst();
@@ -560,12 +580,13 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCOperand c = MCOperand::createExpr(processorNameValueMCExpr::create(b, processorNameValueMCExpr::VariantKind::VK_None, Ctx));
            a.addOperand(c);
            result.push_back(a);
+           callback(a);
            return result;
         }
-        
-        
-        
-        std::vector<MCInst> processorNameValueMCInstExpander::RV3264I_BNEZ_expand(const MCInst& instruction) const
+                
+                
+                
+        std::vector<MCInst> processorNameValueMCInstExpander::RV3264I_BNEZ_expand(const MCInst& instruction, std::function<void(const MCInst &)> callback, std::function<void(MCSymbol* )> callbackSymbol ) const
         {
            std::vector< MCInst > result;
            MCInst a = MCInst();
@@ -576,12 +597,13 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCOperand c = MCOperand::createExpr(processorNameValueMCExpr::create(b, processorNameValueMCExpr::VariantKind::VK_None, Ctx));
            a.addOperand(c);
            result.push_back(a);
+           callback(a);
            return result;
         }
-        
-        
-        
-        std::vector<MCInst> processorNameValueMCInstExpander::RV3264I_BLEZ_expand(const MCInst& instruction) const
+                
+                
+                
+        std::vector<MCInst> processorNameValueMCInstExpander::RV3264I_BLEZ_expand(const MCInst& instruction, std::function<void(const MCInst &)> callback, std::function<void(MCSymbol* )> callbackSymbol ) const
         {
            std::vector< MCInst > result;
            MCInst a = MCInst();
@@ -592,12 +614,13 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCOperand c = MCOperand::createExpr(processorNameValueMCExpr::create(b, processorNameValueMCExpr::VariantKind::VK_None, Ctx));
            a.addOperand(c);
            result.push_back(a);
+           callback(a);
            return result;
         }
-        
-        
-        
-        std::vector<MCInst> processorNameValueMCInstExpander::RV3264I_BGEZ_expand(const MCInst& instruction) const
+                
+                
+                
+        std::vector<MCInst> processorNameValueMCInstExpander::RV3264I_BGEZ_expand(const MCInst& instruction, std::function<void(const MCInst &)> callback, std::function<void(MCSymbol* )> callbackSymbol ) const
         {
            std::vector< MCInst > result;
            MCInst a = MCInst();
@@ -608,12 +631,13 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCOperand c = MCOperand::createExpr(processorNameValueMCExpr::create(b, processorNameValueMCExpr::VariantKind::VK_None, Ctx));
            a.addOperand(c);
            result.push_back(a);
+           callback(a);
            return result;
         }
-        
-        
-        
-        std::vector<MCInst> processorNameValueMCInstExpander::RV3264I_BLTZ_expand(const MCInst& instruction) const
+                
+                
+                
+        std::vector<MCInst> processorNameValueMCInstExpander::RV3264I_BLTZ_expand(const MCInst& instruction, std::function<void(const MCInst &)> callback, std::function<void(MCSymbol* )> callbackSymbol ) const
         {
            std::vector< MCInst > result;
            MCInst a = MCInst();
@@ -624,12 +648,13 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCOperand c = MCOperand::createExpr(processorNameValueMCExpr::create(b, processorNameValueMCExpr::VariantKind::VK_None, Ctx));
            a.addOperand(c);
            result.push_back(a);
+           callback(a);
            return result;
         }
-        
-        
-        
-        std::vector<MCInst> processorNameValueMCInstExpander::RV3264I_BGTZ_expand(const MCInst& instruction) const
+                
+                
+                
+        std::vector<MCInst> processorNameValueMCInstExpander::RV3264I_BGTZ_expand(const MCInst& instruction, std::function<void(const MCInst &)> callback, std::function<void(MCSymbol* )> callbackSymbol ) const
         {
            std::vector< MCInst > result;
            MCInst a = MCInst();
@@ -640,12 +665,13 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCOperand c = MCOperand::createExpr(processorNameValueMCExpr::create(b, processorNameValueMCExpr::VariantKind::VK_None, Ctx));
            a.addOperand(c);
            result.push_back(a);
+           callback(a);
            return result;
         }
-        
-        
-        
-        std::vector<MCInst> processorNameValueMCInstExpander::RV3264I_LA_expand(const MCInst& instruction) const
+                
+                
+                
+        std::vector<MCInst> processorNameValueMCInstExpander::RV3264I_LA_expand(const MCInst& instruction, std::function<void(const MCInst &)> callback, std::function<void(MCSymbol* )> callbackSymbol ) const
         {
            std::vector< MCInst > result;
            MCInst a = MCInst();
@@ -655,6 +681,7 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCOperand c = MCOperand::createExpr(processorNameValueMCExpr::create(b, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264I_hi, Ctx));
            a.addOperand(c);
            result.push_back(a);
+           callback(a);
            MCInst d = MCInst();
            d.setOpcode(processorNameValue::ADDI);
            d.addOperand(instruction.getOperand(0));
@@ -663,12 +690,13 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCOperand f = MCOperand::createExpr(processorNameValueMCExpr::create(e, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264I_lo, Ctx));
            d.addOperand(f);
            result.push_back(d);
+           callback(d);
            return result;
         }
-        
-        
-        
-        std::vector<MCInst> processorNameValueMCInstExpander::RV3264I_LGA_32_expand(const MCInst& instruction) const
+                
+                
+                
+        std::vector<MCInst> processorNameValueMCInstExpander::RV3264I_LGA_32_expand(const MCInst& instruction, std::function<void(const MCInst &)> callback, std::function<void(MCSymbol* )> callbackSymbol ) const
         {
            std::vector< MCInst > result;
            MCInst a = MCInst();
@@ -678,6 +706,7 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCOperand c = MCOperand::createExpr(processorNameValueMCExpr::create(b, processorNameValueMCExpr::VariantKind::VK_GOT_RV3264I_got_hi, Ctx));
            a.addOperand(c);
            result.push_back(a);
+           callback(a);
            MCInst d = MCInst();
            d.setOpcode(processorNameValue::LW);
            d.addOperand(instruction.getOperand(0));
@@ -686,12 +715,13 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCOperand f = MCOperand::createExpr(processorNameValueMCExpr::create(e, processorNameValueMCExpr::VariantKind::VK_PCREL_RV3264I_pcrel_lo, Ctx));
            d.addOperand(f);
            result.push_back(d);
+           callback(d);
            return result;
         }
-        
-        
-        
-        std::vector<MCInst> processorNameValueMCInstExpander::RV3264I_LLA_expand(const MCInst& instruction) const
+                
+                
+                
+        std::vector<MCInst> processorNameValueMCInstExpander::RV3264I_LLA_expand(const MCInst& instruction, std::function<void(const MCInst &)> callback, std::function<void(MCSymbol* )> callbackSymbol ) const
         {
            std::vector< MCInst > result;
            MCInst a = MCInst();
@@ -701,6 +731,7 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCOperand c = MCOperand::createExpr(processorNameValueMCExpr::create(b, processorNameValueMCExpr::VariantKind::VK_PCREL_RV3264I_pcrel_hi, Ctx));
            a.addOperand(c);
            result.push_back(a);
+           callback(a);
            MCInst d = MCInst();
            d.setOpcode(processorNameValue::ADDI);
            d.addOperand(instruction.getOperand(0));
@@ -709,12 +740,13 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCOperand f = MCOperand::createExpr(processorNameValueMCExpr::create(e, processorNameValueMCExpr::VariantKind::VK_PCREL_RV3264I_pcrel_lo, Ctx));
            d.addOperand(f);
            result.push_back(d);
+           callback(d);
            return result;
         }
-        
-        
-        
-        std::vector<MCInst> processorNameValueMCInstExpander::RV3264I_LI_expand(const MCInst& instruction) const
+                
+                
+                
+        std::vector<MCInst> processorNameValueMCInstExpander::RV3264I_LI_expand(const MCInst& instruction, std::function<void(const MCInst &)> callback, std::function<void(MCSymbol* )> callbackSymbol ) const
         {
            std::vector< MCInst > result;
            MCInst a = MCInst();
@@ -724,6 +756,7 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCOperand c = MCOperand::createExpr(processorNameValueMCExpr::create(b, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264I_hi, Ctx));
            a.addOperand(c);
            result.push_back(a);
+           callback(a);
            MCInst d = MCInst();
            d.setOpcode(processorNameValue::ADDI);
            d.addOperand(instruction.getOperand(0));
@@ -732,12 +765,13 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCOperand f = MCOperand::createExpr(processorNameValueMCExpr::create(e, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264I_lo, Ctx));
            d.addOperand(f);
            result.push_back(d);
+           callback(d);
            return result;
         }
-        
-        
-        
-        std::vector<MCInst> processorNameValueMCInstExpander::constMat0_expand(const MCInst& instruction) const
+                
+                
+                
+        std::vector<MCInst> processorNameValueMCInstExpander::constMat0_expand(const MCInst& instruction, std::function<void(const MCInst &)> callback, std::function<void(MCSymbol* )> callbackSymbol ) const
         {
            std::vector< MCInst > result;
            MCInst a = MCInst();
@@ -747,6 +781,7 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCOperand c = MCOperand::createExpr(processorNameValueMCExpr::create(b, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264I_hi, Ctx));
            a.addOperand(c);
            result.push_back(a);
+           callback(a);
            MCInst d = MCInst();
            d.setOpcode(processorNameValue::ADDI);
            d.addOperand(instruction.getOperand(0));
@@ -755,12 +790,13 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCOperand f = MCOperand::createExpr(processorNameValueMCExpr::create(e, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264I_lo, Ctx));
            d.addOperand(f);
            result.push_back(d);
+           callback(d);
            return result;
         }
-        
-        
-        
-        std::vector<MCInst> processorNameValueMCInstExpander::constMat1_expand(const MCInst& instruction) const
+                
+                
+                
+        std::vector<MCInst> processorNameValueMCInstExpander::constMat1_expand(const MCInst& instruction, std::function<void(const MCInst &)> callback, std::function<void(MCSymbol* )> callbackSymbol ) const
         {
            std::vector< MCInst > result;
            MCInst a = MCInst();
@@ -770,6 +806,7 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCOperand c = MCOperand::createExpr(processorNameValueMCExpr::create(b, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264I_hi, Ctx));
            a.addOperand(c);
            result.push_back(a);
+           callback(a);
            MCInst d = MCInst();
            d.setOpcode(processorNameValue::ADDI);
            d.addOperand(instruction.getOperand(0));
@@ -778,12 +815,13 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCOperand f = MCOperand::createExpr(processorNameValueMCExpr::create(e, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264I_lo, Ctx));
            d.addOperand(f);
            result.push_back(d);
+           callback(d);
            return result;
         }
-        
-        
-        
-        std::vector<MCInst> processorNameValueMCInstExpander::constMat2_expand(const MCInst& instruction) const
+                
+                
+                
+        std::vector<MCInst> processorNameValueMCInstExpander::constMat2_expand(const MCInst& instruction, std::function<void(const MCInst &)> callback, std::function<void(MCSymbol* )> callbackSymbol ) const
         {
            std::vector< MCInst > result;
            MCInst a = MCInst();
@@ -793,6 +831,7 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCOperand c = MCOperand::createExpr(processorNameValueMCExpr::create(b, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264I_to32AndHi, Ctx));
            a.addOperand(c);
            result.push_back(a);
+           callback(a);
            MCInst d = MCInst();
            d.setOpcode(processorNameValue::ADDI);
            d.addOperand(instruction.getOperand(0));
@@ -801,12 +840,14 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCOperand f = MCOperand::createExpr(processorNameValueMCExpr::create(e, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264I_to32AndLo, Ctx));
            d.addOperand(f);
            result.push_back(d);
+           callback(d);
            MCInst g = MCInst();
            g.setOpcode(processorNameValue::SLLI);
            g.addOperand(instruction.getOperand(0));
            g.addOperand(instruction.getOperand(0));
            g.addOperand(MCOperand::createImm(RV3264I_Ftype_shamt_decode(16)));
            result.push_back(g);
+           callback(g);
            MCInst h = MCInst();
            h.setOpcode(processorNameValue::ORI);
            h.addOperand(instruction.getOperand(0));
@@ -815,12 +856,14 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCOperand j = MCOperand::createExpr(processorNameValueMCExpr::create(i, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264I_lowerHalfHi, Ctx));
            h.addOperand(j);
            result.push_back(h);
+           callback(h);
            MCInst k = MCInst();
            k.setOpcode(processorNameValue::SLLI);
            k.addOperand(instruction.getOperand(0));
            k.addOperand(instruction.getOperand(0));
            k.addOperand(MCOperand::createImm(RV3264I_Ftype_shamt_decode(16)));
            result.push_back(k);
+           callback(k);
            MCInst l = MCInst();
            l.setOpcode(processorNameValue::ORI);
            l.addOperand(instruction.getOperand(0));
@@ -829,12 +872,13 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCOperand n = MCOperand::createExpr(processorNameValueMCExpr::create(m, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264I_lowerHalfLo, Ctx));
            l.addOperand(n);
            result.push_back(l);
+           callback(l);
            return result;
         }
-        
-        
-        
-        std::vector<MCInst> processorNameValueMCInstExpander::constMat3_expand(const MCInst& instruction) const
+                
+                
+                
+        std::vector<MCInst> processorNameValueMCInstExpander::constMat3_expand(const MCInst& instruction, std::function<void(const MCInst &)> callback, std::function<void(MCSymbol* )> callbackSymbol ) const
         {
            std::vector< MCInst > result;
            MCInst a = MCInst();
@@ -844,6 +888,7 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCOperand c = MCOperand::createExpr(processorNameValueMCExpr::create(b, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264I_to32AndHi, Ctx));
            a.addOperand(c);
            result.push_back(a);
+           callback(a);
            MCInst d = MCInst();
            d.setOpcode(processorNameValue::ADDI);
            d.addOperand(instruction.getOperand(0));
@@ -852,12 +897,14 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCOperand f = MCOperand::createExpr(processorNameValueMCExpr::create(e, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264I_to32AndLo, Ctx));
            d.addOperand(f);
            result.push_back(d);
+           callback(d);
            MCInst g = MCInst();
            g.setOpcode(processorNameValue::SLLI);
            g.addOperand(instruction.getOperand(0));
            g.addOperand(instruction.getOperand(0));
            g.addOperand(MCOperand::createImm(RV3264I_Ftype_shamt_decode(16)));
            result.push_back(g);
+           callback(g);
            MCInst h = MCInst();
            h.setOpcode(processorNameValue::ORI);
            h.addOperand(instruction.getOperand(0));
@@ -866,12 +913,14 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCOperand j = MCOperand::createExpr(processorNameValueMCExpr::create(i, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264I_lowerHalfHi, Ctx));
            h.addOperand(j);
            result.push_back(h);
+           callback(h);
            MCInst k = MCInst();
            k.setOpcode(processorNameValue::SLLI);
            k.addOperand(instruction.getOperand(0));
            k.addOperand(instruction.getOperand(0));
            k.addOperand(MCOperand::createImm(RV3264I_Ftype_shamt_decode(16)));
            result.push_back(k);
+           callback(k);
            MCInst l = MCInst();
            l.setOpcode(processorNameValue::ORI);
            l.addOperand(instruction.getOperand(0));
@@ -880,12 +929,13 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCOperand n = MCOperand::createExpr(processorNameValueMCExpr::create(m, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264I_lowerHalfLo, Ctx));
            l.addOperand(n);
            result.push_back(l);
+           callback(l);
            return result;
         }
-        
-        
-        
-        std::vector<MCInst> processorNameValueMCInstExpander::constMat4_expand(const MCInst& instruction) const
+                
+                
+                
+        std::vector<MCInst> processorNameValueMCInstExpander::constMat4_expand(const MCInst& instruction, std::function<void(const MCInst &)> callback, std::function<void(MCSymbol* )> callbackSymbol ) const
         {
            std::vector< MCInst > result;
            MCInst a = MCInst();
@@ -896,12 +946,13 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCOperand c = MCOperand::createExpr(processorNameValueMCExpr::create(b, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264I_Itype_immS, Ctx));
            a.addOperand(c);
            result.push_back(a);
+           callback(a);
            return result;
         }
-        
-        
-        
-        std::vector<MCInst> processorNameValueMCInstExpander::registerAdjustment0_expand(const MCInst& instruction) const
+                
+                
+                
+        std::vector<MCInst> processorNameValueMCInstExpander::registerAdjustment0_expand(const MCInst& instruction, std::function<void(const MCInst &)> callback, std::function<void(MCSymbol* )> callbackSymbol ) const
         {
            std::vector< MCInst > result;
            MCInst a = MCInst();
@@ -912,6 +963,7 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCOperand c = MCOperand::createExpr(processorNameValueMCExpr::create(b, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264I_Itype_immS, Ctx));
            a.addOperand(c);
            result.push_back(a);
+           callback(a);
            return result;
         }
         """.trim().lines(), output);


### PR DESCRIPTION
This PR is temporary fix to hardcode the generation of label which is required in #148. This pass has to be deleted as soon as the parser can generate it automatically.