### PR TITLE
asm: Emit correct kind of relocations for unknown symbols

### DIFF
--- a/vadl/main/vadl/gcb/passes/DetermineSymbolRelocationTypePass.java
+++ b/vadl/main/vadl/gcb/passes/DetermineSymbolRelocationTypePass.java
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.gcb.passes;
+
+import static vadl.types.BuiltInTable.ADD;
+import static vadl.types.BuiltInTable.ADDS;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.Nullable;
+import vadl.configuration.GeneralConfiguration;
+import vadl.gcb.passes.relocation.model.CompilerRelocation;
+import vadl.pass.Pass;
+import vadl.pass.PassName;
+import vadl.pass.PassResults;
+import vadl.viam.Format;
+import vadl.viam.Instruction;
+import vadl.viam.InstructionSetArchitecture;
+import vadl.viam.Specification;
+import vadl.viam.graph.dependency.BuiltInCall;
+import vadl.viam.graph.dependency.FieldAccessRefNode;
+import vadl.viam.graph.dependency.ReadRegTensorNode;
+import vadl.viam.matching.Matcher;
+import vadl.viam.matching.TreeMatcher;
+import vadl.viam.matching.impl.AnyChildMatcher;
+import vadl.viam.matching.impl.BuiltInMatcher;
+import vadl.viam.matching.impl.IsReadRegMatcher;
+
+/**
+ * Determines the relocation kind for the immediate operands of machine instructions.
+ * If the instruction's behavior adds the immediate to the Program Counter (PC),
+ * then the relocation kind for this operand is RELATIVE.
+ */
+public class DetermineSymbolRelocationTypePass extends Pass {
+  public DetermineSymbolRelocationTypePass(GeneralConfiguration configuration) {
+    super(configuration);
+  }
+
+  @Override
+  public PassName getName() {
+    return new PassName("DetermineSymbolRelocationTypePass");
+  }
+
+  @Nullable
+  @Override
+  public Object execute(PassResults passResults, Specification viam) throws IOException {
+    var fieldUsages =
+        (IdentifyFieldUsagePass.ImmediateDetectionContainer) passResults.lastResultOf(
+            IdentifyFieldUsagePass.class);
+
+    viam.isa().map(InstructionSetArchitecture::ownInstructions).orElse(List.of()).forEach(
+        instruction -> {
+          var immediateKindMap = new HashMap<Format.Field, CompilerRelocation.Kind>();
+          fieldUsages.getImmediates(instruction).forEach(
+              immField -> {
+                var relocationKind = fittingRelocationKindByBehavior(instruction, immField);
+                immediateKindMap.put(immField, relocationKind);
+              }
+          );
+          instruction.attachExtension(new RelocationKindCtx(immediateKindMap));
+        }
+    );
+
+    return null;
+  }
+
+
+  private CompilerRelocation.Kind fittingRelocationKindByBehavior(
+      Instruction instruction, Format.Field field) {
+
+    var behavior = instruction.behavior();
+    var readsPC = behavior.getNodes(ReadRegTensorNode.class)
+        .filter(ReadRegTensorNode::isPcAccess).toList();
+
+    if (readsPC.isEmpty()) {
+      return CompilerRelocation.Kind.ABSOLUTE;
+    }
+
+    var pcRegister = readsPC.getFirst().regTensor();
+
+    var matcher = new BuiltInMatcher(List.of(ADD, ADDS), List.of(
+        new AnyChildMatcher(new IsReadRegMatcher(pcRegister)),
+        new AnyChildMatcher(node ->
+            node instanceof FieldAccessRefNode refNode
+                && refNode.fieldAccess().fieldRef().equals(field)
+        )
+    ));
+    Set<Matcher> matchers = Set.of(
+        matcher,
+        matcher.swapOperands()
+    );
+
+    var inputRegister = TreeMatcher.matches(
+        () -> behavior.getNodes(BuiltInCall.class).map(x -> x),
+        matchers
+    );
+
+    return !inputRegister.isEmpty()
+        ? CompilerRelocation.Kind.RELATIVE
+        : CompilerRelocation.Kind.ABSOLUTE;
+  }
+}

--- a/vadl/main/vadl/gcb/passes/RelocationKindCtx.java
+++ b/vadl/main/vadl/gcb/passes/RelocationKindCtx.java
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.gcb.passes;
+
+import java.util.Map;
+import vadl.gcb.passes.relocation.model.CompilerRelocation;
+import vadl.viam.Definition;
+import vadl.viam.DefinitionExtension;
+import vadl.viam.Format;
+import vadl.viam.Instruction;
+
+/**
+ * An extension for {@link Instruction} to store which kind of relocations
+ * should be emitted for its immediate operands.
+ */
+public class RelocationKindCtx extends DefinitionExtension<Instruction> {
+
+  private final Map<Format.Field, CompilerRelocation.Kind> fieldToKind;
+
+  public RelocationKindCtx(Map<Format.Field, CompilerRelocation.Kind> fieldToKind) {
+    this.fieldToKind = fieldToKind;
+  }
+
+  public Map<Format.Field, CompilerRelocation.Kind> getFieldToKind() {
+    return fieldToKind;
+  }
+
+  @Override
+  public Class<? extends Definition> extendsDefClass() {
+    return Instruction.class;
+  }
+}

