### PR TITLE
chore: Refactor WithSourceLocation to WithLocation

### DIFF
--- a/vadl/main/vadl/ast/Ast.java
+++ b/vadl/main/vadl/ast/Ast.java
@@ -23,7 +23,7 @@ import java.util.Objects;
 import javax.annotation.Nullable;
 import vadl.types.Type;
 import vadl.utils.SourceLocation;
-import vadl.utils.WithSourceLocation;
+import vadl.utils.WithLocation;
 
 /**
  * The abstract syntax tree for the vadl language.
@@ -101,7 +101,7 @@ public class Ast {
   }
 }
 
-abstract class Node implements WithSourceLocation {
+abstract class Node implements WithLocation {
   @Nullable
   SymbolTable symbolTable;
 
@@ -123,12 +123,6 @@ abstract class Node implements WithSourceLocation {
         || n instanceof Statement || n instanceof Definition;
   }
 
-  abstract SourceLocation location();
-
-  @Override
-  public final SourceLocation sourceLocation() {
-    return location();
-  }
 
   abstract SyntaxType syntaxType();
 
@@ -172,7 +166,7 @@ final class BinOp extends Node implements IsBinOp {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return location;
   }
 
@@ -220,7 +214,7 @@ final class UnOp extends Node implements IsUnOp {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return location;
   }
 
@@ -269,7 +263,7 @@ class RecordInstance extends Node {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return sourceLocation;
   }
 
@@ -305,7 +299,7 @@ class MacroReference extends Node {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return sourceLocation;
   }
 

--- a/vadl/main/vadl/ast/BehaviorLowering.java
+++ b/vadl/main/vadl/ast/BehaviorLowering.java
@@ -36,7 +36,7 @@ import vadl.types.Type;
 import vadl.types.UIntType;
 import vadl.utils.Either;
 import vadl.utils.Pair;
-import vadl.utils.WithSourceLocation;
+import vadl.utils.WithLocation;
 import vadl.viam.ArtificialResource;
 import vadl.viam.Constant;
 import vadl.viam.Counter;
@@ -119,9 +119,9 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
     currentGraph = graph;
 
     ControlNode endNode = graph.addWithInputs(new ReturnNode(exprNode));
-    endNode.setSourceLocation(expr.sourceLocation());
+    endNode.setSourceLocation(expr.location());
     ControlNode startNode = graph.add(new StartNode(endNode));
-    startNode.setSourceLocation(expr.sourceLocation());
+    startNode.setSourceLocation(expr.location());
     return graph;
   }
 
@@ -134,7 +134,7 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
     var sideEffects = stmtCtx.sideEffectsOrEmptyList();
 
     var end = graph.addWithInputs(new ProcEndNode(sideEffects));
-    end.setSourceLocation(stmt.sourceLocation());
+    end.setSourceLocation(stmt.location());
 
     ControlNode startSuccessor = end;
     if (stmtCtx.hasControlBlock()) {
@@ -143,7 +143,7 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
       startSuccessor = controlBlock.firstNode();
     }
     var start = new StartNode(startSuccessor);
-    start.setSourceLocation(stmt.sourceLocation());
+    start.setSourceLocation(stmt.location());
     graph.addWithInputs(start);
 
     return graph;
@@ -151,14 +151,14 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
 
   Graph getInstructionGraph(InstructionDefinition definition) {
     var graph = new Graph("%s Behavior".formatted(definition.identifier().name));
-    graph.setSourceLocation(definition.sourceLocation());
+    graph.setSourceLocation(definition.location());
     currentGraph = graph;
 
     var stmtCtx = definition.behavior.accept(this);
     var sideEffects = stmtCtx.sideEffectsOrEmptyList();
 
     var end = graph.addWithInputs(new InstrEndNode(sideEffects));
-    end.setSourceLocation(definition.sourceLocation());
+    end.setSourceLocation(definition.location());
 
     ControlNode startSuccessor = end;
     if (stmtCtx.hasControlBlock()) {
@@ -167,7 +167,7 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
       startSuccessor = controlBlock.firstNode();
     }
     var start = new StartNode(startSuccessor);
-    start.setSourceLocation(definition.sourceLocation());
+    start.setSourceLocation(definition.location());
     graph.addWithInputs(start);
 
     return graph;
@@ -180,7 +180,7 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
     currentGraph = graph;
 
     var end = graph.addWithInputs(new InstrEndNode(new NodeList<>()));
-    end.setSourceLocation(definition.sourceLocation());
+    end.setSourceLocation(definition.location());
 
     var calls = definition.statements.stream()
         .map(s -> (InstrCallNode) Objects.requireNonNull(s.accept(this).controlBlock()).firstNode())
@@ -194,7 +194,7 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
     }
 
     var start = new StartNode(curr);
-    start.setSourceLocation(definition.sourceLocation());
+    start.setSourceLocation(definition.location());
     graph.addWithInputs(start);
 
     return graph;
@@ -202,7 +202,7 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
 
   Function getRegisterFileAliasReadFunc(AliasDefinition definition) {
     var graph = new Graph("%s Read Behavior".formatted(definition.viamId));
-    graph.setSourceLocation(definition.sourceLocation());
+    graph.setSourceLocation(definition.location());
     currentGraph = graph;
 
     var identifier = viamLowering.generateIdentifier(definition.viamId, definition.loc);
@@ -213,7 +213,7 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
     var param = new vadl.viam.Parameter(
         viamLowering.generateIdentifier(
             identifier.name() + "::readFunc::index",
-            identifier.sourceLocation()),
+            identifier.location()),
         type.argTypes().get(0));
 
     // FIXME: Wrap input and output in casts
@@ -232,7 +232,7 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
     // FIXME: Modify based on annotations
     return new Function(
         viamLowering.generateIdentifier(identifier.name() + "::readFunc",
-            identifier.sourceLocation()),
+            identifier.location()),
         new vadl.viam.Parameter[] {param},
         type.resultType(),
         graph
@@ -241,7 +241,7 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
 
   Procedure getRegisterFileAliasWriteProc(AliasDefinition definition) {
     var graph = new Graph("%s Write Procedure".formatted(definition.viamId));
-    graph.setSourceLocation(definition.sourceLocation());
+    graph.setSourceLocation(definition.location());
     currentGraph = graph;
 
     var identifier = viamLowering.generateIdentifier(definition.viamId, definition.loc);
@@ -252,13 +252,13 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
     var indexParam = new vadl.viam.Parameter(
         viamLowering.generateIdentifier(
             identifier.name() + "::writeProc::index",
-            identifier.sourceLocation()),
+            identifier.location()),
         type.argTypes().get(0));
 
     var valueParam = new vadl.viam.Parameter(
         viamLowering.generateIdentifier(
             identifier.name() + "::writeProc::value",
-            identifier.sourceLocation()),
+            identifier.location()),
         type.resultType());
 
 
@@ -279,7 +279,7 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
     // FIXME: Modify based on annotations
     return new Procedure(
         viamLowering.generateIdentifier(identifier.name() + "::readFunc",
-            identifier.sourceLocation()),
+            identifier.location()),
         new vadl.viam.Parameter[] {indexParam, valueParam},
         graph
     );
@@ -295,7 +295,7 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
 
 
   private Pair<BeginNode, BranchEndNode> buildBranch(SubgraphContext branchCtx,
-                                                     WithSourceLocation locatable) {
+                                                     WithLocation locatable) {
     var endNode = addToGraph(new BranchEndNode(branchCtx.sideEffectsOrEmptyList()));
 
     BeginNode beginNode;
@@ -307,8 +307,8 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
     }
     beginNode = addToGraph(beginNode);
 
-    endNode.setSourceLocation(locatable.sourceLocation());
-    beginNode.setSourceLocation(locatable.sourceLocation());
+    endNode.setSourceLocation(locatable.location());
+    beginNode.setSourceLocation(locatable.location());
     return new Pair<>(beginNode, endNode);
   }
 
@@ -325,7 +325,7 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
 
   private static BuiltInCall produceNeqToZero(ExpressionNode node) {
     var constNode = new ConstantNode(Constant.Value.of(0, (DataType) node.type()));
-    constNode.setSourceLocation(node.sourceLocation());
+    constNode.setSourceLocation(node.location());
     return BuiltInCall.of(BuiltInTable.NEQ, node, constNode);
   }
 
@@ -336,7 +336,7 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
     }
 
     var result = expr.accept(this);
-    result.setSourceLocationIfNotSet(expr.sourceLocation());
+    result.setSourceLocationIfNotSet(expr.location());
     expressionCache.put(expr, result);
     return result;
   }
@@ -439,7 +439,7 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
       if (letStatement.identifiers.size() > 1) {
         expression = new TupleGetFieldNode(index, expression, letStatement.getTypeOf(innerName));
       }
-      return new LetNode(new LetNode.Name(innerName, letStatement.sourceLocation()), expression);
+      return new LetNode(new LetNode.Name(innerName, letStatement.location()), expression);
     }
     if (computedTarget instanceof LetExpr letExpr) {
       var expression = fetch(letExpr.valueExpr);
@@ -447,7 +447,7 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
       if (letExpr.identifiers.size() > 1) {
         expression = new TupleGetFieldNode(index, expression, letExpr.getTypeOf(innerName));
       }
-      return new LetNode(new LetNode.Name(innerName, letExpr.sourceLocation()), expression);
+      return new LetNode(new LetNode.Name(innerName, letExpr.location()), expression);
     }
 
     // Parameter of a function
@@ -947,7 +947,7 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
             value,
             null,
             null);
-        write.setSourceLocation(statement.sourceLocation());
+        write.setSourceLocation(statement.location());
         write = Objects.requireNonNull(currentGraph).addWithInputs(write);
         return SubgraphContext.of(statement, write);
       }
@@ -1235,7 +1235,7 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
     }
 
     var raise = new ProcCallNode(exception, args);
-    raise.setSourceLocation(statement.sourceLocation());
+    raise.setSourceLocation(statement.location());
     return SubgraphContext.of(statement, raise);
   }
 
@@ -1291,7 +1291,7 @@ class SubgraphContext {
           if (blockStart != null && blockStart != node) {
             throw new IllegalStateException(
                 "tried to add %s, but blockStart already set: %s @%s".formatted(node, blockStart,
-                    root.sourceLocation()));
+                    root.location()));
           }
           blockStart = controlNode;
         }
@@ -1301,7 +1301,7 @@ class SubgraphContext {
           if (blockEnd != null && directionalNode.successors().count() == 0) {
             throw new IllegalStateException(
                 "tried to add %s, but blockEnd already set: %s @%s".formatted(node, blockEnd,
-                    root.sourceLocation()));
+                    root.location()));
           }
           blockEnd = directionalNode;
         }
@@ -1317,7 +1317,7 @@ class SubgraphContext {
 
     if ((blockStart == null) != (blockEnd == null)) {
       throw new IllegalStateException(
-          "blockStart and blockEnd must be both set or not set @ " + root.sourceLocation());
+          "blockStart and blockEnd must be both set or not set @ " + root.location());
     }
     if (blockStart != null) {
       ctx.controlBlock = new ControlBlock(blockStart, blockEnd);
@@ -1363,7 +1363,7 @@ class SubgraphContext {
     if (hasControlBlock()) {
       throw new IllegalStateException(
           "expected control block to be null but was " + controlBlock + " @ "
-              + root.sourceLocation());
+              + root.location());
     }
     return this;
   }
@@ -1371,7 +1371,7 @@ class SubgraphContext {
   SubgraphContext ensureNoSideEffects() {
     if (sideEffects != null) {
       throw new IllegalStateException(
-          "expected sideEffects to be null but was " + sideEffects + " @ " + root.sourceLocation());
+          "expected sideEffects to be null but was " + sideEffects + " @ " + root.location());
     }
     return this;
   }
@@ -1380,7 +1380,7 @@ class SubgraphContext {
     if (sideEffects == null || sideEffects.isEmpty()) {
       throw new IllegalStateException(
           "expected sideEffects to exist, but it was " + sideEffects + " @ "
-              + root.sourceLocation());
+              + root.location());
     }
     return this;
   }

--- a/vadl/main/vadl/ast/ConstantEvaluator.java
+++ b/vadl/main/vadl/ast/ConstantEvaluator.java
@@ -33,7 +33,7 @@ import vadl.types.DataType;
 import vadl.types.StringType;
 import vadl.types.Type;
 import vadl.utils.SourceLocation;
-import vadl.utils.WithSourceLocation;
+import vadl.utils.WithLocation;
 import vadl.viam.Constant;
 
 
@@ -464,8 +464,8 @@ class EvaluationError extends RuntimeException {
 
   SourceLocation location;
 
-  public EvaluationError(String message, WithSourceLocation location) {
+  public EvaluationError(String message, WithLocation location) {
     super(message);
-    this.location = location.sourceLocation();
+    this.location = location.location();
   }
 }

--- a/vadl/main/vadl/ast/Definition.java
+++ b/vadl/main/vadl/ast/Definition.java
@@ -33,7 +33,6 @@ import vadl.types.DataType;
 import vadl.types.Type;
 import vadl.types.asmTypes.AsmType;
 import vadl.utils.SourceLocation;
-import vadl.utils.WithSourceLocation;
 import vadl.viam.PseudoInstruction;
 import vadl.viam.asm.AsmToken;
 
@@ -196,7 +195,7 @@ class Parameter extends Definition implements IdentifiableNode, TypedNode {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return name.location().join(typeLiteral.location());
   }
 
@@ -284,7 +283,7 @@ class ConstantDefinition extends Definition implements IdentifiableNode, TypedNo
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -381,7 +380,7 @@ class RangeFormatField extends FormatField {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return identifier.location().join(ranges.get(ranges.size() - 1).location());
   }
 
@@ -454,7 +453,7 @@ class TypedFormatField extends FormatField {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return identifier().location().join(typeLiteral.location());
   }
 
@@ -544,7 +543,7 @@ class DerivedFormatField extends FormatField {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return identifier.location().join(expr.location());
   }
 
@@ -636,7 +635,7 @@ class FormatDefinition extends Definition implements IdentifiableNode, TypedNode
     }
 
     @Override
-    SourceLocation location() {
+    public SourceLocation location() {
       return entries.get(0).id.location().join(entries.get(entries.size() - 1).expr.location());
     }
 
@@ -793,7 +792,7 @@ class FormatDefinition extends Definition implements IdentifiableNode, TypedNode
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -900,7 +899,7 @@ class InstructionSetDefinition extends Definition implements IdentifiableNode {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -996,7 +995,7 @@ class CounterDefinition extends Definition implements IdentifiableNode, TypedNod
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -1077,7 +1076,7 @@ class MemoryDefinition extends Definition implements IdentifiableNode, TypedNode
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -1157,7 +1156,7 @@ class RegisterDefinition extends Definition implements IdentifiableNode, TypedNo
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -1233,7 +1232,7 @@ class RegisterFileDefinition extends Definition implements IdentifiableNode, Typ
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -1326,7 +1325,7 @@ class RegisterFileDefinition extends Definition implements IdentifiableNode, Typ
 
 
     @Override
-    SourceLocation location() {
+    public SourceLocation location() {
       return argTypes.get(0).location().join(resultType.location());
     }
 
@@ -1386,7 +1385,7 @@ class InstructionDefinition extends Definition implements IdentifiableNode {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -1459,7 +1458,7 @@ abstract class InstructionSequenceDefinition extends Definition {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 }
@@ -1588,7 +1587,7 @@ class RelocationDefinition extends Definition implements IdentifiableNode, Typed
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -1658,7 +1657,7 @@ class RelocationDefinition extends Definition implements IdentifiableNode, Typed
 
 sealed interface IsEncs permits EncodingDefinition.EncsNode,
     EncodingDefinition.EncodingField, PlaceholderNode, MacroInstanceNode, MacroMatchNode {
-  SourceLocation location();
+  public SourceLocation location();
 
   void prettyPrint(int indent, StringBuilder builder);
 }
@@ -1685,7 +1684,7 @@ class EncodingDefinition extends Definition {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -1860,7 +1859,7 @@ class AssemblyDefinition extends Definition {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -1936,7 +1935,7 @@ class UsingDefinition extends Definition implements IdentifiableNode {
 
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -2014,7 +2013,7 @@ class FunctionDefinition extends Definition implements IdentifiableNode, TypedNo
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -2125,7 +2124,7 @@ class AliasDefinition extends Definition implements IdentifiableNode, TypedNode 
 
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -2234,7 +2233,7 @@ final class EnumerationDefinition extends Definition implements IdentifiableNode
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -2300,7 +2299,7 @@ final class EnumerationDefinition extends Definition implements IdentifiableNode
     return result;
   }
 
-  static class Entry extends Node implements WithSourceLocation {
+  static class Entry extends Node {
 
     @Child
     Identifier name;
@@ -2315,10 +2314,10 @@ final class EnumerationDefinition extends Definition implements IdentifiableNode
     }
 
     @Override
-    SourceLocation location() {
-      var loc = name.sourceLocation();
+    public SourceLocation location() {
+      var loc = name.location();
       if (value != null) {
-        loc = loc.join(value.sourceLocation());
+        loc = loc.join(value.location());
       }
       return loc;
     }
@@ -2380,7 +2379,7 @@ final class ExceptionDefinition extends Definition implements IdentifiableNode {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -2452,7 +2451,7 @@ final class PlaceholderDefinition extends Definition {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -2491,7 +2490,7 @@ final class MacroInstanceDefinition extends Definition implements IsMacroInstanc
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -2628,7 +2627,7 @@ class ImportDefinition extends Definition {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -2781,7 +2780,7 @@ class DefinitionList extends Definition {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return location;
   }
 
@@ -2861,7 +2860,7 @@ final class ModelDefinition extends Definition implements IdentifiableNode {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -2933,7 +2932,7 @@ final class RecordTypeDefinition extends Definition implements IdentifiableNode 
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -2998,7 +2997,7 @@ final class ModelTypeDefinition extends Definition implements IdentifiableNode {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -3060,7 +3059,7 @@ class TemplateParam extends Node implements IdentifiableNode {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     if (value != null) {
       return name.location().join(value.location());
     }
@@ -3133,7 +3132,7 @@ class ProcessDefinition extends Definition implements IdentifiableNode {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -3212,7 +3211,7 @@ class OperationDefinition extends Definition implements IdentifiableNode {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -3296,7 +3295,7 @@ class GroupDefinition extends Definition implements IdentifiableNode {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -3369,7 +3368,7 @@ class ApplicationBinaryInterfaceDefinition extends Definition implements Identif
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -3440,7 +3439,7 @@ class AbiPseudoInstructionDefinition extends Definition {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -3527,7 +3526,7 @@ class AbiSequenceDefinition extends InstructionSequenceDefinition {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -3601,7 +3600,7 @@ class SpecialPurposeRegisterDefinition extends Definition {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -3730,7 +3729,7 @@ class MicroProcessorDefinition extends Definition implements IdentifiableNode {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -3837,7 +3836,7 @@ class PatchDefinition extends Definition {
 
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -3907,7 +3906,7 @@ class SourceDefinition extends Definition implements IdentifiableNode {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -3971,7 +3970,7 @@ class CpuFunctionDefinition extends Definition implements IdentifiableNode {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -4055,7 +4054,7 @@ class CpuProcessDefinition extends Definition {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -4132,7 +4131,7 @@ class MicroArchitectureDefinition extends Definition implements IdentifiableNode
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -4202,7 +4201,7 @@ class MacroInstructionDefinition extends Definition {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -4282,7 +4281,7 @@ class PortBehaviorDefinition extends Definition implements IdentifiableNode {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -4362,7 +4361,7 @@ class PipelineDefinition extends Definition implements IdentifiableNode {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -4432,7 +4431,7 @@ class StageDefinition extends Definition implements IdentifiableNode {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -4500,7 +4499,7 @@ class CacheDefinition extends Definition implements IdentifiableNode {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -4562,7 +4561,7 @@ class LogicDefinition extends Definition implements IdentifiableNode {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -4621,7 +4620,7 @@ class SignalDefinition extends Definition implements IdentifiableNode {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -4706,7 +4705,7 @@ class AsmDescriptionDefinition extends Definition implements IdentifiableNode {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -4825,7 +4824,7 @@ class AsmModifierDefinition extends Definition {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -4888,7 +4887,7 @@ class AsmDirectiveDefinition extends Definition {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -4976,7 +4975,7 @@ class AsmGrammarRuleDefinition extends Definition implements IdentifiableNode {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -5068,7 +5067,7 @@ class AsmGrammarAlternativesDefinition extends Definition {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -5212,7 +5211,7 @@ class AsmGrammarElementDefinition extends Definition {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -5320,7 +5319,7 @@ class AsmGrammarLocalVarDefinition extends Definition implements IdentifiableNod
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -5409,7 +5408,7 @@ class AsmGrammarLiteralDefinition extends Definition {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -5480,7 +5479,7 @@ class AsmGrammarTypeDefinition extends Definition {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 

--- a/vadl/main/vadl/ast/Expr.java
+++ b/vadl/main/vadl/ast/Expr.java
@@ -32,6 +32,7 @@ import vadl.types.TupleType;
 import vadl.types.Type;
 import vadl.types.UIntType;
 import vadl.utils.SourceLocation;
+import vadl.utils.WithLocation;
 
 /**
  * The Expression node of the AST.
@@ -365,7 +366,7 @@ class BinaryExpr extends Expr {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return left.location().join(right.location());
   }
 
@@ -440,7 +441,7 @@ class UnaryExpr extends Expr {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return operand.location().join(operand.location());
   }
 
@@ -508,7 +509,7 @@ class IntegerLiteral extends Expr {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -580,7 +581,7 @@ class BinaryLiteral extends Expr {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -635,7 +636,7 @@ class BoolLiteral extends Expr {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -707,7 +708,7 @@ class StringLiteral extends Expr {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -1098,7 +1099,7 @@ class GroupedExpr extends Expr {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -1152,7 +1153,7 @@ class RangeExpr extends Expr {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return from.location().join(to.location());
   }
 
@@ -1271,7 +1272,7 @@ final class TypeLiteral extends Expr {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -1325,13 +1326,11 @@ final class TypeLiteral extends Expr {
   }
 }
 
-sealed interface IsCallExpr permits CallIndexExpr, IsSymExpr {
+sealed interface IsCallExpr extends WithLocation permits CallIndexExpr, IsSymExpr {
   IsId path();
 
   @Nullable
   Expr size();
-
-  SourceLocation location();
 
   void prettyPrint(int indent, StringBuilder builder);
 }
@@ -1774,7 +1773,7 @@ class IfExpr extends Expr {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return location;
   }
 
@@ -1873,7 +1872,7 @@ class LetExpr extends Expr {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return location;
   }
 
@@ -1954,7 +1953,7 @@ class CastExpr extends Expr {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return location;
   }
 
@@ -2024,7 +2023,7 @@ class MatchExpr extends Expr {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -2135,7 +2134,7 @@ class ExistsInExpr extends Expr {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -2194,7 +2193,7 @@ class ExistsInThenExpr extends Expr {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -2275,7 +2274,7 @@ class ForallThenExpr extends Expr {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -2344,7 +2343,7 @@ class ForallThenExpr extends Expr {
     }
 
     @Override
-    SourceLocation location() {
+    public SourceLocation location() {
       var loc = id.location();
       if (!operations.isEmpty()) {
         loc = loc.join(operations.get(operations.size() - 1).location());
@@ -2410,7 +2409,7 @@ class ForallExpr extends Expr {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -2488,7 +2487,7 @@ class ForallExpr extends Expr {
     }
 
     @Override
-    SourceLocation location() {
+    public SourceLocation location() {
       return id.location().join(domain.location());
     }
 
@@ -2554,7 +2553,7 @@ class SequenceCallExpr extends Expr {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 

--- a/vadl/main/vadl/ast/Group.java
+++ b/vadl/main/vadl/ast/Group.java
@@ -36,7 +36,7 @@ sealed interface Group {
     }
 
     @Override
-    SourceLocation location() {
+    public SourceLocation location() {
       return loc;
     }
 
@@ -78,7 +78,8 @@ sealed interface Group {
   final class Literal extends Node implements Group {
 
     IsId id;
-    @Nullable Expr size;
+    @Nullable
+    Expr size;
     SourceLocation loc;
 
     Literal(IsId id, @Nullable Expr size, SourceLocation loc) {
@@ -88,7 +89,7 @@ sealed interface Group {
     }
 
     @Override
-    SourceLocation location() {
+    public SourceLocation location() {
       return loc;
     }
 
@@ -136,7 +137,7 @@ sealed interface Group {
     }
 
     @Override
-    SourceLocation location() {
+    public SourceLocation location() {
       return loc;
     }
 
@@ -188,7 +189,7 @@ sealed interface Group {
     }
 
     @Override
-    SourceLocation location() {
+    public SourceLocation location() {
       return loc;
     }
 

--- a/vadl/main/vadl/ast/Statement.java
+++ b/vadl/main/vadl/ast/Statement.java
@@ -25,7 +25,7 @@ import vadl.javaannotations.ast.Child;
 import vadl.types.TupleType;
 import vadl.types.Type;
 import vadl.utils.SourceLocation;
-import vadl.utils.WithSourceLocation;
+import vadl.utils.WithLocation;
 
 abstract sealed class Statement extends Node
     permits AssignmentStatement, BlockStatement, CallStatement, ForallStatement,
@@ -123,7 +123,7 @@ final class BlockStatement extends Statement {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return location;
   }
 
@@ -202,7 +202,7 @@ final class LetStatement extends Statement {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return location;
   }
 
@@ -265,7 +265,7 @@ final class IfStatement extends Statement {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return location;
   }
 
@@ -319,7 +319,7 @@ final class AssignmentStatement extends Statement {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return target.location().join(valueExpression.location());
   }
 
@@ -368,7 +368,7 @@ final class StatementList extends Statement {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return location;
   }
 
@@ -398,7 +398,7 @@ final class RaiseStatement extends Statement {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return location;
   }
 
@@ -436,7 +436,7 @@ final class CallStatement extends Statement {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return expr.location();
   }
 
@@ -482,7 +482,7 @@ final class PlaceholderStatement extends Statement {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -515,7 +515,7 @@ final class MacroInstanceStatement extends Statement implements IsMacroInstance 
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -625,7 +625,7 @@ final class MatchStatement extends Statement {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -695,7 +695,7 @@ final class MatchStatement extends Statement {
     return result;
   }
 
-  static final class Case implements WithSourceLocation {
+  static final class Case implements WithLocation {
     List<Expr> patterns;
     Statement result;
 
@@ -728,7 +728,7 @@ final class MatchStatement extends Statement {
     }
 
     @Override
-    public SourceLocation sourceLocation() {
+    public SourceLocation location() {
       return patterns.get(0).location().join(result.location());
     }
   }
@@ -765,7 +765,7 @@ final class InstructionCallStatement extends Statement {
 
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -887,7 +887,7 @@ final class LockStatement extends Statement {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -933,7 +933,7 @@ final class ForallStatement extends Statement {
   }
 
   @Override
-  SourceLocation location() {
+  public SourceLocation location() {
     return loc;
   }
 
@@ -985,7 +985,7 @@ final class ForallStatement extends Statement {
     }
 
     @Override
-    SourceLocation location() {
+    public SourceLocation location() {
       return name.location().join(domain.location());
     }
 

--- a/vadl/main/vadl/ast/SymbolTable.java
+++ b/vadl/main/vadl/ast/SymbolTable.java
@@ -546,7 +546,7 @@ class SymbolTable {
           entry.value.accept(this);
         }
       }
-     
+
       afterTravel(definition);
       return null;
     }

--- a/vadl/main/vadl/cppCodeGen/common/AsmParserFunctionCodeGenerator.java
+++ b/vadl/main/vadl/cppCodeGen/common/AsmParserFunctionCodeGenerator.java
@@ -25,7 +25,6 @@ import vadl.types.BuiltInTable;
 import vadl.types.StringType;
 import vadl.viam.Function;
 import vadl.viam.graph.Node;
-import vadl.viam.graph.control.NewLabelNode;
 import vadl.viam.graph.dependency.AsmBuiltInCall;
 import vadl.viam.graph.dependency.ConstantNode;
 import vadl.viam.graph.dependency.FieldAccessRefNode;
@@ -121,7 +120,7 @@ public class AsmParserFunctionCodeGenerator extends FunctionCodeGenerator {
       );
       ctx.wr("})");
     } else {
-      throw Diagnostic.error("Unknown AsmBuiltin.", toHandle.sourceLocation()).build();
+      throw Diagnostic.error("Unknown AsmBuiltin.", toHandle.location()).build();
     }
   }
 }

--- a/vadl/main/vadl/dump/infoEnrichers/ViamEnricherCollection.java
+++ b/vadl/main/vadl/dump/infoEnrichers/ViamEnricherCollection.java
@@ -252,7 +252,7 @@ public class ViamEnricherCollection {
         if (entity.origin() instanceof Function && entity.parentLevel() > 2) {
           return;
         }
-        var sourceLocation = entity.origin().sourceLocation();
+        var sourceLocation = entity.origin().location();
         if (entity.origin() instanceof Instruction) {
           sourceLocation = ((Instruction) entity.origin()).behavior().sourceLocation();
         }
@@ -303,7 +303,7 @@ public class ViamEnricherCollection {
 
         var nodesWithoutSourceLocation = withBehavior.behaviors()
             .stream().flatMap(Graph::getNodes)
-            .filter(n -> n.sourceLocation().equals(SourceLocation.INVALID_SOURCE_LOCATION))
+            .filter(n -> n.location().equals(SourceLocation.INVALID_SOURCE_LOCATION))
             .toList();
 
         if (nodesWithoutSourceLocation.isEmpty()) {

--- a/vadl/main/vadl/error/DiagUtils.java
+++ b/vadl/main/vadl/error/DiagUtils.java
@@ -34,9 +34,9 @@ public class DiagUtils {
    * @param what The plural phrase that prefixes {@code are not allowed here}.
    */
   public static void throwNotAllowed(Node node, String what) {
-    SourceLocation loc = !node.sourceLocation().equals(SourceLocation.INVALID_SOURCE_LOCATION)
-        ? node.sourceLocation()
-        : node.ensureGraph().parentDefinition().sourceLocation();
+    SourceLocation loc = !node.location().equals(SourceLocation.INVALID_SOURCE_LOCATION)
+        ? node.location()
+        : node.ensureGraph().parentDefinition().location();
     throw Diagnostic.error(
             what + " are not allowed in " + Objects.requireNonNull(node.graph()).name, loc)
         .note("THIS IS AN INTERNAL ERROR")

--- a/vadl/main/vadl/error/Diagnostic.java
+++ b/vadl/main/vadl/error/Diagnostic.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.function.Supplier;
 import org.jetbrains.annotations.Contract;
 import vadl.utils.SourceLocation;
-import vadl.utils.WithSourceLocation;
+import vadl.utils.WithLocation;
 
 
 /**
@@ -61,8 +61,8 @@ public class Diagnostic extends RuntimeException {
 
   /**
    * It's generally recommended to not instantiate Diagnostics on their own but to make use of the
-   * {@link Diagnostic#error(String, WithSourceLocation)} and
-   * {@link Diagnostic#warning(String, WithSourceLocation)}
+   * {@link Diagnostic#error(String, WithLocation)} and
+   * {@link Diagnostic#warning(String, WithLocation)}
    * builders.
    */
   public Diagnostic(Level level, String reason, MultiLocation multiLocation,
@@ -81,8 +81,8 @@ public class Diagnostic extends RuntimeException {
    * @param location where the error occurred (primary location).
    * @return the builder.
    */
-  public static DiagnosticBuilder error(String reason, WithSourceLocation location) {
-    return new DiagnosticBuilder(Level.ERROR, reason, location.sourceLocation());
+  public static DiagnosticBuilder error(String reason, WithLocation location) {
+    return new DiagnosticBuilder(Level.ERROR, reason, location.location());
   }
 
 
@@ -94,8 +94,8 @@ public class Diagnostic extends RuntimeException {
    * @param location where the warning occurred (primary location).
    * @return the builder.
    */
-  public static DiagnosticBuilder warning(String reason, WithSourceLocation location) {
-    return new DiagnosticBuilder(Level.WARNING, reason, location.sourceLocation());
+  public static DiagnosticBuilder warning(String reason, WithLocation location) {
+    return new DiagnosticBuilder(Level.WARNING, reason, location.location());
   }
 
   /**

--- a/vadl/main/vadl/error/DiagnosticBuilder.java
+++ b/vadl/main/vadl/error/DiagnosticBuilder.java
@@ -19,7 +19,7 @@ package vadl.error;
 import com.google.errorprone.annotations.FormatMethod;
 import java.util.ArrayList;
 import vadl.utils.SourceLocation;
-import vadl.utils.WithSourceLocation;
+import vadl.utils.WithLocation;
 
 /**
  * An ergonomic builder for a diagnostic.
@@ -61,9 +61,9 @@ public class DiagnosticBuilder extends Throwable {
    * @return the builder itself.
    */
   @FormatMethod
-  public DiagnosticBuilder locationDescription(WithSourceLocation location, String content,
+  public DiagnosticBuilder locationDescription(WithLocation location, String content,
                                                Object... args) {
-    locationLabel(location.sourceLocation(),
+    locationLabel(location.location(),
         new Diagnostic.Message(Diagnostic.MsgType.PLAIN, content.formatted(args)));
     return this;
   }
@@ -77,9 +77,9 @@ public class DiagnosticBuilder extends Throwable {
    * @return the builder itself.
    */
   @FormatMethod
-  public DiagnosticBuilder locationNote(WithSourceLocation location, String content,
+  public DiagnosticBuilder locationNote(WithLocation location, String content,
                                         Object... args) {
-    locationLabel(location.sourceLocation(),
+    locationLabel(location.location(),
         new Diagnostic.Message(Diagnostic.MsgType.NOTE, content.formatted(args)));
     return this;
   }
@@ -93,9 +93,9 @@ public class DiagnosticBuilder extends Throwable {
    * @return the builder itself.
    */
   @FormatMethod
-  public DiagnosticBuilder locationHelp(WithSourceLocation location, String content,
+  public DiagnosticBuilder locationHelp(WithLocation location, String content,
                                         Object... args) {
-    locationLabel(location.sourceLocation(),
+    locationLabel(location.location(),
         new Diagnostic.Message(Diagnostic.MsgType.HELP, content.formatted(args)));
     return this;
   }

--- a/vadl/main/vadl/gcb/passes/GenerateCompilerRegistersPass.java
+++ b/vadl/main/vadl/gcb/passes/GenerateCompilerRegistersPass.java
@@ -101,7 +101,7 @@ public class GenerateCompilerRegistersPass extends Pass {
 
       var alignment = ensureNonNull(abi.registerFileAlignment().get(registerFile),
           () -> Diagnostic.error("There is not alignment for the register file defined",
-              registerFile.sourceLocation().join(abi.sourceLocation())));
+              registerFile.location().join(abi.location())));
 
       result.add(new CompilerRegisterClass(registerFile, registers, alignment));
     }

--- a/vadl/main/vadl/gcb/passes/IdentifyFieldUsagePass.java
+++ b/vadl/main/vadl/gcb/passes/IdentifyFieldUsagePass.java
@@ -191,7 +191,7 @@ public class IdentifyFieldUsagePass extends Pass {
      * then it also returned.
      *
      * @return a list of pairs. The left indicates the field and the right whether it is
-     *         referencing {@link Register} or {@link RegisterFile}.
+     *     referencing {@link Register} or {@link RegisterFile}.
      */
     public List<Pair<Field, Either<Register, RegisterFile>>> fieldsByRegisterUsage(
         Instruction instruction,
@@ -303,7 +303,7 @@ public class IdentifyFieldUsagePass extends Pass {
                 FieldUsage.REGISTER);
           } else {
             throw Diagnostic.error("Register index is not used as write or read.",
-                fieldRefNode.sourceLocation()).build();
+                fieldRefNode.location()).build();
           }
 
           if (registerRead.isPresent()) {

--- a/vadl/main/vadl/gcb/passes/InstructionPatternPruningPass.java
+++ b/vadl/main/vadl/gcb/passes/InstructionPatternPruningPass.java
@@ -90,8 +90,8 @@ public class InstructionPatternPruningPass extends Pass {
                           if (hasTrueCaseHasException && hasFalseCaseHasException) {
                             throw Diagnostic.error(
                                 "Both branches raise an exception and are pruned",
-                                selectNode.trueCase().sourceLocation()
-                                    .join(selectNode.falseCase().sourceLocation())).build();
+                                selectNode.trueCase().location()
+                                    .join(selectNode.falseCase().location())).build();
                           }
 
                           if (hasTrueCaseHasException) {

--- a/vadl/main/vadl/gcb/passes/IsaMachineInstructionMatchingPass.java
+++ b/vadl/main/vadl/gcb/passes/IsaMachineInstructionMatchingPass.java
@@ -159,14 +159,14 @@ public class IsaMachineInstructionMatchingPass extends Pass implements IsaMatchi
 
     ensure(isa.pc() instanceof Counter.RegisterCounter,
         () -> Diagnostic.error("Only counter to single registers are supported.",
-            Objects.requireNonNull(isa.pc()).sourceLocation()));
+            Objects.requireNonNull(isa.pc()).location()));
     var pc = (Counter.RegisterCounter) isa.pc();
 
     isa.ownInstructions().forEach(instruction -> {
       // Get uninlined or the normal behaviors if nothing was uninlined.
       var behavior = ensureNonNull(uninlined.get(instruction),
           () -> Diagnostic.error("Cannot find the uninlined graph of this instruction",
-              instruction.sourceLocation()));
+              instruction.location()));
 
       var ty = getType(behavior);
 
@@ -394,7 +394,7 @@ public class IsaMachineInstructionMatchingPass extends Pass implements IsaMatchi
       ensure(hasAddi,
           () -> Diagnostic.error(
               "There must be an instruction (addition with immediate), but we haven't found any.",
-              viam.sourceLocation()));
+              viam.location()));
     });
   }
 

--- a/vadl/main/vadl/gcb/passes/NormalizeFieldsToFieldAccessFunctionsPass.java
+++ b/vadl/main/vadl/gcb/passes/NormalizeFieldsToFieldAccessFunctionsPass.java
@@ -105,9 +105,9 @@ public class NormalizeFieldsToFieldAccessFunctionsPass extends Pass {
     var id = fieldRefId.append("accessFunction");
     var graph = new Graph(id.lower());
     ControlNode endNode = graph.addWithInputs(new ReturnNode(fieldRefNode.copy()));
-    endNode.setSourceLocation(fieldRefNode.sourceLocation());
+    endNode.setSourceLocation(fieldRefNode.location());
     ControlNode startNode = graph.add(new StartNode(endNode));
-    startNode.setSourceLocation(fieldRefNode.sourceLocation());
+    startNode.setSourceLocation(fieldRefNode.location());
     return new Function(id, new Parameter[] {}, fieldRefNode.type(), graph);
   }
 
@@ -117,9 +117,9 @@ public class NormalizeFieldsToFieldAccessFunctionsPass extends Pass {
     var graph = new Graph(id.lower());
     ControlNode endNode =
         graph.addWithInputs(new ReturnNode(new ConstantNode(Constant.Value.fromBoolean(true))));
-    endNode.setSourceLocation(fieldRefNode.sourceLocation());
+    endNode.setSourceLocation(fieldRefNode.location());
     ControlNode startNode = graph.add(new StartNode(endNode));
-    startNode.setSourceLocation(fieldRefNode.sourceLocation());
+    startNode.setSourceLocation(fieldRefNode.location());
     return new Function(id, new Parameter[] {}, Type.bool(), graph);
   }
 }

--- a/vadl/main/vadl/gcb/passes/relocation/model/Modifier.java
+++ b/vadl/main/vadl/gcb/passes/relocation/model/Modifier.java
@@ -45,7 +45,7 @@ public record Modifier(String value,
 
     // Check the label for the relocation
     var ctx = ensureNonNull(relocation.extension(RelocationCtx.class),
-        () -> Diagnostic.error("Expected a relocation label", relocation.sourceLocation()));
+        () -> Diagnostic.error("Expected a relocation label", relocation.location()));
 
     return new Modifier("MO_" + name, kind, Optional.of(ctx.label()));
   }

--- a/vadl/main/vadl/gcb/passes/typeNormalization/CreateGcbFieldAccessCppFunctionFromDecodeFunctionPass.java
+++ b/vadl/main/vadl/gcb/passes/typeNormalization/CreateGcbFieldAccessCppFunctionFromDecodeFunctionPass.java
@@ -71,7 +71,7 @@ public class CreateGcbFieldAccessCppFunctionFromDecodeFunctionPass extends Pass 
                 () -> Diagnostic.error(
                     "Decoding function must not be null. Maybe it does not exist "
                         + "or was not generated?",
-                    fieldAccess.sourceLocation())
+                    fieldAccess.location())
             )))
         .forEach(pair -> {
           var function = createGcbFieldAccessCppFunction(pair.right(), pair.left());

--- a/vadl/main/vadl/gcb/passes/typeNormalization/CreateGcbFieldAccessCppFunctionFromEncodingFunctionPass.java
+++ b/vadl/main/vadl/gcb/passes/typeNormalization/CreateGcbFieldAccessCppFunctionFromEncodingFunctionPass.java
@@ -53,14 +53,14 @@ public class CreateGcbFieldAccessCppFunctionFromEncodingFunctionPass extends Pas
    * Output of the pass.
    */
   public record Output(Map<Function, GcbCppFunctionForFieldAccess> byFunction,
-                Map<Format.Field, GcbCppFunctionForFieldAccess> byField) {
+                       Map<Format.Field, GcbCppFunctionForFieldAccess> byField) {
 
   }
 
   @Nullable
   @Override
   public Output execute(PassResults passResults,
-                                                          Specification viam) throws IOException {
+                        Specification viam) throws IOException {
     var byFunction = new IdentityHashMap<Function, GcbCppFunctionForFieldAccess>();
     var byField = new IdentityHashMap<Format.Field, GcbCppFunctionForFieldAccess>();
 
@@ -71,7 +71,7 @@ public class CreateGcbFieldAccessCppFunctionFromEncodingFunctionPass extends Pas
             ensureNonNull(fieldAccess.encoding(),
                 () -> Diagnostic.error(
                     "Encoding must not be null. Maybe it does not exist or was not generated?",
-                    fieldAccess.sourceLocation())
+                    fieldAccess.location())
             )))
         .forEach(pair -> {
           var function = createGcbFieldAccessCppFunction(pair.right(), pair.left());

--- a/vadl/main/vadl/gcb/passes/typeNormalization/CreateGcbFieldAccessCppFunctionFromExtractionFunctionPass.java
+++ b/vadl/main/vadl/gcb/passes/typeNormalization/CreateGcbFieldAccessCppFunctionFromExtractionFunctionPass.java
@@ -53,7 +53,7 @@ public class CreateGcbFieldAccessCppFunctionFromExtractionFunctionPass extends P
    * Output of the pass.
    */
   public record Output(Map<Function, GcbCppFunctionForFieldAccess> byFunction,
-                Map<Format.Field, GcbCppFunctionForFieldAccess> byField) {
+                       Map<Format.Field, GcbCppFunctionForFieldAccess> byField) {
 
   }
 
@@ -73,7 +73,7 @@ public class CreateGcbFieldAccessCppFunctionFromExtractionFunctionPass extends P
                 () -> Diagnostic.error(
                     "Extraction function must not be null. Maybe it does not exist or was not "
                         + "generated?",
-                    fieldAccess.sourceLocation())
+                    fieldAccess.location())
             )))
         .forEach(pair -> {
           var function = createGcbFieldAccessCppFunction(pair.right(), pair.left());

--- a/vadl/main/vadl/gcb/passes/typeNormalization/CreateGcbFieldAccessFunctionFromPredicateFunctionPass.java
+++ b/vadl/main/vadl/gcb/passes/typeNormalization/CreateGcbFieldAccessFunctionFromPredicateFunctionPass.java
@@ -51,7 +51,7 @@ public class CreateGcbFieldAccessFunctionFromPredicateFunctionPass extends Pass 
    * Output of the pass.
    */
   public record Output(Map<Function, GcbCppFunctionForFieldAccess> byFunction,
-                Map<Format.Field, GcbCppFunctionForFieldAccess> byField) {
+                       Map<Format.Field, GcbCppFunctionForFieldAccess> byField) {
 
   }
 
@@ -69,7 +69,7 @@ public class CreateGcbFieldAccessFunctionFromPredicateFunctionPass extends Pass 
             ensureNonNull(fieldAccess.predicate(),
                 () -> Diagnostic.error(
                     "Predicate must not be null. Maybe it does not exist or was not generated?",
-                    fieldAccess.sourceLocation())
+                    fieldAccess.location())
             )))
         .forEach(pair -> {
           var function = createGcbFieldAccessCppFunction(pair.right(), pair.left());

--- a/vadl/main/vadl/gcb/valuetypes/IndexedCompilerRegister.java
+++ b/vadl/main/vadl/gcb/valuetypes/IndexedCompilerRegister.java
@@ -77,7 +77,7 @@ public class IndexedCompilerRegister extends CompilerRegister {
           () -> Diagnostic.error(
               String.format("The aliases for a register file's register '%s' are not defined",
                   registerFile.generateName(addr)),
-              registerFile.sourceLocation().join(abi.sourceLocation())));
+              registerFile.location().join(abi.location())));
 
       int dwarfNumber = dwarfNumberOffset + addr;
 

