### PR TITLE
lcb: Printed InstAlias

### DIFF
--- a/vadl/main/resources/templates/lcb/llvm/lib/Target/MCTargetDesc/TargetInstPrinter.cpp
+++ b/vadl/main/resources/templates/lcb/llvm/lib/Target/MCTargetDesc/TargetInstPrinter.cpp
@@ -17,9 +17,8 @@
 
 using namespace llvm;
 
-#define GET_INSTRUCTION_NAME
+#define PRINT_ALIAS_INSTR
 #include "[(${namespace})]GenAsmWriter.inc"
-#undef GET_INSTRUCTION_NAME
 
 void [(${namespace})]InstPrinter::anchor() {}
 
@@ -31,6 +30,26 @@ void [(${namespace})]InstPrinter::printRegName
     O << AsmUtils::getRegisterName( RegNo );
 }
 
+void [(${namespace})]InstPrinter::printOperand(const MCInst *MI, unsigned OpNo,
+    raw_ostream &O,
+    const char *Modifier) {
+  assert((Modifier == nullptr || Modifier[0] == 0) && "No modifiers supported");
+  const MCOperand &MO = MI->getOperand(OpNo);
+
+  if (MO.isReg()) {
+  printRegName(O, MO.getReg());
+  return;
+  }
+
+  if (MO.isImm()) {
+  O << MO.getImm();
+  return;
+}
+
+assert(MO.isExpr() && "Unknown operand kind in printOperand");
+MO.getExpr()->print(O, &MAI);
+}
+
 void [(${namespace})]InstPrinter::printInst
     ( const MCInst *MI
     , uint64_t Address
@@ -39,7 +58,9 @@ void [(${namespace})]InstPrinter::printInst
     , raw_ostream &O
     )
 {
-    O << "\t" << instToString(MI, Address);
+    if(!printAliasInstr(MI, Address, O)) {
+      O << "\t" << instToString(MI, Address);
+    }
     printAnnotation(O, Annot);
 }
 

--- a/vadl/main/resources/templates/lcb/llvm/lib/Target/MCTargetDesc/TargetInstPrinter.h
+++ b/vadl/main/resources/templates/lcb/llvm/lib/Target/MCTargetDesc/TargetInstPrinter.h
@@ -27,6 +27,8 @@ namespace llvm
 
         MCOperand adjustImmediateOp(const MCInst *MI, unsigned OpIndex) const;
 