--- a/vadl/main/vadl/pass/PassOrders.java
+++ b/vadl/main/vadl/pass/PassOrders.java
@@ -30,6 +30,7 @@ import vadl.configuration.LcbConfiguration;
 import vadl.cppCodeGen.passes.fieldNodeReplacement.FieldNodeReplacementPassForDecoding;
 import vadl.dump.CollectBehaviorDotGraphPass;
 import vadl.dump.HtmlDumpPass;
+import vadl.gcb.passes.DetermineSymbolRelocationTypePass;
 import vadl.gcb.passes.GenerateCompilerRegistersPass;
 import vadl.gcb.passes.GenerateValueRangeImmediatePass;
 import vadl.gcb.passes.IdentifyFieldUsagePass;
@@ -190,6 +191,7 @@ public class PassOrders {
     order.add(new IdentifyFieldUsagePass(gcbConfiguration));
     order.add(new IsaMachineInstructionMatchingPass(gcbConfiguration));
     order.add(new NormalizeFieldsToFieldAccessFunctionsPass(gcbConfiguration));
+    order.add(new DetermineSymbolRelocationTypePass(gcbConfiguration));
     order.add(new GenerateValueRangeImmediatePass(gcbConfiguration));
     order.add(new GenerateFieldAccessEncodingFunctionPass(gcbConfiguration));
     order.add(new FieldNodeReplacementPassForDecoding(gcbConfiguration));

--- a/vadl/main/vadl/pass/PassOrders.java
+++ b/vadl/main/vadl/pass/PassOrders.java
@@ -30,7 +30,7 @@ import vadl.configuration.LcbConfiguration;
 import vadl.cppCodeGen.passes.fieldNodeReplacement.FieldNodeReplacementPassForDecoding;
 import vadl.dump.CollectBehaviorDotGraphPass;
 import vadl.dump.HtmlDumpPass;
-import vadl.gcb.passes.DetermineSymbolRelocationTypePass;
+import vadl.gcb.passes.DetermineRelocationTypeForFieldPass;
 import vadl.gcb.passes.GenerateCompilerRegistersPass;
 import vadl.gcb.passes.GenerateValueRangeImmediatePass;
 import vadl.gcb.passes.IdentifyFieldUsagePass;
@@ -191,7 +191,7 @@ public class PassOrders {
     order.add(new IdentifyFieldUsagePass(gcbConfiguration));
     order.add(new IsaMachineInstructionMatchingPass(gcbConfiguration));
     order.add(new NormalizeFieldsToFieldAccessFunctionsPass(gcbConfiguration));
-    order.add(new DetermineSymbolRelocationTypePass(gcbConfiguration));
+    order.add(new DetermineRelocationTypeForFieldPass(gcbConfiguration));
     order.add(new GenerateValueRangeImmediatePass(gcbConfiguration));
     order.add(new GenerateFieldAccessEncodingFunctionPass(gcbConfiguration));
     order.add(new FieldNodeReplacementPassForDecoding(gcbConfiguration));

--- a/vadl/test/resources/llvm/riscv/asm/rv32im/codeemitter/BType.s
+++ b/vadl/test/resources/llvm/riscv/asm/rv32im/codeemitter/BType.s
@@ -2,7 +2,7 @@
 
 BEQ x1, x2, .label
 # CHECK: # encoding: [0x63,0x80,0x20,0x00]
-# CHECK-NEXT: #   fixup A - offset: 0, value: .label, kind: fixup_imm_RV3264I_Btype_ABSOLUTE_imm
+# CHECK-NEXT: #   fixup A - offset: 0, value: .label, kind: fixup_imm_RV3264I_Btype_RELATIVE_imm
 
 BNE x3, x4, 4
 # CHECK: # encoding: [0x63,0x92,0x41,0x00]
@@ -18,4 +18,4 @@ BLT x9, x10, -2048
 
 BLTU x11, x12, .label
 # CHECK: # encoding: [0x63,0xe0,0xc5,0x00]
-# CHECK-NEXT: #   fixup A - offset: 0, value: .label, kind: fixup_imm_RV3264I_Btype_ABSOLUTE_imm
+# CHECK-NEXT: #   fixup A - offset: 0, value: .label, kind: fixup_imm_RV3264I_Btype_RELATIVE_imm

--- a/vadl/test/resources/llvm/riscv/asm/rv32im/codeemitter/PseudoInstructions.s
+++ b/vadl/test/resources/llvm/riscv/asm/rv32im/codeemitter/PseudoInstructions.s
@@ -59,7 +59,7 @@ BGEZ x4, 4
 
 BGEZ x4, .lbl
 # CHECK: [0x63,0x50,0x02,0x00]
-# CHECK-NEXT: #   fixup A - offset: 0, value: .lbl, kind: fixup_imm_RV3264I_Btype_ABSOLUTE_imm
+# CHECK-NEXT: #   fixup A - offset: 0, value: .lbl, kind: fixup_imm_RV3264I_Btype_RELATIVE_imm
 
 BLTZ x5, 5
 # CHECK: [0x63,0xc2,0x02,0x00]


### PR DESCRIPTION
This PR adjusts the the `MCCodeEmitter` to emit the correct type of relocations when unknown symbols are used as immediate operands. If the instruction's behavior adds the immediate operand to the program counter, a relative relocation is emitted, else an absolute relocation is emitted.