--- a/vadl/main/vadl/iss/codegen/IssTranslateCodeGenerator.java
+++ b/vadl/main/vadl/iss/codegen/IssTranslateCodeGenerator.java
@@ -109,7 +109,7 @@ public class IssTranslateCodeGenerator implements
 
     ensure(current instanceof InstrEndNode, () ->
         error("Instruction contains unsupported features (e.g. if-else on constants).",
-            insn.identifier.sourceLocation())
+            insn.identifier.location())
     );
 
     ctx.wr("\n\treturn true; \n}\n");

--- a/vadl/main/vadl/iss/passes/IssVerificationPass.java
+++ b/vadl/main/vadl/iss/passes/IssVerificationPass.java
@@ -97,10 +97,10 @@ public class IssVerificationPass extends AbstractIssPass {
     var isa = optIsa.get();
     if (isa.pc() == null) {
       diagnostics.add(
-          error("No Program Counter found", isa.identifier.sourceLocation())
-              .locationDescription(isa.sourceLocation(),
+          error("No Program Counter found", isa.identifier.location())
+              .locationDescription(isa.location(),
                   "No `program counter` definition found.")
-              .locationHelp(isa.sourceLocation(), "Add a `program counter` definition.")
+              .locationHelp(isa.location(), "Add a `program counter` definition.")
 
       );
     } else {
@@ -109,8 +109,8 @@ public class IssVerificationPass extends AbstractIssPass {
       if (!(pc instanceof Counter.RegisterCounter)) {
         diagnostics.add(
             error("Only `program counter` definitions supported",
-                pc.sourceLocation())
-                .locationDescription(pc.sourceLocation(),
+                pc.location())
+                .locationDescription(pc.location(),
                     "This is an alias program counter to a register file. "
                         + "However the ISS generator currently only supports register "
                         + "cell program counters.")
@@ -121,9 +121,9 @@ public class IssVerificationPass extends AbstractIssPass {
         var pcReg = ((Counter.RegisterCounter) pc).registerRef();
         if (pcReg.resultType().bitWidth() != 64 && pcReg.resultType().bitWidth() != 32) {
           diagnostics.add(
-              error("Unsupported PC size", pcReg.sourceLocation())
+              error("Unsupported PC size", pcReg.location())
                   .locationDescription(
-                      pcReg.sourceLocation(),
+                      pcReg.location(),
                       "The PC has %s.", pcReg.resultType().bitWidth())
                   .description("We currently only support PCs with a bit-width of 64 or 32.")
                   .note("We have to implement this!")
@@ -206,7 +206,7 @@ public class IssVerificationPass extends AbstractIssPass {
           .findFirst()
           .get()
       ).toList();
-      var location = isa.identifier.sourceLocation();
+      var location = isa.identifier.location();
       var errBuilder = error("Different format sizes", location)
           .locationDescription(location,
               "Found %s different format sizes", formatWidths.size())

--- a/vadl/main/vadl/iss/passes/opDecomposition/IssOpDecompositionPass.java
+++ b/vadl/main/vadl/iss/passes/opDecomposition/IssOpDecompositionPass.java
@@ -271,8 +271,8 @@ class OpDecomposer {
 
 
   private void checkUserSliceOrTruncate(BuiltInCall call, Node user) {
-    var callLoc = call.sourceLocation();
-    var userLoc = user.sourceLocation().orDefault(behavior.sourceLocation());
+    var callLoc = call.location();
+    var userLoc = user.location().orDefault(behavior.sourceLocation());
     if (!(user instanceof SliceNode || user instanceof TruncateNode)) {
       throw Diagnostic.error("Slice or cast required", userLoc)
           .description(

--- a/vadl/main/vadl/iss/template/target/EmitIssTranslateCPass.java
+++ b/vadl/main/vadl/iss/template/target/EmitIssTranslateCPass.java
@@ -96,7 +96,7 @@ public class EmitIssTranslateCPass extends IssTemplateRenderingPass {
           "short", "q",
           "int", 64
       );
-      default -> throw error("Invalid instruction width", refFormat.identifier.sourceLocation())
+      default -> throw error("Invalid instruction width", refFormat.identifier.location())
           .description(
               "The ISS generator requires that every instruction width "
                   + "is one of [8, 16, 32, 64], but found %s",

--- a/vadl/main/vadl/lcb/codegen/assembly/AssemblyInstructionPrinterCodeGeneratorVisitor.java
+++ b/vadl/main/vadl/lcb/codegen/assembly/AssemblyInstructionPrinterCodeGeneratorVisitor.java
@@ -95,7 +95,7 @@ public class AssemblyInstructionPrinterCodeGeneratorVisitor
     if (node.constant() instanceof Constant.Str str) {
       writer.write("std::string " + symbol + " = std::string(\"" + str.value() + "\");\n");
     } else {
-      throw Diagnostic.error("Not supported constant type", node.sourceLocation()).build();
+      throw Diagnostic.error("Not supported constant type", node.location()).build();
     }
   }
 
@@ -131,7 +131,7 @@ public class AssemblyInstructionPrinterCodeGeneratorVisitor
           .or(() -> indexInOutputs(cast.formatField()))
           .orElseThrow(() -> Diagnostic.error(
               "Field is not part of an input or output operand in tablegen",
-              cast.sourceLocation()).build());
+              cast.location()).build());
       var symbol = symbolTable.getNextVariable();
 
       // We need this helper function "getRegisterName..." because
@@ -153,7 +153,7 @@ public class AssemblyInstructionPrinterCodeGeneratorVisitor
       writeImmediateWithRadix(node, 16);
     } else {
       throw Diagnostic.error("Not supported builtin for assembly printing",
-              node.sourceLocation())
+              node.location())
           .build();
     }
   }
@@ -281,13 +281,13 @@ public class AssemblyInstructionPrinterCodeGeneratorVisitor
 
   private void writeImmediateWithRadix(BuiltInCall node, int radix) {
     if (node.arguments().get(0) instanceof FieldRefNode fieldRefNode) {
-      writeImmediateWithRadix(fieldRefNode.formatField(), radix, fieldRefNode.sourceLocation());
+      writeImmediateWithRadix(fieldRefNode.formatField(), radix, fieldRefNode.location());
     } else if (node.arguments().get(0) instanceof FieldAccessRefNode fieldAccessRefNode) {
       writeImmediateWithRadix(fieldAccessRefNode.fieldAccess().fieldRef(), radix,
-          fieldAccessRefNode.sourceLocation());
+          fieldAccessRefNode.location());
     } else {
       throw Diagnostic.error("Not supported argument "
-              + "in assembly printing", node.sourceLocation())
+              + "in assembly printing", node.location())
           .build();
     }
   }
@@ -350,13 +350,13 @@ public class AssemblyInstructionPrinterCodeGeneratorVisitor
           "Field is not used as register. Therefore the compiler generator cannot "
               +
               "detect the register file.",
-          fieldRefNode.sourceLocation()).build();
+          fieldRefNode.location()).build();
     } else if (candidates.size() > 1) {
       throw Diagnostic.error(
           "Field is by multiple register file. Therefore the compiler generator cannot "
               +
               "detect the register file for the assembly.",
-          fieldRefNode.sourceLocation()).build();
+          fieldRefNode.location()).build();
     } else {
       return candidates.iterator().next().registerFile().identifier.simpleName();
     }

--- a/vadl/main/vadl/lcb/codegen/expansion/CompilerInstructionExpansionCodeGenerator.java
+++ b/vadl/main/vadl/lcb/codegen/expansion/CompilerInstructionExpansionCodeGenerator.java
@@ -159,7 +159,7 @@ public class CompilerInstructionExpansionCodeGenerator extends FunctionCodeGener
     ensure(usage.size() == 1, () -> {
       throw Diagnostic.error(
           "Cannot expand pseudo instruction because the usage of the field is unclear",
-          field.sourceLocation()).build();
+          field.location()).build();
     });
 
     switch (usage.get(0)) {
@@ -177,13 +177,13 @@ public class CompilerInstructionExpansionCodeGenerator extends FunctionCodeGener
 
           ensure(variants.size() == 1, () -> Diagnostic.error(
               "There are unexpectedly multiple variant kinds for the pseudo expansion available.",
-              toHandle.sourceLocation()));
+              toHandle.location()));
 
           variant = ensurePresent(
               requireNonNull(variants).stream().filter(VariantKind::isImmediate).findFirst(),
               () -> Diagnostic.error(
                   "Expected a variant for an immediate. But haven't " + "found any",
-                  toHandle.sourceLocation())).value();
+                  toHandle.location())).value();
         }
 
         ctx.ln(
@@ -228,7 +228,7 @@ public class CompilerInstructionExpansionCodeGenerator extends FunctionCodeGener
     ensure(usage.size() == 1, () -> {
       throw Diagnostic.error(
           "Cannot expand pseudo instruction because the usage of the field is unclear",
-          field.sourceLocation()).build();
+          field.location()).build();
     });
 
     switch (usage.get(0)) {
@@ -257,7 +257,7 @@ public class CompilerInstructionExpansionCodeGenerator extends FunctionCodeGener
 
         ensure(registerFiles.size() == 1,
             () -> Diagnostic.error("Found multiple or none register files for this field.",
-                field.sourceLocation()).note(
+                field.location()).note(
                 "The pseudo instruction expansion requires one register file to detect "
                     + "the register file name. In this particular case is the field used by "
                     + "multiple register files or none and we don't know which name to use."));
@@ -270,7 +270,7 @@ public class CompilerInstructionExpansionCodeGenerator extends FunctionCodeGener
             toHandle.constant().asVal().intValue());
       }
       default -> throw Diagnostic.error("Cannot generate cpp code for this argument",
-          field.sourceLocation()).build();
+          field.location()).build();
     }
   }
 
