### PR TITLE
lcb: Print CALL and RET pseudo instructions

### DIFF
--- a/vadl/main/vadl/lcb/codegen/assembly/AssemblyInstructionPrinterCodeGenerator.java
+++ b/vadl/main/vadl/lcb/codegen/assembly/AssemblyInstructionPrinterCodeGenerator.java
@@ -19,7 +19,7 @@ package vadl.lcb.codegen.assembly;
 import java.io.StringWriter;
 import vadl.cppCodeGen.model.CppFunctionCode;
 import vadl.lcb.passes.llvmLowering.tablegen.model.TableGenInstruction;
-import vadl.viam.Instruction;
+import vadl.viam.PrintableInstruction;
 import vadl.viam.graph.control.ReturnNode;
 
 /**
@@ -32,7 +32,7 @@ public class AssemblyInstructionPrinterCodeGenerator {
    * Generate a function which prints the assembly.
    */
   public CppFunctionCode generateFunctionBody(
-      Instruction instruction,
+      PrintableInstruction instruction,
       TableGenInstruction tableGenInstruction) {
     var visitor =
         new AssemblyInstructionPrinterCodeGeneratorVisitor(writer,

--- a/vadl/main/vadl/lcb/codegen/assembly/AssemblyInstructionPrinterCodeGeneratorVisitor.java
+++ b/vadl/main/vadl/lcb/codegen/assembly/AssemblyInstructionPrinterCodeGeneratorVisitor.java
@@ -28,13 +28,15 @@ import vadl.cppCodeGen.SymbolTable;
 import vadl.error.Diagnostic;
 import vadl.lcb.passes.llvmLowering.tablegen.model.ReferencesFormatField;
 import vadl.lcb.passes.llvmLowering.tablegen.model.TableGenInstruction;
+import vadl.lcb.passes.llvmLowering.tablegen.model.tableGenOperand.TableGenInstructionBareSymbolOperand;
+import vadl.lcb.passes.llvmLowering.tablegen.model.tableGenOperand.TableGenInstructionImmediateLabelOperand;
 import vadl.lcb.passes.llvmLowering.tablegen.model.tableGenOperand.TableGenInstructionImmediateOperand;
 import vadl.types.BuiltInTable;
 import vadl.types.DataType;
 import vadl.utils.SourceLocation;
 import vadl.viam.Constant;
 import vadl.viam.Format;
-import vadl.viam.Instruction;
+import vadl.viam.PrintableInstruction;
 import vadl.viam.graph.Graph;
 import vadl.viam.graph.GraphNodeVisitor;
 import vadl.viam.graph.HasRegisterFile;
@@ -69,7 +71,7 @@ import vadl.viam.graph.dependency.ZeroExtendNode;
  */
 public class AssemblyInstructionPrinterCodeGeneratorVisitor
     implements GraphNodeVisitor {
-  private final Instruction instruction;
+  private final PrintableInstruction instruction;
   private final SymbolTable symbolTable = new SymbolTable();
   private final StringWriter writer;
   private final Deque<String> operands = new ArrayDeque<>();
@@ -80,7 +82,7 @@ public class AssemblyInstructionPrinterCodeGeneratorVisitor
    */
   public AssemblyInstructionPrinterCodeGeneratorVisitor(
       StringWriter writer,
-      Instruction instruction,
+      PrintableInstruction instruction,
       TableGenInstruction tableGenInstruction) {
     this.writer = writer;
     this.instruction = instruction;
@@ -106,7 +108,7 @@ public class AssemblyInstructionPrinterCodeGeneratorVisitor
       operands.add(symbol);
 
       writer.write(String.format("std::string %s = std::string(\"%s\");\n", symbol,
-          instruction.identifier.simpleName()));
+          instruction.identifier().simpleName()));
     } else if (node.builtIn() == BuiltInTable.CONCATENATE_STRINGS) {
       for (var arg : node.arguments()) {
         visit(arg);
@@ -278,11 +280,52 @@ public class AssemblyInstructionPrinterCodeGeneratorVisitor
     } else if (node.arguments().get(0) instanceof FieldAccessRefNode fieldAccessRefNode) {
       writeImmediateWithRadix(fieldAccessRefNode.fieldAccess().fieldRef(), radix,
           type, fieldAccessRefNode.location());
+    } else if (node.arguments().get(0) instanceof FuncParamNode funcParamNode) {
+      // This case is for pseudo instructions because they arguments are not fields,
+      // but function parameter nodes.
+      writeImmediateWithRadix(funcParamNode, radix, funcParamNode.location());
     } else {
       throw Diagnostic.error("Not supported argument "
               + "in assembly printing", node.location())
           .build();
     }
+  }
+
+  private void writeImmediateWithRadix(FuncParamNode paramNode, int radix,
+                                       SourceLocation sourceLocation) {
+    var index = ensurePresent(indexInInputs(paramNode), () ->
+        Diagnostic.error("Immediate must be part of an tablegen input.",
+            sourceLocation)
+    );
+
+    var operandSymbol = symbolTable.getNextVariable();
+    var valueSymbol = symbolTable.getNextVariable();
+
+    writer.write(String.format(
+        """
+            MCOperand %s = MI->getOperand(%d);
+            int64_t %s;
+            if (AsmUtils::evaluateConstantImm(&%s, %s)) {
+            """,
+        operandSymbol,
+        index,
+        valueSymbol,
+        operandSymbol,
+        valueSymbol
+    ));
+    writer.write(String.format("\t%s =  MCOperand::createImm(%s);\n", operandSymbol, valueSymbol));
+    writer.write("}\n");
+
+    var symbol = symbolTable.getNextVariable();
+    writer.write(String.format(
+        """
+            std::string %s = AsmUtils::formatImm(MCOperandWrapper(%s), %d, &MAI);
+            """,
+        symbol,
+        operandSymbol,
+        radix
+    ));
+    operands.add(symbol);
   }
 
   private void writeImmediateWithRadix(Format.Field field, int radix, DataType argumentType,
@@ -353,6 +396,39 @@ public class AssemblyInstructionPrinterCodeGeneratorVisitor
     operands.add(symbol);
   }
 
+  private Optional<Integer> indexInInputs(FuncParamNode needle) {
+    if (tableGenInstruction.getInOperands().stream()
+        .filter(x -> x instanceof TableGenInstructionImmediateLabelOperand).count() > 1) {
+      // When we see an immediate label operand, we do not know which operand it is.
+      // Therefore, the support is limited at the moment.
+      throw Diagnostic.error("Currently we cannot support multiple labels when printing",
+          needle.location()).build();
+    }
+
+    if (tableGenInstruction.getInOperands().stream()
+        .anyMatch(x -> x instanceof TableGenInstructionImmediateLabelOperand)
+        && tableGenInstruction.getInOperands().size() > 1) {
+      // When we see an immediate label operand, we do not know which operand it is.
+      // Therefore, the support is limited at the moment.
+      throw Diagnostic.error("Currently we cannot support mixed labels when printing",
+          needle.location()).build();
+    }
+
+    int outputOffset = tableGenInstruction.getOutOperands().size();
+    for (int i = 0; i < tableGenInstruction.getInOperands().size(); i++) {
+      var operand = tableGenInstruction.getInOperands().get(i);
+      if (operand instanceof TableGenInstructionBareSymbolOperand symbolOperand
+          && symbolOperand.origin() instanceof FuncParamNode funcParamNodeOfOperand
+          && needle.parameter().equals(funcParamNodeOfOperand.parameter())) {
+        return Optional.of(outputOffset + i);
+      } else if (operand instanceof TableGenInstructionImmediateLabelOperand) {
+        return Optional.of(outputOffset + i);
+      }
+    }
+
+    return Optional.empty();
+  }
+
   private Optional<Integer> indexInInputs(Format.Field needle) {
     int outputOffset = tableGenInstruction.getOutOperands().size();
     for (int i = 0; i < tableGenInstruction.getInOperands().size(); i++) {
@@ -372,6 +448,20 @@ public class AssemblyInstructionPrinterCodeGeneratorVisitor
       if (operand instanceof ReferencesFormatField x
           && x.formatField().equals(needle)) {
         return Optional.of(i);
+      }
+    }
+
+    return Optional.empty();
+  }
+
+
+  private Optional<Integer> indexInOutputs(FuncParamNode needle) {
+    for (int i = 0; i < tableGenInstruction.getOutOperands().size(); i++) {
+      var operand = tableGenInstruction.getOutOperands().get(i);
+      if (operand instanceof TableGenInstructionBareSymbolOperand symbolOperand
+          && symbolOperand.origin() instanceof FuncParamNode funcParamNodeOfOperand
+          && needle.parameter().equals(funcParamNodeOfOperand.parameter())) {
+        return Optional.of( i);
       }
     }
 

--- a/vadl/main/vadl/lcb/codegen/assembly/AssemblyInstructionPrinterCodeGeneratorVisitor.java
+++ b/vadl/main/vadl/lcb/codegen/assembly/AssemblyInstructionPrinterCodeGeneratorVisitor.java
@@ -454,21 +454,6 @@ public class AssemblyInstructionPrinterCodeGeneratorVisitor
     return Optional.empty();
   }
 
-
-  private Optional<Integer> indexInOutputs(FuncParamNode needle) {
-    for (int i = 0; i < tableGenInstruction.getOutOperands().size(); i++) {
-      var operand = tableGenInstruction.getOutOperands().get(i);
-      if (operand instanceof TableGenInstructionBareSymbolOperand symbolOperand
-          && symbolOperand.origin() instanceof FuncParamNode funcParamNodeOfOperand
-          && needle.parameter().equals(funcParamNodeOfOperand.parameter())) {
-        return Optional.of( i);
-      }
-    }
-
-    return Optional.empty();
-  }
-
-
   private String getRegisterFile(Graph behavior, FieldRefNode fieldRefNode) {
     var candidates = behavior.getNodes(FieldRefNode.class)
         .filter(x -> x.formatField().equals(fieldRefNode.formatField()))

--- a/vadl/main/vadl/lcb/codegen/assembly/AssemblyInstructionPrinterCodeGeneratorVisitor.java
+++ b/vadl/main/vadl/lcb/codegen/assembly/AssemblyInstructionPrinterCodeGeneratorVisitor.java
@@ -29,8 +29,8 @@ import vadl.error.Diagnostic;
 import vadl.lcb.passes.llvmLowering.tablegen.model.ReferencesFormatField;
 import vadl.lcb.passes.llvmLowering.tablegen.model.TableGenInstruction;
 import vadl.lcb.passes.llvmLowering.tablegen.model.tableGenOperand.TableGenInstructionBareSymbolOperand;
-import vadl.lcb.passes.llvmLowering.tablegen.model.tableGenOperand.TableGenInstructionImmediateLabelOperand;
 import vadl.lcb.passes.llvmLowering.tablegen.model.tableGenOperand.TableGenInstructionImmediateOperand;
+import vadl.lcb.passes.llvmLowering.tablegen.model.tableGenOperand.TableGenInstructionLabelOperand;
 import vadl.types.BuiltInTable;
 import vadl.types.DataType;
 import vadl.utils.SourceLocation;
@@ -398,7 +398,7 @@ public class AssemblyInstructionPrinterCodeGeneratorVisitor
 
   private Optional<Integer> indexInInputs(FuncParamNode needle) {
     if (tableGenInstruction.getInOperands().stream()
-        .filter(x -> x instanceof TableGenInstructionImmediateLabelOperand).count() > 1) {
+        .filter(x -> x instanceof TableGenInstructionLabelOperand).count() > 1) {
       // When we see an immediate label operand, we do not know which operand it is.
       // Therefore, the support is limited at the moment.
       throw Diagnostic.error("Currently we cannot support multiple labels when printing",
@@ -406,7 +406,7 @@ public class AssemblyInstructionPrinterCodeGeneratorVisitor
     }
 
     if (tableGenInstruction.getInOperands().stream()
-        .anyMatch(x -> x instanceof TableGenInstructionImmediateLabelOperand)
+        .anyMatch(x -> x instanceof TableGenInstructionLabelOperand)
         && tableGenInstruction.getInOperands().size() > 1) {
       // When we see an immediate label operand, we do not know which operand it is.
       // Therefore, the support is limited at the moment.
@@ -421,7 +421,7 @@ public class AssemblyInstructionPrinterCodeGeneratorVisitor
           && symbolOperand.origin() instanceof FuncParamNode funcParamNodeOfOperand
           && needle.parameter().equals(funcParamNodeOfOperand.parameter())) {
         return Optional.of(outputOffset + i);
-      } else if (operand instanceof TableGenInstructionImmediateLabelOperand) {
+      } else if (operand instanceof TableGenInstructionLabelOperand) {
         return Optional.of(outputOffset + i);
       }
     }

--- a/vadl/main/vadl/lcb/template/lib/Target/MCTargetDesc/EmitInstPrinterCppFilePass.java
+++ b/vadl/main/vadl/lcb/template/lib/Target/MCTargetDesc/EmitInstPrinterCppFilePass.java
@@ -23,15 +23,19 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.annotation.Nonnull;
 import vadl.configuration.LcbConfiguration;
 import vadl.cppCodeGen.model.CppFunctionCode;
 import vadl.lcb.codegen.assembly.AssemblyInstructionPrinterCodeGenerator;
 import vadl.lcb.passes.llvmLowering.GenerateTableGenMachineInstructionRecordPass;
+import vadl.lcb.passes.llvmLowering.GenerateTableGenPseudoInstructionRecordPass;
 import vadl.lcb.passes.llvmLowering.tablegen.model.TableGenMachineInstruction;
+import vadl.lcb.passes.llvmLowering.tablegen.model.TableGenPseudoInstruction;
 import vadl.lcb.template.CommonVarNames;
 import vadl.lcb.template.LcbTemplateRenderingPass;
 import vadl.pass.PassResults;
 import vadl.template.Renderable;
+import vadl.viam.PseudoInstruction;
 import vadl.viam.Specification;
 
 /**
@@ -70,6 +74,18 @@ public class EmitInstPrinterCppFilePass extends LcbTemplateRenderingPass {
   @Override
   protected Map<String, Object> createVariables(final PassResults passResults,
                                                 Specification specification) {
+    var machineInstructions = machineInstructions(passResults, specification);
+    var pseudoInstructions = pseudoInstructions(passResults, specification);
+
+    return Map.of(CommonVarNames.NAMESPACE,
+        lcbConfiguration().targetName().value().toLowerCase(),
+        "instructions",
+        Stream.concat(machineInstructions.stream(), pseudoInstructions.stream()).toList());
+  }
+
+  @Nonnull
+  private List<PrintableInstruction> machineInstructions(PassResults passResults,
+                                                         Specification specification) {
     var machineRecords = (List<TableGenMachineInstruction>) passResults.lastResultOf(
         GenerateTableGenMachineInstructionRecordPass.class);
     var supported = machineRecords.stream().map(TableGenMachineInstruction::instruction)
@@ -89,9 +105,44 @@ public class EmitInstPrinterCppFilePass extends LcbTemplateRenderingPass {
           return new PrintableInstruction(instruction.identifier.simpleName(), result);
         })
         .toList();
+    return printableInstructions;
+  }
 
-    return Map.of(CommonVarNames.NAMESPACE,
-        lcbConfiguration().targetName().value().toLowerCase(),
-        "instructions", printableInstructions);
+  /**
+   * Return {@code true} when the given {@code pseudoInstruction} is {@code CALL} or {@code RET}.
+   */
+  private boolean isCallOrRet(Specification specification, PseudoInstruction pseudoInstruction) {
+    var abi = specification.abi().orElseThrow();
+
+    return pseudoInstruction == abi.callSequence()
+        || pseudoInstruction == abi.returnSequence();
+  }
+
+  @Nonnull
+  private List<PrintableInstruction> pseudoInstructions(PassResults passResults,
+                                                        Specification specification) {
+    var pseudoRecords = (List<TableGenPseudoInstruction>) passResults.lastResultOf(
+        GenerateTableGenPseudoInstructionRecordPass.class);
+
+    // We only support CALL or RET.
+    var supported = pseudoRecords.stream().map(TableGenPseudoInstruction::pseudoInstruction)
+        .filter(x -> isCallOrRet(specification, x))
+        .collect(Collectors.toSet());
+    var tableGenLookup = pseudoRecords.stream().collect(Collectors.toMap(
+        TableGenPseudoInstruction::pseudoInstruction,
+        x -> x));
+    var printableInstructions = specification
+        .isa().map(isa -> isa.ownPseudoInstructions().stream())
+        .orElse(Stream.empty())
+        .filter(supported::contains)
+        .map(instruction -> {
+          var codeGen = new AssemblyInstructionPrinterCodeGenerator();
+          var tableGenRecord =
+              ensureNonNull(tableGenLookup.get(instruction), "tablegen record must exist");
+          var result = codeGen.generateFunctionBody(instruction, tableGenRecord);
+          return new PrintableInstruction(instruction.identifier.simpleName(), result);
+        })
+        .toList();
+    return printableInstructions;
   }
 }

--- a/vadl/main/vadl/viam/Instruction.java
+++ b/vadl/main/vadl/viam/Instruction.java
@@ -28,7 +28,7 @@ import vadl.viam.graph.Graph;
  */
 // TODO: Instruction should have information about source and destination registers
 //  (not from AST, computed by analysis).
-public class Instruction extends Definition implements DefProp.WithBehavior {
+public class Instruction extends Definition implements DefProp.WithBehavior, PrintableInstruction {
 
   private final Graph behavior;
   private final Assembly assembly;
@@ -70,10 +70,17 @@ public class Instruction extends Definition implements DefProp.WithBehavior {
     behavior.setParentDefinition(this);
   }
 
+  @Override
+  public Identifier identifier() {
+    return identifier;
+  }
+
+  @Override
   public Graph behavior() {
     return behavior;
   }
 
+  @Override
   public Assembly assembly() {
     return assembly;
   }

--- a/vadl/main/vadl/viam/Parameter.java
+++ b/vadl/main/vadl/viam/Parameter.java
@@ -16,6 +16,7 @@
 
 package vadl.viam;
 
+import java.util.Objects;
 import javax.annotation.Nullable;
 import vadl.types.Type;
 
@@ -63,6 +64,25 @@ public class Parameter extends Definition implements DefProp.WithType {
     return type;
   }
 
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(identifier, type);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == null) {
+      return false;
+    }
+
+    if (obj instanceof Parameter that) {
+      return Objects.equals(identifier, that.identifier)
+          && Objects.equals(type, that.type);
+    } else {
+      return false;
+    }
+  }
 
   @Override
   public String toString() {

--- a/vadl/main/vadl/viam/PrintableInstruction.java
+++ b/vadl/main/vadl/viam/PrintableInstruction.java
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.viam;
+
+import vadl.viam.graph.Graph;
+
+/**
+ * Indicates that an instruction is printable because it has a behavior and assembly.
+ */
+public interface PrintableInstruction {
+  /**
+   * Get the identifier of an instruction.
+   */
+  Identifier identifier();
+
+  /**
+   * Get the behavior of an instruction.
+   */
+  Graph behavior();
+
+  /**
+   * Get the {@link Assembly} of an instruction.
+   */
+  Assembly assembly();
+}

--- a/vadl/main/vadl/viam/PseudoInstruction.java
+++ b/vadl/main/vadl/viam/PseudoInstruction.java
@@ -28,7 +28,7 @@ import vadl.viam.graph.dependency.FuncParamNode;
  * using the {@link Graph#isPseudoInstruction()} method. The most
  * important graph node to handle is the {@link vadl.viam.graph.control.InstrCallNode}.</p>
  */
-public class PseudoInstruction extends CompilerInstruction {
+public class PseudoInstruction extends CompilerInstruction implements PrintableInstruction {
 
   private final Assembly assembly;
 
@@ -50,6 +50,12 @@ public class PseudoInstruction extends CompilerInstruction {
     this.assembly = assembly;
   }
 
+  @Override
+  public Identifier identifier() {
+    return identifier;
+  }
+
+  @Override
   public Assembly assembly() {
     return assembly;
   }

--- a/vadl/main/vadl/viam/graph/dependency/FuncParamNode.java
+++ b/vadl/main/vadl/viam/graph/dependency/FuncParamNode.java
@@ -17,6 +17,7 @@
 package vadl.viam.graph.dependency;
 
 import java.util.List;
+import java.util.Objects;
 import vadl.javaannotations.viam.DataValue;
 import vadl.viam.Definition;
 import vadl.viam.Parameter;
@@ -75,5 +76,23 @@ public class FuncParamNode extends ParamNode {
   @Override
   public void prettyPrint(StringBuilder sb) {
     sb.append(parameter.simpleName());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(parameter);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == null) {
+      return false;
+    }
+
+    if (obj instanceof FuncParamNode that) {
+      return Objects.equals(parameter, that.parameter);
+    } else {
+      return false;
+    }
   }
 }

--- a/vadl/main/vadl/viam/passes/functionInliner/FunctionInlinerPass.java
+++ b/vadl/main/vadl/viam/passes/functionInliner/FunctionInlinerPass.java
@@ -103,7 +103,7 @@ public class FunctionInlinerPass extends Pass {
               Arrays.stream(functionCall.function().parameters()), Pair::new)
           .forEach(
               pair -> behaviorCopy.getNodes(FuncParamNode.class)
-                  .filter(n -> n.parameter() == pair.right())
+                  .filter(n -> n.parameter().equals(pair.right()))
                   .forEach(usedParam -> usedParam.replaceAndDelete(pair.left().copy())));
 
       // replace the function call by a copy of the return value of the function

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O0/alu64.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O0/alu64.ll
@@ -10,7 +10,7 @@ define i64 @addi(i64 %a) nounwind {
 ; CHECK-NEXT: XOR a2,a0,a2
 ; CHECK-NEXT: SLTIU a2,a2,1
 ; CHECK-NEXT: ADD a1,a1,a2
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = add i64 %a, 1
   ret i64 %1
 }
@@ -43,7 +43,7 @@ define i64 @sltiu(i64 %a) nounwind {
 ; CHECK-NEXT: LW a1,8(sp) # 4-byte Folded Reload
 ; CHECK-NEXT: LW a0,12(sp) # 4-byte Folded Reload
 ; CHECK-NEXT: ADDI sp,sp,16
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = icmp ult i64 %a, 3
   %2 = zext i1 %1 to i64
   ret i64 %2
@@ -53,7 +53,7 @@ define i64 @xori(i64 %a) nounwind {
 ; CHECK-LABEL: xori: # @xori
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: XORI a0,a0,4
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = xor i64 %a, 4
   ret i64 %1
 }
@@ -62,7 +62,7 @@ define i64 @ori(i64 %a) nounwind {
 ; CHECK-LABEL: ori: # @ori
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: ORI a0,a0,5
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = or i64 %a, 5
   ret i64 %1
 }
@@ -72,7 +72,7 @@ define i64 @andi(i64 %a) nounwind {
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: ANDI a0,a0,6
 ; CHECK-NEXT: ADDI a1,zero,0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = and i64 %a, 6
   ret i64 %1
 }
@@ -84,7 +84,7 @@ define i64 @slli(i64 %a) nounwind {
 ; CHECK-NEXT: SLLI a1,a1,7
 ; CHECK-NEXT: OR a1,a1,a2
 ; CHECK-NEXT: SLLI a0,a0,7
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = shl i64 %a, 7
   ret i64 %1
 }
@@ -96,7 +96,7 @@ define i64 @srli(i64 %a) nounwind {
 ; CHECK-NEXT: SRLI a0,a0,8
 ; CHECK-NEXT: OR a0,a0,a2
 ; CHECK-NEXT: SRLI a1,a1,8
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = lshr i64 %a, 8
   ret i64 %1
 }
@@ -108,7 +108,7 @@ define i64 @srai(i64 %a) nounwind {
 ; CHECK-NEXT: SRLI a0,a0,9
 ; CHECK-NEXT: OR a0,a0,a2
 ; CHECK-NEXT: SRAI a1,a1,9
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = ashr i64 %a, 9
   ret i64 %1
 }
@@ -127,7 +127,7 @@ define i64 @add(i64 %a, i64 %b) nounwind {
 ; CHECK-NEXT: SLTU a2,a0,a2
 ; CHECK-NEXT: ADD a1,a1,a2
 ; CHECK-NEXT: ADDI sp,sp,16
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = add i64 %a, %b
   ret i64 %1
 }
@@ -140,7 +140,7 @@ define i64 @sub(i64 %a, i64 %b) nounwind {
 ; CHECK-NEXT: SUB a1,a1,a4
 ; CHECK-NEXT: SUB a1,a1,a3
 ; CHECK-NEXT: SUB a0,a0,a2
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = sub i64 %a, %b
   ret i64 %1
 }
@@ -148,8 +148,7 @@ define i64 @sub(i64 %a, i64 %b) nounwind {
 define i64 @sll(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: sll: # @sll
 ; CHECK-LABEL: # %bb.0:
-; CHECK: LUI ra,%hi(__ashldi3)
-; CHECK-NEXT: JALR ra,%lo(__ashldi3)(ra)
+; CHECK: CALL __ashldi3
 ; CHECK-NEXT: LW ra,12(sp)
   %1 = shl i64 %a, %b
   ret i64 %1
@@ -171,7 +170,7 @@ define i64 @slt(i64 %a, i64 %b) nounwind {
 ; CHECK-NEXT: LW a0,12(sp) # 4-byte Folded Reload
 ; CHECK-NEXT: ADDI a1,zero,0
 ; CHECK-NEXT: ADDI sp,sp,16
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = icmp slt i64 %a, %b
   %2 = zext i1 %1 to i64
   ret i64 %2
@@ -182,7 +181,7 @@ define i64 @xor(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: XOR a0,a0,a2
 ; CHECK-NEXT: XOR a1,a1,a3
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = xor i64 %a, %b
   ret i64 %1
 }
@@ -190,8 +189,7 @@ define i64 @xor(i64 %a, i64 %b) nounwind {
 define i64 @srl(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: srl: # @srl
 ; CHECK-LABEL: # %bb.0:
-; CHECK: LUI ra,%hi(__lshrdi3)
-; CHECK-NEXT: JALR ra,%lo(__lshrdi3)(ra)
+; CHECK: CALL __lshrdi3
 ; CHECK-NEXT: LW ra,12(sp)
   %1 = lshr i64 %a, %b
   ret i64 %1
@@ -200,8 +198,7 @@ define i64 @srl(i64 %a, i64 %b) nounwind {
 define i64 @sra(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: sra: # @sra
 ; CHECK-LABEL: # %bb.0:
-; CHECK: LUI ra,%hi(__ashrdi3)
-; CHECK-NEXT: JALR ra,%lo(__ashrdi3)(ra)
+; CHECK: CALL __ashrdi3
 ; CHECK-NEXT: LW ra,12(sp)
   %1 = ashr i64 %a, %b
   ret i64 %1
@@ -212,7 +209,7 @@ define i64 @or(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: OR a0,a0,a2
 ; CHECK-NEXT: OR a1,a1,a3
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = or i64 %a, %b
   ret i64 %1
 }
@@ -222,7 +219,7 @@ define i64 @and(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: AND a0,a0,a2
 ; CHECK-NEXT: AND a1,a1,a3
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = and i64 %a, %b
   ret i64 %1
 }

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O0/and.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O0/and.ll
@@ -4,7 +4,7 @@
 define i32 @and32_0x7ff(i32 %x) {
 ; CHECK-LABEL: and32_0x7ff: # @and32_0x7ff
 ; CHECK:         ANDI a0,a0,2047
-; CHECK-NEXT:    JALR zero,0(ra)
+; CHECK-NEXT:    RET
   %a = and i32 %x, 2047
   ret i32 %a
 }
@@ -14,7 +14,7 @@ define i32 @and32_0xfff(i32 %x) {
 ; CHECK:       LUI a1,0x1
 ; CHECK-NEXT:  ADDI a1,a1,-1
 ; CHECK-NEXT:  AND a0,a0,a1
-; CHECK-NEXT:  JALR zero,0(ra)
+; CHECK-NEXT:  RET
   %a = and i32 %x, 4095
   ret i32 %a
 }
@@ -23,7 +23,7 @@ define i64 @and64_0x7ff(i64 %x) {
 ; CHECK-LABEL: and64_0x7ff: # @and64_0x7ff
 ; CHECK:         ANDI a0,a0,2047
 ; CHECK-NEXT:    ADDI a1,zero,0
-; CHECK-NEXT:    JALR zero,0(ra)
+; CHECK-NEXT:    RET
   %a = and i64 %x, 2047
   ret i64 %a
 }
@@ -34,7 +34,7 @@ define i64 @and64_0xfff(i64 %x) {
 ; CHECK-NEXT:  ADDI a1,a1,-1
 ; CHECK-NEXT:  AND a0,a0,a1
 ; CHECK-NEXT:  ADDI a1,zero,0
-; CHECK-NEXT:  JALR zero,0(ra)
+; CHECK-NEXT:  RET
   %a = and i64 %x, 4095
   ret i64 %a
 }

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O0/imm.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O0/imm.ll
@@ -3,21 +3,21 @@
 define signext i32 @zero() nounwind {
   ; CHECK-LABEL: zero: # @zero
   ; CHECK: ADDI a0,zero,0
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i32 0
 }
 
 define signext i32 @pos_small() nounwind {
   ; CHECK-LABEL: pos_small: # @pos_small
   ; CHECK: ADDI a0,zero,2047
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i32 2047
 }
 
 define signext i32 @neg_small() nounwind {
   ; CHECK-LABEL: neg_small: # @neg_small
   ; CHECK: ADDI a0,zero,-2048
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i32 -2048
 }
 
@@ -25,7 +25,7 @@ define signext i32 @pos_i32() nounwind {
   ; CHECK-LABEL: pos_i32: # @pos_i32
   ; CHECK: LUI a0,0x67783
   ; CHECK-NEXT: ADDI a0,a0,-1297
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i32 1735928559
 }
 
@@ -33,7 +33,7 @@ define signext i32 @neg_i32() nounwind {
   ; CHECK-LABEL: neg_i32: # @neg_i32
   ; CHECK: LUI a0,0xdeadc
   ; CHECK-NEXT: ADDI a0,a0,-273
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i32 -559038737
 }
 
@@ -41,7 +41,7 @@ define signext i32 @pos_i32_hi20_only() nounwind {
   ; CHECK-LABEL: pos_i32_hi20_only: # @pos_i32_hi20_only
   ; CHECK: LUI a0,0x10
   ; CHECK-NEXT: ADDI a0,a0,0
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i32 65536 ; 0x10000
 }
 
@@ -49,7 +49,7 @@ define signext i32 @neg_i32_hi20_only() nounwind {
   ; CHECK-LABEL: neg_i32_hi20_only: # @neg_i32_hi20_only
   ; CHECK: LUI a0,0xffff0
   ; CHECK-NEXT: ADDI a0,a0,0
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i32 -65536 ; -0x10000
 }
 
@@ -59,7 +59,7 @@ define i64 @imm_end_xori_1() nounwind {
   ; CHECK-NEXT: ADDI a0,a0,-1
   ; CHECK-NEXT: LUI a1,0xe0000
   ; CHECK-NEXT: ADDI a1,a1,0
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i64 -2305843009180139521 ; 0xE000_0000_01FF_FFFF
 }
 
@@ -67,7 +67,7 @@ define void @imm_store_i8_neg1(ptr %p) nounwind {
   ; CHECK-LABEL: imm_store_i8_neg1: # @imm_store_i8_neg1
   ; CHECK: ADDI a1,zero,255
   ; CHECK-NEXT: SB a1,0(a0)
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   store i8 -1, ptr %p
   ret void
 }
@@ -77,7 +77,7 @@ define void @imm_store_i16_neg1(ptr %p) nounwind {
   ; CHECK: LUI a1,0x10
   ; CHECK-NEXT: ADDI a1,a1,-1
   ; CHECK-NEXT: SH a1,0(a0)
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   store i16 -1, ptr %p
   ret void
 }
@@ -86,7 +86,7 @@ define void @imm_store_i32_neg1(ptr %p) nounwind {
   ; CHECK-LABEL: imm_store_i32_neg1: # @imm_store_i32_neg1
   ; CHECK: ADDI a1,zero,-1
   ; CHECK-NEXT: SW a1,0(a0)
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   store i32 -1, ptr %p
   ret void
 }

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O0/indirectbr.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O0/indirectbr.ll
@@ -5,8 +5,7 @@ define i32 @indirectbr(ptr %target) nounwind {
   ; CHECK-LABEL: # %bb.0:
   ; CHECK-NEXT: JALR zero,0(a0)
   ; CHECK-LABEL: LBB0_1: # %test_label
-  ; CHECK: ADDI a0,zero,0
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK: RET
    indirectbr ptr %target, [label %test_label]
 test_label:
   br label %ret
@@ -21,8 +20,8 @@ define i32 @indirectbr_with_offset(ptr %a) nounwind {
   ; CHECK-LABEL: LBB1_1:
   ; CHECK-NEXT: JAL zero,.LBB1_2
   ; CHECK-LABEL: LBB1_2:
-  ; CHECK-NEXT: ADDI a0,zero,0
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK: ADDI a0,zero,0
+  ; CHECK-NEXT: RET
 
   %target = getelementptr inbounds i8, ptr %a, i32 1380
   indirectbr ptr %target, [label %test_label]

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O0/large_stack.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O0/large_stack.ll
@@ -49,7 +49,7 @@ define void @test_emergency_spill_slot(i32 %a) {
 ; CHECK-NEXT: LUI a0,0x62
 ; CHECK-NEXT: ADDI a0,a0,-1408
 ; CHECK-NEXT: ADD sp,sp,a0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %data = alloca [ 100000 x i32 ] , align 4
   %ptr = getelementptr inbounds [100000 x i32], ptr %data, i32 0, i32 80000
   %1 = tail call { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } asm sideeffect "nop", "=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r"()

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O0/mul.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O0/mul.ll
@@ -4,7 +4,7 @@ define signext i32 @square(i32 %a) nounwind {
 ; CHECK-LABEL: square: # @square
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: MUL a0,a0,a0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = mul i32 %a, %a
   ret i32 %1
 }
@@ -13,7 +13,7 @@ define signext i32 @mul(i32 %a, i32 %b) nounwind {
 ; CHECK-LABEL: mul: # @mul
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: MUL a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = mul i32 %a, %b
   ret i32 %1
 }
@@ -23,7 +23,7 @@ define signext i32 @mul_constant(i32 %a) nounwind {
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: ADDI a1,zero,5
 ; CHECK-NEXT: MUL a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = mul i32 %a, 5
   ret i32 %1
 }
@@ -32,7 +32,7 @@ define i32 @mul_pow2(i32 %a) nounwind {
 ; CHECK-LABEL: mul_pow2: # @mul_pow2
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: SLLI a0,a0,3
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = mul i32 %a, 8
   ret i32 %1
 }
@@ -51,7 +51,7 @@ define i64 @mul64(i64 %a, i64 %b) nounwind {
 ; CHECK-NEXT: ADD a1,a1,a3
 ; CHECK-NEXT: MUL a0,a0,a2
 ; CHECK-NEXT: ADDI sp,sp,16
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = mul i64 %a, %b
   ret i64 %1
 }

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O0/pic.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O0/pic.ll
@@ -10,7 +10,7 @@ define ptr @f1() nounwind {
 ; CHECK-LABEL: # %bb.0: # %entry
 ; CHECK-NEXT: AUIPC a0,%got_pcrel_hi(external_var)
 ; CHECK-NEXT: LW a0,%pcrel_lo(external_var)(a0)
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 entry:
   ret ptr @external_var
 }
@@ -21,7 +21,7 @@ define ptr @f2() nounwind {
 ; CHECK-LABEL: .Ltmp0
 ; CHECK-NEXT: AUIPC a0,%pcrel_hi(internal_var)
 ; CHECK-NEXT: ADDI a0,a0,%pcrel_lo(.Ltmp0)
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 entry:
   ret ptr @internal_var
 }

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/alu64.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/alu64.ll
@@ -9,7 +9,7 @@ define i64 @addi(i64 %a) nounwind {
 ; CHECK-NEXT: XOR a2,a0,zero
 ; CHECK-NEXT: SLTIU a2,a2,1
 ; CHECK-NEXT: ADD a1,a1,a2
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = add i64 %a, 1
   ret i64 %1
 }
@@ -21,11 +21,11 @@ define i64 @slti(i64 %a) nounwind {
 ; CHECK-LABEL: # %bb.1:
 ; CHECK: SLTI a0,a1,0
 ; CHECK-NEXT: ADDI a1,zero,0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 ; CHECK-LABEL: .LBB1_2:
 ; CHECK-NEXT: SLTIU a0,a0,2
 ; CHECK-NEXT: ADDI a1,zero,0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = icmp slt i64 %a, 2
   %2 = zext i1 %1 to i64
   ret i64 %2
@@ -38,11 +38,11 @@ define i64 @sltiu(i64 %a) nounwind {
 ; CHECK-LABEL: # %bb.1:
 ; CHECK-NEXT: ADDI a0,zero,0
 ; CHECK-NEXT: ADDI a1,zero,0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 ; CHECK-LABEL: .LBB2_2:
 ; CHECK-NEXT: SLTIU a0,a0,3
 ; CHECK-NEXT: ADDI a1,zero,0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = icmp ult i64 %a, 3
   %2 = zext i1 %1 to i64
   ret i64 %2
@@ -52,7 +52,7 @@ define i64 @xori(i64 %a) nounwind {
 ; CHECK-LABEL: xori: # @xori
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: XORI a0,a0,4
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = xor i64 %a, 4
   ret i64 %1
 }
@@ -61,7 +61,7 @@ define i64 @ori(i64 %a) nounwind {
 ; CHECK-LABEL: ori: # @ori
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: ORI a0,a0,5
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = or i64 %a, 5
   ret i64 %1
 }
@@ -71,7 +71,7 @@ define i64 @andi(i64 %a) nounwind {
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: ANDI a0,a0,6
 ; CHECK-NEXT: ADDI a1,zero,0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = and i64 %a, 6
   ret i64 %1
 }
@@ -83,7 +83,7 @@ define i64 @slli(i64 %a) nounwind {
 ; CHECK-NEXT: SRLI a2,a0,25
 ; CHECK-NEXT: OR a1,a1,a2
 ; CHECK-NEXT: SLLI a0,a0,7
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = shl i64 %a, 7
   ret i64 %1
 }
@@ -95,7 +95,7 @@ define i64 @srli(i64 %a) nounwind {
 ; CHECK-NEXT: SLLI a2,a1,24
 ; CHECK-NEXT: OR a0,a0,a2
 ; CHECK-NEXT: SRLI a1,a1,8
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = lshr i64 %a, 8
   ret i64 %1
 }
@@ -107,7 +107,7 @@ define i64 @srai(i64 %a) nounwind {
 ; CHECK-NEXT: SLLI a2,a1,23
 ; CHECK-NEXT: OR a0,a0,a2
 ; CHECK-NEXT: SRAI a1,a1,9
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = ashr i64 %a, 9
   ret i64 %1
 }
@@ -122,7 +122,7 @@ define i64 @add(i64 %a, i64 %b) nounwind {
 ; CHECK-NEXT: SLTU a0,a2,a0
 ; CHECK-NEXT: ADD a1,a1,a0
 ; CHECK-NEXT: ADDI a0,a2,0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = add i64 %a, %b
   ret i64 %1
 }
@@ -134,7 +134,7 @@ define i64 @sub(i64 %a, i64 %b) nounwind {
 ; CHECK-NEXT: SLTU a3,a0,a2
 ; CHECK-NEXT: SUB a1,a1,a3
 ; CHECK-NEXT: SUB a0,a0,a2
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = sub i64 %a, %b
   ret i64 %1
 }
@@ -144,11 +144,10 @@ define i64 @sll(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: ADDI sp,sp,-16
 ; CHECK-NEXT: SW ra,12(sp) # 4-byte Folded Spill
-; CHECK-NEXT: LUI ra,%hi(__ashldi3)
-; CHECK-NEXT: JALR ra,%lo(__ashldi3)(ra)
+; CHECK-NEXT: CALL __ashldi3
 ; CHECK-NEXT: LW ra,12(sp) # 4-byte Folded Reload
 ; CHECK-NEXT: ADDI sp,sp,16
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = shl i64 %a, %b
   ret i64 %1
 }
@@ -160,11 +159,11 @@ define i64 @slt(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: # %bb.1:
 ; CHECK-NEXT: SLT a0,a1,a3
 ; CHECK-NEXT: ADDI a1,zero,0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 ; CHECK-LABEL: .LBB12_2:
 ; CHECK-NEXT: SLTU a0,a0,a2
 ; CHECK-NEXT: ADDI a1,zero,0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = icmp slt i64 %a, %b
   %2 = zext i1 %1 to i64
   ret i64 %2
@@ -177,11 +176,11 @@ define i64 @sltu(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: # %bb.1:
 ; CHECK-NEXT: SLTU a0,a1,a3
 ; CHECK-NEXT: ADDI a1,zero,0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 ; CHECK-LABEL: .LBB13_2:
 ; CHECK-NEXT: SLTU a0,a0,a2
 ; CHECK-NEXT: ADDI a1,zero,0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = icmp ult i64 %a, %b
   %2 = zext i1 %1 to i64
   ret i64 %2
@@ -192,7 +191,7 @@ define i64 @xor(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: XOR a0,a0,a2
 ; CHECK-NEXT: XOR a1,a1,a3
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = xor i64 %a, %b
   ret i64 %1
 }
@@ -202,11 +201,10 @@ define i64 @srl(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: ADDI sp,sp,-16
 ; CHECK-NEXT: SW ra,12(sp) # 4-byte Folded Spill
-; CHECK-NEXT: LUI ra,%hi(__lshrdi3)
-; CHECK-NEXT: JALR ra,%lo(__lshrdi3)(ra)
+; CHECK-NEXT: CALL __lshrdi3
 ; CHECK-NEXT: LW ra,12(sp) # 4-byte Folded Reload
 ; CHECK-NEXT: ADDI sp,sp,16
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = lshr i64 %a, %b
   ret i64 %1
 }
@@ -216,11 +214,10 @@ define i64 @sra(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: ADDI sp,sp,-16
 ; CHECK-NEXT: SW ra,12(sp) # 4-byte Folded Spill
-; CHECK-NEXT: LUI ra,%hi(__ashrdi3)
-; CHECK-NEXT: JALR ra,%lo(__ashrdi3)(ra)
+; CHECK-NEXT: CALL __ashrdi3
 ; CHECK-NEXT: LW ra,12(sp) # 4-byte Folded Reload
 ; CHECK-NEXT: ADDI sp,sp,16
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = ashr i64 %a, %b
   ret i64 %1
 }
@@ -230,7 +227,7 @@ define i64 @or(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: OR a0,a0,a2
 ; CHECK-NEXT: OR a1,a1,a3
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = or i64 %a, %b
   ret i64 %1
 }
@@ -240,7 +237,7 @@ define i64 @and(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: AND a0,a0,a2
 ; CHECK-NEXT: AND a1,a1,a3
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = and i64 %a, %b
   ret i64 %1
 }
@@ -251,7 +248,7 @@ define signext i32 @addiw(i32 signext %a) nounwind {
 ; CHECK-LABEL: addiw: # @addiw
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: ADDI a0,a0,123
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = add i32 %a, 123
   ret i32 %1
 }
@@ -260,7 +257,7 @@ define signext i32 @slliw(i32 signext %a) nounwind {
 ; CHECK-LABEL: slliw: # @slliw
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: SLLI a0,a0,17
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = shl i32 %a, 17
   ret i32 %1
 }
@@ -269,7 +266,7 @@ define signext i32 @srliw(i32 %a) nounwind {
 ; CHECK-LABEL: srliw: # @srliw
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: SRLI a0,a0,8
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = lshr i32 %a, 8
   ret i32 %1
 }
@@ -278,7 +275,7 @@ define signext i32 @sraiw(i32 %a) nounwind {
 ; CHECK-LABEL: sraiw: # @sraiw
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: SRAI a0,a0,9
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = ashr i32 %a, 9
   ret i32 %1
 }
@@ -289,7 +286,7 @@ define i64 @sraiw_i64(i64 %a) nounwind {
 ; CHECK-NEXT: SRAI a2,a0,9
 ; CHECK-NEXT: SRAI a1,a0,31
 ; CHECK-NEXT: ADDI a0,a2,0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = shl i64 %a, 32
   %2 = ashr i64 %1, 41
   ret i64 %2
@@ -298,7 +295,7 @@ define i64 @sraiw_i64(i64 %a) nounwind {
 define signext i32 @sextw(i32 zeroext %a) nounwind {
 ; CHECK-LABEL: sextw: # @sextw
 ; CHECK-LABEL: # %bb.0:
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   ret i32 %a
 }
 
@@ -306,7 +303,7 @@ define signext i32 @addw(i32 signext %a, i32 signext %b) nounwind {
 ; CHECK-LABEL: addw: # @addw
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: ADD a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = add i32 %a, %b
   ret i32 %1
 }
@@ -315,7 +312,7 @@ define signext i32 @subw(i32 signext %a, i32 signext %b) nounwind {
 ; CHECK-LABEL: subw: # @subw
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: SUB a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = sub i32 %a, %b
   ret i32 %1
 }
@@ -324,7 +321,7 @@ define signext i32 @sllw(i32 signext %a, i32 zeroext %b) nounwind {
 ; CHECK-LABEL: sllw: # @sllw
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: SLL a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = shl i32 %a, %b
   ret i32 %1
 }
@@ -333,7 +330,7 @@ define signext i32 @srlw(i32 signext %a, i32 zeroext %b) nounwind {
 ; CHECK-LABEL: srlw: # @srlw
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: SRL a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = lshr i32 %a, %b
   ret i32 %1
 }
@@ -342,7 +339,7 @@ define signext i32 @sraw(i64 %a, i32 zeroext %b) nounwind {
 ; CHECK-LABEL: sraw: # @sraw
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: SRA a0,a0,a2
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = trunc i64 %a to i32
   %2 = ashr i32 %1, %b
   ret i32 %2
@@ -355,7 +352,7 @@ define i64 @add_hi_and_lo_negone(i64 %0) {
 ; CHECK-NEXT: SLTIU a2,a2,1
 ; CHECK-NEXT: SUB a1,a1,a2
 ; CHECK-NEXT: ADDI a0,a0,-1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %2 = add nsw i64 %0, -1
   ret i64 %2
 }
@@ -367,7 +364,7 @@ define i64 @add_hi_zero_lo_negone(i64 %0) {
 ; CHECK-NEXT: SLTU a2,zero,a2
 ; CHECK-NEXT: ADD a1,a1,a2
 ; CHECK-NEXT: ADDI a0,a0,-1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %2 = add i64 %0, 4294967295
   ret i64 %2
 }
@@ -380,7 +377,7 @@ define i64 @add_lo_negone(i64 %0) {
 ; CHECK-NEXT: ADD a1,a1,a2
 ; CHECK-NEXT: ADDI a1,a1,-2
 ; CHECK-NEXT: ADDI a0,a0,-1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %2 = add nsw i64 %0, -4294967297
   ret i64 %2
 }
@@ -393,7 +390,7 @@ define i64 @add_hi_one_lo_negone(i64 %0) {
 ; CHECK-NEXT: ADD a1,a1,a2
 ; CHECK-NEXT: ADDI a1,a1,1
 ; CHECK-NEXT: ADDI a0,a0,-1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %2 = add nsw i64 %0, 8589934591
   ret i64 %2
 }

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/analyze-branch.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/analyze-branch.ll
@@ -15,17 +15,15 @@ define void @test_bcc_fallthrough_taken(i32 %in) nounwind {
 ; CHECK-NEXT: ADDI a1,zero,42
 ; CHECK-NEXT: BNE a0,a1,.LBB0_2
 ; CHECK-LABEL: # %bb.1: # %true
-; CHECK-NEXT: LUI ra,%hi(test_true)
-; CHECK-NEXT: JALR ra,%lo(test_true)(ra)
+; CHECK-NEXT: CALL test_true
 ; CHECK-NEXT: LW ra,12(sp) # 4-byte Folded Reload
 ; CHECK-NEXT: ADDI sp,sp,16
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 ; CHECK-LABEL: LBB0_2:
-; CHECK-NEXT: LUI ra,%hi(test_false)
-; CHECK-NEXT: JALR ra,%lo(test_false)(ra)
+; CHECK-NEXT: CALL test_false
 ; CHECK-NEXT: LW ra,12(sp) # 4-byte Folded Reload
 ; CHECK-NEXT: ADDI sp,sp,16
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %tst = icmp eq i32 %in, 42
   br i1 %tst, label %true, label %false, !prof !0
 
@@ -51,17 +49,15 @@ define void @test_bcc_fallthrough_nottaken(i32 %in) nounwind {
 ; CHECK-NEXT: BNE a0,a1,.LBB1_1
 ; CHECK-NEXT: JAL zero,.LBB1_2
 ; CHECK-LABEL: .LBB1_1: # %false
-; CHECK-NEXT: LUI ra,%hi(test_false)
-; CHECK-NEXT: JALR ra,%lo(test_false)(ra)
+; CHECK-NEXT: CALL test_false
 ; CHECK-NEXT: LW ra,12(sp) # 4-byte Folded Reload
 ; CHECK-NEXT: ADDI sp,sp,16
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 ; CHECK-LABEL: .LBB1_2: # %true
-; CHECK-NEXT: LUI ra,%hi(test_true)
-; CHECK-NEXT: JALR ra,%lo(test_true)(ra)
+; CHECK-NEXT: CALL test_true
 ; CHECK-NEXT: LW ra,12(sp) # 4-byte Folded Reload
 ; CHECK-NEXT: ADDI sp,sp,16
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 
   %tst = icmp eq i32 %in, 42
   br i1 %tst, label %true, label %false, !prof !1

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/and.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/and.ll
@@ -3,7 +3,7 @@
 define i32 @and32_0x7ff(i32 %x) {
 ; CHECK-LABEL: and32_0x7ff: # @and32_0x7ff
 ; CHECK:         ANDI a0,a0,2047
-; CHECK-NEXT:    JALR zero,0(ra)
+; CHECK-NEXT:    RET
   %a = and i32 %x, 2047
   ret i32 %a
 }
@@ -13,7 +13,7 @@ define i32 @and32_0xfff(i32 %x) {
 ; CHECK:       LUI a1,0x1
 ; CHECK-NEXT:  ADDI a1,a1,-1
 ; CHECK-NEXT:  AND a0,a0,a1
-; CHECK-NEXT:  JALR zero,0(ra)
+; CHECK-NEXT:  RET
   %a = and i32 %x, 4095
   ret i32 %a
 }
@@ -22,7 +22,7 @@ define i64 @and64_0x7ff(i64 %x) {
 ; CHECK-LABEL: and64_0x7ff: # @and64_0x7ff
 ; CHECK:         ANDI a0,a0,2047
 ; CHECK-NEXT:    ADDI a1,zero,0
-; CHECK-NEXT:    JALR zero,0(ra)
+; CHECK-NEXT:    RET
   %a = and i64 %x, 2047
   ret i64 %a
 }
@@ -33,7 +33,7 @@ define i64 @and64_0xfff(i64 %x) {
 ; CHECK-NEXT:  ADDI a1,a1,-1
 ; CHECK-NEXT:  AND a0,a0,a1
 ; CHECK-NEXT:  ADDI a1,zero,0
-; CHECK-NEXT:  JALR zero,0(ra)
+; CHECK-NEXT:  RET
   %a = and i64 %x, 4095
   ret i64 %a
 }

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/branch-opt.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/branch-opt.ll
@@ -9,11 +9,11 @@ define void @u_case1_a(ptr %a, i32 signext %b, ptr %c, ptr %d) {
 ; CHECK-NEXT:    BLTU a0,a1,.LBB0_2
 ; CHECK-NEXT:  # %bb.1: # %block1
 ; CHECK-NEXT:    SW a1,0(a2)
-; CHECK-NEXT:    JALR zero,0(ra)
+; CHECK-NEXT:    RET
 ; CHECK-NEXT:  .LBB0_2: # %block2
 ; CHECK-NEXT:    ADDI a0,zero,87
 ; CHECK-NEXT:    SW a0,0(a3)
-; CHECK-NEXT:    JALR zero,0(ra)
+; CHECK-NEXT:    RET
   store i32 32, ptr %a
   %p = icmp ule i32 %b, 31
   br i1 %p, label %block1, label %block2
@@ -39,11 +39,11 @@ define void @case1_a(ptr %a, i32 signext %b, ptr %c, ptr %d) {
 ; CHECK-NEXT:    BLT a0,a1,.LBB1_2
 ; CHECK-NEXT:  # %bb.1: # %block1
 ; CHECK-NEXT:    SW a1,0(a2)
-; CHECK-NEXT:    JALR zero,0(ra)
+; CHECK-NEXT:    RET
 ; CHECK-NEXT:  .LBB1_2: # %block2
 ; CHECK-NEXT:    ADDI a0,zero,87
 ; CHECK-NEXT:    SW a0,0(a3)
-; CHECK-NEXT:    JALR zero,0(ra)
+; CHECK-NEXT:    RET
   store i32 -1, ptr %a
   %p = icmp sle i32 %b, -2
   br i1 %p, label %block1, label %block2
@@ -69,11 +69,11 @@ define void @u_case2_a(ptr %a, i32 signext %b, ptr %c, ptr %d) {
 ; CHECK-NEXT:    BLTU a1,a0,.LBB2_2
 ; CHECK-NEXT:  # %bb.1: # %block1
 ; CHECK-NEXT:    SW a1,0(a2)
-; CHECK-NEXT:    JALR zero,0(ra)
+; CHECK-NEXT:    RET
 ; CHECK-NEXT:  .LBB2_2: # %block2
 ; CHECK-NEXT:    ADDI a0,zero,87
 ; CHECK-NEXT:    SW a0,0(a3)
-; CHECK-NEXT:    JALR zero,0(ra)
+; CHECK-NEXT:    RET
   store i32 32, ptr %a
   %p = icmp uge i32 %b, 33
   br i1 %p, label %block1, label %block2
@@ -99,11 +99,11 @@ define void @case2_a(ptr %a, i32 signext %b, ptr %c, ptr %d) {
 ; CHECK-NEXT:    BLT a1,a0,.LBB3_2
 ; CHECK-NEXT:  # %bb.1: # %block1
 ; CHECK-NEXT:    SW a1,0(a2)
-; CHECK-NEXT:    JALR zero,0(ra)
+; CHECK-NEXT:    RET
 ; CHECK-NEXT:  .LBB3_2: # %block2
 ; CHECK-NEXT:    ADDI a0,zero,87
 ; CHECK-NEXT:    SW a0,0(a3)
-; CHECK-NEXT:    JALR zero,0(ra)
+; CHECK-NEXT:    RET
   store i32 -4, ptr %a
   %p = icmp sge i32 %b, -3
   br i1 %p, label %block1, label %block2

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/calling-conv.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/calling-conv.ll
@@ -74,8 +74,7 @@ define void @callee() nounwind {
 ; CHECK-NEXT: LW s11,116(s1)
 ; CHECK-NEXT: LW s2,120(s1)
 ; CHECK-NEXT: LW s3,124(s1)
-; CHECK-NEXT: LUI ra,%hi(callee)
-; CHECK-NEXT: JALR ra,%lo(callee)(ra)
+; CHECK-NEXT: CALL callee
 ; CHECK-NEXT: SW s3,124(s1)
 ; CHECK-NEXT: SW s2,120(s1)
 ; CHECK-NEXT: SW s11,116(s1)
@@ -143,7 +142,7 @@ define void @callee() nounwind {
 ; CHECK-NEXT: LW s1,136(sp)                           # 4-byte Folded Reload
 ; CHECK-NEXT: LW ra,140(sp)                           # 4-byte Folded Reload
 ; CHECK-NEXT: ADDI sp,sp,144
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %val = load [32 x i32], ptr @var
   call void @callee()
   store volatile [32 x i32] %val, ptr @var

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/fast-cc.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/fast-cc.ll
@@ -3,7 +3,7 @@
 define fastcc i32 @callee(<16 x i32> %A) nounwind {
 ; CHECK-LABEL: callee:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 ;
 	%B = extractelement <16 x i32> %A, i32 0
 	ret i32 %B
@@ -32,11 +32,10 @@ define i32 @caller(<16 x i32> %A) nounwind {
 ; CHECK-NEXT: SW t0,4(sp)
 ; CHECK-NEXT: LW t0,48(sp)
 ; CHECK-NEXT: SW t0,0(sp)
-; CHECK-NEXT: LUI ra,%hi(callee)
-; CHECK-NEXT: JALR ra,%lo(callee)(ra)
+; CHECK-NEXT: CALL callee
 ; CHECK-NEXT: LW ra,44(sp)                            # 4-byte Folded Reload
 ; CHECK-NEXT: ADDI sp,sp,48
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 	%C = call fastcc i32 @callee(<16 x i32> %A)
 	ret i32 %C
 }

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/global_const_loop.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/global_const_loop.ll
@@ -21,7 +21,7 @@ define dso_local i32 @foo(i32 noundef %i) local_unnamed_addr #0 {
 ; CHECK-NEXT: LW fp,8(sp)                             # 4-byte Folded Reload
 ; CHECK-NEXT: LW ra,12(sp)                            # 4-byte Folded Reload
 ; CHECK-NEXT: ADDI sp,sp,16
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 entry:
   %cmp = icmp slt i32 %i, 1000
   br i1 %cmp, label %while.body.us, label %while.end

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/imm.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/imm.ll
@@ -3,21 +3,21 @@
 define signext i32 @zero() nounwind {
   ; CHECK-LABEL: zero: # @zero
   ; CHECK: ADDI a0,zero,0
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i32 0
 }
 
 define signext i32 @pos_small() nounwind {
   ; CHECK-LABEL: pos_small: # @pos_small
   ; CHECK: ADDI a0,zero,2047
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i32 2047
 }
 
 define signext i32 @neg_small() nounwind {
   ; CHECK-LABEL: neg_small: # @neg_small
   ; CHECK: ADDI a0,zero,-2048
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i32 -2048
 }
 
@@ -25,7 +25,7 @@ define signext i32 @pos_i32() nounwind {
   ; CHECK-LABEL: pos_i32: # @pos_i32
   ; CHECK: LUI a0,0x67783
   ; CHECK-NEXT: ADDI a0,a0,-1297
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i32 1735928559
 }
 
@@ -33,7 +33,7 @@ define signext i32 @neg_i32() nounwind {
   ; CHECK-LABEL: neg_i32: # @neg_i32
   ; CHECK: LUI a0,0xdeadc
   ; CHECK-NEXT: ADDI a0,a0,-273
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i32 -559038737
 }
 
@@ -41,7 +41,7 @@ define signext i32 @pos_i32_hi20_only() nounwind {
   ; CHECK-LABEL: pos_i32_hi20_only: # @pos_i32_hi20_only
   ; CHECK: LUI a0,0x10
   ; CHECK-NEXT: ADDI a0,a0,0
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i32 65536 ; 0x10000
 }
 
@@ -49,7 +49,7 @@ define signext i32 @neg_i32_hi20_only() nounwind {
   ; CHECK-LABEL: neg_i32_hi20_only: # @neg_i32_hi20_only
   ; CHECK: LUI a0,0xffff0
   ; CHECK-NEXT: ADDI a0,a0,0
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i32 -65536 ; -0x10000
 }
 
@@ -59,7 +59,7 @@ define i64 @imm_end_xori_1() nounwind {
   ; CHECK-NEXT: ADDI a0,a0,-1
   ; CHECK-NEXT: LUI a1,0xe0000
   ; CHECK-NEXT: ADDI a1,a1,0
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i64 -2305843009180139521 ; 0xE000_0000_01FF_FFFF
 }
   
@@ -67,7 +67,7 @@ define void @imm_store_i8_neg1(ptr %p) nounwind {
   ; CHECK-LABEL: imm_store_i8_neg1: # @imm_store_i8_neg1
   ; CHECK: ADDI a1,zero,255
   ; CHECK-NEXT: SB a1,0(a0)
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   store i8 -1, ptr %p
   ret void
 }
@@ -77,7 +77,7 @@ define void @imm_store_i16_neg1(ptr %p) nounwind {
   ; CHECK: LUI a1,0x10
   ; CHECK-NEXT: ADDI a1,a1,-1
   ; CHECK-NEXT: SH a1,0(a0)
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   store i16 -1, ptr %p
   ret void
 }
@@ -86,7 +86,7 @@ define void @imm_store_i32_neg1(ptr %p) nounwind {
   ; CHECK-LABEL: imm_store_i32_neg1: # @imm_store_i32_neg1
   ; CHECK: ADDI a1,zero,-1
   ; CHECK-NEXT: SW a1,0(a0)
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   store i32 -1, ptr %p
   ret void
 }

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/indirectbr.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/indirectbr.ll
@@ -6,7 +6,7 @@ define i32 @indirectbr(ptr %target) nounwind {
   ; CHECK-NEXT: JALR zero,0(a0)
   ; CHECK-LABEL: LBB0_1: # %test_label
   ; CHECK: ADDI a0,zero,0
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
    indirectbr ptr %target, [label %test_label]
 test_label:
   br label %ret
@@ -20,7 +20,7 @@ define i32 @indirectbr_with_offset(ptr %a) nounwind {
   ; CHECK-NEXT: JALR zero,1380(a0)
   ; CHECK-LABEL: LBB1_1:
   ; CHECK-NEXT: ADDI a0,zero,0
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
 
   %target = getelementptr inbounds i8, ptr %a, i32 1380
   indirectbr ptr %target, [label %test_label]

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/large_stack.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/large_stack.ll
@@ -48,7 +48,7 @@ define void @test_emergency_spill_slot(i32 %a) {
 ; CHECK-NEXT: LUI a0,0x62
 ; CHECK-NEXT: ADDI a0,a0,-1408
 ; CHECK-NEXT: ADD sp,sp,a0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %data = alloca [ 100000 x i32 ] , align 4
   %ptr = getelementptr inbounds [100000 x i32], ptr %data, i32 0, i32 80000
   %1 = tail call { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } asm sideeffect "nop", "=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r"()

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/mul.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/mul.ll
@@ -4,7 +4,7 @@ define signext i32 @square(i32 %a) nounwind {
 ; CHECK-LABEL: square: # @square
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: MUL a0,a0,a0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = mul i32 %a, %a
   ret i32 %1
 }
@@ -13,7 +13,7 @@ define signext i32 @mul(i32 %a, i32 %b) nounwind {
 ; CHECK-LABEL: mul: # @mul
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: MUL a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = mul i32 %a, %b
   ret i32 %1
 }
@@ -23,7 +23,7 @@ define signext i32 @mul_constant(i32 %a) nounwind {
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: ADDI a1,zero,5
 ; CHECK-NEXT: MUL a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = mul i32 %a, 5
   ret i32 %1
 }
@@ -32,7 +32,7 @@ define i32 @mul_pow2(i32 %a) nounwind {
 ; CHECK-LABEL: mul_pow2: # @mul_pow2
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: SLLI a0,a0,3
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = mul i32 %a, 8
   ret i32 %1
 }
@@ -46,7 +46,7 @@ define i64 @mul64(i64 %a, i64 %b) nounwind {
 ; CHECK-NEXT: MUL a1,a1,a2
 ; CHECK-NEXT: ADD a1,a3,a1
 ; CHECK-NEXT: MUL a0,a0,a2
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = mul i64 %a, %b
   ret i64 %1
 }
@@ -59,7 +59,7 @@ define i64 @mul64_constant(i64 %a) nounwind {
 ; CHECK-NEXT: MULHU a3,a0,a2
 ; CHECK-NEXT: ADD a1,a3,a1
 ; CHECK-NEXT: MUL a0,a0,a2
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = mul i64 %a, 5
   ret i64 %1
 }
@@ -68,7 +68,7 @@ define i32 @mulhs(i32 %a, i32 %b) nounwind {
 ; CHECK-LABEL: mulhs: # @mulhs
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: MULH a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = sext i32 %a to i64
   %2 = sext i32 %b to i64
   %3 = mul i64 %1, %2
@@ -82,7 +82,7 @@ define i32 @mulhs_positive_constant(i32 %a) nounwind {
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: ADDI a1,zero,5
 ; CHECK-NEXT: MULH a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = sext i32 %a to i64
   %2 = mul i64 %1, 5
   %3 = lshr i64 %2, 32
@@ -95,7 +95,7 @@ define i32 @mulhs_negative_constant(i32 %a) nounwind {
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: ADDI a1,zero,-5
 ; CHECK-NEXT: MULH a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = sext i32 %a to i64
   %2 = mul i64 %1, -5
   %3 = lshr i64 %2, 32
@@ -107,7 +107,7 @@ define zeroext i32 @mulhu(i32 zeroext %a, i32 zeroext %b) nounwind {
 ; CHECK-LABEL: mulhu: # @mulhu
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: MULHU a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = zext i32 %a to i64
   %2 = zext i32 %b to i64
   %3 = mul i64 %1, %2
@@ -123,7 +123,7 @@ define i32 @mulhsu(i32 %a, i32 %b) nounwind {
 ; CHECK-NEXT: SRAI a1,a1,31
 ; CHECK-NEXT: MUL a0,a0,a1
 ; CHECK-NEXT: ADD a0,a2,a0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = zext i32 %a to i64
   %2 = sext i32 %b to i64
   %3 = mul i64 %1, %2
@@ -137,7 +137,7 @@ define i32 @mulhu_constant(i32 %a) nounwind {
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: ADDI a1,zero,5
 ; CHECK-NEXT: MULHU a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = zext i32 %a to i64
   %2 = mul i64 %1, 5
   %3 = lshr i64 %2, 32
@@ -151,7 +151,7 @@ define i8 @muladd_demand(i8 %x, i8 %y) nounwind {
 ; CHECK-NEXT: SLLI a0,a0,1
 ; CHECK-NEXT: SUB a0,a1,a0
 ; CHECK-NEXT: ANDI a0,a0,15
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %m = mul i8 %x, 14
   %a = add i8 %y, %m
   %r = and i8 %a, 15
@@ -164,7 +164,7 @@ define i8 @mulsub_demand(i8 %x, i8 %y) nounwind {
 ; CHECK-NEXT: SLLI a0,a0,1
 ; CHECK-NEXT: ADD a0,a1,a0
 ; CHECK-NEXT: ANDI a0,a0,15
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %m = mul i8 %x, 14
   %a = sub i8 %y, %m
   %r = and i8 %a, 15
@@ -177,7 +177,7 @@ define i8 @muladd_demand_2(i8 %x, i8 %y) nounwind {
 ; CHECK-NEXT: SLLI a0,a0,1
 ; CHECK-NEXT: SUB a0,a1,a0
 ; CHECK-NEXT: ORI a0,a0,-16
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %m = mul i8 %x, 14
   %a = add i8 %y, %m
   %r = or i8 %a, 240
@@ -190,7 +190,7 @@ define i8 @mulsub_demand_2(i8 %x, i8 %y) nounwind {
 ; CHECK-NEXT: SLLI a0,a0,1
 ; CHECK-NEXT: ADD a0,a1,a0
 ; CHECK-NEXT: ORI a0,a0,-16
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %m = mul i8 %x, 14
   %a = sub i8 %y, %m
   %r = or i8 %a, 240
@@ -209,7 +209,7 @@ define i64 @muland_demand(i64 %x) nounwind {
 ; CHECK-NEXT: MULHU a3,a0,a2
 ; CHECK-NEXT: ADD a1,a3,a1
 ; CHECK-NEXT: MUL a0,a0,a2
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %and = and i64 %x, 4611686018427387896
   %mul = mul i64 %and, 12
   ret i64 %mul
@@ -221,7 +221,7 @@ define i64 @mulzext_demand(i32 signext %x) nounwind {
 ; CHECK-NEXT: ADDI a1,zero,3
 ; CHECK-NEXT: MUL a1,a0,a1
 ; CHECK-NEXT: ADDI a0,zero,0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %ext = zext i32 %x to i64
   %mul = mul i64 %ext, 12884901888
   ret i64 %mul

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/pic.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/pic.ll
@@ -10,7 +10,7 @@ define ptr @f1() nounwind {
 ; CHECK-LABEL: # %bb.0: # %entry
 ; CHECK-NEXT: AUIPC a0,%got_pcrel_hi(external_var)
 ; CHECK-NEXT: LW a0,%pcrel_lo(external_var)(a0)
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 entry:
   ret ptr @external_var
 }
@@ -21,7 +21,7 @@ define ptr @f2() nounwind {
 ; CHECK-LABEL: .Ltmp0
 ; CHECK-NEXT: AUIPC a0,%pcrel_hi(internal_var)
 ; CHECK-NEXT: ADDI a0,a0,%pcrel_lo(.Ltmp0)
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 entry:
   ret ptr @internal_var
 }

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/rotl-rotr.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/rotl-rotr.ll
@@ -11,7 +11,7 @@ define i32 @rotl_32(i32 %x, i32 %y) nounwind {
 ; CHECK-NEXT: SLL a1,a0,a1
 ; CHECK-NEXT: SRL a0,a0,a2
 ; CHECK-NEXT: OR a0,a1,a0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %z = sub i32 32, %y
   %b = shl i32 %x, %y
   %c = lshr i32 %x, %z
@@ -27,7 +27,7 @@ define i32 @rotr_32(i32 %x, i32 %y) nounwind {
 ; CHECK-NEXT: SRL a1,a0,a1
 ; CHECK-NEXT: SLL a0,a0,a2
 ; CHECK-NEXT: OR a0,a1,a0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %z = sub i32 32, %y
   %b = lshr i32 %x, %y
   %c = shl i32 %x, %z
@@ -48,16 +48,14 @@ define i64 @rotl_64(i64 %x, i64 %y) nounwind {
 ; CHECK-NEXT: ADDI s1,a2,0
 ; CHECK-NEXT: ADDI s2,a1,0
 ; CHECK-NEXT: ADDI s3,a0,0
-; CHECK-NEXT: LUI ra,%hi(__ashldi3)
-; CHECK-NEXT: JALR ra,%lo(__ashldi3)(ra)
+; CHECK-NEXT: CALL __ashldi3
 ; CHECK-NEXT: ADDI s4,a0,0
 ; CHECK-NEXT: ADDI s5,a1,0
 ; CHECK-NEXT: ADDI a0,zero,64
 ; CHECK-NEXT: SUB a2,a0,s1
 ; CHECK-NEXT: ADDI a0,s3,0
 ; CHECK-NEXT: ADDI a1,s2,0
-; CHECK-NEXT: LUI ra,%hi(__lshrdi3)
-; CHECK-NEXT: JALR ra,%lo(__lshrdi3)(ra)
+; CHECK-NEXT: CALL __lshrdi3
 ; CHECK-NEXT: OR a0,s4,a0
 ; CHECK-NEXT: OR a1,s5,a1
 ; CHECK-NEXT: LW s5,8(sp) # 4-byte Folded Reload
@@ -67,7 +65,7 @@ define i64 @rotl_64(i64 %x, i64 %y) nounwind {
 ; CHECK-NEXT: LW s1,24(sp) # 4-byte Folded Reload
 ; CHECK-NEXT: LW ra,28(sp) # 4-byte Folded Reload
 ; CHECK-NEXT: ADDI sp,sp,32
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %z = sub i64 64, %y
   %b = shl i64 %x, %y
   %c = lshr i64 %x, %z
@@ -88,16 +86,14 @@ define i64 @rotr_64(i64 %x, i64 %y) nounwind {
 ; CHECK-NEXT: ADDI s1,a2,0
 ; CHECK-NEXT: ADDI s2,a1,0
 ; CHECK-NEXT: ADDI s3,a0,0
-; CHECK-NEXT: LUI ra,%hi(__lshrdi3)
-; CHECK-NEXT: JALR ra,%lo(__lshrdi3)(ra)
+; CHECK-NEXT: CALL __lshrdi3
 ; CHECK-NEXT: ADDI s4,a0,0
 ; CHECK-NEXT: ADDI s5,a1,0
 ; CHECK-NEXT: ADDI a0,zero,64
 ; CHECK-NEXT: SUB a2,a0,s1
 ; CHECK-NEXT: ADDI a0,s3,0
 ; CHECK-NEXT: ADDI a1,s2,0
-; CHECK-NEXT: LUI ra,%hi(__ashldi3)
-; CHECK-NEXT: JALR ra,%lo(__ashldi3)(ra)
+; CHECK-NEXT: CALL __ashldi3
 ; CHECK-NEXT: OR a0,s4,a0
 ; CHECK-NEXT: OR a1,s5,a1
 ; CHECK-NEXT: LW s5,8(sp) # 4-byte Folded Reload
@@ -107,7 +103,7 @@ define i64 @rotr_64(i64 %x, i64 %y) nounwind {
 ; CHECK-NEXT: LW s1,24(sp) # 4-byte Folded Reload
 ; CHECK-NEXT: LW ra,28(sp) # 4-byte Folded Reload
 ; CHECK-NEXT: ADDI sp,sp,32
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %z = sub i64 64, %y
   %b = lshr i64 %x, %y
   %c = shl i64 %x, %z
@@ -123,7 +119,7 @@ define i32 @rotl_32_mask(i32 %x, i32 %y) nounwind {
 ; CHECK-NEXT: ANDI a2,a2,31
 ; CHECK-NEXT: SRL a0,a0,a2
 ; CHECK-NEXT: OR a0,a1,a0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %z = sub i32 0, %y
   %and = and i32 %z, 31
   %b = shl i32 %x, %y
@@ -141,7 +137,7 @@ define i32 @rotl_32_mask_and_63_and_31(i32 %x, i32 %y) nounwind {
 ; CHECK-NEXT: ANDI a2,a2,31
 ; CHECK-NEXT: SRL a0,a0,a2
 ; CHECK-NEXT: OR a0,a1,a0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %a = and i32 %y, 63
   %b = shl i32 %x, %a
   %c = sub i32 0, %y
@@ -155,7 +151,7 @@ define i32 @rotl_32_mask_or_64_or_32(i32 %x, i32 %y) nounwind {
 ; CHECK-LABEL: rotl_32_mask_or_64_or_32:
 ; CHECK: # %bb.0:
 ; CHECK-NEXT: ADDI a0,zero,0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %a = or i32 %y, 64
   %b = shl i32 %x, %a
   %c = sub i32 0, %y
@@ -173,7 +169,7 @@ define i32 @rotr_32_mask(i32 %x, i32 %y) nounwind {
 ; CHECK-NEXT: ANDI a2,a2,31
 ; CHECK-NEXT: SLL a0,a0,a2
 ; CHECK-NEXT: OR a0,a1,a0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %z = sub i32 0, %y
   %and = and i32 %z, 31
   %b = lshr i32 %x, %y
@@ -191,7 +187,7 @@ define i32 @rotr_32_mask_and_63_and_31(i32 %x, i32 %y) nounwind {
 ; CHECK-NEXT: ANDI a2,a2,31
 ; CHECK-NEXT: SLL a0,a0,a2
 ; CHECK-NEXT: OR a0,a1,a0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %a = and i32 %y, 63
   %b = lshr i32 %x, %a
   %c = sub i32 0, %y
@@ -205,7 +201,7 @@ define i32 @rotr_32_mask_or_64_or_32(i32 %x, i32 %y) nounwind {
 ; CHECK-LABEL: rotr_32_mask_or_64_or_32:
 ; CHECK: # %bb.0:
 ; CHECK-NEXT: ADDI a0,zero,0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %a = or i32 %y, 64
   %b = lshr i32 %x, %a
   %c = sub i32 0, %y
@@ -228,16 +224,14 @@ define i64 @rotl_64_mask(i64 %x, i64 %y) nounwind {
 ; CHECK-NEXT: ADDI s1,a2,0
 ; CHECK-NEXT: ADDI s2,a1,0
 ; CHECK-NEXT: ADDI s3,a0,0
-; CHECK-NEXT: LUI ra,%hi(__ashldi3)
-; CHECK-NEXT: JALR ra,%lo(__ashldi3)(ra)
+; CHECK-NEXT: CALL __ashldi3
 ; CHECK-NEXT: ADDI s4,a0,0
 ; CHECK-NEXT: ADDI s5,a1,0
 ; CHECK-NEXT: SUB a0,zero,s1
 ; CHECK-NEXT: ANDI a2,a0,63
 ; CHECK-NEXT: ADDI a0,s3,0
 ; CHECK-NEXT: ADDI a1,s2,0
-; CHECK-NEXT: LUI ra,%hi(__lshrdi3)
-; CHECK-NEXT: JALR ra,%lo(__lshrdi3)(ra)
+; CHECK-NEXT: CALL __lshrdi3
 ; CHECK-NEXT: OR a0,s4,a0
 ; CHECK-NEXT: OR a1,s5,a1
 ; CHECK-NEXT: LW s5,8(sp) # 4-byte Folded Reload
@@ -247,7 +241,7 @@ define i64 @rotl_64_mask(i64 %x, i64 %y) nounwind {
 ; CHECK-NEXT: LW s1,24(sp) # 4-byte Folded Reload
 ; CHECK-NEXT: LW ra,28(sp) # 4-byte Folded Reload
 ; CHECK-NEXT: ADDI sp,sp,32
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %z = sub i64 0, %y
   %and = and i64 %z, 63
   %b = shl i64 %x, %y

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/select-cc.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/select-cc.ll
@@ -63,7 +63,7 @@ define signext i32 @foo(i32 signext %a, ptr %b) nounwind {
 ; CHECK-NEXT: BLTU a3,a2,.LBB0_14
 ; CHECK-NEXT: JAL zero,.LBB0_28
 ; CHECK-NEXT: .LBB0_14:
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 ; CHECK-NEXT: .LBB0_15:
 ; CHECK-NEXT: ADDI a0,a2,0
 ; CHECK-NEXT: LW a2,0(a1)
@@ -122,7 +122,7 @@ define signext i32 @foo(i32 signext %a, ptr %b) nounwind {
 ; CHECK-NEXT: BLTU a3,a2,.LBB0_14
 ; CHECK-NEXT: .LBB0_28:
 ; CHECK-NEXT: ADDI a0,a1,0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %val1 = load volatile i32, ptr %b
   %tst1 = icmp eq i32 %a, %val1
   %val2 = select i1 %tst1, i32 %a, i32 %val1
@@ -193,7 +193,7 @@ define i32 @select_sge_int16min(i32 signext %x, i32 signext %y, i32 signext %z) 
 ; CHECK-NEXT: ADDI a1,a2,0
 ; CHECK-NEXT: .LBB1_2:
 ; CHECK-NEXT: ADDI a0,a1,0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %a = icmp sge i32 %x, -65536
   %b = select i1 %a, i32 %y, i32 %z
   ret i32 %b
@@ -219,12 +219,12 @@ define i64 @select_sge_int32min(i64 %x, i64 %y, i64 %z) {
 ; CHECK-NEXT: .LBB2_5:
 ; CHECK-NEXT: ADDI a0,a2,0
 ; CHECK-NEXT: ADDI a1,a3,0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 ; CHECK-NEXT: .LBB2_6:
 ; CHECK-NEXT: ADDI a3,a5,0
 ; CHECK-NEXT: ADDI a0,a2,0
 ; CHECK-NEXT: ADDI a1,a3,0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %a = icmp sge i64 %x, -2147483648
   %b = select i1 %a, i64 %y, i64 %z
   ret i64 %b

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/sext-zext-trunc.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/sext-zext-trunc.ll
@@ -27,7 +27,7 @@ define i8 @sext_i1_to_i8(i1 %a) nounwind {
 ; CHECK-NEXT: # %bb.0:
 ; CHECK-NEXT: ANDI a0,a0,1
 ; CHECK-NEXT: SUB a0,zero,a0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = sext i1 %a to i8
   ret i8 %1
 }
@@ -37,7 +37,7 @@ define i16 @sext_i1_to_i16(i1 %a) nounwind {
 ; CHECK-NEXT: # %bb.0:
 ; CHECK-NEXT: ANDI a0,a0,1
 ; CHECK-NEXT: SUB a0,zero,a0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = sext i1 %a to i16
   ret i16 %1
 }
@@ -47,7 +47,7 @@ define i32 @sext_i1_to_i32(i1 %a) nounwind {
 ; CHECK-NEXT: # %bb.0:
 ; CHECK-NEXT: ANDI a0,a0,1
 ; CHECK-NEXT: SUB a0,zero,a0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = sext i1 %a to i32
   ret i32 %1
 }
@@ -58,7 +58,7 @@ define i64 @sext_i1_to_i64(i1 %a) nounwind {
 ; CHECK-NEXT: ANDI a0,a0,1
 ; CHECK-NEXT: SUB a0,zero,a0
 ; CHECK-NEXT: ADDI a1,a0,0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = sext i1 %a to i64
   ret i64 %1
 }
@@ -68,7 +68,7 @@ define i16 @sext_i8_to_i16(i8 %a) nounwind {
 ; CHECK-NEXT: # %bb.0:
 ; CHECK-NEXT: SLLI a0,a0,24
 ; CHECK-NEXT: SRAI a0,a0,24
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = sext i8 %a to i16
   ret i16 %1
 }
@@ -78,7 +78,7 @@ define i32 @sext_i8_to_i32(i8 %a) nounwind {
 ; CHECK-NEXT: # %bb.0:
 ; CHECK-NEXT: SLLI a0,a0,24
 ; CHECK-NEXT: SRAI a0,a0,24
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = sext i8 %a to i32
   ret i32 %1
 }

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O0/alu64.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O0/alu64.ll
@@ -6,7 +6,7 @@ define i64 @addi(i64 %a) nounwind {
 ; CHECK-LABEL: addi: # @addi
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: ADDI a0,a0,1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = add i64 %a, 1
   ret i64 %1
 }
@@ -15,7 +15,7 @@ define i64 @slti(i64 %a) nounwind {
 ; CHECK-LABEL: slti: # @slti
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: SLTI a0,a0,2
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = icmp slt i64 %a, 2
   %2 = zext i1 %1 to i64
   ret i64 %2
@@ -25,7 +25,7 @@ define i64 @sltiu(i64 %a) nounwind {
 ; CHECK-LABEL: sltiu: # @sltiu
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: SLTIU a0,a0,3
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = icmp ult i64 %a, 3
   %2 = zext i1 %1 to i64
   ret i64 %2
@@ -35,7 +35,7 @@ define i64 @xori(i64 %a) nounwind {
 ; CHECK-LABEL: xori: # @xori
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: XORI a0,a0,4
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = xor i64 %a, 4
   ret i64 %1
 }
@@ -44,7 +44,7 @@ define i64 @ori(i64 %a) nounwind {
 ; CHECK-LABEL: ori: # @ori
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: ORI a0,a0,5
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = or i64 %a, 5
   ret i64 %1
 }
@@ -53,7 +53,7 @@ define i64 @andi(i64 %a) nounwind {
 ; CHECK-LABEL: andi: # @andi
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: ANDI a0,a0,6
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = and i64 %a, 6
   ret i64 %1
 }
@@ -62,7 +62,7 @@ define i64 @slli(i64 %a) nounwind {
 ; CHECK-LABEL: slli: # @slli
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: SLLI a0,a0,7
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = shl i64 %a, 7
   ret i64 %1
 }
@@ -71,7 +71,7 @@ define i64 @srli(i64 %a) nounwind {
 ; CHECK-LABEL: srli: # @srli
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: SRLI a0,a0,8
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = lshr i64 %a, 8
   ret i64 %1
 }
@@ -80,7 +80,7 @@ define i64 @srai(i64 %a) nounwind {
 ; CHECK-LABEL: srai: # @srai
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: SRAI a0,a0,9
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = ashr i64 %a, 9
   ret i64 %1
 }
@@ -91,7 +91,7 @@ define i64 @add(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: add: # @add
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: ADD a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = add i64 %a, %b
   ret i64 %1
 }
@@ -100,7 +100,7 @@ define i64 @sub(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: sub: # @sub
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: SUB a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = sub i64 %a, %b
   ret i64 %1
 }
@@ -109,7 +109,7 @@ define i64 @sll(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: sll: # @sll
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: SLL a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = shl i64 %a, %b
   ret i64 %1
 }
@@ -118,7 +118,7 @@ define i64 @slt(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: slt: # @slt
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: SLT a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = icmp slt i64 %a, %b
   %2 = zext i1 %1 to i64
   ret i64 %2
@@ -128,7 +128,7 @@ define i64 @xor(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: xor: # @xor
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: XOR a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = xor i64 %a, %b
   ret i64 %1
 }
@@ -137,7 +137,7 @@ define i64 @srl(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: srl: # @srl
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: SRL a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = lshr i64 %a, %b
   ret i64 %1
 }
@@ -146,7 +146,7 @@ define i64 @sra(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: sra: # @sra
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: SRA a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = ashr i64 %a, %b
   ret i64 %1
 }
@@ -155,7 +155,7 @@ define i64 @or(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: or: # @or
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: OR a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = or i64 %a, %b
   ret i64 %1
 }
@@ -164,7 +164,7 @@ define i64 @and(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: and: # @and
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: AND a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = and i64 %a, %b
   ret i64 %1
 }

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O0/and.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O0/and.ll
@@ -4,7 +4,7 @@
 define i32 @and32_0x7ff(i32 %x) {
 ; CHECK-LABEL: and32_0x7ff: # @and32_0x7ff
 ; CHECK:         ANDI a0,a0,2047
-; CHECK-NEXT:    JALR zero,0(ra)
+; CHECK-NEXT:    RET
   %a = and i32 %x, 2047
   ret i32 %a
 }
@@ -14,7 +14,7 @@ define i32 @and32_0xfff(i32 %x) {
 ; CHECK:       LUI a1,0x1
 ; CHECK-NEXT:  ADDI a1,a1,-1
 ; CHECK-NEXT:  AND a0,a0,a1
-; CHECK-NEXT:  JALR zero,0(ra)
+; CHECK-NEXT:  RET
   %a = and i32 %x, 4095
   ret i32 %a
 }
@@ -22,7 +22,7 @@ define i32 @and32_0xfff(i32 %x) {
 define i64 @and64_0x7ff(i64 %x) {
 ; CHECK-LABEL: and64_0x7ff: # @and64_0x7ff
 ; CHECK:         ANDI a0,a0,2047
-; CHECK-NEXT:    JALR zero,0(ra)
+; CHECK-NEXT:    RET
   %a = and i64 %x, 2047
   ret i64 %a
 }
@@ -32,7 +32,7 @@ define i64 @and64_0xfff(i64 %x) {
 ; CHECK:       LUI a1,0x1
 ; CHECK-NEXT:  ADDI a1,a1,-1
 ; CHECK-NEXT:  AND a0,a0,a1
-; CHECK-NEXT:  JALR zero,0(ra)
+; CHECK-NEXT:  RET
   %a = and i64 %x, 4095
   ret i64 %a
 }

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O0/imm.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O0/imm.ll
@@ -3,21 +3,21 @@
 define signext i32 @zero() nounwind {
   ; CHECK-LABEL: zero: # @zero
   ; CHECK: ADDI a0,zero,0
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i32 0
 }
 
 define signext i32 @pos_small() nounwind {
   ; CHECK-LABEL: pos_small: # @pos_small
   ; CHECK: ADDI a0,zero,2047
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i32 2047
 }
 
 define signext i32 @neg_small() nounwind {
   ; CHECK-LABEL: neg_small: # @neg_small
   ; CHECK: ADDI a0,zero,-2048
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i32 -2048
 }
 
@@ -25,7 +25,7 @@ define signext i32 @pos_i32() nounwind {
   ; CHECK-LABEL: pos_i32: # @pos_i32
   ; CHECK: LUI a0,0x67783
   ; CHECK-NEXT: ADDI a0,a0,-1297
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i32 1735928559
 }
 
@@ -33,7 +33,7 @@ define signext i32 @neg_i32() nounwind {
   ; CHECK-LABEL: neg_i32: # @neg_i32
   ; CHECK: LUI a0,0xdeadc
   ; CHECK-NEXT: ADDI a0,a0,-273
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i32 -559038737
 }
 
@@ -41,7 +41,7 @@ define signext i32 @pos_i32_hi20_only() nounwind {
   ; CHECK-LABEL: pos_i32_hi20_only: # @pos_i32_hi20_only
   ; CHECK: LUI a0,0x10
   ; CHECK-NEXT: ADDI a0,a0,0
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i32 65536 ; 0x10000
 }
 
@@ -49,7 +49,7 @@ define signext i32 @neg_i32_hi20_only() nounwind {
   ; CHECK-LABEL: neg_i32_hi20_only: # @neg_i32_hi20_only
   ; CHECK: LUI a0,0xffff0
   ; CHECK-NEXT: ADDI a0,a0,0
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i32 -65536 ; -0x10000
 }
 
@@ -61,7 +61,7 @@ define i64 @imm_end_xori_1() nounwind {
   ; CHECK-NEXT: ORI a0,a0,-512
   ; CHECK-NEXT: SLLI a0,a0,16
   ; CHECK-NEXT: ORI a0,a0,-1
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i64 -2305843009180139521 ; 0xE000_0000_01FF_FFFF
 }
 
@@ -69,7 +69,7 @@ define void @imm_store_i8_neg1(ptr %p) nounwind {
   ; CHECK-LABEL: imm_store_i8_neg1: # @imm_store_i8_neg1
   ; CHECK: ADDI a1,zero,255
   ; CHECK-NEXT: SB a1,0(a0)
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   store i8 -1, ptr %p
   ret void
 }
@@ -79,7 +79,7 @@ define void @imm_store_i16_neg1(ptr %p) nounwind {
   ; CHECK: LUI a1,0x10
   ; CHECK-NEXT: ADDI a1,a1,-1
   ; CHECK-NEXT: SH a1,0(a0)
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   store i16 -1, ptr %p
   ret void
 }
@@ -93,7 +93,7 @@ define void @imm_store_i32_neg1(ptr %p) nounwind {
   ; CHECK-NEXT: SLLI a1,a1,16
   ; CHECK-NEXT: ORI a1,a1,-1
   ; CHECK-NEXT: SW a1,0(a0)
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   store i32 -1, ptr %p
   ret void
 }

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O0/indirectbr.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O0/indirectbr.ll
@@ -6,7 +6,7 @@ define i32 @indirectbr(ptr %target) nounwind {
   ; CHECK-NEXT: JALR zero,0(a0)
   ; CHECK-LABEL: LBB0_1: # %test_label
   ; CHECK: ADDI a0,zero,0
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
    indirectbr ptr %target, [label %test_label]
 test_label:
   br label %ret
@@ -22,7 +22,7 @@ define i32 @indirectbr_with_offset(ptr %a) nounwind {
   ; CHECK-NEXT: JAL zero,.LBB1_2
   ; CHECK-LABEL: LBB1_2:
   ; CHECK-NEXT: ADDI a0,zero,0
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
 
   %target = getelementptr inbounds i8, ptr %a, i32 1380
   indirectbr ptr %target, [label %test_label]

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O0/large_stack.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O0/large_stack.ll
@@ -50,7 +50,7 @@ define void @test_emergency_spill_slot(i32 %a) {
 ; CHECK-NEXT: LUI a0,0x62
 ; CHECK-NEXT: ADDI a0,a0,-1408
 ; CHECK-NEXT: ADD sp,sp,a0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %data = alloca [ 100000 x i32 ] , align 4
   %ptr = getelementptr inbounds [100000 x i32], ptr %data, i32 0, i32 80000
   %1 = tail call { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } asm sideeffect "nop", "=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r"()

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O0/mul.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O0/mul.ll
@@ -6,7 +6,7 @@ define signext i32 @square(i32 %a) nounwind {
 ; CHECK: MUL a0,a0,a0
 ; CHECK-NEXT: SLLI a0,a0,32
 ; CHECK-NEXT: SRAI a0,a0,32
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = mul i32 %a, %a
   ret i32 %1
 }
@@ -17,7 +17,7 @@ define signext i32 @mul(i32 %a, i32 %b) nounwind {
 ; CHECK: MUL a0,a0,a1
 ; CHECK-NEXT: SLLI a0,a0,32
 ; CHECK-NEXT: SRAI a0,a0,32
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = mul i32 %a, %b
   ret i32 %1
 }
@@ -33,7 +33,7 @@ define signext i32 @mul_constant(i32 %a) nounwind {
 ; CHECK-NEXT: ORI a1,a1,0
 ; CHECK-NEXT: MUL a0,a0,a1
 ; CHECK-NEXT: SRAI a0,a0,32
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = mul i32 %a, 5
   ret i32 %1
 }
@@ -42,7 +42,7 @@ define i32 @mul_pow2(i32 %a) nounwind {
 ; CHECK-LABEL: mul_pow2: # @mul_pow2
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: SLLI a0,a0,3
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = mul i32 %a, 8
   ret i32 %1
 }
@@ -51,7 +51,7 @@ define i64 @mul64(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: mul64: # @mul64
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: MUL a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = mul i64 %a, %b
   ret i64 %1
 }

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O0/pic.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O0/pic.ll
@@ -11,7 +11,7 @@ define ptr @f1() nounwind {
 ; CHECK-LABEL: .Ltmp0:
 ; CHECK-NEXT: AUIPC a0,%got_pcrel_hi(external_var)
 ; CHECK-NEXT: LD a0,%pcrel_lo(.Ltmp0)(a0)
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 entry:
   ret ptr @external_var
 }
@@ -22,7 +22,7 @@ define ptr @f2() nounwind {
 ; CHECK-LABEL: .Ltmp1:
 ; CHECK-NEXT: AUIPC a0,%pcrel_hi(internal_var)
 ; CHECK-NEXT: ADDI a0,a0,%pcrel_lo(.Ltmp1)
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 entry:
   ret ptr @internal_var
 }

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O0/static_global_var.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O0/static_global_var.ll
@@ -29,7 +29,7 @@ define void @init_heap_beebs(ptr noundef %heap, i64 noundef %heap_size) #0 {
 ; CHECK-NEXT: ADDI a1,zero,0
 ; CHECK-NEXT: SD a1,0(a0)
 ; CHECK-NEXT: ADDI sp,sp,16
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 entry:
   %heap.addr = alloca ptr, align 8
   %heap_size.addr = alloca i64, align 8

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/alu64.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/alu64.ll
@@ -6,7 +6,7 @@ define i64 @addi(i64 %a) nounwind {
 ; CHECK-LABEL: addi: # @addi
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: ADDI a0,a0,1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = add i64 %a, 1
   ret i64 %1
 }
@@ -15,7 +15,7 @@ define i64 @slti(i64 %a) nounwind {
 ; CHECK-LABEL: slti: # @slti
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: SLTI a0,a0,2
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = icmp slt i64 %a, 2
   %2 = zext i1 %1 to i64
   ret i64 %2
@@ -25,7 +25,7 @@ define i64 @sltiu(i64 %a) nounwind {
 ; CHECK-LABEL: sltiu: # @sltiu
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: SLTIU a0,a0,3
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = icmp ult i64 %a, 3
   %2 = zext i1 %1 to i64
   ret i64 %2
@@ -35,7 +35,7 @@ define i64 @xori(i64 %a) nounwind {
 ; CHECK-LABEL: xori: # @xori
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: XORI a0,a0,4
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = xor i64 %a, 4
   ret i64 %1
 }
@@ -44,7 +44,7 @@ define i64 @ori(i64 %a) nounwind {
 ; CHECK-LABEL: ori: # @ori
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: ORI a0,a0,5
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = or i64 %a, 5
   ret i64 %1
 }
@@ -53,7 +53,7 @@ define i64 @andi(i64 %a) nounwind {
 ; CHECK-LABEL: andi: # @andi
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: ANDI a0,a0,6
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = and i64 %a, 6
   ret i64 %1
 }
@@ -62,7 +62,7 @@ define i64 @slli(i64 %a) nounwind {
 ; CHECK-LABEL: slli: # @slli
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: SLLI a0,a0,7
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = shl i64 %a, 7
   ret i64 %1
 }
@@ -71,7 +71,7 @@ define i64 @srli(i64 %a) nounwind {
 ; CHECK-LABEL: srli: # @srli
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: SRLI a0,a0,8
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = lshr i64 %a, 8
   ret i64 %1
 }
@@ -80,7 +80,7 @@ define i64 @srai(i64 %a) nounwind {
 ; CHECK-LABEL: srai: # @srai
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: SRAI a0,a0,9
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = ashr i64 %a, 9
   ret i64 %1
 }
@@ -91,7 +91,7 @@ define i64 @add(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: add: # @add
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: ADD a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = add i64 %a, %b
   ret i64 %1
 }
@@ -100,7 +100,7 @@ define i64 @sub(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: sub: # @sub
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: SUB a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = sub i64 %a, %b
   ret i64 %1
 }
@@ -109,7 +109,7 @@ define i64 @sll(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: sll: # @sll
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: SLL a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = shl i64 %a, %b
   ret i64 %1
 }
@@ -118,7 +118,7 @@ define i64 @slt(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: slt: # @slt
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: SLT a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = icmp slt i64 %a, %b
   %2 = zext i1 %1 to i64
   ret i64 %2
@@ -128,7 +128,7 @@ define i64 @sltu(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: sltu: # @sltu
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: SLTU a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = icmp ult i64 %a, %b
   %2 = zext i1 %1 to i64
   ret i64 %2
@@ -138,7 +138,7 @@ define i64 @xor(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: xor: # @xor
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: XOR a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = xor i64 %a, %b
   ret i64 %1
 }
@@ -147,7 +147,7 @@ define i64 @srl(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: srl: # @srl
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: SRL a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = lshr i64 %a, %b
   ret i64 %1
 }
@@ -156,7 +156,7 @@ define i64 @sra(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: sra: # @sra
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: SRA a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = ashr i64 %a, %b
   ret i64 %1
 }
@@ -165,7 +165,7 @@ define i64 @or(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: or: # @or
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: OR a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = or i64 %a, %b
   ret i64 %1
 }
@@ -174,7 +174,7 @@ define i64 @and(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: and: # @and
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: AND a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = and i64 %a, %b
   ret i64 %1
 }
@@ -193,7 +193,7 @@ define signext i32 @addiw(i32 signext %a) nounwind {
 ; CHECK-NEXT: ORI a1,a1,0
 ; CHECK-NEXT: ADD a0,a0,a1
 ; CHECK-NEXT: SRAI a0,a0,32
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = add i32 %a, 123
   ret i32 %1
 }
@@ -203,7 +203,7 @@ define signext i32 @slliw(i32 signext %a) nounwind {
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: SLLI a0,a0,49
 ; CHECK-NEXT: SRAI a0,a0,32
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = shl i32 %a, 17
   ret i32 %1
 }
@@ -219,7 +219,7 @@ define signext i32 @srliw(i32 %a) nounwind {
 ; CHECK-NEXT: ORI a1,a1,-256
 ; CHECK-NEXT: AND a0,a0,a1
 ; CHECK-NEXT: SRLI a0,a0,8
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = lshr i32 %a, 8
   ret i32 %1
 }
@@ -229,7 +229,7 @@ define signext i32 @sraiw(i32 %a) nounwind {
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: SLLI a0,a0,32
 ; CHECK-NEXT: SRAI a0,a0,41
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = ashr i32 %a, 9
   ret i32 %1
 }
@@ -239,7 +239,7 @@ define i64 @sraiw_i64(i64 %a) nounwind {
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: SLLI a0,a0,32
 ; CHECK-NEXT: SRAI a0,a0,41
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = shl i64 %a, 32
   %2 = ashr i64 %1, 41
   ret i64 %2
@@ -250,7 +250,7 @@ define signext i32 @sextw(i32 zeroext %a) nounwind {
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: SLLI a0,a0,32
 ; CHECK-NEXT: SRAI a0,a0,32
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   ret i32 %a
 }
 
@@ -260,7 +260,7 @@ define signext i32 @addw(i32 signext %a, i32 signext %b) nounwind {
 ; CHECK-NEXT: ADD a0,a0,a1
 ; CHECK-NEXT: SLLI a0,a0,32
 ; CHECK-NEXT: SRAI a0,a0,32
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = add i32 %a, %b
   ret i32 %1
 }
@@ -271,7 +271,7 @@ define signext i32 @subw(i32 signext %a, i32 signext %b) nounwind {
 ; CHECK-NEXT: SUB a0,a0,a1
 ; CHECK-NEXT: SLLI a0,a0,32
 ; CHECK-NEXT: SRAI a0,a0,32
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = sub i32 %a, %b
   ret i32 %1
 }
@@ -282,7 +282,7 @@ define signext i32 @sllw(i32 signext %a, i32 zeroext %b) nounwind {
 ; CHECK-NEXT: SLL a0,a0,a1
 ; CHECK-NEXT: SLLI a0,a0,32
 ; CHECK-NEXT: SRAI a0,a0,32
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = shl i32 %a, %b
   ret i32 %1
 }
@@ -300,7 +300,7 @@ define signext i32 @srlw(i32 signext %a, i32 zeroext %b) nounwind {
 ; CHECK-NEXT: SRL a0,a0,a1
 ; CHECK-NEXT: SLLI a0,a0,32
 ; CHECK-NEXT: SRAI a0,a0,32
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = lshr i32 %a, %b
   ret i32 %1
 }
@@ -311,7 +311,7 @@ define signext i32 @sraw(i64 %a, i32 zeroext %b) nounwind {
 ; CHECK-NEXT: SLLI a0,a0,32
 ; CHECK-NEXT: SRAI a0,a0,32
 ; CHECK-NEXT: SRA a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = trunc i64 %a to i32
   %2 = ashr i32 %1, %b
   ret i32 %2
@@ -321,7 +321,7 @@ define i64 @add_hi_and_lo_negone(i64 %0) {
 ; CHECK-LABEL: add_hi_and_lo_negone: # @add_hi_and_lo_negone
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: ADDI a0,a0,-1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %2 = add nsw i64 %0, -1
   ret i64 %2
 }
@@ -336,7 +336,7 @@ define i64 @add_hi_zero_lo_negone(i64 %0) {
 ; CHECK-NEXT: SLLI a1,a1,16
 ; CHECK-NEXT: ORI a1,a1,-1
 ; CHECK-NEXT: ADD a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %2 = add i64 %0, 4294967295
   ret i64 %2
 }
@@ -351,7 +351,7 @@ define i64 @add_lo_negone(i64 %0) {
 ; CHECK-NEXT: SLLI a1,a1,16
 ; CHECK-NEXT: ORI a1,a1,-1
 ; CHECK-NEXT: ADD a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %2 = add nsw i64 %0, -4294967297
   ret i64 %2
 }
@@ -366,7 +366,7 @@ define i64 @add_hi_one_lo_negone(i64 %0) {
 ; CHECK-NEXT: SLLI a1,a1,16
 ; CHECK-NEXT: ORI a1,a1,-1
 ; CHECK-NEXT: ADD a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %2 = add nsw i64 %0, 8589934591
   ret i64 %2
 }

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/analyze-branch.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/analyze-branch.ll
@@ -22,17 +22,15 @@ define void @test_bcc_fallthrough_taken(i32 %in) nounwind {
 ; CHECK-NEXT: ADDI a1,zero,42
 ; CHECK-NEXT: BNE a0,a1,.LBB0_2
 ; CHECK-LABEL: # %bb.1: # %true
-; CHECK-NEXT: LUI ra,%hi(test_true)
-; CHECK-NEXT: JALR ra,%lo(test_true)(ra)
+; CHECK-NEXT: CALL test_true
 ; CHECK-NEXT: LD ra,8(sp) # 8-byte Folded Reload
 ; CHECK-NEXT: ADDI sp,sp,16
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 ; CHECK-LABEL: .LBB0_2: # %false
-; CHECK-NEXT: LUI ra,%hi(test_false)
-; CHECK-NEXT: JALR ra,%lo(test_false)(ra)
+; CHECK-NEXT: CALL test_false
 ; CHECK-NEXT: LD ra,8(sp) # 8-byte Folded Reload
 ; CHECK-NEXT: ADDI sp,sp,16
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %tst = icmp eq i32 %in, 42
   br i1 %tst, label %true, label %false, !prof !0
 
@@ -65,17 +63,15 @@ define void @test_bcc_fallthrough_nottaken(i32 %in) nounwind {
 ; CHECK-NEXT: BNE a0,a1,.LBB1_1
 ; CHECK-NEXT: JAL zero,.LBB1_2
 ; CHECK-LABEL: .LBB1_1: # %false
-; CHECK-NEXT: LUI ra,%hi(test_false)
-; CHECK-NEXT: JALR ra,%lo(test_false)(ra)
+; CHECK-NEXT: CALL test_false
 ; CHECK-NEXT: LD ra,8(sp)
 ; CHECK-NEXT: ADDI sp,sp,16
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 ; CHECK-LABEL: .LBB1_2: # %true
-; CHECK-NEXT: LUI ra,%hi(test_true)
-; CHECK-NEXT: JALR ra,%lo(test_true)(ra)
+; CHECK-NEXT: CALL test_true
 ; CHECK-NEXT: LD ra,8(sp)
 ; CHECK-NEXT: ADDI sp,sp,16
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %tst = icmp eq i32 %in, 42
   br i1 %tst, label %true, label %false, !prof !1
 

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/and.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/and.ll
@@ -3,7 +3,7 @@
 define i32 @and32_0x7ff(i32 %x) {
 ; CHECK-LABEL: and32_0x7ff: # @and32_0x7ff
 ; CHECK:         ANDI a0,a0,2047
-; CHECK-NEXT:    JALR zero,0(ra)
+; CHECK-NEXT:    RET
   %a = and i32 %x, 2047
   ret i32 %a
 }
@@ -13,7 +13,7 @@ define i32 @and32_0xfff(i32 %x) {
 ; CHECK:       LUI a1,0x1
 ; CHECK-NEXT:  ADDI a1,a1,-1
 ; CHECK-NEXT:  AND a0,a0,a1
-; CHECK-NEXT:  JALR zero,0(ra)
+; CHECK-NEXT:  RET
   %a = and i32 %x, 4095
   ret i32 %a
 }
@@ -21,7 +21,7 @@ define i32 @and32_0xfff(i32 %x) {
 define i64 @and64_0x7ff(i64 %x) {
 ; CHECK-LABEL: and64_0x7ff: # @and64_0x7ff
 ; CHECK:         ANDI a0,a0,2047
-; CHECK-NEXT:    JALR zero,0(ra)
+; CHECK-NEXT:    RET
   %a = and i64 %x, 2047
   ret i64 %a
 }
@@ -31,7 +31,7 @@ define i64 @and64_0xfff(i64 %x) {
 ; CHECK:       LUI a1,0x1
 ; CHECK-NEXT:  ADDI a1,a1,-1
 ; CHECK-NEXT:  AND a0,a0,a1
-; CHECK-NEXT:  JALR zero,0(ra)
+; CHECK-NEXT:  RET
   %a = and i64 %x, 4095
   ret i64 %a
 }

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/branch-opt.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/branch-opt.ll
@@ -10,12 +10,12 @@ define void @u_case1_a(ptr %a, i32 signext %b, ptr %c, ptr %d) {
 ; CHECK-NEXT:  # %bb.1: # %block1
 ; CHECK-NEXT:    LD a0,0(sp)
 ; CHECK-NEXT:    SW a1,0(a0)
-; CHECK-NEXT:    JALR zero,0(ra)
+; CHECK-NEXT:    RET
 ; CHECK-NEXT:  .LBB0_2: # %block2
 ; CHECK-NEXT:    LD a0,8(sp)
 ; CHECK-NEXT:    ADDI a1,zero,87
 ; CHECK-NEXT:    SW a1,0(a0)
-; CHECK-NEXT:    JALR zero,0(ra)
+; CHECK-NEXT:    RET
   store i32 32, ptr %a
   %p = icmp ule i32 %b, 31
   br i1 %p, label %block1, label %block2
@@ -47,12 +47,12 @@ define void @case1_a(ptr %a, i32 signext %b, ptr %c, ptr %d) {
 ; CHECK-LABEL:   # %bb.1: # %block1
 ; CHECK-NEXT:    LD a0,0(sp)
 ; CHECK-NEXT:    SW a1,0(a0)
-; CHECK-NEXT:    JALR zero,0(ra)
+; CHECK-NEXT:    RET
 ; CHECK-NEXT:  .LBB1_2: # %block2
 ; CHECK-NEXT:    LD a0,8(sp)
 ; CHECK-NEXT:    ADDI a1,zero,87
 ; CHECK-NEXT:    SW a1,0(a0)
-; CHECK-NEXT:    JALR zero,0(ra)
+; CHECK-NEXT:    RET
   store i32 -1, ptr %a
   %p = icmp sle i32 %b, -2
   br i1 %p, label %block1, label %block2
@@ -79,12 +79,12 @@ define void @u_case2_a(ptr %a, i32 signext %b, ptr %c, ptr %d) {
 ; CHECK-NEXT:  # %bb.1: # %block1
 ; CHECK-NEXT:    LD a0,0(sp)
 ; CHECK-NEXT:    SW a1,0(a0)
-; CHECK-NEXT:    JALR zero,0(ra)
+; CHECK-NEXT:    RET
 ; CHECK-NEXT:  .LBB2_2: # %block2
 ; CHECK-NEXT:    LD a0,8(sp)
 ; CHECK-NEXT:    ADDI a1,zero,87
 ; CHECK-NEXT:    SW a1,0(a0)
-; CHECK-NEXT:    JALR zero,0(ra)
+; CHECK-NEXT:    RET
   store i32 32, ptr %a
   %p = icmp uge i32 %b, 33
   br i1 %p, label %block1, label %block2
@@ -116,12 +116,12 @@ define void @case2_a(ptr %a, i32 signext %b, ptr %c, ptr %d) {
 ; CHECK-LABEL: # %bb.1: # %block1
 ; CHECK-NEXT: LD a0,0(sp)
 ; CHECK-NEXT: SW a1,0(a0)
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 ; CHECK-LABEL: .LBB3_2: # %block2
 ; CHECK-NEXT: LD a0,8(sp)
 ; CHECK-NEXT: ADDI a1,zero,87
 ; CHECK-NEXT: SW a1,0(a0)
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   store i32 -4, ptr %a
   %p = icmp sge i32 %b, -3
   br i1 %p, label %block1, label %block2

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/calling-conv.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/calling-conv.ll
@@ -105,8 +105,7 @@ define void @callee() nounwind {
 ; CHECK-NEXT: LW s2,0(a0)
 ; CHECK-NEXT: LW a0,0(s1)
 ; CHECK-NEXT: SD a0,0(sp)                             # 8-byte Folded Spill
-; CHECK-NEXT: LUI ra,%hi(callee)
-; CHECK-NEXT: JALR ra,%lo(callee)(ra)
+; CHECK-NEXT: CALL callee
 ; CHECK-NEXT: SW s2,124(s1)
 ; CHECK-NEXT: SW s11,120(s1)
 ; CHECK-NEXT: SW s10,116(s1)
@@ -174,7 +173,7 @@ define void @callee() nounwind {
 ; CHECK-NEXT: LD s1,256(sp)                           # 8-byte Folded Reload
 ; CHECK-NEXT: LD ra,264(sp)                           # 8-byte Folded Reload
 ; CHECK-NEXT: ADDI sp,sp,272
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %val = load [32 x i32], ptr @var
   call void @callee()
   store volatile [32 x i32] %val, ptr @var

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/cmp-bool.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/cmp-bool.ll
@@ -11,7 +11,7 @@ define void @bool_eq(i1 zeroext %a, i1 zeroext %b, ptr nocapture %c) nounwind {
 ; CHECK-NEXT: .LBB0_2: # %if.end
 ; CHECK-NEXT: LD ra,8(sp) # 8-byte Folded Reload
 ; CHECK-NEXT: ADDI sp,sp,16
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 entry:
   %0 = xor i1 %a, %b
   br i1 %0, label %if.end, label %if.then
@@ -36,7 +36,7 @@ define void @bool_ne(i1 zeroext %a, i1 zeroext %b, ptr nocapture %c) nounwind {
 ; CHECK-NEXT: .LBB1_2: # %if.end
 ; CHECK-NEXT: LD ra,8(sp) # 8-byte Folded Reload
 ; CHECK-NEXT: ADDI sp,sp,16
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 entry:
   %cmp = xor i1 %a, %b
   br i1 %cmp, label %if.then, label %if.end

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/fast-cc.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/fast-cc.ll
@@ -3,7 +3,7 @@
 define fastcc i32 @callee(<16 x i32> %A) nounwind {
 ; CHECK-LABEL: callee:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 ;
 	%B = extractelement <16 x i32> %A, i32 0
 	ret i32 %B
@@ -44,11 +44,10 @@ define i32 @caller(<16 x i32> %A) nounwind {
 ; CHECK-NEXT: SD a2,8(sp)
 ; CHECK-NEXT: LD a2,128(sp)
 ; CHECK-NEXT: SD a2,0(sp)
-; CHECK-NEXT: LUI ra,%hi(callee)
-; CHECK-NEXT: JALR ra,%lo(callee)(ra)
+; CHECK-NEXT: CALL callee
 ; CHECK-NEXT: LD ra,120(sp)                           # 8-byte Folded Reload
 ; CHECK-NEXT: ADDI sp,sp,128
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 	%C = call fastcc i32 @callee(<16 x i32> %A)
 	ret i32 %C
 }

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/global_const_loop.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/global_const_loop.ll
@@ -23,7 +23,7 @@ define dso_local i32 @foo(i32 noundef %i) local_unnamed_addr #0 {
 ; CHECK-NEXT: LD fp,0(sp)                            # 8-byte Folded Reload
 ; CHECK-NEXT: LD ra,8(sp)                            # 8-byte Folded Reload
 ; CHECK-NEXT: ADDI sp,sp,16
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 entry:
   %cmp = icmp slt i32 %i, 1000
   br i1 %cmp, label %while.body.us, label %while.end

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/imm.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/imm.ll
@@ -3,21 +3,21 @@
 define signext i32 @zero() nounwind {
   ; CHECK-LABEL: zero: # @zero
   ; CHECK: ADDI a0,zero,0
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i32 0
 }
 
 define signext i32 @pos_small() nounwind {
   ; CHECK-LABEL: pos_small: # @pos_small
   ; CHECK: ADDI a0,zero,2047
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i32 2047
 }
 
 define signext i32 @neg_small() nounwind {
   ; CHECK-LABEL: neg_small: # @neg_small
   ; CHECK: ADDI a0,zero,-2048
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i32 -2048
 }
 
@@ -25,7 +25,7 @@ define signext i32 @pos_i32() nounwind {
   ; CHECK-LABEL: pos_i32: # @pos_i32
   ; CHECK: LUI a0,0x67783
   ; CHECK-NEXT: ADDI a0,a0,-1297
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i32 1735928559
 }
 
@@ -33,7 +33,7 @@ define signext i32 @neg_i32() nounwind {
   ; CHECK-LABEL: neg_i32: # @neg_i32
   ; CHECK: LUI a0,0xdeadc
   ; CHECK-NEXT: ADDI a0,a0,-273
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i32 -559038737
 }
 
@@ -41,7 +41,7 @@ define signext i32 @pos_i32_hi20_only() nounwind {
   ; CHECK-LABEL: pos_i32_hi20_only: # @pos_i32_hi20_only
   ; CHECK: LUI a0,0x10
   ; CHECK-NEXT: ADDI a0,a0,0
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i32 65536 ; 0x10000
 }
 
@@ -49,7 +49,7 @@ define signext i32 @neg_i32_hi20_only() nounwind {
   ; CHECK-LABEL: neg_i32_hi20_only: # @neg_i32_hi20_only
   ; CHECK: LUI a0,0xffff0
   ; CHECK-NEXT: ADDI a0,a0,0
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i32 -65536 ; -0x10000
 }
 
@@ -61,7 +61,7 @@ define i64 @imm_end_xori_1() nounwind {
   ; CHECK-NEXT: ORI a0,a0,-512
   ; CHECK-NEXT: SLLI a0,a0,16
   ; CHECK-NEXT: ORI a0,a0,-1
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i64 -2305843009180139521 ; 0xE000_0000_01FF_FFFF
 }
 
@@ -69,7 +69,7 @@ define void @imm_store_i8_neg1(ptr %p) nounwind {
   ; CHECK-LABEL: imm_store_i8_neg1: # @imm_store_i8_neg1
   ; CHECK: ADDI a1,zero,255
   ; CHECK-NEXT: SB a1,0(a0)
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   store i8 -1, ptr %p
   ret void
 }
@@ -79,7 +79,7 @@ define void @imm_store_i16_neg1(ptr %p) nounwind {
   ; CHECK: LUI a1,0x10
   ; CHECK-NEXT: ADDI a1,a1,-1
   ; CHECK-NEXT: SH a1,0(a0)
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   store i16 -1, ptr %p
   ret void
 }
@@ -93,7 +93,7 @@ define void @imm_store_i32_neg1(ptr %p) nounwind {
   ; CHECK-NEXT: SLLI a1,a1,16
   ; CHECK-NEXT: ORI a1,a1,-1
   ; CHECK-NEXT: SW a1,0(a0)
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   store i32 -1, ptr %p
   ret void
 }

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/indirectbr.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/indirectbr.ll
@@ -6,7 +6,7 @@ define i32 @indirectbr(ptr %target) nounwind {
   ; CHECK-NEXT: JALR zero,0(a0)
   ; CHECK-LABEL: LBB0_1: # %test_label
   ; CHECK: ADDI a0,zero,0
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
    indirectbr ptr %target, [label %test_label]
 test_label:
   br label %ret
@@ -20,7 +20,7 @@ define i32 @indirectbr_with_offset(ptr %a) nounwind {
   ; CHECK-NEXT: JALR zero,1380(a0)
   ; CHECK-LABEL: LBB1_1:
   ; CHECK-NEXT: ADDI a0,zero,0
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
 
   %target = getelementptr inbounds i8, ptr %a, i32 1380
   indirectbr ptr %target, [label %test_label]

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/large_stack.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/large_stack.ll
@@ -48,7 +48,7 @@ define void @test_emergency_spill_slot(i32 %a) {
 ; CHECK-NEXT: LUI a0,0x62
 ; CHECK-NEXT: ADDI a0,a0,-1408
 ; CHECK-NEXT: ADD sp,sp,a0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %data = alloca [ 100000 x i32 ] , align 4
   %ptr = getelementptr inbounds [100000 x i32], ptr %data, i32 0, i32 80000
   %1 = tail call { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } asm sideeffect "nop", "=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r"()

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/mul.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/mul.ll
@@ -6,7 +6,7 @@ define signext i32 @square(i32 %a) nounwind {
 ; CHECK: MUL a0,a0,a0
 ; CHECK-NEXT: SLLI a0,a0,32
 ; CHECK-NEXT: SRAI a0,a0,32
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = mul i32 %a, %a
   ret i32 %1
 }
@@ -17,7 +17,7 @@ define signext i32 @mul(i32 %a, i32 %b) nounwind {
 ; CHECK: MUL a0,a0,a1
 ; CHECK-NEXT: SLLI a0,a0,32
 ; CHECK-NEXT: SRAI a0,a0,32
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = mul i32 %a, %b
   ret i32 %1
 }
@@ -33,7 +33,7 @@ define signext i32 @mul_constant(i32 %a) nounwind {
 ; CHECK-NEXT: ORI a1,a1,0
 ; CHECK-NEXT: MUL a0,a0,a1
 ; CHECK-NEXT: SRAI a0,a0,32
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = mul i32 %a, 5
   ret i32 %1
 }
@@ -42,7 +42,7 @@ define i32 @mul_pow2(i32 %a) nounwind {
 ; CHECK-LABEL: mul_pow2: # @mul_pow2
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: SLLI a0,a0,3
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = mul i32 %a, 8
   ret i32 %1
 }
@@ -51,7 +51,7 @@ define i64 @mul64(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: mul64: # @mul64
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: MUL a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = mul i64 %a, %b
   ret i64 %1
 }

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/pic.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/pic.ll
@@ -11,7 +11,7 @@ define ptr @f1() nounwind {
 ; CHECK-LABEL: .Ltmp0:
 ; CHECK-NEXT: AUIPC a0,%got_pcrel_hi(external_var)
 ; CHECK-NEXT: LD a0,%pcrel_lo(.Ltmp0)(a0)
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 entry:
   ret ptr @external_var
 }
@@ -22,7 +22,7 @@ define ptr @f2() nounwind {
 ; CHECK-LABEL: .Ltmp1:
 ; CHECK-NEXT: AUIPC a0,%pcrel_hi(internal_var)
 ; CHECK-NEXT: ADDI a0,a0,%pcrel_lo(.Ltmp1)
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 entry:
   ret ptr @internal_var
 }

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/rotl-rotr.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/rotl-rotr.ll
@@ -20,7 +20,7 @@ define i32 @rotl_32(i32 %x, i32 %y) nounwind {
 ; CHECK-NEXT: AND a1,a1,a3
 ; CHECK-NEXT: SLL a0,a0,a1
 ; CHECK-NEXT: OR a0,a0,a2
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %z = sub i32 32, %y
   %b = shl i32 %x, %y
   %c = lshr i32 %x, %z
@@ -45,7 +45,7 @@ define i32 @rotr_32(i32 %x, i32 %y) nounwind {
 ; CHECK-NEXT: AND a1,a1,a2
 ; CHECK-NEXT: SLL a0,a0,a1
 ; CHECK-NEXT: OR a0,a3,a0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %z = sub i32 32, %y
   %b = lshr i32 %x, %y
   %c = shl i32 %x, %z
@@ -61,7 +61,7 @@ define i64 @rotl_64(i64 %x, i64 %y) nounwind {
 ; CHECK-NEXT: SLL a1,a0,a1
 ; CHECK-NEXT: SRL a0,a0,a2
 ; CHECK-NEXT: OR a0,a1,a0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %z = sub i64 64, %y
   %b = shl i64 %x, %y
   %c = lshr i64 %x, %z
@@ -77,7 +77,7 @@ define i64 @rotr_64(i64 %x, i64 %y) nounwind {
 ; CHECK-NEXT: SRL a1,a0,a1
 ; CHECK-NEXT: SLL a0,a0,a2
 ; CHECK-NEXT: OR a0,a1,a0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %z = sub i64 64, %y
   %b = lshr i64 %x, %y
   %c = shl i64 %x, %z
@@ -101,7 +101,7 @@ define i32 @rotl_32_mask(i32 %x, i32 %y) nounwind {
 ; CHECK-NEXT: AND a1,a1,a3
 ; CHECK-NEXT: SLL a0,a0,a1
 ; CHECK-NEXT: OR a0,a0,a2
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %z = sub i32 0, %y
   %and = and i32 %z, 31
   %b = shl i32 %x, %y
@@ -126,7 +126,7 @@ define i32 @rotl_32_mask_and_63_and_31(i32 %x, i32 %y) nounwind {
 ; CHECK-NEXT: ANDI a1,a1,63
 ; CHECK-NEXT: SLL a0,a0,a1
 ; CHECK-NEXT: OR a0,a0,a2
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %a = and i32 %y, 63
   %b = shl i32 %x, %a
   %c = sub i32 0, %y
@@ -140,7 +140,7 @@ define i32 @rotl_32_mask_or_64_or_32(i32 %x, i32 %y) nounwind {
 ; CHECK-LABEL: rotl_32_mask_or_64_or_32:
 ; CHECK: # %bb.0:
 ; CHECK-NEXT: ADDI a0,zero,0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %a = or i32 %y, 64
   %b = shl i32 %x, %a
   %c = sub i32 0, %y
@@ -166,7 +166,7 @@ define i32 @rotr_32_mask(i32 %x, i32 %y) nounwind {
 ; CHECK-NEXT: ANDI a1,a1,31
 ; CHECK-NEXT: SLL a0,a0,a1
 ; CHECK-NEXT: OR a0,a2,a0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %z = sub i32 0, %y
   %and = and i32 %z, 31
   %b = lshr i32 %x, %y
@@ -191,7 +191,7 @@ define i32 @rotr_32_mask_and_63_and_31(i32 %x, i32 %y) nounwind {
 ; CHECK-NEXT: ANDI a1,a1,31
 ; CHECK-NEXT: SLL a0,a0,a1
 ; CHECK-NEXT: OR a0,a2,a0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %a = and i32 %y, 63
   %b = lshr i32 %x, %a
   %c = sub i32 0, %y
@@ -205,7 +205,7 @@ define i32 @rotr_32_mask_or_64_or_32(i32 %x, i32 %y) nounwind {
 ; CHECK-LABEL: rotr_32_mask_or_64_or_32:
 ; CHECK: # %bb.0:
 ; CHECK-NEXT: ADDI a0,zero,0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %a = or i32 %y, 64
   %b = lshr i32 %x, %a
   %c = sub i32 0, %y
@@ -223,7 +223,7 @@ define i64 @rotl_64_mask(i64 %x, i64 %y) nounwind {
 ; CHECK-NEXT: ANDI a2,a2,63
 ; CHECK-NEXT: SRL a0,a0,a2
 ; CHECK-NEXT: OR a0,a1,a0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %z = sub i64 0, %y
   %and = and i64 %z, 63
   %b = shl i64 %x, %y

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/select-cc.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/select-cc.ll
@@ -88,7 +88,7 @@ define signext i32 @foo(i32 signext %a, ptr %b) nounwind {
 ; CHECK-NEXT: .LBB0_15:
 ; CHECK-NEXT: SLLI a0,a0,32
 ; CHECK-NEXT: SRAI a0,a0,32
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 ; CHECK-NEXT: .LBB0_16:
 ; CHECK-NEXT: ADDI a0,a3,0
 ; CHECK-NEXT: AND a4,a0,a2
@@ -158,7 +158,7 @@ define signext i32 @foo(i32 signext %a, ptr %b) nounwind {
 ; CHECK-NEXT: ADDI a0,a1,0
 ; CHECK-NEXT: SLLI a0,a0,32
 ; CHECK-NEXT: SRAI a0,a0,32
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %val1 = load volatile i32, ptr %b
   %tst1 = icmp eq i32 %a, %val1
   %val2 = select i1 %tst1, i32 %a, i32 %val1
@@ -229,7 +229,7 @@ define i32 @select_sge_int16min(i32 signext %x, i32 signext %y, i32 signext %z) 
 ; CHECK-NEXT: LD a1,0(sp)
 ; CHECK-NEXT: .LBB1_2:
 ; CHECK-NEXT: ADDI a0,a1,0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %a = icmp sge i32 %x, -65536
   %b = select i1 %a, i32 %y, i32 %z
   ret i32 %b
@@ -249,7 +249,7 @@ define i64 @select_sge_int32min(i64 %x, i64 %y, i64 %z) {
 ; CHECK-NEXT: LD a1,0(sp)
 ; CHECK-LABEL: .LBB2_2:
 ; CHECK-NEXT: ADDI a0,a1,0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %a = icmp sge i64 %x, -2147483648
   %b = select i1 %a, i64 %y, i64 %z
   ret i64 %b

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/sext-zext-trunc.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/sext-zext-trunc.ll
@@ -27,7 +27,7 @@ define i8 @sext_i1_to_i8(i1 %a) nounwind {
 ; CHECK-NEXT: # %bb.0:
 ; CHECK-NEXT: ANDI a0,a0,1
 ; CHECK-NEXT: SUB a0,zero,a0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = sext i1 %a to i8
   ret i8 %1
 }
@@ -37,7 +37,7 @@ define i16 @sext_i1_to_i16(i1 %a) nounwind {
 ; CHECK-NEXT: # %bb.0:
 ; CHECK-NEXT: ANDI a0,a0,1
 ; CHECK-NEXT: SUB a0,zero,a0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = sext i1 %a to i16
   ret i16 %1
 }
@@ -47,7 +47,7 @@ define i32 @sext_i1_to_i32(i1 %a) nounwind {
 ; CHECK-NEXT: # %bb.0:
 ; CHECK-NEXT: ANDI a0,a0,1
 ; CHECK-NEXT: SUB a0,zero,a0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = sext i1 %a to i32
   ret i32 %1
 }
@@ -57,7 +57,7 @@ define i64 @sext_i1_to_i64(i1 %a) nounwind {
 ; CHECK-NEXT: # %bb.0:
 ; CHECK-NEXT: ANDI a0,a0,1
 ; CHECK-NEXT: SUB a0,zero,a0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = sext i1 %a to i64
   ret i64 %1
 }
@@ -67,7 +67,7 @@ define i16 @sext_i8_to_i16(i8 %a) nounwind {
 ; CHECK-NEXT: # %bb.0:
 ; CHECK-NEXT: SLLI a0,a0,56
 ; CHECK-NEXT: SRAI a0,a0,56
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = sext i8 %a to i16
   ret i16 %1
 }
@@ -77,7 +77,7 @@ define i32 @sext_i8_to_i32(i8 %a) nounwind {
 ; CHECK-NEXT: # %bb.0:
 ; CHECK-NEXT: SLLI a0,a0,56
 ; CHECK-NEXT: SRAI a0,a0,56
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = sext i8 %a to i32
   ret i32 %1
 }

--- a/vadl/test/resources/testSource/sys/risc-v/rv3264im.vadl
+++ b/vadl/test/resources/testSource/sys/risc-v/rv3264im.vadl
@@ -310,7 +310,7 @@ $Arch3264 ( // ((((((((((((((((((((((((((((((((((((((((
 
   pseudo instruction CALL( symbol : Bits<32> ) =
   {
-      LUI{ rd = 1 as Bits5, imm = hi( symbol ) }
+      LUI { rd = 1 as Bits5, imm = hi( symbol ) }
       JALR{ rd = 1 as Bits5, rs1 = 1 as Bits5, imm = lo( symbol ) }
   }
   assembly CALL = (mnemonic, " ", hex( symbol ))


### PR DESCRIPTION
This PR is preparing the use of the `plt` suffix for `CALL` instructions. It is easier to let the upstream assembler and upstream linker handle the correct expansion at the moment. Note that it is easier to keep the expanding for the rest of pseudo instructions than support the printing for e.g. `MV`. (We have a problem at the moment which deduce the register file automatically for pseudo instruction's printing).
To sum up, we stopped expand `CALL` and `RET` and added the support for printing both in assembly.