### PR TITLE
typechecker: Fix crash typechecking enum field before enum definition

### DIFF
--- a/vadl/main/vadl/ast/Definition.java
+++ b/vadl/main/vadl/ast/Definition.java
@@ -2231,6 +2231,7 @@ final class EnumerationDefinition extends Definition implements IdentifiableNode
                         List<Entry> entries, SourceLocation location) {
     this.id = id;
     this.enumType = enumType;
+    entries.forEach(e -> e.enumDef = this);
     this.entries = entries;
     this.loc = location;
   }
@@ -2324,9 +2325,20 @@ final class EnumerationDefinition extends Definition implements IdentifiableNode
 
     Identifier name;
 
+    /**
+     * Potentially set by the typechecker if no value was explicitly assigned.
+     * In that case the typechecker will increment the value of the last entry by one and insert
+     * it here as a {@link IntegerLiteral}.
+     */
     @Nullable
     @Child
     Expr value;
+
+    /**
+     * Points to the parent definition of the entry, is set in the constructor of the parent.
+     */
+    @LazyInit
+    EnumerationDefinition enumDef;
 
 
     public Entry(Identifier name, @Nullable Expr value) {

--- a/vadl/main/vadl/ast/TypeChecker.java
+++ b/vadl/main/vadl/ast/TypeChecker.java
@@ -1907,6 +1907,7 @@ public class TypeChecker
     }
 
     if (origin instanceof EnumerationDefinition.Entry enumEntry) {
+      check(enumEntry.enumDef);
       expr.type = check(requireNonNull(enumEntry.value));
       return;
     }

--- a/vadl/test/vadl/ast/TypecheckerTest.java
+++ b/vadl/test/vadl/ast/TypecheckerTest.java
@@ -810,6 +810,25 @@ public class TypecheckerTest {
   }
 
   @Test
+  public void enumEntryReferenceBeforeDefinition() {
+    // There once was a crash with code like that:
+    // https://github.com/OpenVADL/openvadl/issues/190
+    var prog = """
+          constant friday:  Bits<Nums::second> = 5
+        
+          enumeration Nums : Bits<4> =
+            { first = 10
+            , second
+            }
+        """;
+    var ast = Assertions.assertDoesNotThrow(() -> VadlParser.parse(prog), "Cannot parse input");
+    var typechecker = new TypeChecker();
+    Assertions.assertDoesNotThrow(() -> typechecker.verify(ast), "Program isn't typesafe");
+    var finder = new AstFinder();
+    Assertions.assertEquals(Type.bits(11), finder.getConstantType(ast, "friday"));
+  }
+
+  @Test
   public void validIfExprTest() {
     var prog = """
           constant x = if 4 = 7 then 3 as Bits<32> else 4 as Bits<32>


### PR DESCRIPTION
Typechecking a reference to an enumeration field requires that the whole enumeration was already typechecked. Because the typechecker might set the value of the field if it is implicitly defined (no explicit value was assigned).

@Jozott00 I added you as a reviewer since git blame pointed to you as the author 😜