@@ -324,7 +324,7 @@ public class CompilerInstructionExpansionCodeGenerator extends FunctionCodeGener
 
       handleRelocationOperand(ctx, argumentSymbol, relocation);
     } else {
-      throw Diagnostic.error("Cannot handle node", toHandle.sourceLocation()).build();
+      throw Diagnostic.error("Cannot handle node", toHandle.location()).build();
     }
   }
 
@@ -362,10 +362,10 @@ public class CompilerInstructionExpansionCodeGenerator extends FunctionCodeGener
 
     throw Diagnostic.error(
             String.format("Cannot assign field '%s' because the field is not a field.",
-                field.identifier.simpleName()), parameter.sourceLocation())
-        .locationDescription(argument.sourceLocation(), "Trying to match this argument.")
-        .locationDescription(field.sourceLocation(), "Trying to assign this field.")
-        .locationDescription(compilerInstruction.sourceLocation(),
+                field.identifier.simpleName()), parameter.location())
+        .locationDescription(argument.location(), "Trying to match this argument.")
+        .locationDescription(field.location(), "Trying to assign this field.")
+        .locationDescription(compilerInstruction.location(),
             "This pseudo instruction is affected.")
         .help("The parameter '%s' must match any pseudo instruction's parameter names",
             parameter.simpleName()).build();
