### PR TITLE
frontend: Replace `register file` by `register` with tensor types

### DIFF
--- a/vadl/main/vadl/ast/AstUtils.java
+++ b/vadl/main/vadl/ast/AstUtils.java
@@ -30,6 +30,7 @@ import vadl.types.Type;
 import vadl.types.UIntType;
 
 class AstUtils {
+
   @Nullable
   static BuiltInTable.BuiltIn getBuiltIn(String name, List<Type> argTypes) {
 

--- a/vadl/main/vadl/ast/AstVisitor.java
+++ b/vadl/main/vadl/ast/AstVisitor.java
@@ -467,14 +467,6 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   }
 
   @Override
-  public Void visit(RegisterFileDefinition definition) {
-    beforeTravel(definition);
-    definition.children().forEach(this::travel);
-    afterTravel(definition);
-    return null;
-  }
-
-  @Override
   public Void visit(RelocationDefinition definition) {
     beforeTravel(definition);
     definition.children().forEach(this::travel);

--- a/vadl/main/vadl/ast/Definition.java
+++ b/vadl/main/vadl/ast/Definition.java
@@ -1138,7 +1138,7 @@ class RegisterDefinition extends Definition implements IdentifiableNode, TypedNo
   SourceLocation loc;
 
   @Nullable
-  Type type;
+  TensorType type;
 
   public RegisterDefinition(IdentifierOrPlaceholder identifier, RelationTypeLiteral typeLiteral,
                             SourceLocation location) {
@@ -1247,7 +1247,10 @@ class RegisterDefinition extends Definition implements IdentifiableNode, TypedNo
 
     @Override
     public SourceLocation location() {
-      return argTypes.get(0).location().join(resultType.location());
+      if (argTypes.isEmpty()) {
+        return resultType.location();
+      }
+      return argTypes.getFirst().location().join(resultType.location());
     }
 
     @Override

--- a/vadl/main/vadl/ast/Definition.java
+++ b/vadl/main/vadl/ast/Definition.java
@@ -29,7 +29,6 @@ import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import vadl.javaannotations.ast.Child;
 import vadl.types.ConcreteRelationType;
-import vadl.types.DataType;
 import vadl.types.Type;
 import vadl.types.asmTypes.AsmType;
 import vadl.utils.SourceLocation;
@@ -157,8 +156,6 @@ interface DefinitionVisitor<R> {
   R visit(RecordTypeDefinition definition);
 
   R visit(RegisterDefinition definition);
-
-  R visit(RegisterFileDefinition definition);
 
   R visit(RelocationDefinition definition);
 
@@ -1137,13 +1134,13 @@ class MemoryDefinition extends Definition implements IdentifiableNode, TypedNode
 class RegisterDefinition extends Definition implements IdentifiableNode, TypedNode {
   IdentifierOrPlaceholder identifier;
   @Child
-  TypeLiteral typeLiteral;
+  RelationTypeLiteral typeLiteral;
   SourceLocation loc;
 
   @Nullable
-  DataType type;
+  Type type;
 
-  public RegisterDefinition(IdentifierOrPlaceholder identifier, TypeLiteral typeLiteral,
+  public RegisterDefinition(IdentifierOrPlaceholder identifier, RelationTypeLiteral typeLiteral,
                             SourceLocation location) {
     this.identifier = identifier;
     this.typeLiteral = typeLiteral;
@@ -1206,83 +1203,6 @@ class RegisterDefinition extends Definition implements IdentifiableNode, TypedNo
 
   @Override
   public Type type() {
-    return typeLiteral.type();
-  }
-}
-
-class RegisterFileDefinition extends Definition implements IdentifiableNode, TypedNode {
-  IdentifierOrPlaceholder identifier;
-  @Child
-  RelationTypeLiteral typeLiteral;
-  SourceLocation loc;
-
-  @Nullable
-  ConcreteRelationType type = null;
-
-  public RegisterFileDefinition(IdentifierOrPlaceholder identifier, RelationTypeLiteral typeLiteral,
-                                SourceLocation location) {
-    this.identifier = identifier;
-    this.typeLiteral = typeLiteral;
-    this.loc = location;
-  }
-
-  @Override
-  public Identifier identifier() {
-    return (Identifier) identifier;
-  }
-
-  @Override
-  public SourceLocation location() {
-    return loc;
-  }
-
-  @Override
-  SyntaxType syntaxType() {
-    return BasicSyntaxType.ISA_DEFS;
-  }
-
-  @Override
-  void prettyPrint(int indent, StringBuilder builder) {
-    annotations.prettyPrint(indent, builder);
-    builder.append(prettyIndentString(indent));
-    builder.append("register file ");
-    identifier.prettyPrint(indent, builder);
-    builder.append(": ");
-    typeLiteral.prettyPrint(indent, builder);
-    builder.append("\n");
-  }
-
-  @Override
-  <R> R accept(DefinitionVisitor<R> visitor) {
-    return visitor.visit(this);
-  }
-
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-
-    RegisterFileDefinition that = (RegisterFileDefinition) o;
-    return annotations.equals(that.annotations)
-        && identifier.equals(that.identifier)
-        && typeLiteral.equals(that.typeLiteral);
-  }
-
-  @Override
-  public int hashCode() {
-    int result = annotations.hashCode();
-    result = 31 * result + identifier.hashCode();
-    result = 31 * result + typeLiteral.hashCode();
-    return result;
-  }
-
-  @Override
-  public ConcreteRelationType type() {
     return Objects.requireNonNull(type);
   }
 
@@ -1290,7 +1210,8 @@ class RegisterFileDefinition extends Definition implements IdentifiableNode, Typ
     @Child
     final List<TypeLiteral> argTypes;
     @Child
-    final TypeLiteral resultType;
+    TypeLiteral resultType;
+
 
     RelationTypeLiteral(List<TypeLiteral> argTypes, TypeLiteral resultType) {
       this.argTypes = argTypes;
@@ -1313,7 +1234,7 @@ class RegisterFileDefinition extends Definition implements IdentifiableNode, Typ
       if (obj == null || obj.getClass() != this.getClass()) {
         return false;
       }
-      var that = (RelationTypeLiteral) obj;
+      var that = (RegisterDefinition.RelationTypeLiteral) obj;
       return Objects.equals(this.argTypes, that.argTypes)
           && Objects.equals(this.resultType, that.resultType);
     }
@@ -1344,7 +1265,9 @@ class RegisterFileDefinition extends Definition implements IdentifiableNode, Typ
         isFirst = false;
         argType.prettyPrint(0, builder);
       }
-      builder.append(" -> ");
+      if (!argTypes.isEmpty()) {
+        builder.append(" -> ");
+      }
       resultType.prettyPrint(indent, builder);
     }
   }
@@ -2139,7 +2062,6 @@ class AliasDefinition extends Definition implements IdentifiableNode, TypedNode 
     builder.append(prettyIndentString(indent)).append("alias ");
     switch (kind) {
       case REGISTER -> builder.append("register ");
-      case REGISTER_FILE -> builder.append("register file ");
       case PROGRAM_COUNTER -> builder.append("program counter ");
       default -> {
       }
@@ -2194,7 +2116,7 @@ class AliasDefinition extends Definition implements IdentifiableNode, TypedNode 
   }
 
   enum AliasKind {
-    REGISTER, REGISTER_FILE, PROGRAM_COUNTER
+    REGISTER, PROGRAM_COUNTER
   }
 }
 

--- a/vadl/main/vadl/ast/Expr.java
+++ b/vadl/main/vadl/ast/Expr.java
@@ -1259,6 +1259,14 @@ final class TypeLiteral extends Expr {
     }
   }
 
+  /**
+   * Returns a flat list of dimension sizes of the type to a single list.
+   */
+  List<Expr> sizeIndices() {
+    return sizeIndices.stream()
+        .flatMap(Collection::stream).toList();
+  }
+
   @Override
   public List<Node> children() {
     // This is too complicated for the @Child annotation

--- a/vadl/main/vadl/ast/MacroExpander.java
+++ b/vadl/main/vadl/ast/MacroExpander.java
@@ -508,13 +508,6 @@ class MacroExpander
   }
 
   @Override
-  public Definition visit(RegisterFileDefinition definition) {
-    var id = resolvePlaceholderOrIdentifier(definition.identifier);
-    return new RegisterFileDefinition(id, definition.typeLiteral,
-        copyLoc(definition.loc)).withAnnotations(expandAnnotations(definition.annotations));
-  }
-
-  @Override
   public Definition visit(InstructionDefinition definition) {
     var identifier = resolvePlaceholderOrIdentifier(definition.identifier);
     var typeId = resolvePlaceholderOrIdentifier(definition.typeIdentifier);

--- a/vadl/main/vadl/ast/ModelRemover.java
+++ b/vadl/main/vadl/ast/ModelRemover.java
@@ -84,11 +84,6 @@ public class ModelRemover implements DefinitionVisitor<Definition> {
   }
 
   @Override
-  public Definition visit(RegisterFileDefinition definition) {
-    return definition;
-  }
-
-  @Override
   public Definition visit(InstructionDefinition definition) {
     return definition;
   }

--- a/vadl/main/vadl/ast/SymbolTable.java
+++ b/vadl/main/vadl/ast/SymbolTable.java
@@ -249,6 +249,15 @@ class SymbolTable {
     return null;
   }
 
+  <T extends Node> @Nullable T findIdAs(IsId id, Class<T> type) {
+    return switch (id) {
+      case Identifier i -> findAs(i, type);
+      case IdentifierPath i -> findAs(i, type);
+      case IdentifierOrPlaceholder ignored ->
+          throw new IllegalStateException("Placeholder should never be found here.");
+    };
+  }
+
   // FIXME: I don't like how it's called require but still returns null
   <T extends Node> @Nullable T requireAs(Identifier usage, Class<T> type) {
     var origin = resolveNode(usage.name);

--- a/vadl/main/vadl/ast/TensorType.java
+++ b/vadl/main/vadl/ast/TensorType.java
@@ -1,0 +1,172 @@
+// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.ast;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import vadl.types.BitsType;
+import vadl.types.DataType;
+import vadl.types.Type;
+import vadl.utils.Pair;
+
+/**
+ * A frontend type that represents a potentially multidimensional {@link DataType}.
+ * E.g. {@code Bits<32><32>} and the equivalent {@code Bits<5> -> Bits<32>} are such tensor types.
+ *
+ * <p>It has exactly one base type, which defines the innermost type that can be accessed without
+ * slicing.
+ * Additionally, it holds a list of {@link Index} which defines addressable indices/dimensions
+ * with their respective size and type.</p>
+ *
+ * @see Index
+ */
+// FIXME: Is this a Bits Subtype?
+class TensorType extends BitsType {
+
+  /**
+   * An index dimension of a {@link TensorType}.
+   * E.g., for the mapping type {@code Bits<5> -> Bits<32>} the argument type is an index of
+   * {@code (size: 32, type: Bits<5>)}.
+   *
+   * <p>The dimension type {@code Bits<12><32>} also has one index (outermost dimension)
+   * of {@code (size: 12, type: null)}.
+   * As the user does not define the access type in the second example (dimension notation),
+   * it must not be checked and is therefore null.
+   *
+   * @param size size of the index dimension
+   * @param type optional type of the index dimension (only used for mapping types)
+   */
+  record Index(int size, @Nullable BitsType type) {
+    /**
+     * Constructs an index from a given mapping type argument.
+     * The index size is given from the type size.
+     * E.g. the index of {@code Bits<5> -> ...} has a size of {@code 32} (power of 2).
+     *
+     * @param bitsType the type of the mapping argument
+     * @return an index with the size being {@code 2^bitsType.width}.
+     */
+    static Index ofMappingArg(BitsType bitsType) {
+      return new Index((int) Math.pow(2, bitsType.bitWidth()), bitsType);
+    }
+
+    /**
+     * Returns a type that fits the given index size.
+     * If no type for the index is given, a bits type with the minimal required size is constructed.
+     *
+     * @return a type that may hold at least the size of the index.
+     */
+    BitsType viamType() {
+      return type == null ? Type.bits(BitsType.minimalRequiredWidthFor(size - 1)) : type;
+    }
+  }
+
+  // hashmap that contains all global occurrences of the tensor type
+  static final HashMap<Pair<List<Index>, DataType>, TensorType> cache = new HashMap<>();
+
+  // the size of the n > 0th indices. e.g., in Bits<2><32> this would be List.of(2)
+  final List<Index> indices;
+  // the 0th dimension. e.g., in Bits<2><32> this would be Bits<32>
+  final DataType baseType;
+
+  // private to prevent multiple instances of the same type
+  private TensorType(List<Index> indices, DataType baseType) {
+    super(indices.stream().map(Index::size).reduce(baseType.bitWidth(), (a, b) -> a * b));
+    this.indices = indices;
+    this.baseType = baseType;
+  }
+
+  /**
+   * Construct a tensor type.
+   * If there already exists such a tensor type, no new one is constructed.
+   *
+   * @param indexDims index dimensions. {@code Bits<5><4><32>} would have two such dimensions.
+   * @param baseType  the innermost dimension type. {@code Bits<5><32>} has a base type
+   *                  of {@code Bits<32>}
+   */
+  static TensorType of(List<Index> indexDims, DataType baseType) {
+    return cache.computeIfAbsent(new Pair<>(indexDims, baseType),
+        k -> new TensorType(indexDims, baseType));
+  }
+
+  /**
+   * Construct a tensor type with no index dimensions.
+   */
+  static TensorType of(DataType baseType) {
+    return of(List.of(), baseType);
+  }
+
+  /**
+   * Returns the width if the tensor was accessed as a whole.
+   */
+  int mergedWidth() {
+    return indices.stream().map(Index::size).reduce(baseType.bitWidth(), (a, b) -> a * b);
+  }
+
+  /**
+   * Returns the type if the tensor was accessed as a whole.
+   * If the tensor has no indices, this is equivalent to the base type.
+   * Otherwise, it is a Bits type of size {@link #mergedWidth()}.
+   */
+  DataType mergedType() {
+    if (indices.isEmpty()) {
+      return baseType;
+    }
+    return Type.bits(mergedWidth());
+  }
+
+  /**
+   * Tries to unpack to base type.
+   *
+   * @return the base type if no indices are given, this type otherwise.
+   */
+  Type unpack() {
+    if (indices.isEmpty()) {
+      return baseType;
+    }
+    return this;
+  }
+
+  /**
+   * The type when accessing some value of this tensor type with a certain number of indices.
+   * E.g. given {@code X: Bits<5><4><32>}, when calling this method on this type with
+   * {@code 1}, the return type would be {@code Bits<4><32>}, which would correspond to an access
+   * such as {@code X(2)}.
+   *
+   * @param accessedIndices the number of indices that are "accessed". This must be <= the number
+   *                        of indices, otherwise a runtime exception is thrown.
+   * @return the tensor type of the partial access. If {@code accessedIndices == indices.size()}
+   *     the return tensor type will have no indices, but only the base type set.
+   */
+  TensorType typeAfterNIndices(int accessedIndices) {
+    if (accessedIndices > indices.size()) {
+      throw new IllegalStateException(
+          "More indices accessed than available: %s vs %s".formatted(accessedIndices,
+              indices.size()));
+    }
+    return of(indices.subList(accessedIndices, indices.size()), baseType);
+  }
+
+
+  @Override
+  public String name() {
+    var baseTypeName = baseType.getClass().getSimpleName().replace("Type", "");
+    var dims = this.indices.stream().map(d -> "<" + d + ">").collect(Collectors.joining());
+    return baseTypeName + dims + "<" + baseType.bitWidth() + ">";
+  }
+}

--- a/vadl/main/vadl/ast/TypeChecker.java
+++ b/vadl/main/vadl/ast/TypeChecker.java
@@ -202,12 +202,12 @@ public class TypeChecker
             node.getClass().getSimpleName(), node.location().toIDEString()));
   }
 