+        void printOperand(const MCInst *MI, unsigned OpNo, raw_ostream &O, const char *Modifier = nullptr);
+
         /*
         [#th:block th:each="register, iterStat : ${systemRegisters}" ]
             void print[(${register.name})]SystemRegister
@@ -43,6 +45,10 @@ namespace llvm
         std::pair<const char *, uint64_t>
         getMnemonic(const MCInst *MI) override;
         void printInstruction(const MCInst *MI, uint64_t Address, raw_ostream &OS);
+        bool printAliasInstr(const MCInst *MI, uint64_t Address, raw_ostream &O);
+        void printCustomAliasOperand(const MCInst *MI, uint64_t Address,
+                        unsigned OpIdx, unsigned PrintMethodIdx,
+                        raw_ostream &O);
         static const char *getRegisterName(MCRegister Reg);
 
     private:

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O0/alu64.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O0/alu64.ll
@@ -10,7 +10,7 @@ define i64 @addi(i64 %a) nounwind {
 ; CHECK-NEXT: XOR a2,a0,a2
 ; CHECK-NEXT: SLTIU a2,a2,1
 ; CHECK-NEXT: ADD a1,a1,a2
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = add i64 %a, 1
   ret i64 %1
 }
@@ -43,7 +43,7 @@ define i64 @sltiu(i64 %a) nounwind {
 ; CHECK-NEXT: LW a1,8(sp) # 4-byte Folded Reload
 ; CHECK-NEXT: LW a0,12(sp) # 4-byte Folded Reload
 ; CHECK-NEXT: ADDI sp,sp,16
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = icmp ult i64 %a, 3
   %2 = zext i1 %1 to i64
   ret i64 %2
@@ -53,7 +53,7 @@ define i64 @xori(i64 %a) nounwind {
 ; CHECK-LABEL: xori: # @xori
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: XORI a0,a0,4
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = xor i64 %a, 4
   ret i64 %1
 }
@@ -62,7 +62,7 @@ define i64 @ori(i64 %a) nounwind {
 ; CHECK-LABEL: ori: # @ori
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: ORI a0,a0,5
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = or i64 %a, 5
   ret i64 %1
 }
@@ -72,7 +72,7 @@ define i64 @andi(i64 %a) nounwind {
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: ANDI a0,a0,6
 ; CHECK-NEXT: ADDI a1,zero,0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = and i64 %a, 6
   ret i64 %1
 }
@@ -84,7 +84,7 @@ define i64 @slli(i64 %a) nounwind {
 ; CHECK-NEXT: SLLI a1,a1,7
 ; CHECK-NEXT: OR a1,a1,a2
 ; CHECK-NEXT: SLLI a0,a0,7
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = shl i64 %a, 7
   ret i64 %1
 }
@@ -96,7 +96,7 @@ define i64 @srli(i64 %a) nounwind {
 ; CHECK-NEXT: SRLI a0,a0,8
 ; CHECK-NEXT: OR a0,a0,a2
 ; CHECK-NEXT: SRLI a1,a1,8
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = lshr i64 %a, 8
   ret i64 %1
 }
@@ -108,7 +108,7 @@ define i64 @srai(i64 %a) nounwind {
 ; CHECK-NEXT: SRLI a0,a0,9
 ; CHECK-NEXT: OR a0,a0,a2
 ; CHECK-NEXT: SRAI a1,a1,9
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = ashr i64 %a, 9
   ret i64 %1
 }
@@ -127,7 +127,7 @@ define i64 @add(i64 %a, i64 %b) nounwind {
 ; CHECK-NEXT: SLTU a2,a0,a2
 ; CHECK-NEXT: ADD a1,a1,a2
 ; CHECK-NEXT: ADDI sp,sp,16
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = add i64 %a, %b
   ret i64 %1
 }
@@ -140,7 +140,7 @@ define i64 @sub(i64 %a, i64 %b) nounwind {
 ; CHECK-NEXT: SUB a1,a1,a4
 ; CHECK-NEXT: SUB a1,a1,a3
 ; CHECK-NEXT: SUB a0,a0,a2
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = sub i64 %a, %b
   ret i64 %1
 }
@@ -171,7 +171,7 @@ define i64 @slt(i64 %a, i64 %b) nounwind {
 ; CHECK-NEXT: LW a0,12(sp) # 4-byte Folded Reload
 ; CHECK-NEXT: ADDI a1,zero,0
 ; CHECK-NEXT: ADDI sp,sp,16
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = icmp slt i64 %a, %b
   %2 = zext i1 %1 to i64
   ret i64 %2
@@ -182,7 +182,7 @@ define i64 @xor(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: XOR a0,a0,a2
 ; CHECK-NEXT: XOR a1,a1,a3
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = xor i64 %a, %b
   ret i64 %1
 }
@@ -212,7 +212,7 @@ define i64 @or(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: OR a0,a0,a2
 ; CHECK-NEXT: OR a1,a1,a3
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = or i64 %a, %b
   ret i64 %1
 }
@@ -222,7 +222,7 @@ define i64 @and(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: AND a0,a0,a2
 ; CHECK-NEXT: AND a1,a1,a3
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = and i64 %a, %b
   ret i64 %1
 }

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O0/and.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O0/and.ll
@@ -4,7 +4,7 @@
 define i32 @and32_0x7ff(i32 %x) {
 ; CHECK-LABEL: and32_0x7ff: # @and32_0x7ff
 ; CHECK:         ANDI a0,a0,2047
-; CHECK-NEXT:    JALR zero,0(ra)
+; CHECK-NEXT:    RET
   %a = and i32 %x, 2047
   ret i32 %a
 }
@@ -14,7 +14,7 @@ define i32 @and32_0xfff(i32 %x) {
 ; CHECK:       LUI a1,0x1
 ; CHECK-NEXT:  ADDI a1,a1,-1
 ; CHECK-NEXT:  AND a0,a0,a1
-; CHECK-NEXT:  JALR zero,0(ra)
+; CHECK-NEXT:  RET
   %a = and i32 %x, 4095
   ret i32 %a
 }
@@ -23,7 +23,7 @@ define i64 @and64_0x7ff(i64 %x) {
 ; CHECK-LABEL: and64_0x7ff: # @and64_0x7ff
 ; CHECK:         ANDI a0,a0,2047
 ; CHECK-NEXT:    ADDI a1,zero,0
-; CHECK-NEXT:    JALR zero,0(ra)
+; CHECK-NEXT:    RET
   %a = and i64 %x, 2047
   ret i64 %a
 }
@@ -34,7 +34,7 @@ define i64 @and64_0xfff(i64 %x) {
 ; CHECK-NEXT:  ADDI a1,a1,-1
 ; CHECK-NEXT:  AND a0,a0,a1
 ; CHECK-NEXT:  ADDI a1,zero,0
-; CHECK-NEXT:  JALR zero,0(ra)
+; CHECK-NEXT:  RET
   %a = and i64 %x, 4095
   ret i64 %a
 }

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O0/imm.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O0/imm.ll
@@ -3,21 +3,21 @@
 define signext i32 @zero() nounwind {
   ; CHECK-LABEL: zero: # @zero
   ; CHECK: ADDI a0,zero,0
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i32 0
 }
 
 define signext i32 @pos_small() nounwind {
   ; CHECK-LABEL: pos_small: # @pos_small
   ; CHECK: ADDI a0,zero,2047
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i32 2047
 }
 
 define signext i32 @neg_small() nounwind {
   ; CHECK-LABEL: neg_small: # @neg_small
   ; CHECK: ADDI a0,zero,-2048
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i32 -2048
 }
 
@@ -25,7 +25,7 @@ define signext i32 @pos_i32() nounwind {
   ; CHECK-LABEL: pos_i32: # @pos_i32
   ; CHECK: LUI a0,0x67783
   ; CHECK-NEXT: ADDI a0,a0,-1297
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i32 1735928559
 }
 
@@ -33,7 +33,7 @@ define signext i32 @neg_i32() nounwind {
   ; CHECK-LABEL: neg_i32: # @neg_i32
   ; CHECK: LUI a0,0xdeadc
   ; CHECK-NEXT: ADDI a0,a0,-273
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i32 -559038737
 }
 
@@ -41,7 +41,7 @@ define signext i32 @pos_i32_hi20_only() nounwind {
   ; CHECK-LABEL: pos_i32_hi20_only: # @pos_i32_hi20_only
   ; CHECK: LUI a0,0x10
   ; CHECK-NEXT: ADDI a0,a0,0
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i32 65536 ; 0x10000
 }
 
@@ -49,7 +49,7 @@ define signext i32 @neg_i32_hi20_only() nounwind {
   ; CHECK-LABEL: neg_i32_hi20_only: # @neg_i32_hi20_only
   ; CHECK: LUI a0,0xffff0
   ; CHECK-NEXT: ADDI a0,a0,0
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i32 -65536 ; -0x10000
 }
 
@@ -59,7 +59,7 @@ define i64 @imm_end_xori_1() nounwind {
   ; CHECK-NEXT: ADDI a0,a0,-1
   ; CHECK-NEXT: LUI a1,0xe0000
   ; CHECK-NEXT: ADDI a1,a1,0
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i64 -2305843009180139521 ; 0xE000_0000_01FF_FFFF
 }
 
@@ -67,7 +67,7 @@ define void @imm_store_i8_neg1(ptr %p) nounwind {
   ; CHECK-LABEL: imm_store_i8_neg1: # @imm_store_i8_neg1
   ; CHECK: ADDI a1,zero,255
   ; CHECK-NEXT: SB a1,0(a0)
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   store i8 -1, ptr %p
   ret void
 }
@@ -77,7 +77,7 @@ define void @imm_store_i16_neg1(ptr %p) nounwind {
   ; CHECK: LUI a1,0x10
   ; CHECK-NEXT: ADDI a1,a1,-1
   ; CHECK-NEXT: SH a1,0(a0)
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   store i16 -1, ptr %p
   ret void
 }
@@ -86,7 +86,7 @@ define void @imm_store_i32_neg1(ptr %p) nounwind {
   ; CHECK-LABEL: imm_store_i32_neg1: # @imm_store_i32_neg1
   ; CHECK: ADDI a1,zero,-1
   ; CHECK-NEXT: SW a1,0(a0)
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   store i32 -1, ptr %p
   ret void
 }

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O0/indirectbr.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O0/indirectbr.ll
@@ -6,7 +6,7 @@ define i32 @indirectbr(ptr %target) nounwind {
   ; CHECK-NEXT: JALR zero,0(a0)
   ; CHECK-LABEL: LBB0_1: # %test_label
   ; CHECK: ADDI a0,zero,0
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
    indirectbr ptr %target, [label %test_label]
 test_label:
   br label %ret
@@ -22,7 +22,7 @@ define i32 @indirectbr_with_offset(ptr %a) nounwind {
   ; CHECK-NEXT: JAL zero,.LBB1_2
   ; CHECK-LABEL: LBB1_2:
   ; CHECK-NEXT: ADDI a0,zero,0
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
 
   %target = getelementptr inbounds i8, ptr %a, i32 1380
   indirectbr ptr %target, [label %test_label]

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O0/large_stack.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O0/large_stack.ll
@@ -49,7 +49,7 @@ define void @test_emergency_spill_slot(i32 %a) {
 ; CHECK-NEXT: LUI a0,0x62
 ; CHECK-NEXT: ADDI a0,a0,-1408
 ; CHECK-NEXT: ADD sp,sp,a0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %data = alloca [ 100000 x i32 ] , align 4
   %ptr = getelementptr inbounds [100000 x i32], ptr %data, i32 0, i32 80000
   %1 = tail call { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } asm sideeffect "nop", "=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r"()

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O0/mul.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O0/mul.ll
@@ -4,7 +4,7 @@ define signext i32 @square(i32 %a) nounwind {
 ; CHECK-LABEL: square: # @square
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: MUL a0,a0,a0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = mul i32 %a, %a
   ret i32 %1
 }
@@ -13,7 +13,7 @@ define signext i32 @mul(i32 %a, i32 %b) nounwind {
 ; CHECK-LABEL: mul: # @mul
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: MUL a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = mul i32 %a, %b
   ret i32 %1
 }
@@ -23,7 +23,7 @@ define signext i32 @mul_constant(i32 %a) nounwind {
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: ADDI a1,zero,5
 ; CHECK-NEXT: MUL a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = mul i32 %a, 5
   ret i32 %1
 }
@@ -32,7 +32,7 @@ define i32 @mul_pow2(i32 %a) nounwind {
 ; CHECK-LABEL: mul_pow2: # @mul_pow2
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: SLLI a0,a0,3
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = mul i32 %a, 8
   ret i32 %1
 }
@@ -51,7 +51,7 @@ define i64 @mul64(i64 %a, i64 %b) nounwind {
 ; CHECK-NEXT: ADD a1,a1,a3
 ; CHECK-NEXT: MUL a0,a0,a2
 ; CHECK-NEXT: ADDI sp,sp,16
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = mul i64 %a, %b
   ret i64 %1
 }

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O0/pic.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O0/pic.ll
@@ -10,7 +10,7 @@ define ptr @f1() nounwind {
 ; CHECK-LABEL: # %bb.0: # %entry
 ; CHECK-NEXT: AUIPC a0,%got_pcrel_hi(external_var)
 ; CHECK-NEXT: LW a0,%pcrel_lo(external_var)(a0)
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 entry:
   ret ptr @external_var
 }
@@ -21,7 +21,7 @@ define ptr @f2() nounwind {
 ; CHECK-LABEL: .Ltmp0
 ; CHECK-NEXT: AUIPC a0,%pcrel_hi(internal_var)
 ; CHECK-NEXT: ADDI a0,a0,%pcrel_lo(.Ltmp0)
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 entry:
   ret ptr @internal_var
 }

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/alu64.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/alu64.ll
@@ -9,7 +9,7 @@ define i64 @addi(i64 %a) nounwind {
 ; CHECK-NEXT: XOR a2,a0,zero
 ; CHECK-NEXT: SLTIU a2,a2,1
 ; CHECK-NEXT: ADD a1,a1,a2
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = add i64 %a, 1
   ret i64 %1
 }
@@ -21,11 +21,11 @@ define i64 @slti(i64 %a) nounwind {
 ; CHECK-LABEL: # %bb.1:
 ; CHECK: SLTI a0,a1,0
 ; CHECK-NEXT: ADDI a1,zero,0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 ; CHECK-LABEL: .LBB1_2:
 ; CHECK-NEXT: SLTIU a0,a0,2
 ; CHECK-NEXT: ADDI a1,zero,0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = icmp slt i64 %a, 2
   %2 = zext i1 %1 to i64
   ret i64 %2
@@ -38,11 +38,11 @@ define i64 @sltiu(i64 %a) nounwind {
 ; CHECK-LABEL: # %bb.1:
 ; CHECK-NEXT: ADDI a0,zero,0
 ; CHECK-NEXT: ADDI a1,zero,0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 ; CHECK-LABEL: .LBB2_2:
 ; CHECK-NEXT: SLTIU a0,a0,3
 ; CHECK-NEXT: ADDI a1,zero,0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = icmp ult i64 %a, 3
   %2 = zext i1 %1 to i64
   ret i64 %2
@@ -52,7 +52,7 @@ define i64 @xori(i64 %a) nounwind {
 ; CHECK-LABEL: xori: # @xori
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: XORI a0,a0,4
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = xor i64 %a, 4
   ret i64 %1
 }
@@ -61,7 +61,7 @@ define i64 @ori(i64 %a) nounwind {
 ; CHECK-LABEL: ori: # @ori
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: ORI a0,a0,5
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = or i64 %a, 5
   ret i64 %1
 }
@@ -71,7 +71,7 @@ define i64 @andi(i64 %a) nounwind {
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: ANDI a0,a0,6
 ; CHECK-NEXT: ADDI a1,zero,0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = and i64 %a, 6
   ret i64 %1
 }
@@ -83,7 +83,7 @@ define i64 @slli(i64 %a) nounwind {
 ; CHECK-NEXT: SRLI a2,a0,25
 ; CHECK-NEXT: OR a1,a1,a2
 ; CHECK-NEXT: SLLI a0,a0,7
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = shl i64 %a, 7
   ret i64 %1
 }
@@ -95,7 +95,7 @@ define i64 @srli(i64 %a) nounwind {
 ; CHECK-NEXT: SLLI a2,a1,24
 ; CHECK-NEXT: OR a0,a0,a2
 ; CHECK-NEXT: SRLI a1,a1,8
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = lshr i64 %a, 8
   ret i64 %1
 }
@@ -107,7 +107,7 @@ define i64 @srai(i64 %a) nounwind {
 ; CHECK-NEXT: SLLI a2,a1,23
 ; CHECK-NEXT: OR a0,a0,a2
 ; CHECK-NEXT: SRAI a1,a1,9
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = ashr i64 %a, 9
   ret i64 %1
 }
@@ -122,7 +122,7 @@ define i64 @add(i64 %a, i64 %b) nounwind {
 ; CHECK-NEXT: SLTU a0,a2,a0
 ; CHECK-NEXT: ADD a1,a1,a0
 ; CHECK-NEXT: ADDI a0,a2,0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = add i64 %a, %b
   ret i64 %1
 }
@@ -134,7 +134,7 @@ define i64 @sub(i64 %a, i64 %b) nounwind {
 ; CHECK-NEXT: SLTU a3,a0,a2
 ; CHECK-NEXT: SUB a1,a1,a3
 ; CHECK-NEXT: SUB a0,a0,a2
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = sub i64 %a, %b
   ret i64 %1
 }
@@ -148,7 +148,7 @@ define i64 @sll(i64 %a, i64 %b) nounwind {
 ; CHECK-NEXT: JALR ra,%lo(__ashldi3)(ra)
 ; CHECK-NEXT: LW ra,12(sp) # 4-byte Folded Reload
 ; CHECK-NEXT: ADDI sp,sp,16
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = shl i64 %a, %b
   ret i64 %1
 }
@@ -160,11 +160,11 @@ define i64 @slt(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: # %bb.1:
 ; CHECK-NEXT: SLT a0,a1,a3
 ; CHECK-NEXT: ADDI a1,zero,0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 ; CHECK-LABEL: .LBB12_2:
 ; CHECK-NEXT: SLTU a0,a0,a2
 ; CHECK-NEXT: ADDI a1,zero,0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = icmp slt i64 %a, %b
   %2 = zext i1 %1 to i64
   ret i64 %2
@@ -177,11 +177,11 @@ define i64 @sltu(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: # %bb.1:
 ; CHECK-NEXT: SLTU a0,a1,a3
 ; CHECK-NEXT: ADDI a1,zero,0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 ; CHECK-LABEL: .LBB13_2:
 ; CHECK-NEXT: SLTU a0,a0,a2
 ; CHECK-NEXT: ADDI a1,zero,0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = icmp ult i64 %a, %b
   %2 = zext i1 %1 to i64
   ret i64 %2
@@ -192,7 +192,7 @@ define i64 @xor(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: XOR a0,a0,a2
 ; CHECK-NEXT: XOR a1,a1,a3
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = xor i64 %a, %b
   ret i64 %1
 }
@@ -206,7 +206,7 @@ define i64 @srl(i64 %a, i64 %b) nounwind {
 ; CHECK-NEXT: JALR ra,%lo(__lshrdi3)(ra)
 ; CHECK-NEXT: LW ra,12(sp) # 4-byte Folded Reload
 ; CHECK-NEXT: ADDI sp,sp,16
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = lshr i64 %a, %b
   ret i64 %1
 }
@@ -220,7 +220,7 @@ define i64 @sra(i64 %a, i64 %b) nounwind {
 ; CHECK-NEXT: JALR ra,%lo(__ashrdi3)(ra)
 ; CHECK-NEXT: LW ra,12(sp) # 4-byte Folded Reload
 ; CHECK-NEXT: ADDI sp,sp,16
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = ashr i64 %a, %b
   ret i64 %1
 }
@@ -230,7 +230,7 @@ define i64 @or(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: OR a0,a0,a2
 ; CHECK-NEXT: OR a1,a1,a3
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = or i64 %a, %b
   ret i64 %1
 }
@@ -240,7 +240,7 @@ define i64 @and(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: AND a0,a0,a2
 ; CHECK-NEXT: AND a1,a1,a3
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = and i64 %a, %b
   ret i64 %1
 }
@@ -251,7 +251,7 @@ define signext i32 @addiw(i32 signext %a) nounwind {
 ; CHECK-LABEL: addiw: # @addiw
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: ADDI a0,a0,123
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = add i32 %a, 123
   ret i32 %1
 }
@@ -260,7 +260,7 @@ define signext i32 @slliw(i32 signext %a) nounwind {
 ; CHECK-LABEL: slliw: # @slliw
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: SLLI a0,a0,17
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = shl i32 %a, 17
   ret i32 %1
 }
@@ -269,7 +269,7 @@ define signext i32 @srliw(i32 %a) nounwind {
 ; CHECK-LABEL: srliw: # @srliw
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: SRLI a0,a0,8
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = lshr i32 %a, 8
   ret i32 %1
 }
@@ -278,7 +278,7 @@ define signext i32 @sraiw(i32 %a) nounwind {
 ; CHECK-LABEL: sraiw: # @sraiw
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: SRAI a0,a0,9
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = ashr i32 %a, 9
   ret i32 %1
 }
@@ -289,7 +289,7 @@ define i64 @sraiw_i64(i64 %a) nounwind {
 ; CHECK-NEXT: SRAI a2,a0,9
 ; CHECK-NEXT: SRAI a1,a0,31
 ; CHECK-NEXT: ADDI a0,a2,0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = shl i64 %a, 32
   %2 = ashr i64 %1, 41
   ret i64 %2
@@ -298,7 +298,7 @@ define i64 @sraiw_i64(i64 %a) nounwind {
 define signext i32 @sextw(i32 zeroext %a) nounwind {
 ; CHECK-LABEL: sextw: # @sextw
 ; CHECK-LABEL: # %bb.0:
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   ret i32 %a
 }
 
@@ -306,7 +306,7 @@ define signext i32 @addw(i32 signext %a, i32 signext %b) nounwind {
 ; CHECK-LABEL: addw: # @addw
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: ADD a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = add i32 %a, %b
   ret i32 %1
 }
@@ -315,7 +315,7 @@ define signext i32 @subw(i32 signext %a, i32 signext %b) nounwind {
 ; CHECK-LABEL: subw: # @subw
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: SUB a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = sub i32 %a, %b
   ret i32 %1
 }
@@ -324,7 +324,7 @@ define signext i32 @sllw(i32 signext %a, i32 zeroext %b) nounwind {
 ; CHECK-LABEL: sllw: # @sllw
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: SLL a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = shl i32 %a, %b
   ret i32 %1
 }
@@ -333,7 +333,7 @@ define signext i32 @srlw(i32 signext %a, i32 zeroext %b) nounwind {
 ; CHECK-LABEL: srlw: # @srlw
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: SRL a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = lshr i32 %a, %b
   ret i32 %1
 }
@@ -342,7 +342,7 @@ define signext i32 @sraw(i64 %a, i32 zeroext %b) nounwind {
 ; CHECK-LABEL: sraw: # @sraw
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: SRA a0,a0,a2
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = trunc i64 %a to i32
   %2 = ashr i32 %1, %b
   ret i32 %2
@@ -355,7 +355,7 @@ define i64 @add_hi_and_lo_negone(i64 %0) {
 ; CHECK-NEXT: SLTIU a2,a2,1
 ; CHECK-NEXT: SUB a1,a1,a2
 ; CHECK-NEXT: ADDI a0,a0,-1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %2 = add nsw i64 %0, -1
   ret i64 %2
 }
@@ -367,7 +367,7 @@ define i64 @add_hi_zero_lo_negone(i64 %0) {
 ; CHECK-NEXT: SLTU a2,zero,a2
 ; CHECK-NEXT: ADD a1,a1,a2
 ; CHECK-NEXT: ADDI a0,a0,-1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %2 = add i64 %0, 4294967295
   ret i64 %2
 }
@@ -380,7 +380,7 @@ define i64 @add_lo_negone(i64 %0) {
 ; CHECK-NEXT: ADD a1,a1,a2
 ; CHECK-NEXT: ADDI a1,a1,-2
 ; CHECK-NEXT: ADDI a0,a0,-1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %2 = add nsw i64 %0, -4294967297
   ret i64 %2
 }
@@ -393,7 +393,7 @@ define i64 @add_hi_one_lo_negone(i64 %0) {
 ; CHECK-NEXT: ADD a1,a1,a2
 ; CHECK-NEXT: ADDI a1,a1,1
 ; CHECK-NEXT: ADDI a0,a0,-1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %2 = add nsw i64 %0, 8589934591
   ret i64 %2
 }

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/analyze-branch.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/analyze-branch.ll
@@ -19,13 +19,13 @@ define void @test_bcc_fallthrough_taken(i32 %in) nounwind {
 ; CHECK-NEXT: JALR ra,%lo(test_true)(ra)
 ; CHECK-NEXT: LW ra,12(sp) # 4-byte Folded Reload
 ; CHECK-NEXT: ADDI sp,sp,16
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 ; CHECK-LABEL: LBB0_2:
 ; CHECK-NEXT: LUI ra,%hi(test_false)
 ; CHECK-NEXT: JALR ra,%lo(test_false)(ra)
 ; CHECK-NEXT: LW ra,12(sp) # 4-byte Folded Reload
 ; CHECK-NEXT: ADDI sp,sp,16
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %tst = icmp eq i32 %in, 42
   br i1 %tst, label %true, label %false, !prof !0
 
@@ -55,13 +55,13 @@ define void @test_bcc_fallthrough_nottaken(i32 %in) nounwind {
 ; CHECK-NEXT: JALR ra,%lo(test_false)(ra)
 ; CHECK-NEXT: LW ra,12(sp) # 4-byte Folded Reload
 ; CHECK-NEXT: ADDI sp,sp,16
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 ; CHECK-LABEL: .LBB1_2: # %true
 ; CHECK-NEXT: LUI ra,%hi(test_true)
 ; CHECK-NEXT: JALR ra,%lo(test_true)(ra)
 ; CHECK-NEXT: LW ra,12(sp) # 4-byte Folded Reload
 ; CHECK-NEXT: ADDI sp,sp,16
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 
   %tst = icmp eq i32 %in, 42
   br i1 %tst, label %true, label %false, !prof !1

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/and.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/and.ll
@@ -3,7 +3,7 @@
 define i32 @and32_0x7ff(i32 %x) {
 ; CHECK-LABEL: and32_0x7ff: # @and32_0x7ff
 ; CHECK:         ANDI a0,a0,2047
-; CHECK-NEXT:    JALR zero,0(ra)
+; CHECK-NEXT:    RET
   %a = and i32 %x, 2047
   ret i32 %a
 }
@@ -13,7 +13,7 @@ define i32 @and32_0xfff(i32 %x) {
 ; CHECK:       LUI a1,0x1
 ; CHECK-NEXT:  ADDI a1,a1,-1
 ; CHECK-NEXT:  AND a0,a0,a1
-; CHECK-NEXT:  JALR zero,0(ra)
+; CHECK-NEXT:  RET
   %a = and i32 %x, 4095
   ret i32 %a
 }
@@ -22,7 +22,7 @@ define i64 @and64_0x7ff(i64 %x) {
 ; CHECK-LABEL: and64_0x7ff: # @and64_0x7ff
 ; CHECK:         ANDI a0,a0,2047
 ; CHECK-NEXT:    ADDI a1,zero,0
-; CHECK-NEXT:    JALR zero,0(ra)
+; CHECK-NEXT:    RET
   %a = and i64 %x, 2047
   ret i64 %a
 }
@@ -33,7 +33,7 @@ define i64 @and64_0xfff(i64 %x) {
 ; CHECK-NEXT:  ADDI a1,a1,-1
 ; CHECK-NEXT:  AND a0,a0,a1
 ; CHECK-NEXT:  ADDI a1,zero,0
-; CHECK-NEXT:  JALR zero,0(ra)
+; CHECK-NEXT:  RET
   %a = and i64 %x, 4095
   ret i64 %a
 }

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/branch-opt.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/branch-opt.ll
@@ -9,11 +9,11 @@ define void @u_case1_a(ptr %a, i32 signext %b, ptr %c, ptr %d) {
 ; CHECK-NEXT:    BLTU a0,a1,.LBB0_2
 ; CHECK-NEXT:  # %bb.1: # %block1
 ; CHECK-NEXT:    SW a1,0(a2)
-; CHECK-NEXT:    JALR zero,0(ra)
+; CHECK-NEXT:    RET
 ; CHECK-NEXT:  .LBB0_2: # %block2
 ; CHECK-NEXT:    ADDI a0,zero,87
 ; CHECK-NEXT:    SW a0,0(a3)
-; CHECK-NEXT:    JALR zero,0(ra)
+; CHECK-NEXT:    RET
   store i32 32, ptr %a
   %p = icmp ule i32 %b, 31
   br i1 %p, label %block1, label %block2
@@ -39,11 +39,11 @@ define void @case1_a(ptr %a, i32 signext %b, ptr %c, ptr %d) {
 ; CHECK-NEXT:    BLT a0,a1,.LBB1_2
 ; CHECK-NEXT:  # %bb.1: # %block1
 ; CHECK-NEXT:    SW a1,0(a2)
-; CHECK-NEXT:    JALR zero,0(ra)
+; CHECK-NEXT:    RET
 ; CHECK-NEXT:  .LBB1_2: # %block2
 ; CHECK-NEXT:    ADDI a0,zero,87
 ; CHECK-NEXT:    SW a0,0(a3)
-; CHECK-NEXT:    JALR zero,0(ra)
+; CHECK-NEXT:    RET
   store i32 -1, ptr %a
   %p = icmp sle i32 %b, -2
   br i1 %p, label %block1, label %block2
@@ -69,11 +69,11 @@ define void @u_case2_a(ptr %a, i32 signext %b, ptr %c, ptr %d) {
 ; CHECK-NEXT:    BLTU a1,a0,.LBB2_2
 ; CHECK-NEXT:  # %bb.1: # %block1
 ; CHECK-NEXT:    SW a1,0(a2)
-; CHECK-NEXT:    JALR zero,0(ra)
+; CHECK-NEXT:    RET
 ; CHECK-NEXT:  .LBB2_2: # %block2
 ; CHECK-NEXT:    ADDI a0,zero,87
 ; CHECK-NEXT:    SW a0,0(a3)
-; CHECK-NEXT:    JALR zero,0(ra)
+; CHECK-NEXT:    RET
   store i32 32, ptr %a
   %p = icmp uge i32 %b, 33
   br i1 %p, label %block1, label %block2
@@ -99,11 +99,11 @@ define void @case2_a(ptr %a, i32 signext %b, ptr %c, ptr %d) {
 ; CHECK-NEXT:    BLT a1,a0,.LBB3_2
 ; CHECK-NEXT:  # %bb.1: # %block1
 ; CHECK-NEXT:    SW a1,0(a2)
-; CHECK-NEXT:    JALR zero,0(ra)
+; CHECK-NEXT:    RET
 ; CHECK-NEXT:  .LBB3_2: # %block2
 ; CHECK-NEXT:    ADDI a0,zero,87
 ; CHECK-NEXT:    SW a0,0(a3)
-; CHECK-NEXT:    JALR zero,0(ra)
+; CHECK-NEXT:    RET
   store i32 -4, ptr %a
   %p = icmp sge i32 %b, -3
   br i1 %p, label %block1, label %block2

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/calling-conv.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/calling-conv.ll
@@ -143,7 +143,7 @@ define void @callee() nounwind {
 ; CHECK-NEXT: LW s1,136(sp)                           # 4-byte Folded Reload
 ; CHECK-NEXT: LW ra,140(sp)                           # 4-byte Folded Reload
 ; CHECK-NEXT: ADDI sp,sp,144
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %val = load [32 x i32], ptr @var
   call void @callee()
   store volatile [32 x i32] %val, ptr @var

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/fast-cc.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/fast-cc.ll
@@ -3,7 +3,7 @@
 define fastcc i32 @callee(<16 x i32> %A) nounwind {
 ; CHECK-LABEL: callee:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 ;
 	%B = extractelement <16 x i32> %A, i32 0
 	ret i32 %B
@@ -36,7 +36,7 @@ define i32 @caller(<16 x i32> %A) nounwind {
 ; CHECK-NEXT: JALR ra,%lo(callee)(ra)
 ; CHECK-NEXT: LW ra,44(sp)                            # 4-byte Folded Reload
 ; CHECK-NEXT: ADDI sp,sp,48
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 	%C = call fastcc i32 @callee(<16 x i32> %A)
 	ret i32 %C
 }

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/global_const_loop.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/global_const_loop.ll
@@ -21,7 +21,7 @@ define dso_local i32 @foo(i32 noundef %i) local_unnamed_addr #0 {
 ; CHECK-NEXT: LW fp,8(sp)                             # 4-byte Folded Reload
 ; CHECK-NEXT: LW ra,12(sp)                            # 4-byte Folded Reload
 ; CHECK-NEXT: ADDI sp,sp,16
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 entry:
   %cmp = icmp slt i32 %i, 1000
   br i1 %cmp, label %while.body.us, label %while.end

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/imm.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/imm.ll
@@ -3,21 +3,21 @@
 define signext i32 @zero() nounwind {
   ; CHECK-LABEL: zero: # @zero
   ; CHECK: ADDI a0,zero,0
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i32 0
 }
 
 define signext i32 @pos_small() nounwind {
   ; CHECK-LABEL: pos_small: # @pos_small
   ; CHECK: ADDI a0,zero,2047
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i32 2047
 }
 
 define signext i32 @neg_small() nounwind {
   ; CHECK-LABEL: neg_small: # @neg_small
   ; CHECK: ADDI a0,zero,-2048
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i32 -2048
 }
 
@@ -25,7 +25,7 @@ define signext i32 @pos_i32() nounwind {
   ; CHECK-LABEL: pos_i32: # @pos_i32
   ; CHECK: LUI a0,0x67783
   ; CHECK-NEXT: ADDI a0,a0,-1297
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i32 1735928559
 }
 
@@ -33,7 +33,7 @@ define signext i32 @neg_i32() nounwind {
   ; CHECK-LABEL: neg_i32: # @neg_i32
   ; CHECK: LUI a0,0xdeadc
   ; CHECK-NEXT: ADDI a0,a0,-273
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i32 -559038737
 }
 
@@ -41,7 +41,7 @@ define signext i32 @pos_i32_hi20_only() nounwind {
   ; CHECK-LABEL: pos_i32_hi20_only: # @pos_i32_hi20_only
   ; CHECK: LUI a0,0x10
   ; CHECK-NEXT: ADDI a0,a0,0
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i32 65536 ; 0x10000
 }
 
@@ -49,7 +49,7 @@ define signext i32 @neg_i32_hi20_only() nounwind {
   ; CHECK-LABEL: neg_i32_hi20_only: # @neg_i32_hi20_only
   ; CHECK: LUI a0,0xffff0
   ; CHECK-NEXT: ADDI a0,a0,0
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i32 -65536 ; -0x10000
 }
 
@@ -59,7 +59,7 @@ define i64 @imm_end_xori_1() nounwind {
   ; CHECK-NEXT: ADDI a0,a0,-1
   ; CHECK-NEXT: LUI a1,0xe0000
   ; CHECK-NEXT: ADDI a1,a1,0
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i64 -2305843009180139521 ; 0xE000_0000_01FF_FFFF
 }
   
@@ -67,7 +67,7 @@ define void @imm_store_i8_neg1(ptr %p) nounwind {
   ; CHECK-LABEL: imm_store_i8_neg1: # @imm_store_i8_neg1
   ; CHECK: ADDI a1,zero,255
   ; CHECK-NEXT: SB a1,0(a0)
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   store i8 -1, ptr %p
   ret void
 }
@@ -77,7 +77,7 @@ define void @imm_store_i16_neg1(ptr %p) nounwind {
   ; CHECK: LUI a1,0x10
   ; CHECK-NEXT: ADDI a1,a1,-1
   ; CHECK-NEXT: SH a1,0(a0)
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   store i16 -1, ptr %p
   ret void
 }
@@ -86,7 +86,7 @@ define void @imm_store_i32_neg1(ptr %p) nounwind {
   ; CHECK-LABEL: imm_store_i32_neg1: # @imm_store_i32_neg1
   ; CHECK: ADDI a1,zero,-1
   ; CHECK-NEXT: SW a1,0(a0)
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   store i32 -1, ptr %p
   ret void
 }

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/indirectbr.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/indirectbr.ll
@@ -6,7 +6,7 @@ define i32 @indirectbr(ptr %target) nounwind {
   ; CHECK-NEXT: JALR zero,0(a0)
   ; CHECK-LABEL: LBB0_1: # %test_label
   ; CHECK: ADDI a0,zero,0
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
    indirectbr ptr %target, [label %test_label]
 test_label:
   br label %ret
@@ -20,7 +20,7 @@ define i32 @indirectbr_with_offset(ptr %a) nounwind {
   ; CHECK-NEXT: JALR zero,1380(a0)
   ; CHECK-LABEL: LBB1_1:
   ; CHECK-NEXT: ADDI a0,zero,0
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
 
   %target = getelementptr inbounds i8, ptr %a, i32 1380
   indirectbr ptr %target, [label %test_label]

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/large_stack.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/large_stack.ll
@@ -48,7 +48,7 @@ define void @test_emergency_spill_slot(i32 %a) {
 ; CHECK-NEXT: LUI a0,0x62
 ; CHECK-NEXT: ADDI a0,a0,-1408
 ; CHECK-NEXT: ADD sp,sp,a0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %data = alloca [ 100000 x i32 ] , align 4
   %ptr = getelementptr inbounds [100000 x i32], ptr %data, i32 0, i32 80000
   %1 = tail call { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } asm sideeffect "nop", "=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r"()

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/mul.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/mul.ll
@@ -4,7 +4,7 @@ define signext i32 @square(i32 %a) nounwind {
 ; CHECK-LABEL: square: # @square
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: MUL a0,a0,a0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = mul i32 %a, %a
   ret i32 %1
 }
@@ -13,7 +13,7 @@ define signext i32 @mul(i32 %a, i32 %b) nounwind {
 ; CHECK-LABEL: mul: # @mul
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: MUL a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = mul i32 %a, %b
   ret i32 %1
 }
@@ -23,7 +23,7 @@ define signext i32 @mul_constant(i32 %a) nounwind {
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: ADDI a1,zero,5
 ; CHECK-NEXT: MUL a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = mul i32 %a, 5
   ret i32 %1
 }
@@ -32,7 +32,7 @@ define i32 @mul_pow2(i32 %a) nounwind {
 ; CHECK-LABEL: mul_pow2: # @mul_pow2
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: SLLI a0,a0,3
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = mul i32 %a, 8
   ret i32 %1
 }
@@ -46,7 +46,7 @@ define i64 @mul64(i64 %a, i64 %b) nounwind {
 ; CHECK-NEXT: MUL a1,a1,a2
 ; CHECK-NEXT: ADD a1,a3,a1
 ; CHECK-NEXT: MUL a0,a0,a2
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = mul i64 %a, %b
   ret i64 %1
 }
@@ -59,7 +59,7 @@ define i64 @mul64_constant(i64 %a) nounwind {
 ; CHECK-NEXT: MULHU a3,a0,a2
 ; CHECK-NEXT: ADD a1,a3,a1
 ; CHECK-NEXT: MUL a0,a0,a2
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = mul i64 %a, 5
   ret i64 %1
 }
@@ -68,7 +68,7 @@ define i32 @mulhs(i32 %a, i32 %b) nounwind {
 ; CHECK-LABEL: mulhs: # @mulhs
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: MULH a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = sext i32 %a to i64
   %2 = sext i32 %b to i64
   %3 = mul i64 %1, %2
@@ -82,7 +82,7 @@ define i32 @mulhs_positive_constant(i32 %a) nounwind {
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: ADDI a1,zero,5
 ; CHECK-NEXT: MULH a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = sext i32 %a to i64
   %2 = mul i64 %1, 5
   %3 = lshr i64 %2, 32
@@ -95,7 +95,7 @@ define i32 @mulhs_negative_constant(i32 %a) nounwind {
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: ADDI a1,zero,-5
 ; CHECK-NEXT: MULH a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = sext i32 %a to i64
   %2 = mul i64 %1, -5
   %3 = lshr i64 %2, 32
@@ -107,7 +107,7 @@ define zeroext i32 @mulhu(i32 zeroext %a, i32 zeroext %b) nounwind {
 ; CHECK-LABEL: mulhu: # @mulhu
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: MULHU a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = zext i32 %a to i64
   %2 = zext i32 %b to i64
   %3 = mul i64 %1, %2
@@ -123,7 +123,7 @@ define i32 @mulhsu(i32 %a, i32 %b) nounwind {
 ; CHECK-NEXT: SRAI a1,a1,31
 ; CHECK-NEXT: MUL a0,a0,a1
 ; CHECK-NEXT: ADD a0,a2,a0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = zext i32 %a to i64
   %2 = sext i32 %b to i64
   %3 = mul i64 %1, %2
@@ -137,7 +137,7 @@ define i32 @mulhu_constant(i32 %a) nounwind {
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: ADDI a1,zero,5
 ; CHECK-NEXT: MULHU a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = zext i32 %a to i64
   %2 = mul i64 %1, 5
   %3 = lshr i64 %2, 32
@@ -151,7 +151,7 @@ define i8 @muladd_demand(i8 %x, i8 %y) nounwind {
 ; CHECK-NEXT: SLLI a0,a0,1
 ; CHECK-NEXT: SUB a0,a1,a0
 ; CHECK-NEXT: ANDI a0,a0,15
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %m = mul i8 %x, 14
   %a = add i8 %y, %m
   %r = and i8 %a, 15
@@ -164,7 +164,7 @@ define i8 @mulsub_demand(i8 %x, i8 %y) nounwind {
 ; CHECK-NEXT: SLLI a0,a0,1
 ; CHECK-NEXT: ADD a0,a1,a0
 ; CHECK-NEXT: ANDI a0,a0,15
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %m = mul i8 %x, 14
   %a = sub i8 %y, %m
   %r = and i8 %a, 15
@@ -177,7 +177,7 @@ define i8 @muladd_demand_2(i8 %x, i8 %y) nounwind {
 ; CHECK-NEXT: SLLI a0,a0,1
 ; CHECK-NEXT: SUB a0,a1,a0
 ; CHECK-NEXT: ORI a0,a0,-16
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %m = mul i8 %x, 14
   %a = add i8 %y, %m
   %r = or i8 %a, 240
@@ -190,7 +190,7 @@ define i8 @mulsub_demand_2(i8 %x, i8 %y) nounwind {
 ; CHECK-NEXT: SLLI a0,a0,1
 ; CHECK-NEXT: ADD a0,a1,a0
 ; CHECK-NEXT: ORI a0,a0,-16
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %m = mul i8 %x, 14
   %a = sub i8 %y, %m
   %r = or i8 %a, 240
@@ -209,7 +209,7 @@ define i64 @muland_demand(i64 %x) nounwind {
 ; CHECK-NEXT: MULHU a3,a0,a2
 ; CHECK-NEXT: ADD a1,a3,a1
 ; CHECK-NEXT: MUL a0,a0,a2
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %and = and i64 %x, 4611686018427387896
   %mul = mul i64 %and, 12
   ret i64 %mul
@@ -221,7 +221,7 @@ define i64 @mulzext_demand(i32 signext %x) nounwind {
 ; CHECK-NEXT: ADDI a1,zero,3
 ; CHECK-NEXT: MUL a1,a0,a1
 ; CHECK-NEXT: ADDI a0,zero,0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %ext = zext i32 %x to i64
   %mul = mul i64 %ext, 12884901888
   ret i64 %mul

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/pic.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/pic.ll
@@ -10,7 +10,7 @@ define ptr @f1() nounwind {
 ; CHECK-LABEL: # %bb.0: # %entry
 ; CHECK-NEXT: AUIPC a0,%got_pcrel_hi(external_var)
 ; CHECK-NEXT: LW a0,%pcrel_lo(external_var)(a0)
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 entry:
   ret ptr @external_var
 }
@@ -21,7 +21,7 @@ define ptr @f2() nounwind {
 ; CHECK-LABEL: .Ltmp0
 ; CHECK-NEXT: AUIPC a0,%pcrel_hi(internal_var)
 ; CHECK-NEXT: ADDI a0,a0,%pcrel_lo(.Ltmp0)
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 entry:
   ret ptr @internal_var
 }

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/rotl-rotr.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/rotl-rotr.ll
@@ -11,7 +11,7 @@ define i32 @rotl_32(i32 %x, i32 %y) nounwind {
 ; CHECK-NEXT: SLL a1,a0,a1
 ; CHECK-NEXT: SRL a0,a0,a2
 ; CHECK-NEXT: OR a0,a1,a0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %z = sub i32 32, %y
   %b = shl i32 %x, %y
   %c = lshr i32 %x, %z
@@ -27,7 +27,7 @@ define i32 @rotr_32(i32 %x, i32 %y) nounwind {
 ; CHECK-NEXT: SRL a1,a0,a1
 ; CHECK-NEXT: SLL a0,a0,a2
 ; CHECK-NEXT: OR a0,a1,a0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %z = sub i32 32, %y
   %b = lshr i32 %x, %y
   %c = shl i32 %x, %z
@@ -67,7 +67,7 @@ define i64 @rotl_64(i64 %x, i64 %y) nounwind {
 ; CHECK-NEXT: LW s1,24(sp) # 4-byte Folded Reload
 ; CHECK-NEXT: LW ra,28(sp) # 4-byte Folded Reload
 ; CHECK-NEXT: ADDI sp,sp,32
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %z = sub i64 64, %y
   %b = shl i64 %x, %y
   %c = lshr i64 %x, %z
@@ -107,7 +107,7 @@ define i64 @rotr_64(i64 %x, i64 %y) nounwind {
 ; CHECK-NEXT: LW s1,24(sp) # 4-byte Folded Reload
 ; CHECK-NEXT: LW ra,28(sp) # 4-byte Folded Reload
 ; CHECK-NEXT: ADDI sp,sp,32
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %z = sub i64 64, %y
   %b = lshr i64 %x, %y
   %c = shl i64 %x, %z
@@ -123,7 +123,7 @@ define i32 @rotl_32_mask(i32 %x, i32 %y) nounwind {
 ; CHECK-NEXT: ANDI a2,a2,31
 ; CHECK-NEXT: SRL a0,a0,a2
 ; CHECK-NEXT: OR a0,a1,a0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %z = sub i32 0, %y
   %and = and i32 %z, 31
   %b = shl i32 %x, %y
@@ -141,7 +141,7 @@ define i32 @rotl_32_mask_and_63_and_31(i32 %x, i32 %y) nounwind {
 ; CHECK-NEXT: ANDI a2,a2,31
 ; CHECK-NEXT: SRL a0,a0,a2
 ; CHECK-NEXT: OR a0,a1,a0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %a = and i32 %y, 63
   %b = shl i32 %x, %a
   %c = sub i32 0, %y
@@ -155,7 +155,7 @@ define i32 @rotl_32_mask_or_64_or_32(i32 %x, i32 %y) nounwind {
 ; CHECK-LABEL: rotl_32_mask_or_64_or_32:
 ; CHECK: # %bb.0:
 ; CHECK-NEXT: ADDI a0,zero,0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %a = or i32 %y, 64
   %b = shl i32 %x, %a
   %c = sub i32 0, %y
@@ -173,7 +173,7 @@ define i32 @rotr_32_mask(i32 %x, i32 %y) nounwind {
 ; CHECK-NEXT: ANDI a2,a2,31
 ; CHECK-NEXT: SLL a0,a0,a2
 ; CHECK-NEXT: OR a0,a1,a0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %z = sub i32 0, %y
   %and = and i32 %z, 31
   %b = lshr i32 %x, %y
@@ -191,7 +191,7 @@ define i32 @rotr_32_mask_and_63_and_31(i32 %x, i32 %y) nounwind {
 ; CHECK-NEXT: ANDI a2,a2,31
 ; CHECK-NEXT: SLL a0,a0,a2
 ; CHECK-NEXT: OR a0,a1,a0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %a = and i32 %y, 63
   %b = lshr i32 %x, %a
   %c = sub i32 0, %y
@@ -205,7 +205,7 @@ define i32 @rotr_32_mask_or_64_or_32(i32 %x, i32 %y) nounwind {
 ; CHECK-LABEL: rotr_32_mask_or_64_or_32:
 ; CHECK: # %bb.0:
 ; CHECK-NEXT: ADDI a0,zero,0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %a = or i32 %y, 64
   %b = lshr i32 %x, %a
   %c = sub i32 0, %y
@@ -247,7 +247,7 @@ define i64 @rotl_64_mask(i64 %x, i64 %y) nounwind {
 ; CHECK-NEXT: LW s1,24(sp) # 4-byte Folded Reload
 ; CHECK-NEXT: LW ra,28(sp) # 4-byte Folded Reload
 ; CHECK-NEXT: ADDI sp,sp,32
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %z = sub i64 0, %y
   %and = and i64 %z, 63
   %b = shl i64 %x, %y

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/select-cc.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/select-cc.ll
@@ -63,7 +63,7 @@ define signext i32 @foo(i32 signext %a, ptr %b) nounwind {
 ; CHECK-NEXT: BLTU a3,a2,.LBB0_14
 ; CHECK-NEXT: JAL zero,.LBB0_28
 ; CHECK-NEXT: .LBB0_14:
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 ; CHECK-NEXT: .LBB0_15:
 ; CHECK-NEXT: ADDI a0,a2,0
 ; CHECK-NEXT: LW a2,0(a1)
@@ -122,7 +122,7 @@ define signext i32 @foo(i32 signext %a, ptr %b) nounwind {
 ; CHECK-NEXT: BLTU a3,a2,.LBB0_14
 ; CHECK-NEXT: .LBB0_28:
 ; CHECK-NEXT: ADDI a0,a1,0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %val1 = load volatile i32, ptr %b
   %tst1 = icmp eq i32 %a, %val1
   %val2 = select i1 %tst1, i32 %a, i32 %val1
@@ -193,7 +193,7 @@ define i32 @select_sge_int16min(i32 signext %x, i32 signext %y, i32 signext %z) 
 ; CHECK-NEXT: ADDI a1,a2,0
 ; CHECK-NEXT: .LBB1_2:
 ; CHECK-NEXT: ADDI a0,a1,0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %a = icmp sge i32 %x, -65536
   %b = select i1 %a, i32 %y, i32 %z
   ret i32 %b
@@ -219,12 +219,12 @@ define i64 @select_sge_int32min(i64 %x, i64 %y, i64 %z) {
 ; CHECK-NEXT: .LBB2_5:
 ; CHECK-NEXT: ADDI a0,a2,0
 ; CHECK-NEXT: ADDI a1,a3,0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 ; CHECK-NEXT: .LBB2_6:
 ; CHECK-NEXT: ADDI a3,a5,0
 ; CHECK-NEXT: ADDI a0,a2,0
 ; CHECK-NEXT: ADDI a1,a3,0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %a = icmp sge i64 %x, -2147483648
   %b = select i1 %a, i64 %y, i64 %z
   ret i64 %b

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/sext-zext-trunc.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/sext-zext-trunc.ll
@@ -27,7 +27,7 @@ define i8 @sext_i1_to_i8(i1 %a) nounwind {
 ; CHECK-NEXT: # %bb.0:
 ; CHECK-NEXT: ANDI a0,a0,1
 ; CHECK-NEXT: SUB a0,zero,a0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = sext i1 %a to i8
   ret i8 %1
 }
@@ -37,7 +37,7 @@ define i16 @sext_i1_to_i16(i1 %a) nounwind {
 ; CHECK-NEXT: # %bb.0:
 ; CHECK-NEXT: ANDI a0,a0,1
 ; CHECK-NEXT: SUB a0,zero,a0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = sext i1 %a to i16
   ret i16 %1
 }
@@ -47,7 +47,7 @@ define i32 @sext_i1_to_i32(i1 %a) nounwind {
 ; CHECK-NEXT: # %bb.0:
 ; CHECK-NEXT: ANDI a0,a0,1
 ; CHECK-NEXT: SUB a0,zero,a0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = sext i1 %a to i32
   ret i32 %1
 }
@@ -58,7 +58,7 @@ define i64 @sext_i1_to_i64(i1 %a) nounwind {
 ; CHECK-NEXT: ANDI a0,a0,1
 ; CHECK-NEXT: SUB a0,zero,a0
 ; CHECK-NEXT: ADDI a1,a0,0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = sext i1 %a to i64
   ret i64 %1
 }
@@ -68,7 +68,7 @@ define i16 @sext_i8_to_i16(i8 %a) nounwind {
 ; CHECK-NEXT: # %bb.0:
 ; CHECK-NEXT: SLLI a0,a0,24
 ; CHECK-NEXT: SRAI a0,a0,24
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = sext i8 %a to i16
   ret i16 %1
 }
@@ -78,7 +78,7 @@ define i32 @sext_i8_to_i32(i8 %a) nounwind {
 ; CHECK-NEXT: # %bb.0:
 ; CHECK-NEXT: SLLI a0,a0,24
 ; CHECK-NEXT: SRAI a0,a0,24
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = sext i8 %a to i32
   ret i32 %1
 }

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O0/alu64.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O0/alu64.ll
@@ -6,7 +6,7 @@ define i64 @addi(i64 %a) nounwind {
 ; CHECK-LABEL: addi: # @addi
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: ADDI a0,a0,1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = add i64 %a, 1
   ret i64 %1
 }
@@ -15,7 +15,7 @@ define i64 @slti(i64 %a) nounwind {
 ; CHECK-LABEL: slti: # @slti
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: SLTI a0,a0,2
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = icmp slt i64 %a, 2
   %2 = zext i1 %1 to i64
   ret i64 %2
@@ -25,7 +25,7 @@ define i64 @sltiu(i64 %a) nounwind {
 ; CHECK-LABEL: sltiu: # @sltiu
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: SLTIU a0,a0,3
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = icmp ult i64 %a, 3
   %2 = zext i1 %1 to i64
   ret i64 %2
@@ -35,7 +35,7 @@ define i64 @xori(i64 %a) nounwind {
 ; CHECK-LABEL: xori: # @xori
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: XORI a0,a0,4
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = xor i64 %a, 4
   ret i64 %1
 }
@@ -44,7 +44,7 @@ define i64 @ori(i64 %a) nounwind {
 ; CHECK-LABEL: ori: # @ori
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: ORI a0,a0,5
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = or i64 %a, 5
   ret i64 %1
 }
@@ -53,7 +53,7 @@ define i64 @andi(i64 %a) nounwind {
 ; CHECK-LABEL: andi: # @andi
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: ANDI a0,a0,6
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = and i64 %a, 6
   ret i64 %1
 }
@@ -62,7 +62,7 @@ define i64 @slli(i64 %a) nounwind {
 ; CHECK-LABEL: slli: # @slli
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: SLLI a0,a0,7
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = shl i64 %a, 7
   ret i64 %1
 }
@@ -71,7 +71,7 @@ define i64 @srli(i64 %a) nounwind {
 ; CHECK-LABEL: srli: # @srli
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: SRLI a0,a0,8
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = lshr i64 %a, 8
   ret i64 %1
 }
@@ -80,7 +80,7 @@ define i64 @srai(i64 %a) nounwind {
 ; CHECK-LABEL: srai: # @srai
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: SRAI a0,a0,9
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = ashr i64 %a, 9
   ret i64 %1
 }
@@ -91,7 +91,7 @@ define i64 @add(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: add: # @add
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: ADD a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = add i64 %a, %b
   ret i64 %1
 }
@@ -100,7 +100,7 @@ define i64 @sub(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: sub: # @sub
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: SUB a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = sub i64 %a, %b
   ret i64 %1
 }
@@ -109,7 +109,7 @@ define i64 @sll(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: sll: # @sll
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: SLL a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = shl i64 %a, %b
   ret i64 %1
 }
@@ -118,7 +118,7 @@ define i64 @slt(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: slt: # @slt
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: SLT a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = icmp slt i64 %a, %b
   %2 = zext i1 %1 to i64
   ret i64 %2
@@ -128,7 +128,7 @@ define i64 @xor(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: xor: # @xor
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: XOR a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = xor i64 %a, %b
   ret i64 %1
 }
@@ -137,7 +137,7 @@ define i64 @srl(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: srl: # @srl
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: SRL a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = lshr i64 %a, %b
   ret i64 %1
 }
@@ -146,7 +146,7 @@ define i64 @sra(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: sra: # @sra
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: SRA a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = ashr i64 %a, %b
   ret i64 %1
 }
@@ -155,7 +155,7 @@ define i64 @or(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: or: # @or
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: OR a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = or i64 %a, %b
   ret i64 %1
 }
@@ -164,7 +164,7 @@ define i64 @and(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: and: # @and
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: AND a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = and i64 %a, %b
   ret i64 %1
 }

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O0/and.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O0/and.ll
@@ -4,7 +4,7 @@
 define i32 @and32_0x7ff(i32 %x) {
 ; CHECK-LABEL: and32_0x7ff: # @and32_0x7ff
 ; CHECK:         ANDI a0,a0,2047
-; CHECK-NEXT:    JALR zero,0(ra)
+; CHECK-NEXT:    RET
   %a = and i32 %x, 2047
   ret i32 %a
 }
@@ -14,7 +14,7 @@ define i32 @and32_0xfff(i32 %x) {
 ; CHECK:       LUI a1,0x1
 ; CHECK-NEXT:  ADDI a1,a1,-1
 ; CHECK-NEXT:  AND a0,a0,a1
-; CHECK-NEXT:  JALR zero,0(ra)
+; CHECK-NEXT:  RET
   %a = and i32 %x, 4095
   ret i32 %a
 }
@@ -22,7 +22,7 @@ define i32 @and32_0xfff(i32 %x) {
 define i64 @and64_0x7ff(i64 %x) {
 ; CHECK-LABEL: and64_0x7ff: # @and64_0x7ff
 ; CHECK:         ANDI a0,a0,2047
-; CHECK-NEXT:    JALR zero,0(ra)
+; CHECK-NEXT:    RET
   %a = and i64 %x, 2047
   ret i64 %a
 }
@@ -32,7 +32,7 @@ define i64 @and64_0xfff(i64 %x) {
 ; CHECK:       LUI a1,0x1
 ; CHECK-NEXT:  ADDI a1,a1,-1
 ; CHECK-NEXT:  AND a0,a0,a1
-; CHECK-NEXT:  JALR zero,0(ra)
+; CHECK-NEXT:  RET
   %a = and i64 %x, 4095
   ret i64 %a
 }

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O0/imm.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O0/imm.ll
@@ -3,21 +3,21 @@
 define signext i32 @zero() nounwind {
   ; CHECK-LABEL: zero: # @zero
   ; CHECK: ADDI a0,zero,0
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i32 0
 }
 
 define signext i32 @pos_small() nounwind {
   ; CHECK-LABEL: pos_small: # @pos_small
   ; CHECK: ADDI a0,zero,2047
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i32 2047
 }
 
 define signext i32 @neg_small() nounwind {
   ; CHECK-LABEL: neg_small: # @neg_small
   ; CHECK: ADDI a0,zero,-2048
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i32 -2048
 }
 
@@ -25,7 +25,7 @@ define signext i32 @pos_i32() nounwind {
   ; CHECK-LABEL: pos_i32: # @pos_i32
   ; CHECK: LUI a0,0x67783
   ; CHECK-NEXT: ADDI a0,a0,-1297
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i32 1735928559
 }
 
@@ -33,7 +33,7 @@ define signext i32 @neg_i32() nounwind {
   ; CHECK-LABEL: neg_i32: # @neg_i32
   ; CHECK: LUI a0,0xdeadc
   ; CHECK-NEXT: ADDI a0,a0,-273
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i32 -559038737
 }
 
@@ -41,7 +41,7 @@ define signext i32 @pos_i32_hi20_only() nounwind {
   ; CHECK-LABEL: pos_i32_hi20_only: # @pos_i32_hi20_only
   ; CHECK: LUI a0,0x10
   ; CHECK-NEXT: ADDI a0,a0,0
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i32 65536 ; 0x10000
 }
 
@@ -49,7 +49,7 @@ define signext i32 @neg_i32_hi20_only() nounwind {
   ; CHECK-LABEL: neg_i32_hi20_only: # @neg_i32_hi20_only
   ; CHECK: LUI a0,0xffff0
   ; CHECK-NEXT: ADDI a0,a0,0
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i32 -65536 ; -0x10000
 }
 
@@ -61,7 +61,7 @@ define i64 @imm_end_xori_1() nounwind {
   ; CHECK-NEXT: ORI a0,a0,-512
   ; CHECK-NEXT: SLLI a0,a0,16
   ; CHECK-NEXT: ORI a0,a0,-1
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i64 -2305843009180139521 ; 0xE000_0000_01FF_FFFF
 }
 
@@ -69,7 +69,7 @@ define void @imm_store_i8_neg1(ptr %p) nounwind {
   ; CHECK-LABEL: imm_store_i8_neg1: # @imm_store_i8_neg1
   ; CHECK: ADDI a1,zero,255
   ; CHECK-NEXT: SB a1,0(a0)
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   store i8 -1, ptr %p
   ret void
 }
@@ -79,7 +79,7 @@ define void @imm_store_i16_neg1(ptr %p) nounwind {
   ; CHECK: LUI a1,0x10
   ; CHECK-NEXT: ADDI a1,a1,-1
   ; CHECK-NEXT: SH a1,0(a0)
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   store i16 -1, ptr %p
   ret void
 }
@@ -93,7 +93,7 @@ define void @imm_store_i32_neg1(ptr %p) nounwind {
   ; CHECK-NEXT: SLLI a1,a1,16
   ; CHECK-NEXT: ORI a1,a1,-1
   ; CHECK-NEXT: SW a1,0(a0)
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   store i32 -1, ptr %p
   ret void
 }

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O0/indirectbr.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O0/indirectbr.ll
@@ -6,7 +6,7 @@ define i32 @indirectbr(ptr %target) nounwind {
   ; CHECK-NEXT: JALR zero,0(a0)
   ; CHECK-LABEL: LBB0_1: # %test_label
   ; CHECK: ADDI a0,zero,0
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
    indirectbr ptr %target, [label %test_label]
 test_label:
   br label %ret
@@ -22,7 +22,7 @@ define i32 @indirectbr_with_offset(ptr %a) nounwind {
   ; CHECK-NEXT: JAL zero,.LBB1_2
   ; CHECK-LABEL: LBB1_2:
   ; CHECK-NEXT: ADDI a0,zero,0
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
 
   %target = getelementptr inbounds i8, ptr %a, i32 1380
   indirectbr ptr %target, [label %test_label]

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O0/large_stack.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O0/large_stack.ll
@@ -50,7 +50,7 @@ define void @test_emergency_spill_slot(i32 %a) {
 ; CHECK-NEXT: LUI a0,0x62
 ; CHECK-NEXT: ADDI a0,a0,-1408
 ; CHECK-NEXT: ADD sp,sp,a0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %data = alloca [ 100000 x i32 ] , align 4
   %ptr = getelementptr inbounds [100000 x i32], ptr %data, i32 0, i32 80000
   %1 = tail call { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } asm sideeffect "nop", "=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r"()

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O0/mul.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O0/mul.ll
@@ -6,7 +6,7 @@ define signext i32 @square(i32 %a) nounwind {
 ; CHECK: MUL a0,a0,a0
 ; CHECK-NEXT: SLLI a0,a0,32
 ; CHECK-NEXT: SRAI a0,a0,32
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = mul i32 %a, %a
   ret i32 %1
 }
@@ -17,7 +17,7 @@ define signext i32 @mul(i32 %a, i32 %b) nounwind {
 ; CHECK: MUL a0,a0,a1
 ; CHECK-NEXT: SLLI a0,a0,32
 ; CHECK-NEXT: SRAI a0,a0,32
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = mul i32 %a, %b
   ret i32 %1
 }
@@ -33,7 +33,7 @@ define signext i32 @mul_constant(i32 %a) nounwind {
 ; CHECK-NEXT: ORI a1,a1,0
 ; CHECK-NEXT: MUL a0,a0,a1
 ; CHECK-NEXT: SRAI a0,a0,32
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = mul i32 %a, 5
   ret i32 %1
 }
@@ -42,7 +42,7 @@ define i32 @mul_pow2(i32 %a) nounwind {
 ; CHECK-LABEL: mul_pow2: # @mul_pow2
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: SLLI a0,a0,3
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = mul i32 %a, 8
   ret i32 %1
 }
@@ -51,7 +51,7 @@ define i64 @mul64(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: mul64: # @mul64
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: MUL a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = mul i64 %a, %b
   ret i64 %1
 }

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O0/pic.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O0/pic.ll
@@ -11,7 +11,7 @@ define ptr @f1() nounwind {
 ; CHECK-LABEL: .Ltmp0:
 ; CHECK-NEXT: AUIPC a0,%got_pcrel_hi(external_var)
 ; CHECK-NEXT: LD a0,%pcrel_lo(.Ltmp0)(a0)
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 entry:
   ret ptr @external_var
 }
@@ -22,7 +22,7 @@ define ptr @f2() nounwind {
 ; CHECK-LABEL: .Ltmp1:
 ; CHECK-NEXT: AUIPC a0,%pcrel_hi(internal_var)
 ; CHECK-NEXT: ADDI a0,a0,%pcrel_lo(.Ltmp1)
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 entry:
   ret ptr @internal_var
 }

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O0/static_global_var.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O0/static_global_var.ll
@@ -29,7 +29,7 @@ define void @init_heap_beebs(ptr noundef %heap, i64 noundef %heap_size) #0 {
 ; CHECK-NEXT: ADDI a1,zero,0
 ; CHECK-NEXT: SD a1,0(a0)
 ; CHECK-NEXT: ADDI sp,sp,16
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 entry:
   %heap.addr = alloca ptr, align 8
   %heap_size.addr = alloca i64, align 8

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/alu64.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/alu64.ll
@@ -6,7 +6,7 @@ define i64 @addi(i64 %a) nounwind {
 ; CHECK-LABEL: addi: # @addi
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: ADDI a0,a0,1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = add i64 %a, 1
   ret i64 %1
 }
@@ -15,7 +15,7 @@ define i64 @slti(i64 %a) nounwind {
 ; CHECK-LABEL: slti: # @slti
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: SLTI a0,a0,2
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = icmp slt i64 %a, 2
   %2 = zext i1 %1 to i64
   ret i64 %2
@@ -25,7 +25,7 @@ define i64 @sltiu(i64 %a) nounwind {
 ; CHECK-LABEL: sltiu: # @sltiu
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: SLTIU a0,a0,3
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = icmp ult i64 %a, 3
   %2 = zext i1 %1 to i64
   ret i64 %2
@@ -35,7 +35,7 @@ define i64 @xori(i64 %a) nounwind {
 ; CHECK-LABEL: xori: # @xori
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: XORI a0,a0,4
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = xor i64 %a, 4
   ret i64 %1
 }
@@ -44,7 +44,7 @@ define i64 @ori(i64 %a) nounwind {
 ; CHECK-LABEL: ori: # @ori
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: ORI a0,a0,5
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = or i64 %a, 5
   ret i64 %1
 }
@@ -53,7 +53,7 @@ define i64 @andi(i64 %a) nounwind {
 ; CHECK-LABEL: andi: # @andi
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: ANDI a0,a0,6
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = and i64 %a, 6
   ret i64 %1
 }
@@ -62,7 +62,7 @@ define i64 @slli(i64 %a) nounwind {
 ; CHECK-LABEL: slli: # @slli
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: SLLI a0,a0,7
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = shl i64 %a, 7
   ret i64 %1
 }
@@ -71,7 +71,7 @@ define i64 @srli(i64 %a) nounwind {
 ; CHECK-LABEL: srli: # @srli
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: SRLI a0,a0,8
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = lshr i64 %a, 8
   ret i64 %1
 }
@@ -80,7 +80,7 @@ define i64 @srai(i64 %a) nounwind {
 ; CHECK-LABEL: srai: # @srai
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: SRAI a0,a0,9
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = ashr i64 %a, 9
   ret i64 %1
 }
@@ -91,7 +91,7 @@ define i64 @add(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: add: # @add
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: ADD a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = add i64 %a, %b
   ret i64 %1
 }
@@ -100,7 +100,7 @@ define i64 @sub(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: sub: # @sub
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: SUB a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = sub i64 %a, %b
   ret i64 %1
 }
@@ -109,7 +109,7 @@ define i64 @sll(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: sll: # @sll
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: SLL a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = shl i64 %a, %b
   ret i64 %1
 }
@@ -118,7 +118,7 @@ define i64 @slt(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: slt: # @slt
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: SLT a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = icmp slt i64 %a, %b
   %2 = zext i1 %1 to i64
   ret i64 %2
@@ -128,7 +128,7 @@ define i64 @sltu(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: sltu: # @sltu
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: SLTU a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = icmp ult i64 %a, %b
   %2 = zext i1 %1 to i64
   ret i64 %2
@@ -138,7 +138,7 @@ define i64 @xor(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: xor: # @xor
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: XOR a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = xor i64 %a, %b
   ret i64 %1
 }
@@ -147,7 +147,7 @@ define i64 @srl(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: srl: # @srl
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: SRL a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = lshr i64 %a, %b
   ret i64 %1
 }
@@ -156,7 +156,7 @@ define i64 @sra(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: sra: # @sra
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: SRA a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = ashr i64 %a, %b
   ret i64 %1
 }
@@ -165,7 +165,7 @@ define i64 @or(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: or: # @or
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: OR a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = or i64 %a, %b
   ret i64 %1
 }
@@ -174,7 +174,7 @@ define i64 @and(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: and: # @and
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: AND a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = and i64 %a, %b
   ret i64 %1
 }
@@ -193,7 +193,7 @@ define signext i32 @addiw(i32 signext %a) nounwind {
 ; CHECK-NEXT: ORI a1,a1,0
 ; CHECK-NEXT: ADD a0,a0,a1
 ; CHECK-NEXT: SRAI a0,a0,32
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = add i32 %a, 123
   ret i32 %1
 }
@@ -203,7 +203,7 @@ define signext i32 @slliw(i32 signext %a) nounwind {
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: SLLI a0,a0,49
 ; CHECK-NEXT: SRAI a0,a0,32
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = shl i32 %a, 17
   ret i32 %1
 }
@@ -219,7 +219,7 @@ define signext i32 @srliw(i32 %a) nounwind {
 ; CHECK-NEXT: ORI a1,a1,-256
 ; CHECK-NEXT: AND a0,a0,a1
 ; CHECK-NEXT: SRLI a0,a0,8
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = lshr i32 %a, 8
   ret i32 %1
 }
@@ -229,7 +229,7 @@ define signext i32 @sraiw(i32 %a) nounwind {
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: SLLI a0,a0,32
 ; CHECK-NEXT: SRAI a0,a0,41
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = ashr i32 %a, 9
   ret i32 %1
 }
@@ -239,7 +239,7 @@ define i64 @sraiw_i64(i64 %a) nounwind {
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: SLLI a0,a0,32
 ; CHECK-NEXT: SRAI a0,a0,41
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = shl i64 %a, 32
   %2 = ashr i64 %1, 41
   ret i64 %2
@@ -250,7 +250,7 @@ define signext i32 @sextw(i32 zeroext %a) nounwind {
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: SLLI a0,a0,32
 ; CHECK-NEXT: SRAI a0,a0,32
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   ret i32 %a
 }
 
@@ -260,7 +260,7 @@ define signext i32 @addw(i32 signext %a, i32 signext %b) nounwind {
 ; CHECK-NEXT: ADD a0,a0,a1
 ; CHECK-NEXT: SLLI a0,a0,32
 ; CHECK-NEXT: SRAI a0,a0,32
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = add i32 %a, %b
   ret i32 %1
 }
@@ -271,7 +271,7 @@ define signext i32 @subw(i32 signext %a, i32 signext %b) nounwind {
 ; CHECK-NEXT: SUB a0,a0,a1
 ; CHECK-NEXT: SLLI a0,a0,32
 ; CHECK-NEXT: SRAI a0,a0,32
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = sub i32 %a, %b
   ret i32 %1
 }
@@ -282,7 +282,7 @@ define signext i32 @sllw(i32 signext %a, i32 zeroext %b) nounwind {
 ; CHECK-NEXT: SLL a0,a0,a1
 ; CHECK-NEXT: SLLI a0,a0,32
 ; CHECK-NEXT: SRAI a0,a0,32
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = shl i32 %a, %b
   ret i32 %1
 }
@@ -300,7 +300,7 @@ define signext i32 @srlw(i32 signext %a, i32 zeroext %b) nounwind {
 ; CHECK-NEXT: SRL a0,a0,a1
 ; CHECK-NEXT: SLLI a0,a0,32
 ; CHECK-NEXT: SRAI a0,a0,32
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = lshr i32 %a, %b
   ret i32 %1
 }
@@ -311,7 +311,7 @@ define signext i32 @sraw(i64 %a, i32 zeroext %b) nounwind {
 ; CHECK-NEXT: SLLI a0,a0,32
 ; CHECK-NEXT: SRAI a0,a0,32
 ; CHECK-NEXT: SRA a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = trunc i64 %a to i32
   %2 = ashr i32 %1, %b
   ret i32 %2
@@ -321,7 +321,7 @@ define i64 @add_hi_and_lo_negone(i64 %0) {
 ; CHECK-LABEL: add_hi_and_lo_negone: # @add_hi_and_lo_negone
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: ADDI a0,a0,-1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %2 = add nsw i64 %0, -1
   ret i64 %2
 }
@@ -336,7 +336,7 @@ define i64 @add_hi_zero_lo_negone(i64 %0) {
 ; CHECK-NEXT: SLLI a1,a1,16
 ; CHECK-NEXT: ORI a1,a1,-1
 ; CHECK-NEXT: ADD a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %2 = add i64 %0, 4294967295
   ret i64 %2
 }
@@ -351,7 +351,7 @@ define i64 @add_lo_negone(i64 %0) {
 ; CHECK-NEXT: SLLI a1,a1,16
 ; CHECK-NEXT: ORI a1,a1,-1
 ; CHECK-NEXT: ADD a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %2 = add nsw i64 %0, -4294967297
   ret i64 %2
 }
@@ -366,7 +366,7 @@ define i64 @add_hi_one_lo_negone(i64 %0) {
 ; CHECK-NEXT: SLLI a1,a1,16
 ; CHECK-NEXT: ORI a1,a1,-1
 ; CHECK-NEXT: ADD a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %2 = add nsw i64 %0, 8589934591
   ret i64 %2
 }

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/analyze-branch.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/analyze-branch.ll
@@ -26,13 +26,13 @@ define void @test_bcc_fallthrough_taken(i32 %in) nounwind {
 ; CHECK-NEXT: JALR ra,%lo(test_true)(ra)
 ; CHECK-NEXT: LD ra,8(sp) # 8-byte Folded Reload
 ; CHECK-NEXT: ADDI sp,sp,16
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 ; CHECK-LABEL: .LBB0_2: # %false
 ; CHECK-NEXT: LUI ra,%hi(test_false)
 ; CHECK-NEXT: JALR ra,%lo(test_false)(ra)
 ; CHECK-NEXT: LD ra,8(sp) # 8-byte Folded Reload
 ; CHECK-NEXT: ADDI sp,sp,16
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %tst = icmp eq i32 %in, 42
   br i1 %tst, label %true, label %false, !prof !0
 
@@ -69,13 +69,13 @@ define void @test_bcc_fallthrough_nottaken(i32 %in) nounwind {
 ; CHECK-NEXT: JALR ra,%lo(test_false)(ra)
 ; CHECK-NEXT: LD ra,8(sp)
 ; CHECK-NEXT: ADDI sp,sp,16
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 ; CHECK-LABEL: .LBB1_2: # %true
 ; CHECK-NEXT: LUI ra,%hi(test_true)
 ; CHECK-NEXT: JALR ra,%lo(test_true)(ra)
 ; CHECK-NEXT: LD ra,8(sp)
 ; CHECK-NEXT: ADDI sp,sp,16
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %tst = icmp eq i32 %in, 42
   br i1 %tst, label %true, label %false, !prof !1
 

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/and.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/and.ll
@@ -3,7 +3,7 @@
 define i32 @and32_0x7ff(i32 %x) {
 ; CHECK-LABEL: and32_0x7ff: # @and32_0x7ff
 ; CHECK:         ANDI a0,a0,2047
-; CHECK-NEXT:    JALR zero,0(ra)
+; CHECK-NEXT:    RET
   %a = and i32 %x, 2047
   ret i32 %a
 }
@@ -13,7 +13,7 @@ define i32 @and32_0xfff(i32 %x) {
 ; CHECK:       LUI a1,0x1
 ; CHECK-NEXT:  ADDI a1,a1,-1
 ; CHECK-NEXT:  AND a0,a0,a1
-; CHECK-NEXT:  JALR zero,0(ra)
+; CHECK-NEXT:  RET
   %a = and i32 %x, 4095
   ret i32 %a
 }
@@ -21,7 +21,7 @@ define i32 @and32_0xfff(i32 %x) {
 define i64 @and64_0x7ff(i64 %x) {
 ; CHECK-LABEL: and64_0x7ff: # @and64_0x7ff
 ; CHECK:         ANDI a0,a0,2047
-; CHECK-NEXT:    JALR zero,0(ra)
+; CHECK-NEXT:    RET
   %a = and i64 %x, 2047
   ret i64 %a
 }
@@ -31,7 +31,7 @@ define i64 @and64_0xfff(i64 %x) {
 ; CHECK:       LUI a1,0x1
 ; CHECK-NEXT:  ADDI a1,a1,-1
 ; CHECK-NEXT:  AND a0,a0,a1
-; CHECK-NEXT:  JALR zero,0(ra)
+; CHECK-NEXT:  RET
   %a = and i64 %x, 4095
   ret i64 %a
 }

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/branch-opt.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/branch-opt.ll
@@ -10,12 +10,12 @@ define void @u_case1_a(ptr %a, i32 signext %b, ptr %c, ptr %d) {
 ; CHECK-NEXT:  # %bb.1: # %block1
 ; CHECK-NEXT:    LD a0,0(sp)
 ; CHECK-NEXT:    SW a1,0(a0)
-; CHECK-NEXT:    JALR zero,0(ra)
+; CHECK-NEXT:    RET
 ; CHECK-NEXT:  .LBB0_2: # %block2
 ; CHECK-NEXT:    LD a0,8(sp)
 ; CHECK-NEXT:    ADDI a1,zero,87
 ; CHECK-NEXT:    SW a1,0(a0)
-; CHECK-NEXT:    JALR zero,0(ra)
+; CHECK-NEXT:    RET
   store i32 32, ptr %a
   %p = icmp ule i32 %b, 31
   br i1 %p, label %block1, label %block2
@@ -47,12 +47,12 @@ define void @case1_a(ptr %a, i32 signext %b, ptr %c, ptr %d) {
 ; CHECK-LABEL:   # %bb.1: # %block1
 ; CHECK-NEXT:    LD a0,0(sp)
 ; CHECK-NEXT:    SW a1,0(a0)
-; CHECK-NEXT:    JALR zero,0(ra)
+; CHECK-NEXT:    RET
 ; CHECK-NEXT:  .LBB1_2: # %block2
 ; CHECK-NEXT:    LD a0,8(sp)
 ; CHECK-NEXT:    ADDI a1,zero,87
 ; CHECK-NEXT:    SW a1,0(a0)
-; CHECK-NEXT:    JALR zero,0(ra)
+; CHECK-NEXT:    RET
   store i32 -1, ptr %a
   %p = icmp sle i32 %b, -2
   br i1 %p, label %block1, label %block2
@@ -79,12 +79,12 @@ define void @u_case2_a(ptr %a, i32 signext %b, ptr %c, ptr %d) {
 ; CHECK-NEXT:  # %bb.1: # %block1
 ; CHECK-NEXT:    LD a0,0(sp)
 ; CHECK-NEXT:    SW a1,0(a0)
-; CHECK-NEXT:    JALR zero,0(ra)
+; CHECK-NEXT:    RET
 ; CHECK-NEXT:  .LBB2_2: # %block2
 ; CHECK-NEXT:    LD a0,8(sp)
 ; CHECK-NEXT:    ADDI a1,zero,87
 ; CHECK-NEXT:    SW a1,0(a0)
-; CHECK-NEXT:    JALR zero,0(ra)
+; CHECK-NEXT:    RET
   store i32 32, ptr %a
   %p = icmp uge i32 %b, 33
   br i1 %p, label %block1, label %block2
@@ -116,12 +116,12 @@ define void @case2_a(ptr %a, i32 signext %b, ptr %c, ptr %d) {
 ; CHECK-LABEL: # %bb.1: # %block1
 ; CHECK-NEXT: LD a0,0(sp)
 ; CHECK-NEXT: SW a1,0(a0)
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 ; CHECK-LABEL: .LBB3_2: # %block2
 ; CHECK-NEXT: LD a0,8(sp)
 ; CHECK-NEXT: ADDI a1,zero,87
 ; CHECK-NEXT: SW a1,0(a0)
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   store i32 -4, ptr %a
   %p = icmp sge i32 %b, -3
   br i1 %p, label %block1, label %block2

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/calling-conv.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/calling-conv.ll
@@ -174,7 +174,7 @@ define void @callee() nounwind {
 ; CHECK-NEXT: LD s1,256(sp)                           # 8-byte Folded Reload
 ; CHECK-NEXT: LD ra,264(sp)                           # 8-byte Folded Reload
 ; CHECK-NEXT: ADDI sp,sp,272
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %val = load [32 x i32], ptr @var
   call void @callee()
   store volatile [32 x i32] %val, ptr @var

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/cmp-bool.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/cmp-bool.ll
@@ -11,7 +11,7 @@ define void @bool_eq(i1 zeroext %a, i1 zeroext %b, ptr nocapture %c) nounwind {
 ; CHECK-NEXT: .LBB0_2: # %if.end
 ; CHECK-NEXT: LD ra,8(sp) # 8-byte Folded Reload
 ; CHECK-NEXT: ADDI sp,sp,16
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 entry:
   %0 = xor i1 %a, %b
   br i1 %0, label %if.end, label %if.then
@@ -36,7 +36,7 @@ define void @bool_ne(i1 zeroext %a, i1 zeroext %b, ptr nocapture %c) nounwind {
 ; CHECK-NEXT: .LBB1_2: # %if.end
 ; CHECK-NEXT: LD ra,8(sp) # 8-byte Folded Reload
 ; CHECK-NEXT: ADDI sp,sp,16
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 entry:
   %cmp = xor i1 %a, %b
   br i1 %cmp, label %if.then, label %if.end

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/fast-cc.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/fast-cc.ll
@@ -3,7 +3,7 @@
 define fastcc i32 @callee(<16 x i32> %A) nounwind {
 ; CHECK-LABEL: callee:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 ;
 	%B = extractelement <16 x i32> %A, i32 0
 	ret i32 %B
@@ -48,7 +48,7 @@ define i32 @caller(<16 x i32> %A) nounwind {
 ; CHECK-NEXT: JALR ra,%lo(callee)(ra)
 ; CHECK-NEXT: LD ra,120(sp)                           # 8-byte Folded Reload
 ; CHECK-NEXT: ADDI sp,sp,128
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 	%C = call fastcc i32 @callee(<16 x i32> %A)
 	ret i32 %C
 }

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/global_const_loop.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/global_const_loop.ll
@@ -23,7 +23,7 @@ define dso_local i32 @foo(i32 noundef %i) local_unnamed_addr #0 {
 ; CHECK-NEXT: LD fp,0(sp)                            # 8-byte Folded Reload
 ; CHECK-NEXT: LD ra,8(sp)                            # 8-byte Folded Reload
 ; CHECK-NEXT: ADDI sp,sp,16
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 entry:
   %cmp = icmp slt i32 %i, 1000
   br i1 %cmp, label %while.body.us, label %while.end

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/imm.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/imm.ll
@@ -3,21 +3,21 @@
 define signext i32 @zero() nounwind {
   ; CHECK-LABEL: zero: # @zero
   ; CHECK: ADDI a0,zero,0
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i32 0
 }
 
 define signext i32 @pos_small() nounwind {
   ; CHECK-LABEL: pos_small: # @pos_small
   ; CHECK: ADDI a0,zero,2047
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i32 2047
 }
 
 define signext i32 @neg_small() nounwind {
   ; CHECK-LABEL: neg_small: # @neg_small
   ; CHECK: ADDI a0,zero,-2048
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i32 -2048
 }
 
@@ -25,7 +25,7 @@ define signext i32 @pos_i32() nounwind {
   ; CHECK-LABEL: pos_i32: # @pos_i32
   ; CHECK: LUI a0,0x67783
   ; CHECK-NEXT: ADDI a0,a0,-1297
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i32 1735928559
 }
 
@@ -33,7 +33,7 @@ define signext i32 @neg_i32() nounwind {
   ; CHECK-LABEL: neg_i32: # @neg_i32
   ; CHECK: LUI a0,0xdeadc
   ; CHECK-NEXT: ADDI a0,a0,-273
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i32 -559038737
 }
 
@@ -41,7 +41,7 @@ define signext i32 @pos_i32_hi20_only() nounwind {
   ; CHECK-LABEL: pos_i32_hi20_only: # @pos_i32_hi20_only
   ; CHECK: LUI a0,0x10
   ; CHECK-NEXT: ADDI a0,a0,0
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i32 65536 ; 0x10000
 }
 
@@ -49,7 +49,7 @@ define signext i32 @neg_i32_hi20_only() nounwind {
   ; CHECK-LABEL: neg_i32_hi20_only: # @neg_i32_hi20_only
   ; CHECK: LUI a0,0xffff0
   ; CHECK-NEXT: ADDI a0,a0,0
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i32 -65536 ; -0x10000
 }
 
@@ -61,7 +61,7 @@ define i64 @imm_end_xori_1() nounwind {
   ; CHECK-NEXT: ORI a0,a0,-512
   ; CHECK-NEXT: SLLI a0,a0,16
   ; CHECK-NEXT: ORI a0,a0,-1
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   ret i64 -2305843009180139521 ; 0xE000_0000_01FF_FFFF
 }
 
@@ -69,7 +69,7 @@ define void @imm_store_i8_neg1(ptr %p) nounwind {
   ; CHECK-LABEL: imm_store_i8_neg1: # @imm_store_i8_neg1
   ; CHECK: ADDI a1,zero,255
   ; CHECK-NEXT: SB a1,0(a0)
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   store i8 -1, ptr %p
   ret void
 }
@@ -79,7 +79,7 @@ define void @imm_store_i16_neg1(ptr %p) nounwind {
   ; CHECK: LUI a1,0x10
   ; CHECK-NEXT: ADDI a1,a1,-1
   ; CHECK-NEXT: SH a1,0(a0)
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   store i16 -1, ptr %p
   ret void
 }
@@ -93,7 +93,7 @@ define void @imm_store_i32_neg1(ptr %p) nounwind {
   ; CHECK-NEXT: SLLI a1,a1,16
   ; CHECK-NEXT: ORI a1,a1,-1
   ; CHECK-NEXT: SW a1,0(a0)
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
   store i32 -1, ptr %p
   ret void
 }

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/indirectbr.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/indirectbr.ll
@@ -6,7 +6,7 @@ define i32 @indirectbr(ptr %target) nounwind {
   ; CHECK-NEXT: JALR zero,0(a0)
   ; CHECK-LABEL: LBB0_1: # %test_label
   ; CHECK: ADDI a0,zero,0
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
    indirectbr ptr %target, [label %test_label]
 test_label:
   br label %ret
@@ -20,7 +20,7 @@ define i32 @indirectbr_with_offset(ptr %a) nounwind {
   ; CHECK-NEXT: JALR zero,1380(a0)
   ; CHECK-LABEL: LBB1_1:
   ; CHECK-NEXT: ADDI a0,zero,0
-  ; CHECK-NEXT: JALR zero,0(ra)
+  ; CHECK-NEXT: RET
 
   %target = getelementptr inbounds i8, ptr %a, i32 1380
   indirectbr ptr %target, [label %test_label]

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/large_stack.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/large_stack.ll
@@ -48,7 +48,7 @@ define void @test_emergency_spill_slot(i32 %a) {
 ; CHECK-NEXT: LUI a0,0x62
 ; CHECK-NEXT: ADDI a0,a0,-1408
 ; CHECK-NEXT: ADD sp,sp,a0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %data = alloca [ 100000 x i32 ] , align 4
   %ptr = getelementptr inbounds [100000 x i32], ptr %data, i32 0, i32 80000
   %1 = tail call { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } asm sideeffect "nop", "=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r"()

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/mul.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/mul.ll
@@ -6,7 +6,7 @@ define signext i32 @square(i32 %a) nounwind {
 ; CHECK: MUL a0,a0,a0
 ; CHECK-NEXT: SLLI a0,a0,32
 ; CHECK-NEXT: SRAI a0,a0,32
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = mul i32 %a, %a
   ret i32 %1
 }
@@ -17,7 +17,7 @@ define signext i32 @mul(i32 %a, i32 %b) nounwind {
 ; CHECK: MUL a0,a0,a1
 ; CHECK-NEXT: SLLI a0,a0,32
 ; CHECK-NEXT: SRAI a0,a0,32
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = mul i32 %a, %b
   ret i32 %1
 }
@@ -33,7 +33,7 @@ define signext i32 @mul_constant(i32 %a) nounwind {
 ; CHECK-NEXT: ORI a1,a1,0
 ; CHECK-NEXT: MUL a0,a0,a1
 ; CHECK-NEXT: SRAI a0,a0,32
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = mul i32 %a, 5
   ret i32 %1
 }
@@ -42,7 +42,7 @@ define i32 @mul_pow2(i32 %a) nounwind {
 ; CHECK-LABEL: mul_pow2: # @mul_pow2
 ; CHECK-LABEL: # %bb.0:
 ; CHECK: SLLI a0,a0,3
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = mul i32 %a, 8
   ret i32 %1
 }
@@ -51,7 +51,7 @@ define i64 @mul64(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: mul64: # @mul64
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: MUL a0,a0,a1
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = mul i64 %a, %b
   ret i64 %1
 }

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/pic.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/pic.ll
@@ -11,7 +11,7 @@ define ptr @f1() nounwind {
 ; CHECK-LABEL: .Ltmp0:
 ; CHECK-NEXT: AUIPC a0,%got_pcrel_hi(external_var)
 ; CHECK-NEXT: LD a0,%pcrel_lo(.Ltmp0)(a0)
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 entry:
   ret ptr @external_var
 }
@@ -22,7 +22,7 @@ define ptr @f2() nounwind {
 ; CHECK-LABEL: .Ltmp1:
 ; CHECK-NEXT: AUIPC a0,%pcrel_hi(internal_var)
 ; CHECK-NEXT: ADDI a0,a0,%pcrel_lo(.Ltmp1)
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 entry:
   ret ptr @internal_var
 }

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/rotl-rotr.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/rotl-rotr.ll
@@ -20,7 +20,7 @@ define i32 @rotl_32(i32 %x, i32 %y) nounwind {
 ; CHECK-NEXT: AND a1,a1,a3
 ; CHECK-NEXT: SLL a0,a0,a1
 ; CHECK-NEXT: OR a0,a0,a2
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %z = sub i32 32, %y
   %b = shl i32 %x, %y
   %c = lshr i32 %x, %z
@@ -45,7 +45,7 @@ define i32 @rotr_32(i32 %x, i32 %y) nounwind {
 ; CHECK-NEXT: AND a1,a1,a2
 ; CHECK-NEXT: SLL a0,a0,a1
 ; CHECK-NEXT: OR a0,a3,a0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %z = sub i32 32, %y
   %b = lshr i32 %x, %y
   %c = shl i32 %x, %z
@@ -61,7 +61,7 @@ define i64 @rotl_64(i64 %x, i64 %y) nounwind {
 ; CHECK-NEXT: SLL a1,a0,a1
 ; CHECK-NEXT: SRL a0,a0,a2
 ; CHECK-NEXT: OR a0,a1,a0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %z = sub i64 64, %y
   %b = shl i64 %x, %y
   %c = lshr i64 %x, %z
@@ -77,7 +77,7 @@ define i64 @rotr_64(i64 %x, i64 %y) nounwind {
 ; CHECK-NEXT: SRL a1,a0,a1
 ; CHECK-NEXT: SLL a0,a0,a2
 ; CHECK-NEXT: OR a0,a1,a0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %z = sub i64 64, %y
   %b = lshr i64 %x, %y
   %c = shl i64 %x, %z
@@ -101,7 +101,7 @@ define i32 @rotl_32_mask(i32 %x, i32 %y) nounwind {
 ; CHECK-NEXT: AND a1,a1,a3
 ; CHECK-NEXT: SLL a0,a0,a1
 ; CHECK-NEXT: OR a0,a0,a2
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %z = sub i32 0, %y
   %and = and i32 %z, 31
   %b = shl i32 %x, %y
@@ -126,7 +126,7 @@ define i32 @rotl_32_mask_and_63_and_31(i32 %x, i32 %y) nounwind {
 ; CHECK-NEXT: ANDI a1,a1,63
 ; CHECK-NEXT: SLL a0,a0,a1
 ; CHECK-NEXT: OR a0,a0,a2
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %a = and i32 %y, 63
   %b = shl i32 %x, %a
   %c = sub i32 0, %y
@@ -140,7 +140,7 @@ define i32 @rotl_32_mask_or_64_or_32(i32 %x, i32 %y) nounwind {
 ; CHECK-LABEL: rotl_32_mask_or_64_or_32:
 ; CHECK: # %bb.0:
 ; CHECK-NEXT: ADDI a0,zero,0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %a = or i32 %y, 64
   %b = shl i32 %x, %a
   %c = sub i32 0, %y
@@ -166,7 +166,7 @@ define i32 @rotr_32_mask(i32 %x, i32 %y) nounwind {
 ; CHECK-NEXT: ANDI a1,a1,31
 ; CHECK-NEXT: SLL a0,a0,a1
 ; CHECK-NEXT: OR a0,a2,a0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %z = sub i32 0, %y
   %and = and i32 %z, 31
   %b = lshr i32 %x, %y
@@ -191,7 +191,7 @@ define i32 @rotr_32_mask_and_63_and_31(i32 %x, i32 %y) nounwind {
 ; CHECK-NEXT: ANDI a1,a1,31
 ; CHECK-NEXT: SLL a0,a0,a1
 ; CHECK-NEXT: OR a0,a2,a0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %a = and i32 %y, 63
   %b = lshr i32 %x, %a
   %c = sub i32 0, %y
@@ -205,7 +205,7 @@ define i32 @rotr_32_mask_or_64_or_32(i32 %x, i32 %y) nounwind {
 ; CHECK-LABEL: rotr_32_mask_or_64_or_32:
 ; CHECK: # %bb.0:
 ; CHECK-NEXT: ADDI a0,zero,0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %a = or i32 %y, 64
   %b = lshr i32 %x, %a
   %c = sub i32 0, %y
@@ -223,7 +223,7 @@ define i64 @rotl_64_mask(i64 %x, i64 %y) nounwind {
 ; CHECK-NEXT: ANDI a2,a2,63
 ; CHECK-NEXT: SRL a0,a0,a2
 ; CHECK-NEXT: OR a0,a1,a0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %z = sub i64 0, %y
   %and = and i64 %z, 63
   %b = shl i64 %x, %y

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/select-cc.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/select-cc.ll
@@ -88,7 +88,7 @@ define signext i32 @foo(i32 signext %a, ptr %b) nounwind {
 ; CHECK-NEXT: .LBB0_15:
 ; CHECK-NEXT: SLLI a0,a0,32
 ; CHECK-NEXT: SRAI a0,a0,32
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
 ; CHECK-NEXT: .LBB0_16:
 ; CHECK-NEXT: ADDI a0,a3,0
 ; CHECK-NEXT: AND a4,a0,a2
@@ -158,7 +158,7 @@ define signext i32 @foo(i32 signext %a, ptr %b) nounwind {
 ; CHECK-NEXT: ADDI a0,a1,0
 ; CHECK-NEXT: SLLI a0,a0,32
 ; CHECK-NEXT: SRAI a0,a0,32
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %val1 = load volatile i32, ptr %b
   %tst1 = icmp eq i32 %a, %val1
   %val2 = select i1 %tst1, i32 %a, i32 %val1
@@ -229,7 +229,7 @@ define i32 @select_sge_int16min(i32 signext %x, i32 signext %y, i32 signext %z) 
 ; CHECK-NEXT: LD a1,0(sp)
 ; CHECK-NEXT: .LBB1_2:
 ; CHECK-NEXT: ADDI a0,a1,0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %a = icmp sge i32 %x, -65536
   %b = select i1 %a, i32 %y, i32 %z
   ret i32 %b
@@ -249,7 +249,7 @@ define i64 @select_sge_int32min(i64 %x, i64 %y, i64 %z) {
 ; CHECK-NEXT: LD a1,0(sp)
 ; CHECK-LABEL: .LBB2_2:
 ; CHECK-NEXT: ADDI a0,a1,0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %a = icmp sge i64 %x, -2147483648
   %b = select i1 %a, i64 %y, i64 %z
   ret i64 %b

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/sext-zext-trunc.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/sext-zext-trunc.ll
@@ -27,7 +27,7 @@ define i8 @sext_i1_to_i8(i1 %a) nounwind {
 ; CHECK-NEXT: # %bb.0:
 ; CHECK-NEXT: ANDI a0,a0,1
 ; CHECK-NEXT: SUB a0,zero,a0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = sext i1 %a to i8
   ret i8 %1
 }
@@ -37,7 +37,7 @@ define i16 @sext_i1_to_i16(i1 %a) nounwind {
 ; CHECK-NEXT: # %bb.0:
 ; CHECK-NEXT: ANDI a0,a0,1
 ; CHECK-NEXT: SUB a0,zero,a0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = sext i1 %a to i16
   ret i16 %1
 }
@@ -47,7 +47,7 @@ define i32 @sext_i1_to_i32(i1 %a) nounwind {
 ; CHECK-NEXT: # %bb.0:
 ; CHECK-NEXT: ANDI a0,a0,1
 ; CHECK-NEXT: SUB a0,zero,a0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = sext i1 %a to i32
   ret i32 %1
 }
@@ -57,7 +57,7 @@ define i64 @sext_i1_to_i64(i1 %a) nounwind {
 ; CHECK-NEXT: # %bb.0:
 ; CHECK-NEXT: ANDI a0,a0,1
 ; CHECK-NEXT: SUB a0,zero,a0
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = sext i1 %a to i64
   ret i64 %1
 }
@@ -67,7 +67,7 @@ define i16 @sext_i8_to_i16(i8 %a) nounwind {
 ; CHECK-NEXT: # %bb.0:
 ; CHECK-NEXT: SLLI a0,a0,56
 ; CHECK-NEXT: SRAI a0,a0,56
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = sext i8 %a to i16
   ret i16 %1
 }
@@ -77,7 +77,7 @@ define i32 @sext_i8_to_i32(i8 %a) nounwind {
 ; CHECK-NEXT: # %bb.0:
 ; CHECK-NEXT: SLLI a0,a0,56
 ; CHECK-NEXT: SRAI a0,a0,56
-; CHECK-NEXT: JALR zero,0(ra)
+; CHECK-NEXT: RET
   %1 = sext i8 %a to i32
   ret i32 %1
 }


### PR DESCRIPTION
TableGen automatically generates a functions to print an `InstAlias`. This function needs to be called in the `InstPrinter`.