@@ -435,14 +435,14 @@ public class CompilerInstructionExpansionCodeGenerator extends FunctionCodeGener
         handle(newContext, cn);
       } else if (argument instanceof FuncCallNode fn) {
         ensure(fn.function() instanceof Relocation,
-            () -> Diagnostic.error("Function must be a relocation", fn.sourceLocation()));
+            () -> Diagnostic.error("Function must be a relocation", fn.location()));
         handle(newContext, fn);
       } else if (argument instanceof FuncParamNode fn) {
         handle(newContext, fn);
       } else if (argument instanceof ZeroExtendNode zn) {
         handle(newContext, zn);
       } else {
-        throw Diagnostic.error("Not implemented for this node type.", argument.sourceLocation())
+        throw Diagnostic.error("Not implemented for this node type.", argument.location())
             .build();
       }
     });
@@ -461,14 +461,14 @@ public class CompilerInstructionExpansionCodeGenerator extends FunctionCodeGener
 
     var llvmRecord = ensureNonNull(machineInstructionRecords.get(instruction),
         () -> Diagnostic.error("Cannot find llvmRecord for instruction used in pseudo instruction",
-            instruction.sourceLocation()));
+            instruction.location()));
 
     var order = llvmRecord.info().outputInputOperandsFormatFields();
 
     for (var item : order) {
       var l = ensureNonNull(lookup.get(item),
           () -> Diagnostic.error("Cannot find format's field in pseudo instruction",
-              item.sourceLocation()));
+              item.location()));
       result.add(Pair.of(item, l));
     }
 