-  private Diagnostic typeMissmatchError(WithLocation locatable, Type expected, Type actual) {
+  private static Diagnostic typeMissmatchError(WithLocation locatable, Type expected, Type actual) {
     return typeMissmatchError(locatable, "`%s`".formatted(expected), actual);
   }
 
-  private Diagnostic typeMissmatchError(WithLocation locatable, String expectation,
-                                        Type actual) {
+  private static Diagnostic typeMissmatchError(WithLocation locatable, String expectation,
+                                               Type actual) {
     return error("Type Mismatch", locatable)
         .locationDescription(locatable, "Expected %s but got `%s`.",
             expectation, actual)
@@ -383,6 +383,28 @@ public class TypeChecker
     }
 
     return new CastExpr(inner, to);
+  }
+
+  /**
+   * Wraps the expr provided with an implicit cast if it is possible, and not useless.
+   * However, in comparison to {@link #wrapImplicitCast(Expr, Type)}, this will throw a
+   * type mismatch exception,
+   * if the inner expression could not implicitly cast to the given type.
+   *
+   * @param inner expression to wrap.
+   * @param to    which the expression should be cast.
+   * @return the original expression.
+   * @throws Diagnostic if the inner expression cannot be implicitly cast to type.
+   */
+  private static Expr tryWrapImplicitCast(Expr inner, Type to) {
+    if (inner.type == null) {
+      throw new IllegalStateException("The type of the inner expression must be known.");
+    }
+    var wrapped = wrapImplicitCast(inner, to);
+    if (!wrapped.type().equals(to)) {
+      throw typeMissmatchError(inner, to, inner.type());
+    }
+    return wrapped;
   }
 
   @Nullable
@@ -578,25 +600,25 @@ public class TypeChecker
 
   @Override
   public Void visit(RegisterDefinition definition) {
-    check(definition.typeLiteral);
-    if (!(definition.typeLiteral.type instanceof DataType regType)) {
-      var type = definition.typeLiteral.type;
-      throw error("Invalid Type", definition)
-          .description("Expected register type to be one of Bits, SInt, UInt or Bool.")
-          .note("Type was %s.", type == null ? "unknown" : type)
-          .build();
-    }
-    definition.type = regType;
-    return null;
-  }
-
-  @Override
-  public Void visit(RegisterFileDefinition definition) {
     definition.typeLiteral.argTypes().forEach(this::check);
     check(definition.typeLiteral.resultType());
-    definition.type = Type.concreteRelation(
-        definition.typeLiteral.argTypes().stream().map(arg -> arg.type).toList(),
-        requireNonNull(definition.typeLiteral.resultType().type));
+    if (definition.typeLiteral.argTypes().isEmpty()) {
+      // relation without args is not a register file (normal single type)
+      var typeLit = definition.typeLiteral.resultType;
+      if (!(typeLit.type instanceof DataType regType)) {
+        var type = definition.type;
+        throw error("Invalid Type", definition)
+            .description("Expected register type to be one of Bits, SInt, UInt or Bool.")
+            .note("Type was %s.", type == null ? "unknown" : type)
+            .build();
+      }
+      definition.type = regType;
+    } else {
+      // is a register file
+      definition.type = Type.concreteRelation(
+          definition.typeLiteral.argTypes().stream().map(arg -> arg.type).toList(),
+          requireNonNull(definition.typeLiteral.resultType().type));
+    }
 
     return null;
   }
@@ -737,59 +759,55 @@ public class TypeChecker
 
   @Override
   public Void visit(AliasDefinition definition) {
-    if (definition.kind == AliasDefinition.AliasKind.REGISTER_FILE) {
-      if (!(definition.value instanceof Identifier valIdent)) {
-        throw error("Invalid alias", definition.value)
-            .locationDescription(definition.value, "The target must be an identifier but was `%s`",
-                definition.value.getClass().getSimpleName())
-            .build();
-      }
 
-      var regFile =
-          requireNonNull(definition.symbolTable).findAs(valIdent, RegisterFileDefinition.class);
-
-      if (regFile == null) {
-        throw error("Invalid alias", valIdent)
-            .locationDescription(valIdent, "Doesn't point to a register file.")
-            .build();
-      }
-
-      check(regFile);
-      definition.computedTarget = regFile;
-
-
-      if (definition.aliasType == null && definition.targetType == null) {
-        definition.type = regFile.type();
-        return null;
-      } else if (definition.aliasType != null && definition.targetType != null) {
-        definition.type =
-            Type.concreteRelation(check(definition.aliasType), check(definition.targetType));
-        return null;
-      }
-
-      // FIXME: Either make this illegal in the grammar or implement the correct semantic once
-      // that is clarified: https://github.com/OpenVADL/open-vadl/issues/80#issue-2940372881
-      throw new IllegalStateException();
-    }
+    var targetIdent = switch (definition.value) {
+      case Identifier ident -> ident;
+      case CallIndexExpr expr -> expr.target.path();
+      default -> throw error("Invalid alias", definition.value)
+          .locationDescription(definition.value, "The target must be a direct register access.")
+          .build();
+    };
 
     if (definition.kind == AliasDefinition.AliasKind.REGISTER) {
+      var reg = definition.symbolTable().findIdAs(targetIdent, RegisterDefinition.class);
+      if (reg == null) {
+        // if this does not directly reference a register,
+        // it might reference an other alias definition
+        var alias = definition.symbolTable().findIdAs(targetIdent, AliasDefinition.class);
+        if (alias == null || alias.kind != AliasDefinition.AliasKind.REGISTER) {
+          throw error("Unknown alias source register", targetIdent.location())
+              .locationDescription(targetIdent.location(), "Unknown register `%s`.", targetIdent)
+              .build();
+        }
+        check(alias);
+        reg = (RegisterDefinition) requireNonNull(alias.computedTarget);
+      }
+
+      check(reg);
+      definition.computedTarget = reg;
+
       if (definition.targetType != null) {
-        throw error("Invalid Register Alias", definition.targetType)
-            .build();
+        // FIXME: Support relational alias types on registers
+        throw new IllegalStateException(
+            "Relational alias types are not yet supported, found at: %s".formatted(
+                definition.loc.toIDEString()));
       }
+
       var valType = check(definition.value);
-      if (definition.aliasType == null) {
-        definition.type = valType;
-      } else {
+
+      if (definition.aliasType != null) {
         definition.type = check(definition.aliasType);
+        definition.value = tryWrapImplicitCast(definition.value, definition.type);
+      } else {
+        definition.type = valType;
       }
+
       return null;
     }
 
     throw new IllegalStateException(
-        "Kind %s not yet implemented, found at: %s".formatted(definition.kind.toString(),
+        "Kind %s not yet implemented, found at: %s".formatted(definition.kind,
             definition.loc.toIDEString()));
-
   }
 
   @Override
@@ -2546,7 +2564,7 @@ public class TypeChecker
   @Override
   public Void visit(CallIndexExpr expr) {
 
-    // The first call of the multicalls depends on the thing that is beeing called.
+    // The first call of the multicalls depends on the thing that is being called.
     // However since the definitions aren't part of the typesystem we need to resolve them
     // manually.
     // If no target matches, we can assume a slice and index call (depending on the type).
@@ -2555,36 +2573,40 @@ public class TypeChecker
         .findAs(expr.target.path().pathToString(), Definition.class);
 
     // Handle register File
-    if (callTarget instanceof RegisterFileDefinition
+    if (callTarget instanceof RegisterDefinition
         || (callTarget instanceof AliasDefinition aliasDef
-        && aliasDef.kind.equals(AliasDefinition.AliasKind.REGISTER_FILE))) {
+        && aliasDef.kind.equals(AliasDefinition.AliasKind.REGISTER))) {
       if (expr.argsIndices.isEmpty() || expr.argsIndices.get(0).values.size() != 1) {
         throw error("Invalid Register Usage", expr)
             .description("A register call must have exactly one argument.")
             .build();
       }
 
-      var argList = expr.argsIndices.get(0);
-      var arg = argList.values.get(0);
-      check(arg);
-
+      expr.computedTarget = callTarget;
       check(callTarget);
-      var callTargetType = (ConcreteRelationType) ((TypedNode) callTarget).type();
-      var requiredArgType =
-          requireNonNull(requireNonNull(callTargetType).argTypes().get(0));
-      argList.values.set(0, wrapImplicitCast(arg, requiredArgType));
-      arg = argList.values.get(0);
-      var actualArgType = arg.type();
 
-      if (!actualArgType.equals(requiredArgType)) {
-        throw typeMissmatchError(expr, requiredArgType, actualArgType);
+      // the start of the index calls (might be 1 if the destination is a reg file)
+      var indexSubListStart = 0;
+      var callTargetType = ((TypedNode) callTarget).type();
+      var typeBeforeIndex = callTargetType;
+      if (callTargetType instanceof ConcreteRelationType relType) {
+        // If the call type is a relation type, it is a register file, so the first
+        // argument list must be treated as a list of arguments to the register file.
+        // FIXME: This must be more generic if the relation has multiple arguments
+        var argList = expr.argsIndices.get(0);
+        var arg = argList.values.get(0);
+        check(arg);
+        var requiredArgType = relType.argTypes().get(0);
+        argList.values.set(0, tryWrapImplicitCast(arg, requiredArgType));
+        typeBeforeIndex = relType.resultType();
+        argList.type = typeBeforeIndex;
+        indexSubListStart = 1;
       }
 
-      expr.computedTarget = callTarget;
-      var typeBeforeIndex = callTargetType.resultType();
-      argList.type = typeBeforeIndex;
+      // all further argument indices are slice calls
       visitSliceIndexCall(expr, typeBeforeIndex,
-          expr.argsIndices.subList(1, expr.argsIndices.size()));
+          expr.argsIndices.subList(indexSubListStart, expr.argsIndices.size()));
+      // the after the index slice we might have a type that can be called like .next
       visitSubCall(expr, expr.type());
       return null;
     }

--- a/vadl/main/vadl/ast/Ungrouper.java
+++ b/vadl/main/vadl/ast/Ungrouper.java
@@ -281,12 +281,6 @@ public class Ungrouper
   }
 
   @Override
-  public Void visit(RegisterFileDefinition definition) {
-    ungroupAnnotations(definition);
-    return null;
-  }
-
-  @Override
   public Void visit(InstructionDefinition definition) {
     ungroupAnnotations(definition);
     definition.behavior.accept(this);

--- a/vadl/main/vadl/ast/ViamLowering.java
+++ b/vadl/main/vadl/ast/ViamLowering.java
@@ -34,9 +34,11 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import javax.annotation.Nullable;
 import vadl.error.Diagnostic;
 import vadl.types.BitsType;
+import vadl.types.ConcreteRelationType;
 import vadl.types.DataType;
 import vadl.types.Type;
 import vadl.types.asmTypes.AsmType;
@@ -63,7 +65,6 @@ import vadl.viam.Procedure;
 import vadl.viam.PseudoInstruction;
 import vadl.viam.RegisterTensor;
 import vadl.viam.Relocation;
-import vadl.viam.Resource;
 import vadl.viam.Specification;
 import vadl.viam.annotations.AsmParserCaseSensitive;
 import vadl.viam.annotations.AsmParserCommentString;
@@ -294,23 +295,18 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
   @Override
   public Optional<vadl.viam.Definition> visit(AliasDefinition definition) {
 
-    if (definition.kind.equals(AliasDefinition.AliasKind.REGISTER_FILE)) {
+    if (definition.kind.equals(AliasDefinition.AliasKind.REGISTER)) {
       var identifier = generateIdentifier(definition.viamId, definition.loc);
       var innerResource =
-          (Resource) fetch(Objects.requireNonNull(definition.computedTarget)).orElseThrow();
+          (RegisterTensor) fetch(Objects.requireNonNull(definition.computedTarget)).orElseThrow();
 
       return Optional.of(new ArtificialResource(
           identifier,
-          ArtificialResource.Kind.REG_FILE_ALIAS,
+          ArtificialResource.Kind.REG_ALIAS,
           innerResource,
-          new BehaviorLowering(this).getRegisterFileAliasReadFunc(definition),
-          new BehaviorLowering(this).getRegisterFileAliasWriteProc(definition)
+          new BehaviorLowering(this).getRegisterAliasReadFunc(definition),
+          new BehaviorLowering(this).getRegisterAliasWriteProc(definition)
       ));
-    }
-
-    if (definition.kind.equals(AliasDefinition.AliasKind.REGISTER)) {
-      // FIXME: Do nothing for now, the VIAM cannot represent that yet
-      return Optional.empty();
     }
 
     throw new RuntimeException("The ViamGenerator does not support `%s` of kind %s yet".formatted(
@@ -402,9 +398,10 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
 
     Map<RegisterTensor, Abi.Alignment> registerFileAlignment =
         definitionCache.keySet()
-            .stream().filter(x -> x instanceof RegisterFileDefinition)
-            .map(x -> (RegisterFileDefinition) x)
+            .stream().filter(x -> x instanceof RegisterDefinition)
+            .map(x -> (RegisterDefinition) x)
             .map(x -> (RegisterTensor) fetch(x).orElseThrow())
+            .filter(RegisterTensor::isRegisterFile)
             .collect(Collectors.toMap(
                 x -> x,
                 x -> Abi.Alignment.HALF_WORD
@@ -1360,34 +1357,43 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
 
   @Override
   public Optional<vadl.viam.Definition> visit(RegisterDefinition definition) {
-    var resultType = (DataType) getViamType(definition.type());
+    var type = getViamType(definition.type());
+
+    DataType resultType;
+    var dimensions = new ArrayList<RegisterTensor.Dimension>();
+    if (type instanceof ConcreteRelationType relType) {
+      // if it is a relation type, it is a register file of the form x -> y, otherwise
+      var argTypes = relType.argTypes();
+      IntStream.range(0, argTypes.size()).forEach(i -> {
+        var t = argTypes.get(i).asDataType();
+        dimensions.add(dimFromMappingType(i, t));
+      });
+      resultType = relType.resultType().asDataType();
+    } else {
+      // the type is no mapping type
+      resultType = type.asDataType();
+    }
+
+    // FIXME: Handle mutli-dimension types
+    // now we add the dimensions of the form T<d0><d1>..
+    dimensions.add(dimFromType(dimensions.size(), resultType));
+
+    // FIXME: Remove this and add it using the [zero: ..] annotation
+    var constraints = new ArrayList<RegisterTensor.Constraint>();
+    if (type instanceof ConcreteRelationType relType) {
+      var zeroConstraint = new RegisterTensor.Constraint(
+          List.of(Constant.Value.of(0, relType.argTypes().getFirst().asDataType())),
+          Constant.Value.of(0, resultType));
+      constraints.add(zeroConstraint);
+    }
+
+
     var reg = new RegisterTensor(
         generateIdentifier(definition.viamId, definition.identifier()),
-        List.of(dimFromType(0, resultType)),
-        new RegisterTensor.Constraint[] {}
+        dimensions,
+        constraints.toArray(new RegisterTensor.Constraint[0])
     );
     return Optional.of(reg);
-  }
-
-  @Override
-  public Optional<vadl.viam.Definition> visit(RegisterFileDefinition definition) {
-    var addrType = (DataType) getViamType(requireNonNull(definition.type).argTypes().get(0));
-    var resultType = (DataType) getViamType(requireNonNull(definition.type).resultType());
-
-    // FIXME: Add proper constraints. This is currently only temporarily hardcoded to
-    //    fix the riscv iss simulation.
-    var zeroConstraint = new RegisterTensor.Constraint(List.of(Constant.Value.of(0, addrType)),
-        Constant.Value.of(0, resultType));
-
-    var regFile = new RegisterTensor(
-        generateIdentifier(definition.viamId, definition.identifier()),
-        List.of(
-            dimFromMappingType(0, addrType),
-            dimFromType(1, resultType)
-        ),
-        new RegisterTensor.Constraint[] {zeroConstraint}
-    );
-    return Optional.of(regFile);
   }
 
   @Override
@@ -1520,7 +1526,7 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
       var registerFile =
           ensurePresent(
               Optional.ofNullable(
-                      callExpr.symbolTable.requireAs(identifier, RegisterFileDefinition.class))
+                      callExpr.symbolTable.requireAs(identifier, RegisterDefinition.class))
                   .flatMap(this::fetch)
                   .map(x -> (RegisterTensor) x),
               () -> error("Cannot find register file with the name "

--- a/vadl/main/vadl/ast/vadl.ATG
+++ b/vadl/main/vadl/ast/vadl.ATG
@@ -363,8 +363,6 @@ PRODUCTIONS
   | encodingDefinition<out def>
   | assemblyDefinition<out def>
   | memoryDefinition<out def>
-  | IF (la.kind == _REGISTER && scanner.Peek().kind == _FILE)
-    registerFileDefinition<out def>
   | registerDefinition<out def>
   | aliasDefinition<out def>
   | exceptionDefinition<out def>
@@ -547,24 +545,19 @@ PRODUCTIONS
   registerDefinition<out RegisterDefinition def>            (. var startLocation = lookaheadLoc(); .)
   = REGISTER
     identifierOrPlaceholder<out IdentifierOrPlaceholder id>
-    SYM_COLON typeLiteral<out TypeLiteral t1>               (. def = new RegisterDefinition(id, t1, startLocation.join(t1.location())); .)
-  .
-
-  registerFileDefinition<out Definition def>                          (. var startLocation = lookaheadLoc(); .)
-  = REGISTER FILE
-    identifierOrPlaceholder<out IdentifierOrPlaceholder id>
     SYM_COLON
-    relationType<out RegisterFileDefinition.RelationTypeLiteral type> (. def = new RegisterFileDefinition(id, type, startLocation.join(loc())); .)
+    relationType<out RegisterDefinition.RelationTypeLiteral type> (. def = new RegisterDefinition(id, type, startLocation.join(loc())); .)
   .
 
-  relationType<out RegisterFileDefinition.RelationTypeLiteral type> (. var argTypes = new ArrayList<TypeLiteral>(); .)
-  = typeLiteral<out TypeLiteral argType>                     (. argTypes.add(argType); .)
-    {
+  relationType<out RegisterDefinition.RelationTypeLiteral type> (. var argTypes = new ArrayList<TypeLiteral>(); .)
+  = typeLiteral<out TypeLiteral t0>                             (. var resultType = t0; .)
+    [{
       SYM_MUL
-      typeLiteral<out argType>                               (. argTypes.add(argType); .)
+      typeLiteral<out TypeLiteral argType>                      (. argTypes.add(argType); .)
     }
     SYM_ARROW
-    typeLiteral<out TypeLiteral resultType>                  (. type = new RegisterFileDefinition.RelationTypeLiteral(argTypes, resultType); .)
+    typeLiteral<out TypeLiteral t1>                             (. argTypes.add(0, resultType); resultType = t1; .) // switch result types
+    ]                                                           (. type = new RegisterDefinition.RelationTypeLiteral(argTypes, resultType); .)
   .
 
   aliasDefinition<out Definition def>                 (. var startLocation = lookaheadLoc(); AliasDefinition.AliasKind kind = null;
@@ -574,9 +567,8 @@ PRODUCTIONS
   = ALIAS
     (
       REGISTER                                        (. kind = AliasDefinition.AliasKind.REGISTER; .)
-      [ FILE                                          (. kind = AliasDefinition.AliasKind.REGISTER_FILE; .)
-      ]
       identifierOrPlaceholder<out id>
+      // FIXME: This should probably use the same relationType as the register definition
       [
         SYM_COLON
         typeLiteral<out aliasType>
@@ -1021,8 +1013,6 @@ PRODUCTIONS
     | logicDefinition<out def>
     | signalDefinition<out def>
     | memoryDefinition<out def>
-    | IF (la.kind == _REGISTER && scanner.Peek().kind == _FILE)
-      registerFileDefinition<out def> // TODO Pass type MIA_DEFS - currently only ISA_DEFS
     | registerDefinition<out def>     // TODO Pass type MIA_DEFS - currently only ISA_DEFS
     | processDefinition<out def>
     | operationDefinition<out def>

--- a/vadl/main/vadl/utils/NPair.java
+++ b/vadl/main/vadl/utils/NPair.java
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.utils;
+
+import javax.annotation.Nullable;
+
+/**
+ * A pair that may contain nullable values.
+ */
+public record NPair<T, X>(@Nullable T left, @Nullable X right) {
+
+  public static <T, X> NPair<T, X> of(@Nullable T left, @Nullable X right) {
+    return new NPair<T, X>(left, right);
+  }
+
+}

--- a/vadl/main/vadl/viam/ArtificialResource.java
+++ b/vadl/main/vadl/viam/ArtificialResource.java
@@ -39,7 +39,7 @@ public class ArtificialResource extends Resource {
    * A hint what the artificial resources were created from.
    */
   public enum Kind {
-    REG_FILE_ALIAS
+    REG_ALIAS
   }
 
   private final Kind kind;

--- a/vadl/main/vadl/viam/RegisterTensor.java
+++ b/vadl/main/vadl/viam/RegisterTensor.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Streams;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import vadl.types.BitsType;
 import vadl.types.ConcreteRelationType;
@@ -244,6 +245,12 @@ public class RegisterTensor extends Resource {
           "Provided index type does not match respective tensor image type: %s != %s",
           provided, actual);
     });
+  }
+
+  @Override
+  public String toString() {
+    var dims = dimensions.stream().map(d -> "<" + d.size + ">").collect(Collectors.joining());
+    return simpleName() + ": " + dims;
   }
 
   /**

--- a/vadl/test/resources/dumps/mini.dump
+++ b/vadl/test/resources/dumps/mini.dump
@@ -23,7 +23,7 @@ InstructionSetDefinition name: "RV3264I"
 . : TypeLiteral type: null
 . : ' Identifier name: "Bits" type: null
 . : ' IntegerLiteral literal: 5 (5) type: null
-. RegisterFileDefinition name: "X"
+. RegisterDefinition name: "X"
 . : TypeLiteral type: null
 . : ' Identifier name: "Index" type: null
 . : TypeLiteral type: null

--- a/vadl/test/resources/dumps/mini.vadl
+++ b/vadl/test/resources/dumps/mini.vadl
@@ -18,7 +18,7 @@ instruction set architecture RV3264I = {
   using Index    = Bits< 5>               // 5 bit register index type for 32 registers
 
   [X(0) = 0]                              // register with index 0 always is 0
-  register file    X : Index   -> Regs    // integer register file with 32 registers of 32 bits
+  register    X : Index   -> Regs    // integer register with 32 registers of 32 bits
 
   format Rtype : Inst =                   // Rtype register 3 operand instruction format
     { funct7 : Bits7                      // [31..25] 7 bit function code

--- a/vadl/test/resources/dumps/rv64im.dump
+++ b/vadl/test/resources/dumps/rv64im.dump
@@ -97,7 +97,7 @@ ImportDefinition
 . : ' | TypeLiteral type: null
 . : ' | . Identifier name: "UInt" type: null
 . : ' | . Identifier name: "SftLen" type: null
-. : ' RegisterFileDefinition name: "X"
+. : ' RegisterDefinition name: "X"
 . : ' | TypeLiteral type: null
 . : ' | . Identifier name: "Index" type: null
 . : ' | TypeLiteral type: null

--- a/vadl/test/resources/macros/hexagon.expanded.vadl
+++ b/vadl/test/resources/macros/hexagon.expanded.vadl
@@ -18,7 +18,7 @@ instruction set architecture QDSP6 = {
   [littleEndian ]
   memory MEM: Address -> Byte
 
-  register file R: Index -> Word
+  register R: Index -> Word
 
   alias register SP : Word = R(29)
   alias register FP : Word = R(30)
@@ -32,7 +32,7 @@ instruction set architecture QDSP6 = {
   constant C_INDEX_P: Index = 4
   constant C_INDEX_PC: Index = 9
 
-  register file C: Index -> Word
+  register C: Index -> Word
 
   alias register SA0 = C(0)
   alias register LC0 = C(1)

--- a/vadl/test/resources/macros/hexagon.vadl
+++ b/vadl/test/resources/macros/hexagon.vadl
@@ -17,7 +17,7 @@ instruction set architecture QDSP6 =
   using SWord = SInt<32>
   using SDouble = SInt<64>
 
-  using Index          = Bits<5>           // register file index for 32 registers
+  using Index          = Bits<5>           // register index for 32 registers
   using PredicateIndex = Bits<2>           // predicate index for 4 predicates
 
   [littleEndian]
@@ -26,7 +26,7 @@ instruction set architecture QDSP6 =
   // Data must be aligned to its native access size.
   // Any unaligned memory access will cause a memory-alignment exception.
 
-  register file R   : Index -> Word   // general purpose register file
+  register R   : Index -> Word   // general purpose register
   alias register SP : Word = R(29)    // stack pointer
   alias register FP : Word = R(30)    // frame pointer
   alias register LR : Word = R(31)    // link register
@@ -38,7 +38,7 @@ instruction set architecture QDSP6 =
 
   constant C_INDEX_P  : Index = 4
   constant C_INDEX_PC : Index = 9
-  register file C   : Index -> Word        // control register file
+  register C   : Index -> Word        // control register
   alias register SA0             = C(0)    // Loop start address register 0
   alias register LC0             = C(1)    // Loop count register 0
   alias register SA1             = C(2)    // Loop start address register 1

--- a/vadl/test/resources/macros/isaDefs.expanded.vadl
+++ b/vadl/test/resources/macros/isaDefs.expanded.vadl
@@ -1,5 +1,5 @@
 instruction set architecture IsaDefsTest = {
-  register file X: Bits<5> -> Bits<32>
+  register X: Bits<5> -> Bits<32>
 
   format Rtype: Bits<32> =
   { rd : Bits<5>

--- a/vadl/test/resources/macros/isaDefs.vadl
+++ b/vadl/test/resources/macros/isaDefs.vadl
@@ -3,7 +3,7 @@
 
 instruction set architecture IsaDefsTest = {
 
-  register file X : Bits<5> -> Bits<32>
+  register X : Bits<5> -> Bits<32>
 
   format Rtype : Bits<32> =
     { rd: Bits<5>

--- a/vadl/test/resources/macros/rv3264im.expanded.vadl
+++ b/vadl/test/resources/macros/rv3264im.expanded.vadl
@@ -26,7 +26,7 @@ instruction set architecture RV3264I = {
   using UShft = UInt<SftLen>
 
   [(X(0) = 0) ]
-  register file X: Index -> Regs
+  register X: Index -> Regs
 
   program counter PC: Address
 

--- a/vadl/test/resources/macros/rv3264im.vadl
+++ b/vadl/test/resources/macros/rv3264im.vadl
@@ -52,7 +52,7 @@ instruction set architecture RV3264I = {
   using UShft    = UInt<SftLen>           // 5 or 6 bit unsigned shift ammount
 
   [X(0) = 0]                              // register with index 0 always is 0
-  register file    X : Index   -> Regs    // integer register file with 32 registers of 32 bits
+  register    X : Index   -> Regs    // integer register with 32 registers of 32 bits
   program counter PC : Address            // PC points to the start of the current instruction
   memory         MEM : Address -> Byte    // byte addressed memory
 

--- a/vadl/test/resources/testFiles/mini.vadl
+++ b/vadl/test/resources/testFiles/mini.vadl
@@ -18,7 +18,7 @@ instruction set architecture RV3264I = {
   using Index    = Bits< 5>               // 5 bit register index type for 32 registers
 
   [X(0) = 0]                              // register with index 0 always is 0
-  register file    X : Index   -> Regs    // integer register file with 32 registers of 32 bits
+  register    X : Index   -> Regs    // integer register with 32 registers of 32 bits
 
   format Rtype : Inst =                   // Rtype register 3 operand instruction format
     { funct7 : Bits7                      // [31..25] 7 bit function code

--- a/vadl/test/resources/testSource/ast/riscv/rv3264im.vadl
+++ b/vadl/test/resources/testSource/ast/riscv/rv3264im.vadl
@@ -52,7 +52,7 @@
   using UShft    = UInt<SftLen>           // 5 or 6 bit unsigned shift ammount
 
   [X(0) = 0]                              // register with index 0 always is 0
-  register file    X : Index   -> Regs    // integer register file with 32 registers of 32 bits
+  register    X : Index   -> Regs    // integer register with 32 registers of 32 bits
   program counter PC : Address            // PC points to the start of the current instruction
   memory         MEM : Address -> Byte    // byte addressed memory
 

--- a/vadl/test/resources/testSource/lcb/riscv32_pattern_trees.vadl
+++ b/vadl/test/resources/testSource/lcb/riscv32_pattern_trees.vadl
@@ -25,7 +25,7 @@ instruction set architecture RV3264IM = {
   using UShft    = UInt<SftLen>           // 5 or 6 bit unsigned shift amount
 
   [X(0) = 0]                              // register with index 0 always is 0
-  register file    X : Index   -> Regs    // integer register file with 32 registers of 32 bits
+  register    X : Index   -> Regs    // integer register with 32 registers of 32 bits
   program counter PC : Address            // PC points to the start of the current instruction
   memory         MEM : Address -> Byte    // byte addressed memory
 

--- a/vadl/test/resources/testSource/passes/algebraicSimplification/algebraic_simplification.vadl
+++ b/vadl/test/resources/testSource/passes/algebraicSimplification/algebraic_simplification.vadl
@@ -3,7 +3,7 @@ instruction set architecture Tests = {
   using Index = Bits<5>
   using Address  = Bits<32>
 
-  register file X: Index -> Bits<32>
+  register X: Index -> Bits<32>
 
   instruction SHIFT_LEFT_0: TMP = {
     X(ONE) := (X(ONE) << 0) as Bits<32>

--- a/vadl/test/resources/testSource/passes/singleResourceWriteValidation/invalid_regfile_1.vadl
+++ b/vadl/test/resources/testSource/passes/singleResourceWriteValidation/invalid_regfile_1.vadl
@@ -3,7 +3,7 @@
 
 instruction set architecture RegDualBranch = {
 
-  register file X: Bits<8> -> Bits<32>
+  register X: Bits<8> -> Bits<32>
 
   instruction TEST: TMP = {
     X(F1 + F2) := 1

--- a/vadl/test/resources/testSource/passes/singleResourceWriteValidation/invalid_regfile_2.vadl
+++ b/vadl/test/resources/testSource/passes/singleResourceWriteValidation/invalid_regfile_2.vadl
@@ -3,7 +3,7 @@
 
 instruction set architecture RegDualBranch = {
 
-  register file X: Bits<8> -> Bits<32>
+  register X: Bits<8> -> Bits<32>
 
   instruction TEST: TMP = {
     if (F1 = 2) then {

--- a/vadl/test/resources/testSource/passes/singleResourceWriteValidation/invalid_regfile_3.vadl
+++ b/vadl/test/resources/testSource/passes/singleResourceWriteValidation/invalid_regfile_3.vadl
@@ -3,7 +3,7 @@
 
 instruction set architecture RegDualBranch = {
 
-  register file X: Bits<8> -> Bits<32>
+  register X: Bits<8> -> Bits<32>
 
   instruction TEST: TMP = {
     if (F1 = 2) then {

--- a/vadl/test/resources/testSource/passes/singleResourceWriteValidation/invalid_regfile_4.vadl
+++ b/vadl/test/resources/testSource/passes/singleResourceWriteValidation/invalid_regfile_4.vadl
@@ -3,7 +3,7 @@
 
 instruction set architecture RegDualBranch = {
 
-  register file X: Bits<8> -> Bits<32>
+  register X: Bits<8> -> Bits<32>
 
   instruction TEST: TMP = {
     if (F1 = 2) then {

--- a/vadl/test/resources/testSource/passes/singleResourceWriteValidation/valid_regfile_writes.vadl
+++ b/vadl/test/resources/testSource/passes/singleResourceWriteValidation/valid_regfile_writes.vadl
@@ -1,7 +1,7 @@
 
 instruction set architecture ValidRegFileWrites = {
 
-  register file X: Bits<8> -> Bits<32>
+  register X: Bits<8> -> Bits<32>
 
   instruction TEST1: TMP = {
     if F1 = 1 then {

--- a/vadl/test/resources/testSource/sys/risc-v/rv3264im.vadl
+++ b/vadl/test/resources/testSource/sys/risc-v/rv3264im.vadl
@@ -52,7 +52,7 @@
   using UShft    = UInt<SftLen>           // 5 or 6 bit unsigned shift ammount
 
   [X(0) = 0]                              // register with index 0 always is 0
-  register file    X : Index   -> Regs    // integer register file with 32 registers of 32 bits
+  register    X : Index   -> Regs    // integer register with 32 registers of 32 bits
   program counter PC : Address            // PC points to the start of the current instruction
   memory         MEM : Address -> Byte    // byte addressed memory
 

--- a/vadl/test/resources/testSource/unit/function/valid_functionUsage.vadl
+++ b/vadl/test/resources/testSource/unit/function/valid_functionUsage.vadl
@@ -5,7 +5,7 @@ instruction set architecture FunctionCallTest = {
 
   function addition( a: UInt<10>, b: UInt<10>) -> UInt<10> = a + b
 
-  register file X: Bits<5> -> Bits<30>
+  register X: Bits<5> -> Bits<30>
   format TF: Bits<3> = {
     f: Bits<3>
   }

--- a/vadl/test/resources/testSource/unit/register/valid_alias_regfile.vadl
+++ b/vadl/test/resources/testSource/unit/register/valid_alias_regfile.vadl
@@ -3,12 +3,12 @@ instruction set architecture Test = {
   using Regs = Bits<32>
   using Index = Bits<5>
 
-  register file X: Index -> Regs
+  register X: Index -> Regs
 
   [A(12) = 0]
-  alias register file A = X
+  alias register A = X
 
-  alias register file B = X
+  alias register B = X
 
 
   instruction ReadA_Hit: F = {

--- a/vadl/test/resources/testSource/unit/register/valid_pc_alias_regfile.vadl
+++ b/vadl/test/resources/testSource/unit/register/valid_pc_alias_regfile.vadl
@@ -3,7 +3,7 @@ instruction set architecture PcTest = {
   using Regs = Bits<32>
   using Index = Bits<5>
 
-  register file X: Index -> Regs
+  register X: Index -> Regs
   alias program counter PC: Regs = X(31)
 
   instruction READ_PC: F = A := PC

--- a/vadl/test/resources/testSource/unit/register/valid_reg_read.vadl
+++ b/vadl/test/resources/testSource/unit/register/valid_reg_read.vadl
@@ -6,7 +6,7 @@ instruction set architecture Test = {
   [ read full ]
   register C: HELPER
 
-  register file D: Regs -> Regs
+  register D: Regs -> Regs
 
   // full read
   instruction FIRST: HELPER = A := B
@@ -17,7 +17,7 @@ instruction set architecture Test = {
   // partial read on full access
   instruction THIRD: HELPER = A := C.ONE
 
-  // register file read
+  // register read
   instruction FOURTH: HELPER = A := D(B.ONE)
 
 

--- a/vadl/test/resources/testSource/unit/register/valid_reg_write.vadl
+++ b/vadl/test/resources/testSource/unit/register/valid_reg_write.vadl
@@ -6,7 +6,7 @@ instruction set architecture Test = {
   [ write full ]
   register C: HELPER
 
-  register file D: Regs -> Regs
+  register D: Regs -> Regs
 
   // full write
   instruction FIRST: HELPER = B := A
@@ -18,7 +18,7 @@ instruction set architecture Test = {
   // not yet supported
   //   instruction THIRD: HELPER = C.ONE := A
 
-  // register file write
+  // register write
   instruction FOURTH: HELPER = D(B.ONE) := A
 
 

--- a/vadl/test/resources/testSource/unit/register/valid_regfile.vadl
+++ b/vadl/test/resources/testSource/unit/register/valid_regfile.vadl
@@ -4,10 +4,10 @@ instruction set architecture Test = {
   using Index = Bits<5>
   using Regs  = Bits<32>
 
-  register file X: Index -> Regs
+  register X: Index -> Regs
 
   [ Y(2) = 0 ]
-  register file Y: Index -> Regs
+  register Y: Index -> Regs
 
 }
 

--- a/vadl/test/vadl/ast/AnnotationTest.java
+++ b/vadl/test/vadl/ast/AnnotationTest.java
@@ -31,7 +31,7 @@ public class AnnotationTest {
         instruction set architecture TEST =
         {
           [ X(0) = 0 ]
-          register file X : Bits<32> -> Bits<5>
+          register X : Bits<32> -> Bits<5>
         }
         """;
     var ast = VadlParser.parse(prog);

--- a/vadl/test/vadl/ast/AsmLL1CheckerTest.java
+++ b/vadl/test/vadl/ast/AsmLL1CheckerTest.java
@@ -23,18 +23,18 @@ import vadl.error.Diagnostic;
 public class AsmLL1CheckerTest {
   private final String base = """
        instruction set architecture ISA = {
-        register file X : Bits<5> -> Bits<32>
-        
+        register X : Bits<5> -> Bits<32>
+      
         format Rtype : Bits<1> =
         { funct7 : Bits<1> }
-        
+      
         instruction DO : Rtype =
         {
            X(0) := 1
         }
         encoding DO = { funct7 = 0b0 }
         assembly DO = (mnemonic)
-        
+      
         pseudo instruction NOP( symbol: Bits<5>) = {
         }
         assembly NOP = (mnemonic)
@@ -50,10 +50,10 @@ public class AsmLL1CheckerTest {
         global pointer = zero
         frame pointer = zero
         thread pointer = zero
-        
+      
         return value = zero
         function argument = zero
-        
+      
         caller saved = zero
         callee saved = zero
       }
@@ -62,7 +62,7 @@ public class AsmLL1CheckerTest {
   private String inputWrappedByValidAsmDescription(String input) {
     return """
           %s
-                
+        
           assembly description AD for ABI = {
             %s
           }
@@ -171,10 +171,10 @@ public class AsmLL1CheckerTest {
     var prog = """
           instruction set architecture ISA = {}
           application binary interface ABI for ISA = {}
-                
+        
           assembly description AD for ABI = {
             function minusOne (x : SInt<64>) -> SInt<64> = x - 1
-                
+        
             grammar = {
               RuleA :
                 attr = minusOne<Integer>
@@ -195,11 +195,11 @@ public class AsmLL1CheckerTest {
     var prog = """
           instruction set architecture ISA = {}
           application binary interface ABI for ISA = {}
-                
+        
           assembly description AD for ABI = {
             function one -> SInt<64> = 1
             function add (a: SInt<64>, b: SInt<64>) -> SInt<64> = a + b
-                
+        
             grammar = {
               RuleA :
                 (
@@ -490,7 +490,7 @@ public class AsmLL1CheckerTest {
               ?(laideq(0,"r1")) A
               | B
             ) @instruction ;
-                
+        
             A : Register @operand ;
             B : Register @operand ;
           }

--- a/vadl/test/vadl/ast/InstructionTest.java
+++ b/vadl/test/vadl/ast/InstructionTest.java
@@ -27,7 +27,7 @@ public class InstructionTest {
   void parseCombinedInstructionDefinition() {
     var prog = """
         instruction set architecture RV32I = {
-          register file X : Bits<5> -> Bits<32>
+          register X : Bits<5> -> Bits<32>
           format R_TYPE : Bits<32> = {
             funct7 [31..25],
             rs2    [24..20],
@@ -36,17 +36,17 @@ public class InstructionTest {
             rd     [11..7],
             opcode [6..0]
           }
-
+        
           instruction ADD : R_TYPE = {
             X(rd) := X(rs1) + X(rs2)
           }
-
+        
           encoding ADD = {
             opcode = 0b011'0011,
             funct3 = 0b000,
             funct7 = 0b000'0000
           }
-
+        
           assembly ADD = (mnemonic, " ", rd, ", ", rs1, ", ", rs2)
         }
         """;
@@ -68,9 +68,9 @@ public class InstructionTest {
           format R_TYPE : Bits<32> = {
             a: Bits<10>, b: Bits<10>, c: Bits<10>, d: Bits<10>
           }
-
+        
           instruction ADD : R_TYPE = {}
-
+        
           encoding ADD = {
             a = 1,
             $Encoding(b = 2, none, c=3)

--- a/vadl/test/vadl/ast/NameResolutionTest.java
+++ b/vadl/test/vadl/ast/NameResolutionTest.java
@@ -141,8 +141,8 @@ public class NameResolutionTest {
   void resolveTwoOverlappingRegisterFileDefinitions() {
     var prog = """
         instruction set architecture FLO = {
-          register file X : Bits<5> -> Bits<32>
-          register file X : Bits<2> -> Bits<4>
+          register X : Bits<5> -> Bits<32>
+          register X : Bits<2> -> Bits<4>
         }
         """;
     var thrown = Assertions.assertThrows(DiagnosticList.class, () -> VadlParser.parse(prog),

--- a/vadl/test/vadl/ast/ParserTest.java
+++ b/vadl/test/vadl/ast/ParserTest.java
@@ -156,7 +156,7 @@ public class ParserTest {
   void registerFileDefinition() {
     var prog = """
         instruction set architecture FLO = {
-          register file X : Bits<5> -> Bits<32>
+          register X : Bits<5> -> Bits<32>
         }
         """;
 

--- a/vadl/test/vadl/ast/TypecheckerAbiTest.java
+++ b/vadl/test/vadl/ast/TypecheckerAbiTest.java
@@ -25,7 +25,7 @@ public class TypecheckerAbiTest {
 
   private final String base = """
        instruction set architecture ISA = {
-        register file X : Bits<5> -> Bits<32>
+        register X : Bits<5> -> Bits<32>
       
         format Rtype : Bits<1> =
         { funct7 : Bits<1> }

--- a/vadl/test/vadl/ast/TypecheckerAsmTest.java
+++ b/vadl/test/vadl/ast/TypecheckerAsmTest.java
@@ -33,7 +33,7 @@ public class TypecheckerAsmTest {
 
   private final String base = """
        instruction set architecture ISA = {
-        register file X : Bits<5> -> Bits<32>
+        register X : Bits<5> -> Bits<32>
       
         format Rtype : Bits<1> =
         { funct7 : Bits<1> }

--- a/vadl/test/vadl/ast/TypecheckerTest.java
+++ b/vadl/test/vadl/ast/TypecheckerTest.java
@@ -930,7 +930,7 @@ public class TypecheckerTest {
           using Inst     = Bits<32>               // instruction word is 32 bit
           using Regs     = Bits<32>               // untyped register word type
         
-          register file    X : Bits<5>   -> Regs  // integer register file with 32 registers of 32 bits
+          register    X : Bits<5>   -> Regs  // integer register with 32 registers of 32 bits
         
           format Rtype : Inst =                   // Rtype register 3 operand instruction format
             { funct7 : Bits<7>                    // [31..25] 7 bit function code
@@ -959,7 +959,7 @@ public class TypecheckerTest {
               using Inst     = Bits<32>               // instruction word is 32 bit
               using Regs     = Bits<32>               // untyped register word type
         
-              register file    X : Bits<5>   -> Regs  // integer register file with 32 registers of 32 bits
+              register    X : Bits<5>   -> Regs  // integer register with 32 registers of 32 bits
         
               format Rtype : Inst =                   // Rtype register 3 operand instruction format
                 { funct7 : Bits<7>                    // [31..25] 7 bit function code
@@ -990,7 +990,7 @@ public class TypecheckerTest {
           using Inst     = Bits<32>               // instruction word is 32 bit
           using Regs     = Bits<32>               // untyped register word type
         
-          register file    X : Bits<5>   -> Regs  // integer register file with 32 registers of 32 bits
+          register    X : Bits<5>   -> Regs  // integer register with 32 registers of 32 bits
         
           format Rtype : Inst =                   // Rtype register 3 operand instruction format
             { funct7 : Bits<7>                    // [31..25] 7 bit function code

--- a/vadl/test/vadl/ast/ViamLoweringTest.java
+++ b/vadl/test/vadl/ast/ViamLoweringTest.java
@@ -25,7 +25,7 @@ public class ViamLoweringTest {
 
   private final String base = """
        instruction set architecture ISA = {
-        register file X : Bits<5> -> Bits<32>
+        register X : Bits<5> -> Bits<32>
       
         pseudo instruction NOP( symbol: Bits<5>) = {
         }


### PR DESCRIPTION
This PR is an *alternative* PR to #195. 

In comparison to #195, this PR uses a more generic approach by using a new `TensorType` in the frontend that represents both, mapping and multi dimensional types. 

Because of this, this PR additionally adds rudimentary support for multi-dimensional registers:
```
instruction set architecture TEST = {
        
        register A: Bits<5><32>
        register B: Bits<5> -> Bits<5><32>
        register C: Bits<32><5><32>
        
        function t1 -> Bits<32> = A(0)
        function t2 -> Bits<32> = B(A(0) as Bits<5>)(2)
        function t3 -> Bits<32> = B(2, A(0) as Bits<3>)
        function t4 -> Bits<32> = C(B(A(0) as Bits<5>, 4) as Bits<5>, 2)        
        function t5 -> Bits<1> = C(B(A(0) as Bits<5>, 4) as Bits<5>, 2)(2)
}
```

This `TensorType` could be used as a frontend super type for all `DataType` related operations for a more complete multi dimensional type support.