--- a/vadl/main/vadl/lcb/passes/isaMatching/database/Database.java
+++ b/vadl/main/vadl/lcb/passes/isaMatching/database/Database.java
@@ -51,11 +51,11 @@ public class Database {
     var labelingResult = ensureNonNull(
         (IsaMachineInstructionMatchingPass.Result) passResults.lastResultOf(
             IsaMachineInstructionMatchingPass.class),
-        () -> Diagnostic.error("Cannot find semantics of the instructions", viam.sourceLocation()));
+        () -> Diagnostic.error("Cannot find semantics of the instructions", viam.location()));
     var labelingPseudoResult = ensureNonNull(
         (IsaPseudoInstructionMatchingPass.Result) passResults.lastResultOf(
             IsaPseudoInstructionMatchingPass.class),
-        () -> Diagnostic.error("Cannot find semantics of the instructions", viam.sourceLocation()));
+        () -> Diagnostic.error("Cannot find semantics of the instructions", viam.location()));
     this.labelledMachineInstructions = labelingResult.labels();
     this.labelledPseudoInstructions = labelingPseudoResult.labels();
   }

--- a/vadl/main/vadl/lcb/passes/llvmLowering/LlvmLoweringPass.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/LlvmLoweringPass.java
@@ -123,7 +123,7 @@ public class LlvmLoweringPass extends Pass {
         }
       }
 
-      throw Diagnostic.error("Cannot find field in inputs.", field.sourceLocation()).build();
+      throw Diagnostic.error("Cannot find field in inputs.", field.location()).build();
     }
 
     /**
@@ -276,7 +276,7 @@ public class LlvmLoweringPass extends Pass {
       IdentityHashMap<Instruction, LlvmLoweringRecord.Machine> machineInstructionRecords,
       IdentityHashMap<PseudoInstruction, LlvmLoweringRecord.Pseudo> pseudoInstructionRecords,
       IdentityHashMap<CompilerInstruction, LlvmLoweringRecord.Compiler>
-          compilerInstructionRecords) {
+      compilerInstructionRecords) {
 
   }
 
@@ -291,11 +291,11 @@ public class LlvmLoweringPass extends Pass {
     var labelingResult = ensureNonNull(
         (IsaMachineInstructionMatchingPass.Result) passResults.lastResultOf(
             IsaMachineInstructionMatchingPass.class),
-        () -> Diagnostic.error("Cannot find semantics of the instructions", viam.sourceLocation()));
+        () -> Diagnostic.error("Cannot find semantics of the instructions", viam.location()));
     var labelingResultPseudo = ensureNonNull(
         (IsaPseudoInstructionMatchingPass.Result) passResults.lastResultOf(
             IsaPseudoInstructionMatchingPass.class),
-        () -> Diagnostic.error("Cannot find semantics of the instructions", viam.sourceLocation()));
+        () -> Diagnostic.error("Cannot find semantics of the instructions", viam.location()));
     var fieldUsages = (IdentifyFieldUsagePass.ImmediateDetectionContainer) passResults.lastResultOf(
         IdentifyFieldUsagePass.class);
     var abi = (Abi) viam.definitions().filter(x -> x instanceof Abi).findFirst().orElseThrow();
@@ -489,7 +489,7 @@ public class LlvmLoweringPass extends Pass {
                       .flatMap(x -> x.usages().filter(y -> y instanceof HasRegisterFile)
                           .map(y -> ((HasRegisterFile) y).registerFile()))
                       .findFirst(), () -> Diagnostic.error("Expected to find register file",
-                      field.sourceLocation()));
+                      field.location()));
           // We use the funcParamNode's name because we need to make sure that the register
           // renaming is handled.
           // pseudo instruction BEQZ( rs : Index, offset : Bits<12> ) =
@@ -510,7 +510,7 @@ public class LlvmLoweringPass extends Pass {
                       .flatMap(x -> x.usages().filter(y -> y instanceof HasRegisterFile)
                           .map(y -> ((HasRegisterFile) y).registerFile()))
                       .findFirst(), () -> Diagnostic.error("Expected to find register file",
-                      field.sourceLocation()));
+                      field.location()));
           args.add(new LcbMachineInstructionParameterNode(
               new TableGenInstructionOperand(null,
                   registerFile.generateName(constantNode.constant().asVal()))));
@@ -529,7 +529,7 @@ public class LlvmLoweringPass extends Pass {
                           x.fieldAccess().fieldRef().equals(field))
                       .findFirst(),
                   () -> Diagnostic.error("Cannot find field access function for field",
-                      field.sourceLocation()));
+                      field.location()));
           var operand =
               ensurePresent(
                   Stream.concat(machineRecord.info().inputs().stream(),
@@ -542,7 +542,7 @@ public class LlvmLoweringPass extends Pass {
                           z.immediateOperand().fieldAccessRef().equals(fieldAccess.fieldAccess()))
                       )
                       .findFirst(),
-                  () -> Diagnostic.error("Cannot find operand", argument.sourceLocation()));
+                  () -> Diagnostic.error("Cannot find operand", argument.location()));
 
           args.add(new LcbMachineInstructionParameterNode(operand));
         } else if (argument instanceof ConstantNode constantNode) {

--- a/vadl/main/vadl/lcb/passes/llvmLowering/domain/selectionDag/LlvmReadRegFileNode.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/domain/selectionDag/LlvmReadRegFileNode.java
@@ -65,7 +65,7 @@ public class LlvmReadRegFileNode extends ReadRegFileNode implements LlvmNodeLowe
     } else if (address instanceof FuncParamNode funcParamNode) {
       instructionOperand = new TableGenInstructionIndexedRegisterFileOperand(this, funcParamNode);
     } else {
-      throw Diagnostic.error("Not supported", address.sourceLocation()).build();
+      throw Diagnostic.error("Not supported", address.location()).build();
     }
   }
 

--- a/vadl/main/vadl/lcb/passes/llvmLowering/immediates/GenerateTableGenImmediateRecordPass.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/immediates/GenerateTableGenImmediateRecordPass.java
@@ -31,7 +31,6 @@ import vadl.pass.Pass;
 import vadl.pass.PassName;
 import vadl.pass.PassResults;
 import vadl.viam.Abi;
-import vadl.viam.PseudoInstruction;
 import vadl.viam.Specification;
 
 /**
@@ -66,7 +65,7 @@ public class GenerateTableGenImmediateRecordPass extends Pass {
                 ensurePresent(ValueType.from(upcastedType), () -> Diagnostic.error(
                     "Compiler generator was not able to change the type to the architecture's "
                         + "bit width: " + upcastedType.toString(),
-                    fieldAccess.sourceLocation()));
+                    fieldAccess.location()));
             return new TableGenImmediateRecord(fieldAccess,
                 upcastedValueType);
           } else {

--- a/vadl/main/vadl/lcb/passes/llvmLowering/strategies/LlvmCompilerInstructionLowerStrategy.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/strategies/LlvmCompilerInstructionLowerStrategy.java
@@ -22,21 +22,17 @@ import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.BiPredicate;
 import java.util.stream.Stream;
 import vadl.error.DeferredDiagnosticStore;
 import vadl.error.Diagnostic;
-import vadl.gcb.passes.IdentifyFieldUsagePass;
 import vadl.gcb.passes.IsaMachineInstructionMatchingPass;
 import vadl.gcb.passes.pseudo.PseudoFuncParamNode;
 import vadl.lcb.passes.llvmLowering.LlvmLoweringPass;
 import vadl.lcb.passes.llvmLowering.domain.LlvmLoweringRecord;
 import vadl.lcb.passes.llvmLowering.domain.RegisterRef;
-import vadl.lcb.passes.llvmLowering.tablegen.model.ReferencesFormatField;
 import vadl.lcb.passes.llvmLowering.tablegen.model.tableGenOperand.TableGenInstructionOperand;
 import vadl.utils.Pair;
 import vadl.viam.CompilerInstruction;
-import vadl.viam.Parameter;
 import vadl.viam.graph.Graph;
 import vadl.viam.graph.HasRegisterFile;
 import vadl.viam.graph.Node;
@@ -45,7 +41,6 @@ import vadl.viam.graph.dependency.ConstantNode;
 import vadl.viam.graph.dependency.ExpressionNode;
 import vadl.viam.graph.dependency.FieldAccessRefNode;
 import vadl.viam.graph.dependency.FieldRefNode;
-import vadl.viam.graph.dependency.FuncCallNode;
 import vadl.viam.graph.dependency.FuncParamNode;
 import vadl.viam.graph.dependency.WriteRegFileNode;
 
@@ -83,7 +78,7 @@ public abstract class LlvmCompilerInstructionLowerStrategy {
           Diagnostic.warning(
               "Cannot generate instruction selectors for pseudo instruction with multiple "
                   + "machine instructions",
-              compilerInstruction.sourceLocation()).build());
+              compilerInstruction.location()).build());
     }
 
 
@@ -223,7 +218,7 @@ public abstract class LlvmCompilerInstructionLowerStrategy {
                               "There is no constraint value for this register. "
                                   +
                                   "Therefore, we cannot generate instruction selectors for it.",
-                              occurrence.sourceLocation()).build());
+                              occurrence.location()).build());
                         }
                       });
 

--- a/vadl/main/vadl/lcb/passes/llvmLowering/strategies/LlvmInstructionLoweringStrategy.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/strategies/LlvmInstructionLoweringStrategy.java
@@ -298,7 +298,7 @@ public abstract class LlvmInstructionLoweringStrategy {
     if (!checkIfNoControlFlow(copy) && !checkIfNotAllowedDataflowNodes(copy)) {
       DeferredDiagnosticStore.add(
           Diagnostic.warning("Instruction is not lowerable and will be skipped",
-              instruction.sourceLocation()).build());
+              instruction.location()).build());
       return Optional.empty();
     }
 
@@ -350,7 +350,7 @@ public abstract class LlvmInstructionLoweringStrategy {
     if (!graph.getNodes(LlvmUnlowerableSD.class).toList().isEmpty()) {
       DeferredDiagnosticStore.add(
           Diagnostic.warning("Instruction is not lowerable and will be skipped",
-              instruction.sourceLocation()).build());
+              instruction.location()).build());
       return true;
     }
 
@@ -360,7 +360,7 @@ public abstract class LlvmInstructionLoweringStrategy {
       DeferredDiagnosticStore.add(
           Diagnostic.warning(
               "Instruction is not lowerable because it tries to match fixed registers.",
-              instruction.sourceLocation()).build());
+              instruction.location()).build());
       return true;
     }
 
@@ -373,7 +373,7 @@ public abstract class LlvmInstructionLoweringStrategy {
           Diagnostic.warning(
               "Instruction is not lowerable because it tries to sign extend "
                   + "before writing a register file.",
-              instruction.sourceLocation()).build());
+              instruction.location()).build());
       return true;
     }
 
@@ -617,7 +617,7 @@ public abstract class LlvmInstructionLoweringStrategy {
     } else {
       throw Diagnostic.error(
           "Cannot construct a tablegen instruction operand from the type.",
-          operand.sourceLocation()).build();
+          operand.location()).build();
     }
   }
 
@@ -653,7 +653,7 @@ public abstract class LlvmInstructionLoweringStrategy {
     } else if (node.address() instanceof FuncParamNode funcParamNode) {
       return new TableGenInstructionFrameRegisterOperand(node, funcParamNode);
     } else {
-      throw Diagnostic.error("Node's address is not supported", node.address().sourceLocation())
+      throw Diagnostic.error("Node's address is not supported", node.address().location())
           .build();
     }
   }
@@ -676,7 +676,7 @@ public abstract class LlvmInstructionLoweringStrategy {
           .findFirst();
       var constRegisterValue = ensurePresent(constraintValue,
           () -> Diagnostic.error("Register file with constant index has no constant value.",
-                  constantNode.sourceLocation())
+                  constantNode.location())
               .help("Consider adding a constraint to register file for the given index."));
       // Update the type of the constant because it needs to be upcasted.
       // Heuristically, we take the type of the index because indices were also upcasted.
@@ -687,7 +687,7 @@ public abstract class LlvmInstructionLoweringStrategy {
       throw Diagnostic.error(
           "The compiler generator needs to generate a tablegen instruction operand from this "
               + "address for a field but it does not support it.",
-          node.address().sourceLocation()).build();
+          node.address().location()).build();
     }
   }
 
@@ -703,7 +703,7 @@ public abstract class LlvmInstructionLoweringStrategy {
       throw Diagnostic.error(
           "The compiler generator needs to generate a tablegen instruction operand from this "
               + "address for a field but it does not support it.",
-          node.address().sourceLocation()).build();
+          node.address().location()).build();
     }
   }
 
@@ -717,7 +717,7 @@ public abstract class LlvmInstructionLoweringStrategy {
     } else if (node.usage() == LlvmFieldAccessRefNode.Usage.BasicBlock) {
       return new TableGenInstructionImmediateLabelOperand(node);
     } else {
-      throw Diagnostic.error("Not supported usage", node.sourceLocation()).build();
+      throw Diagnostic.error("Not supported usage", node.location()).build();
     }
   }
 

--- a/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/LlvmInstructionLoweringConditionalBranchesStrategyImpl.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/LlvmInstructionLoweringConditionalBranchesStrategyImpl.java
@@ -170,7 +170,7 @@ public class LlvmInstructionLoweringConditionalBranchesStrategyImpl
     var brcc = ensurePresent(
         behavior.getNodes(LlvmBrCcSD.class)
             .findFirst(), () -> Diagnostic.error("Cannot find a comparison in the behavior",
-            instruction.sourceLocation()));
+            instruction.location()));
     var register = (ReadRegFileNode) brcc.first();
     var llvmRegisterNode =
         new LlvmReadRegFileNode(register.registerFile(),
@@ -197,7 +197,7 @@ public class LlvmInstructionLoweringConditionalBranchesStrategyImpl
         ensurePresent(
             Arrays.stream(registerFile.constraints()).filter(x -> x.value().intValue() == 0)
                 .findFirst(),
-            () -> Diagnostic.error("Cannot find zero constraint", registerFile.sourceLocation()));
+            () -> Diagnostic.error("Cannot find zero constraint", registerFile.location()));
     var constant =
         new Constant.Str(registerFile.simpleName() + zeroConstraint.address().intValue());
     return new ConstantNode(constant);

--- a/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/LlvmInstructionLoweringFrameIndexHelper.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/LlvmInstructionLoweringFrameIndexHelper.java
@@ -90,7 +90,7 @@ public abstract class LlvmInstructionLoweringFrameIndexHelper
         && llvmReadRegFileNode.address() instanceof FuncParamNode funcParamNode) {
       return new TableGenInstructionFrameRegisterOperand(llvmReadRegFileNode, funcParamNode);
     } else {
-      throw Diagnostic.error("Node type is not supported to be replaced", node.sourceLocation())
+      throw Diagnostic.error("Node type is not supported to be replaced", node.location())
           .build();
     }
   }

--- a/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/LlvmInstructionLoweringIndirectJumpStrategyImpl.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/LlvmInstructionLoweringIndirectJumpStrategyImpl.java
@@ -224,10 +224,10 @@ public class LlvmInstructionLoweringIndirectJumpStrategyImpl
                 new Query.Builder().machineInstructionLabel(MachineInstructionLabel.JALR).build())
             .firstMachineInstruction();
     var immediate = ensurePresent(jalr.behavior().getNodes(FieldAccessRefNode.class).findFirst(),
-        () -> Diagnostic.error("Cannot find an immediate.", jalr.sourceLocation()));
+        () -> Diagnostic.error("Cannot find an immediate.", jalr.location()));
     var llvmType = ensurePresent(ValueType.from(immediate.fieldAccess().type()),
         () -> Diagnostic.error("Cannot construct llvm type from field access",
-            immediate.sourceLocation()));
+            immediate.location()));
     var fieldRef = new LlvmFieldAccessRefNode(immediate.fieldAccess(), immediate.type(), llvmType,
         LlvmFieldAccessRefNode.Usage.Immediate);
     var machine = new Graph("machine");
@@ -262,7 +262,7 @@ public class LlvmInstructionLoweringIndirectJumpStrategyImpl
             .firstMachineInstruction();
     var immediate = ensurePresent(
         jalr.behavior().getNodes(FieldAccessRefNode.class).findFirst(),
-        () -> Diagnostic.error("Cannot find immediate.", jalr.sourceLocation()));
+        () -> Diagnostic.error("Cannot find immediate.", jalr.location()));
 
     var selector = new Graph("selector");
     var ref = (ReadRegFileNode) inputRegister.reference().copy();
@@ -274,7 +274,7 @@ public class LlvmInstructionLoweringIndirectJumpStrategyImpl
 
     var llvmType = ensurePresent(ValueType.from(immediate.fieldAccess().type()),
         () -> Diagnostic.error("Cannot construct llvm type from field access",
-            immediate.sourceLocation()));
+            immediate.location()));
     var fieldRef = new LlvmFieldAccessRefNode(immediate.fieldAccess(), immediate.type(), llvmType,
         LlvmFieldAccessRefNode.Usage.Immediate);
     selector.addWithInputs(new LlvmBrindSD(new NodeList<>(
@@ -319,7 +319,7 @@ public class LlvmInstructionLoweringIndirectJumpStrategyImpl
             Arrays.stream(registerFile.constraints()).filter(x -> x.value().intValue() == 0)
                 .findFirst(),
             () -> Diagnostic.error("There must a constraint for the zero register.",
-                registerFile.sourceLocation())
+                registerFile.location())
         );
 
     return registerFile.simpleName() + constraint.address().intValue();

--- a/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/LlvmInstructionLoweringMemoryLoadStrategyImpl.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/LlvmInstructionLoweringMemoryLoadStrategyImpl.java
@@ -114,7 +114,7 @@ public class LlvmInstructionLoweringMemoryLoadStrategyImpl
         var register = ensurePresent(
             addition.arguments().stream().filter(x -> x instanceof ReadRegFileNode).findFirst(),
             () -> Diagnostic.error("Expected a register node as child.",
-                addition.sourceLocation()));
+                addition.location()));
 
         addition.replaceAndDelete(register);
 
@@ -126,7 +126,7 @@ public class LlvmInstructionLoweringMemoryLoadStrategyImpl
         for (var imm : immediates) {
           var ty = ensurePresent(ValueType.from(register.type()),
               () -> Diagnostic.error("Register must have valid llvm type",
-                  register.sourceLocation()));
+                  register.location()));
           imm.replaceAndDelete(
               new LcbMachineInstructionValueNode(ty, Constant.Value.of(0, Type.signedInt(32))));
         }

--- a/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/LlvmInstructionLoweringMemoryStoreStrategyImpl.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/LlvmInstructionLoweringMemoryStoreStrategyImpl.java
@@ -117,7 +117,7 @@ public class LlvmInstructionLoweringMemoryStoreStrategyImpl
         var register = ensurePresent(
             addition.arguments().stream().filter(x -> x instanceof ReadRegFileNode).findFirst(),
             () -> Diagnostic.error("Expected a register node as child.",
-                addition.sourceLocation()));
+                addition.location()));
 
         addition.replaceAndDelete(register);
 
@@ -129,7 +129,7 @@ public class LlvmInstructionLoweringMemoryStoreStrategyImpl
         for (var imm : immediates) {
           var ty = ensurePresent(ValueType.from(register.type()),
               () -> Diagnostic.error("Register must have valid llvm type",
-                  register.sourceLocation()));
+                  register.location()));
           imm.replaceAndDelete(new LcbMachineInstructionValueNode(ty, Constant.Value.of(0,
               Type.signedInt(32))));
         }

--- a/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/LlvmPseudoInstructionLoweringUnconditionalJumpsStrategyImpl.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/LlvmPseudoInstructionLoweringUnconditionalJumpsStrategyImpl.java
@@ -178,18 +178,18 @@ public class LlvmPseudoInstructionLoweringUnconditionalJumpsStrategyImpl extends
   private static @Nonnull ValueType upcastFieldAccess(Format.FieldAccess fieldAccess) {
     return ensurePresent(ValueType.from(fieldAccess.type()),
         () -> Diagnostic.error("Cannot convert immediate type to LLVM type.",
-                fieldAccess.sourceLocation())
+                fieldAccess.location())
             .help("Check whether this type exists in LLVM"));
   }
 
   private static @Nonnull InstrCallNode getInstrCallNodeOrThrowError(PseudoInstruction pseudo) {
     ensure(pseudo.behavior().getNodes(InstrCallNode.class).count() == 1,
         () -> Diagnostic.error("Expected only one machine instruction",
-            pseudo.sourceLocation()));
+            pseudo.location()));
     return
         ensurePresent(pseudo.behavior().getNodes(InstrCallNode.class).findFirst(),
             () -> Diagnostic.error("Expected only one machine instruction",
-                pseudo.sourceLocation()));
+                pseudo.location()));
   }
 
   private static @Nonnull Format.FieldAccess getFieldAccessFunctionFromFormatOrThrowError(
@@ -198,10 +198,10 @@ public class LlvmPseudoInstructionLoweringUnconditionalJumpsStrategyImpl extends
         Diagnostic.error(
             "Machine instruction must only have one field access function to be able to "
                 + "deduce the immediate layout for the machine instruction.",
-            machineInstruction.sourceLocation()));
+            machineInstruction.location()));
     return
         ensurePresent(machineInstruction.target().format().fieldAccesses().stream().findFirst(),
             () -> Diagnostic.error("Cannot find a field access function",
-                machineInstruction.sourceLocation()));
+                machineInstruction.location()));
   }
 }

--- a/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/conditionals/LlvmInstructionLoweringLessThanImmediateUnsignedConditionalsStrategyImpl.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/conditionals/LlvmInstructionLoweringLessThanImmediateUnsignedConditionalsStrategyImpl.java
@@ -98,7 +98,7 @@ public class LlvmInstructionLoweringLessThanImmediateUnsignedConditionalsStrateg
     return ensurePresent(supportedInstructions.getOrDefault(label, Collections.emptyList())
             .stream().findFirst(),
         () -> Diagnostic.error(String.format("No instruction with label '%s' detected.", label),
-            instruction.sourceLocation()));
+            instruction.location()));
   }
 
 
@@ -154,7 +154,7 @@ public class LlvmInstructionLoweringLessThanImmediateUnsignedConditionalsStrateg
                       xori.behavior().getNodes(ReadRegFileNode.class).map(
                               ReadRegFileNode::registerFile)
                           .findFirst(),
-                      () -> Diagnostic.error("Cannot find a register", xori.sourceLocation()));
+                      () -> Diagnostic.error("Cannot find a register", xori.location()));
 
               var zeroConstraint =
                   ensurePresent(
@@ -162,7 +162,7 @@ public class LlvmInstructionLoweringLessThanImmediateUnsignedConditionalsStrateg
                           .filter(x -> x.value().intValue() == 0)
                           .findFirst(),
                       () -> Diagnostic.error("Cannot find zero register for register file",
-                          registerFile.sourceLocation()));
+                          registerFile.location()));
               // Cannot construct a `ReadReg` because this register does not really exist.
               // (for the VIAM spec)
               var zeroRegister = new ConstantNode(

--- a/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/conditionals/LlvmInstructionLoweringLessThanSignedConditionalsStrategyImpl.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/conditionals/LlvmInstructionLoweringLessThanSignedConditionalsStrategyImpl.java
@@ -152,7 +152,7 @@ public class LlvmInstructionLoweringLessThanSignedConditionalsStrategyImpl
     return ensurePresent(supportedInstructions.getOrDefault(label, Collections.emptyList())
             .stream().findFirst(),
         () -> Diagnostic.error(String.format("No instruction with label '%s' detected.", label),
-            instruction.sourceLocation()));
+            instruction.location()));
   }
 
   /**

--- a/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/conditionals/LlvmInstructionLoweringLessThanUnsignedConditionalsStrategyImpl.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/conditionals/LlvmInstructionLoweringLessThanUnsignedConditionalsStrategyImpl.java
@@ -151,7 +151,7 @@ public class LlvmInstructionLoweringLessThanUnsignedConditionalsStrategyImpl
     return ensurePresent(supportedInstructions.getOrDefault(label, Collections.emptyList())
             .stream().findFirst(),
         () -> Diagnostic.error(String.format("No instruction with label '%s' detected.", label),
-            instruction.sourceLocation()));
+            instruction.location()));
   }
 
   /**
@@ -303,7 +303,7 @@ public class LlvmInstructionLoweringLessThanUnsignedConditionalsStrategyImpl
                       xor.behavior().getNodes(ReadRegFileNode.class).map(
                               ReadRegFileNode::registerFile)
                           .findFirst(),
-                      () -> Diagnostic.error("Cannot find a register", xor.sourceLocation()));
+                      () -> Diagnostic.error("Cannot find a register", xor.location()));
 
               var zeroConstraint =
                   ensurePresent(
@@ -311,7 +311,7 @@ public class LlvmInstructionLoweringLessThanUnsignedConditionalsStrategyImpl
                           .filter(x -> x.value().intValue() == 0)
                           .findFirst(),
                       () -> Diagnostic.error("Cannot find zero register for register file",
-                          registerFile.sourceLocation()));
+                          registerFile.location()));
               // Cannot construct a `ReadReg` because this register does not really exist.
               // (for the VIAM spec)
               var zeroRegister = new ConstantNode(

--- a/vadl/main/vadl/lcb/passes/llvmLowering/strategies/nodeLowering/LcbConstantNodeReplacement.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/strategies/nodeLowering/LcbConstantNodeReplacement.java
@@ -63,11 +63,11 @@ public class LcbConstantNodeReplacement
       DeferredDiagnosticStore.add(
           Diagnostic.warning("Constant must be upcasted but it has multiple candidates. "
                   + "The compiler generator considered only the first type as upcast.",
-              node.sourceLocation()).build());
+              node.location()).build());
     } else if (distinctTypes.isEmpty()) {
       DeferredDiagnosticStore.add(
           Diagnostic.warning("Constant must be upcasted but it has no candidates.",
-              node.sourceLocation()).build());
+              node.location()).build());
       return node;
     }
 

--- a/vadl/main/vadl/lcb/passes/llvmLowering/strategies/nodeLowering/LcbReadRegFileNodeReplacement.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/strategies/nodeLowering/LcbReadRegFileNodeReplacement.java
@@ -57,7 +57,7 @@ public class LcbReadRegFileNodeReplacement
         DeferredDiagnosticStore.add(Diagnostic.warning(
             "Reading from a register file with constant index but the register has no "
                 + "constraint value.",
-            address.sourceLocation()).build());
+            address.location()).build());
         return readRegFileNode;
       }
     } else {

--- a/vadl/main/vadl/lcb/passes/llvmLowering/tablegen/lowering/TableGenPatternPrinterVisitor.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/tablegen/lowering/TableGenPatternPrinterVisitor.java
@@ -99,7 +99,7 @@ public class TableGenPatternPrinterVisitor
             constant.intValue()));
       } else {
         throw Diagnostic.error(String.format("Constant has no valid LLVM type: '%s'.",
-            node.constant().type().toString()), node.sourceLocation()).build();
+            node.constant().type().toString()), node.location()).build();
       }
     } else if (node.constant() instanceof Constant.Str str) {
       writer.write(str.value());

--- a/vadl/main/vadl/lcb/passes/llvmLowering/tablegen/model/tableGenOperand/TableGenConstantOperand.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/tablegen/model/tableGenOperand/TableGenConstantOperand.java
@@ -54,7 +54,7 @@ public class TableGenConstantOperand extends TableGenInstructionOperand {
     var unpackedLlvmType = ensurePresent(llvmType, () -> Diagnostic.error(
         "Constant value at given index has an invalid type which is not supported by llvm: "
             + constant.type(),
-        origin != null ? origin.sourceLocation() : SourceLocation.INVALID_SOURCE_LOCATION));
+        origin != null ? origin.location() : SourceLocation.INVALID_SOURCE_LOCATION));
     return "(" + unpackedLlvmType.getLlvmType() + " " + constant.asVal().intValue() + ")";
   }
 }

--- a/vadl/main/vadl/lcb/passes/llvmLowering/tablegen/model/tableGenOperand/TableGenInstructionImmediateLabelOperand.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/tablegen/model/tableGenOperand/TableGenInstructionImmediateLabelOperand.java
@@ -53,7 +53,7 @@ public class TableGenInstructionImmediateLabelOperand extends TableGenInstructio
     ensure(node.usage() == LlvmFieldAccessRefNode.Usage.BasicBlock,
         () -> Diagnostic.error(
             "Field reference has wrong type. It is expected to be basic block but it is not.",
-            node.sourceLocation()));
+            node.location()));
     this.immediateOperand = node.immediateOperand();
   }
 

--- a/vadl/main/vadl/lcb/passes/pseudo/PseudoExpansionFunctionGeneratorPass.java
+++ b/vadl/main/vadl/lcb/passes/pseudo/PseudoExpansionFunctionGeneratorPass.java
@@ -31,7 +31,6 @@ import vadl.pass.PassResults;
 import vadl.utils.Pair;
 import vadl.utils.SourceLocation;
 import vadl.viam.Abi;
-import vadl.viam.CompilerInstruction;
 import vadl.viam.Identifier;
 import vadl.viam.Parameter;
 import vadl.viam.PseudoInstruction;

--- a/vadl/main/vadl/lcb/template/lib/Target/AsmParser/EmitAsmParserCppFilePass.java
+++ b/vadl/main/vadl/lcb/template/lib/Target/AsmParser/EmitAsmParserCppFilePass.java
@@ -195,9 +195,9 @@ public class EmitAsmParserCppFilePass extends LcbTemplateRenderingPass {
 
   private ValueRange valueRange(Instruction instruction) {
     var ctx = ensureNonNull(instruction.extension(ValueRangeCtx.class),
-        () -> Diagnostic.error("Has no extension value range", instruction.sourceLocation()));
+        () -> Diagnostic.error("Has no extension value range", instruction.location()));
     return ensurePresent(ctx.getFirst(),
-        () -> Diagnostic.error("Has no value range", instruction.sourceLocation()));
+        () -> Diagnostic.error("Has no value range", instruction.location()));
   }
 
   @Override

--- a/vadl/main/vadl/lcb/template/lib/Target/EmitDAGToDAGISelCppFilePass.java
+++ b/vadl/main/vadl/lcb/template/lib/Target/EmitDAGToDAGISelCppFilePass.java
@@ -74,18 +74,18 @@ public class EmitDAGToDAGISelCppFilePass extends LcbTemplateRenderingPass {
                 .getOrDefault(MachineInstructionLabel.LUI, Collections.emptyList())
                 .stream().findFirst(),
             () -> Diagnostic.error("Expected an instruction of load upper immediate",
-                specification.sourceLocation()));
+                specification.location()));
     var registerFile =
         ensurePresent(
             lui.behavior().getNodes(WriteRegFileNode.class)
                 .map(WriteRegFileNode::registerFile)
                 .findFirst(),
             () -> Diagnostic.error("Cannot find a register for load upper immediate",
-                lui.sourceLocation()));
+                lui.location()));
     var zero = ensurePresent(
         Arrays.stream(registerFile.constraints()).filter(x -> x.value().intValue() == 0)
             .findFirst(),
-        () -> Diagnostic.error("Cannot find a zero constraint", registerFile.sourceLocation()));
+        () -> Diagnostic.error("Cannot find a zero constraint", registerFile.location()));
     var zeroRegister = registerFile.identifier.simpleName() + zero.address().intValue();
 
     return Map.of(CommonVarNames.NAMESPACE,

--- a/vadl/main/vadl/lcb/template/lib/Target/EmitISelLoweringCppFilePass.java
+++ b/vadl/main/vadl/lcb/template/lib/Target/EmitISelLoweringCppFilePass.java
@@ -98,7 +98,7 @@ public class EmitISelLoweringCppFilePass extends LcbTemplateRenderingPass {
         (IsaMachineInstructionMatchingPass.Result) passResults.lastResultOf(
             IsaMachineInstructionMatchingPass.class),
         () -> Diagnostic.error("Cannot find semantics of the instructions",
-            specification.sourceLocation()))
+            specification.location()))
         .labels();
     var coverageSummary =
         (ISelLoweringOperationActionPass.CoverageSummary) passResults.lastResultOf(
@@ -149,7 +149,7 @@ public class EmitISelLoweringCppFilePass extends LcbTemplateRenderingPass {
     var instruction = queryResult.firstMachineInstruction();
     Supplier<DiagnosticBuilder> error =
         () -> Diagnostic.error("Addition-Register-Immediate requires a value range",
-            instruction.sourceLocation());
+            instruction.location());
     var valueRangeCtx = ensureNonNull(instruction.extension(ValueRangeCtx.class), error);
     var valueRange = ensurePresent(valueRangeCtx.getFirst(), error);
 
@@ -177,7 +177,7 @@ public class EmitISelLoweringCppFilePass extends LcbTemplateRenderingPass {
       if (valueRangeCtx != null && !valueRangeCtx.ranges().isEmpty()) {
         var valueRange = ensurePresent(valueRangeCtx.getFirst(),
             () -> Diagnostic.error("Conditional instruction requires a value range",
-                instruction.sourceLocation()));
+                instruction.location()));
 
         if (valueRange.lowest() < smallest) {
           smallest = valueRange.lowest();
@@ -221,7 +221,7 @@ public class EmitISelLoweringCppFilePass extends LcbTemplateRenderingPass {
     return queryResult.machineInstructions().stream().map(instruction -> {
       Supplier<DiagnosticBuilder> error =
           () -> Diagnostic.error("Memory instruction requires a value range",
-              instruction.sourceLocation());
+              instruction.location());
 
       var ctx = ensureNonNull(instruction.extension(ValueRangeCtx.class), error);
       var valueRange = ensurePresent(ctx.getFirst(), error);
@@ -239,11 +239,11 @@ public class EmitISelLoweringCppFilePass extends LcbTemplateRenderingPass {
     return queryResult.machineInstructions().stream().map(instruction -> {
       var machineInstructionLabel = ensureNonNull(flipped.get(instruction),
           () -> Diagnostic.error("Cannot find a label to the instruction",
-              instruction.sourceLocation()));
+              instruction.location()));
       var condCode =
           ensureNonNull(LlvmMachineInstructionUtil.getLlvmCondCodeByLabel(machineInstructionLabel),
               () -> Diagnostic.error("There is no cond code for the machine instruction label.",
-                  instruction.sourceLocation()));
+                  instruction.location()));
       return new BranchInstruction(instruction.simpleName(), condCode.name());
     }).toList();
   }

--- a/vadl/main/vadl/lcb/template/lib/Target/EmitInstrInfoCppFilePass.java
+++ b/vadl/main/vadl/lcb/template/lib/Target/EmitInstrInfoCppFilePass.java
@@ -217,7 +217,7 @@ public class EmitInstrInfoCppFilePass extends LcbTemplateRenderingPass {
     return ensurePresent(jump,
         () -> Diagnostic.error(
             "Compiler generator requires a pseudo instruction for an unconditional jump",
-            specification.sourceLocation()
+            specification.location()
         ));
   }
 
@@ -277,7 +277,7 @@ public class EmitInstrInfoCppFilePass extends LcbTemplateRenderingPass {
                 .map(ReadRegFileNode::registerFile)
                 .findFirst(), () -> Diagnostic.error(
                 "Expected that the instruction has at least one register file",
-                instruction.sourceLocation()));
+                instruction.location()));
   }
 
   @Override
@@ -381,7 +381,7 @@ public class EmitInstrInfoCppFilePass extends LcbTemplateRenderingPass {
         var immediates = fieldUsages.getImmediates(machineInstruction);
         ensure(immediates.size() == 1,
             () -> Diagnostic.error("We only support branch instructions with one label.",
-                machineInstruction.sourceLocation()));
+                machineInstruction.location()));
         var immediate = unwrap(immediates.stream().findFirst());
         int bitWidth = immediate.size();
         branchInstructions.add(
@@ -411,7 +411,7 @@ public class EmitInstrInfoCppFilePass extends LcbTemplateRenderingPass {
       var immediates = fieldUsages.getImmediates(machineInstruction);
       ensure(immediates.size() == 1,
           () -> Diagnostic.error("We only support branch instructions with one label.",
-              machineInstruction.sourceLocation()));
+              machineInstruction.location()));
       var immediate = unwrap(immediates.stream().findFirst());
       int bitWidth = immediate.size();
       branchInstructions.add(
@@ -456,18 +456,18 @@ public class EmitInstrInfoCppFilePass extends LcbTemplateRenderingPass {
                       IdentifyFieldUsagePass.RegisterUsage.SOURCE)
                   .stream().findFirst(),
               () -> Diagnostic.error("Cannot find a register operand.",
-                  instruction.sourceLocation()));
+                  instruction.location()));
 
       var immediate =
           ensurePresent(fieldUsages.getImmediates(instruction).stream().findFirst(),
               () -> Diagnostic.error("Cannot find an immediate operand.",
-                  instruction.sourceLocation()));
+                  instruction.location()));
 
       var ctx = instruction.extension(TableGenInstructionCtx.class);
       var loweringRecord =
           ensureNonNull(ctx,
               () -> Diagnostic.error("Cannot find a TableGen record for this instruction.",
-                  instruction.sourceLocation())).record();
+                  instruction.location())).record();
 
       // MCInst have the output at the beginning.
       // Therefore, we need to offset the inputs.

--- a/vadl/main/vadl/lcb/template/lib/Target/EmitInstrInfoTableGenFilePass.java
+++ b/vadl/main/vadl/lcb/template/lib/Target/EmitInstrInfoTableGenFilePass.java
@@ -97,12 +97,12 @@ public class EmitInstrInfoTableGenFilePass extends LcbTemplateRenderingPass {
         Objects.requireNonNull(labelledMachineInstructions.get(MachineInstructionLabel.LUI));
     var lui = ensurePresent(luiRaw.stream().findFirst(),
         () -> Diagnostic.error("There must be a load upper immediate instruction",
-            specification.sourceLocation()));
+            specification.location()));
     var rawAddi = addi64 != null ? addi64 : Objects.requireNonNull(addi32);
 
     var addi = ensurePresent(rawAddi.stream().findFirst(),
         () -> Diagnostic.error("Instruction set requires an addition with immediate",
-            specification.sourceLocation()));
+            specification.location()));
 
     var renderedImmediates = ((List<TableGenImmediateRecord>) passResults.lastResultOf(
         GenerateTableGenImmediateRecordPass.class))

--- a/vadl/main/vadl/lcb/template/lib/Target/EmitRegisterInfoCppFilePass.java
+++ b/vadl/main/vadl/lcb/template/lib/Target/EmitRegisterInfoCppFilePass.java
@@ -200,10 +200,10 @@ public class EmitRegisterInfoCppFilePass extends LcbTemplateRenderingPass {
       for (var instruction : instructionLabels.getOrDefault(label, Collections.emptyList())) {
         var behavior = ensureNonNull(uninlined.get(instruction),
             () -> Diagnostic.error("No uninlined behavior was found.",
-                instruction.sourceLocation()));
+                instruction.location()));
         var immediate = ensurePresent(behavior.getNodes(FieldAccessRefNode.class).findAny(), () ->
             Diagnostic.error("Cannot find an immediate for frame index elimination.",
-                instruction.sourceLocation()));
+                instruction.location()));
         var indices =
             extractFrameIndexAndImmIndexFromMachineInstruction(tableGenMachineInstructions,
                 instruction);

--- a/vadl/main/vadl/lcb/template/lib/Target/EmitRegisterInfoTableGenFilePass.java
+++ b/vadl/main/vadl/lcb/template/lib/Target/EmitRegisterInfoTableGenFilePass.java
@@ -84,7 +84,7 @@ public class EmitRegisterInfoTableGenFilePass extends LcbTemplateRenderingPass {
     var registerClasses = output.registerClasses();
 
     if (registerClasses.size() > 1) {
-      throw Diagnostic.error("Supporting only one register file", specification.sourceLocation())
+      throw Diagnostic.error("Supporting only one register file", specification.location())
           .build();
     }
 

--- a/vadl/main/vadl/lcb/template/lib/Target/MCTargetDesc/EmitAsmUtilsCppFilePass.java
+++ b/vadl/main/vadl/lcb/template/lib/Target/MCTargetDesc/EmitAsmUtilsCppFilePass.java
@@ -107,7 +107,7 @@ public class EmitAsmUtilsCppFilePass extends LcbTemplateRenderingPass {
                       .filter(x -> x.relocation().equals(mapping.getRelocation()))
                       .findFirst(), () -> Diagnostic.error(
                       "Cannot find an ELF relocation for the given relocation function.",
-                      mapping.getRelocation().sourceLocation()));
+                      mapping.getRelocation().location()));
 
           var variantKind = elfRelocation.variantKind();
           return Map.of(

--- a/vadl/main/vadl/lcb/template/utils/PseudoInstructionProvider.java
+++ b/vadl/main/vadl/lcb/template/utils/PseudoInstructionProvider.java
@@ -52,7 +52,7 @@ public class PseudoInstructionProvider {
                 DeferredDiagnosticStore.add(Diagnostic.warning(
                     "Instruction was not lowered. "
                         + "Therefore, it cannot be used in the pseudo instruction",
-                    i.sourceLocation()).build());
+                    i.location()).build());
               }
               return isSupported;
             }));

--- a/vadl/main/vadl/rtl/passes/StageOrderingPass.java
+++ b/vadl/main/vadl/rtl/passes/StageOrderingPass.java
@@ -77,7 +77,7 @@ public class StageOrderingPass extends Pass {
     var onlyReadFrom = new HashSet<>(readFrom);
     onlyReadFrom.removeAll(reading);
     ViamError.ensure(onlyReadFrom.size() == 1, () -> Diagnostic.error(
-        "Exactly one start stage expected", mia.sourceLocation()));
+        "Exactly one start stage expected", mia.location()));
 
     // check we can order every stage
     var unordered = new HashSet<>(mia.stages());
@@ -85,15 +85,15 @@ public class StageOrderingPass extends Pass {
     unordered.removeAll(readFrom);
     var anyUnordered = unordered.stream().findAny();
     ViamError.ensure(anyUnordered.isEmpty(), () -> Diagnostic.error(
-        "All stages need to be ordered", anyUnordered.get().sourceLocation()));
+        "All stages need to be ordered", anyUnordered.get().location()));
 
     var start = onlyReadFrom.stream().findAny().orElseThrow(
-        () -> new ViamError("Exactly one start stage expected").addLocation(mia.sourceLocation()));
+        () -> new ViamError("Exactly one start stage expected").addLocation(mia.location()));
 
     var order = new ArrayList<Stage>();
     follow(dep, start, order);
     ViamError.ensure(order.size() == mia.stages().size(), () -> Diagnostic.error(
-        "All stages need to be ordered", mia.sourceLocation()));
+        "All stages need to be ordered", mia.location()));
 
     return order;
   }
@@ -104,7 +104,7 @@ public class StageOrderingPass extends Pass {
     // find successor
     var succ = dep.stream().filter(p -> p.left() == cur).toList();
     ViamError.ensure(succ.size() <= 1, () -> Diagnostic.error(
-        "Can not order stage, more than one successor", cur.sourceLocation()));
+        "Can not order stage, more than one successor", cur.location()));
 
     // recurse
     if (!succ.isEmpty()) {

--- a/vadl/main/vadl/utils/SourceLocation.java
+++ b/vadl/main/vadl/utils/SourceLocation.java
@@ -46,7 +46,7 @@ public record SourceLocation(
     Position begin,
     Position end,
     @Nullable SourceLocation expandedFrom
-) implements WithSourceLocation {
+) implements WithLocation {
 
   private static final URI INVALID_MEMORY = URI.create("memory://unknown");
 
@@ -283,7 +283,7 @@ public record SourceLocation(
   }
 
   @Override
-  public SourceLocation sourceLocation() {
+  public SourceLocation location() {
     return this;
   }
 

--- a/vadl/main/vadl/utils/WithLocation.java
+++ b/vadl/main/vadl/utils/WithLocation.java
@@ -21,11 +21,11 @@ package vadl.utils;
  *
  * <p>Provides a method to retrieve the source location associated with the implementing entity.
  */
-public interface WithSourceLocation {
+public interface WithLocation {
   /**
    * Retrieves the source location associated with the entity.
    *
    * @return the {@link SourceLocation} object that represents the location in the source code.
    */
-  SourceLocation sourceLocation();
+  SourceLocation location();
 }

--- a/vadl/main/vadl/viam/Annotation.java
+++ b/vadl/main/vadl/viam/Annotation.java
@@ -21,14 +21,14 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.jetbrains.annotations.Contract;
 import vadl.utils.SourceLocation;
-import vadl.utils.WithSourceLocation;
+import vadl.utils.WithLocation;
 
 /**
  * Represents an abstract annotation that can be associated with a definition.
  * This class provides mechanisms to ensure the correctness of its state and
  * the associated definition.
  */
-public abstract class Annotation<T extends Definition> implements WithSourceLocation {
+public abstract class Annotation<T extends Definition> implements WithLocation {
 
   @Nullable
   private T parentDefinition;
@@ -95,7 +95,7 @@ public abstract class Annotation<T extends Definition> implements WithSourceLoca
   }
 
   @Override
-  public final SourceLocation sourceLocation() {
+  public final SourceLocation location() {
     return sourceLocation;
   }
 

--- a/vadl/main/vadl/viam/Definition.java
+++ b/vadl/main/vadl/viam/Definition.java
@@ -24,7 +24,7 @@ import java.util.function.Supplier;
 import javax.annotation.Nullable;
 import org.jetbrains.annotations.Contract;
 import vadl.utils.SourceLocation;
-import vadl.utils.WithSourceLocation;
+import vadl.utils.WithLocation;
 import vadl.viam.graph.Graph;
 
 /**
@@ -43,7 +43,7 @@ import vadl.viam.graph.Graph;
  * Those definition extensions are added by passes that want to directly associate
  * information to specific definitions. </p>
  */
-public abstract class Definition implements WithSourceLocation {
+public abstract class Definition implements WithLocation {
 
   public final Identifier identifier;
   private SourceLocation sourceLocation = SourceLocation.INVALID_SOURCE_LOCATION;
@@ -65,7 +65,7 @@ public abstract class Definition implements WithSourceLocation {
   }
 
   @Override
-  public SourceLocation sourceLocation() {
+  public SourceLocation location() {
     return sourceLocation;
   }
 

--- a/vadl/main/vadl/viam/Format.java
+++ b/vadl/main/vadl/viam/Format.java
@@ -328,7 +328,7 @@ public class Format extends Definition implements DefProp.WithType {
     public void setEncoding(Function encoding) {
       ViamError.ensure(this.encoding == null, () -> Diagnostic.error(
           "Cannot regenerate an encoding for a field access which already has an encoding.",
-          encoding.sourceLocation()));
+          encoding.location()));
       this.encoding = encoding;
       verify();
     }

--- a/vadl/main/vadl/viam/Identifier.java
+++ b/vadl/main/vadl/viam/Identifier.java
@@ -20,15 +20,15 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 import vadl.utils.SourceLocation;
-import vadl.utils.WithSourceLocation;
+import vadl.utils.WithLocation;
 
 /**
  * Source level identifier class.
  */
 public record Identifier(
     String[] parts,
-    SourceLocation sourceLocation
-) implements WithSourceLocation {
+    SourceLocation location
+) implements WithLocation {
 
   /**
    * Normalize the parts of the identifier by removing leading and trailing dots.
@@ -64,7 +64,7 @@ public record Identifier(
   public Identifier prepend(Identifier scope) {
     return new Identifier(
         Stream.concat(Arrays.stream(scope.parts), Arrays.stream(this.parts)).toArray(String[]::new),
-        this.sourceLocation
+        this.location
     );
   }
 
@@ -81,7 +81,7 @@ public record Identifier(
   public Identifier append(String... parts) {
     return new Identifier(
         Stream.concat(Arrays.stream(this.parts), Arrays.stream(parts)).toArray(String[]::new),
-        this.sourceLocation
+        this.location
     );
   }
 
@@ -91,7 +91,7 @@ public record Identifier(
   public Identifier extendSimpleName(String suffix) {
     return new Identifier(
         Arrays.copyOf(this.parts, this.parts.length - 1),
-        this.sourceLocation
+        this.location
     ).append(this.parts[this.parts.length - 1] + suffix);
   }
 
@@ -113,7 +113,7 @@ public record Identifier(
    */
   public Identifier tail() {
     return new Identifier(Arrays.stream(this.parts()).skip(1).toArray(String[]::new),
-        sourceLocation);
+        location);
   }
 
   @Override

--- a/vadl/main/vadl/viam/Relocation.java
+++ b/vadl/main/vadl/viam/Relocation.java
@@ -68,7 +68,7 @@ public class Relocation extends Function {
 
     ViamError.ensure(parameters().length == 1,
         () -> Diagnostic.error("Relocations must have exactly one argument.",
-            this.sourceLocation()));
+            this.location()));
   }
 
   @Override

--- a/vadl/main/vadl/viam/Stage.java
+++ b/vadl/main/vadl/viam/Stage.java
@@ -50,8 +50,8 @@ public class Stage extends Definition implements DefProp.WithBehavior {
    * Instantiate a new stage definition.
    *
    * @param identifier stage identifier
-   * @param behavior behavior graph
-   * @param outputs list of stage outputs
+   * @param behavior   behavior graph
+   * @param outputs    list of stage outputs
    */
   public Stage(Identifier identifier, Graph behavior, List<StageOutput> outputs) {
     super(identifier);
@@ -148,7 +148,7 @@ public class Stage extends Definition implements DefProp.WithBehavior {
 
   @Override
   public String toString() {
-    return "Stage{ name='" + simpleName() + "', sourceLocation=" + sourceLocation() + "}";
+    return "Stage{ name='" + simpleName() + "', sourceLocation=" + location() + "}";
   }
 
   @Override

--- a/vadl/main/vadl/viam/ViamError.java
+++ b/vadl/main/vadl/viam/ViamError.java
@@ -78,7 +78,7 @@ public class ViamError extends RuntimeException {
   public ViamError addContext(Definition definition) {
     return this.addContext("name", definition.identifier.name())
         .addContext("definition", definition)
-        .addLocation(definition.sourceLocation());
+        .addLocation(definition.location());
 
   }
 

--- a/vadl/main/vadl/viam/graph/Graph.java
+++ b/vadl/main/vadl/viam/graph/Graph.java
@@ -202,7 +202,7 @@ public class Graph {
         return target;
       }
 
-      target.setSourceLocationIfNotSet(node.sourceLocation());
+      target.setSourceLocationIfNotSet(node.location());
       target.ensure(!target.isDeleted(), "cannot add deleted input node");
       var newT = addWithInputs(target);
       // just return the new target AND the node, as the original one is not initialized and thus

--- a/vadl/main/vadl/viam/graph/Node.java
+++ b/vadl/main/vadl/viam/graph/Node.java
@@ -27,7 +27,7 @@ import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import org.jetbrains.annotations.Contract;
 import vadl.utils.SourceLocation;
-import vadl.utils.WithSourceLocation;
+import vadl.utils.WithLocation;
 import vadl.viam.graph.dependency.DependencyNode;
 
 /**
@@ -37,7 +37,7 @@ import vadl.viam.graph.dependency.DependencyNode;
  * contains implicitly updated information like predecessor
  * and usages.
  */
-public abstract class Node implements WithSourceLocation {
+public abstract class Node implements WithLocation {
 
   public final Id id;
   private @Nullable Graph graph;
@@ -80,7 +80,7 @@ public abstract class Node implements WithSourceLocation {
   }
 
   @Override
-  public SourceLocation sourceLocation() {
+  public SourceLocation location() {
     return sourceLocation;
   }
 

--- a/vadl/main/vadl/viam/graph/ViamGraphError.java
+++ b/vadl/main/vadl/viam/graph/ViamGraphError.java
@@ -84,7 +84,7 @@ public class ViamGraphError extends ViamError {
   }
 
 
-  //// STATIC HELPER
+  /// / STATIC HELPER
 
   @FormatMethod
   private static void ensureInternal(boolean condition, @Nullable Graph graph, @Nullable Node node1,

--- a/vadl/main/vadl/viam/graph/visualize/DotGraphVisualizer.java
+++ b/vadl/main/vadl/viam/graph/visualize/DotGraphVisualizer.java
@@ -117,10 +117,10 @@ public class DotGraphVisualizer implements GraphVisualizer<String, Graph> {
       label.append(" -> ");
       label.append(((ExpressionNode) node).type().name());
     }
-    if (withSourceLocation && node.sourceLocation().isValid()) {
+    if (withSourceLocation && node.location().isValid()) {
       label
           .append("\\n@ ")
-          .append(node.sourceLocation().toConciseString());
+          .append(node.location().toConciseString());
     }
     return label.toString();
   }


### PR DESCRIPTION
The previous `WithSourceLocation` was quite a bit more verbose and in the frontend every AST Node had (historically) two methods to get the location because `location()` was implemented before the `sourceLocation()` arose from the VIAM.

In a discussion we decided to rename the interface and only keep one `location()` getter in the frontend.