### PR TITLE
iss: Support `rv32csr.vadl` specification

### DIFF
--- a/docs/handbook/iss.md
+++ b/docs/handbook/iss.md
@@ -335,6 +335,6 @@ However, it’s enough to demonstrate how to run simple C programs.
 
 | Previous                  |                            Next |
 |:--------------------------|--------------------------------:|
-| [Tutorial](tutorial.html) | [LLVM Combiler Backend](lcb.md) |
+| [Tutorial](tutorial.html) | [LLVM Compiler Backend](lcb.md) |
 
 </div>

--- a/vadl/main/resources/templates/iss/tests/tcg/plugins/endstate.c
+++ b/vadl/main/resources/templates/iss/tests/tcg/plugins/endstate.c
@@ -58,7 +58,7 @@ static void vcpu_mem(unsigned int cpu_index, qemu_plugin_meminfo_t meminfo,
                      uint64_t vaddr, void *udata) {
 
     qemu_plugin_mem_value last = qemu_plugin_mem_get_value(meminfo);
-    if (last.type != QEMU_PLUGIN_MEM_VALUE_U64) {
+    if (last.type != QEMU_PLUGIN_MEM_VALUE_U64 && last.type != QEMU_PLUGIN_MEM_VALUE_U32) {
         return;
     }
 
@@ -68,7 +68,7 @@ static void vcpu_mem(unsigned int cpu_index, qemu_plugin_meminfo_t meminfo,
         return;
     }
 
-    uint64_t val_written = last.data.u64;
+    uint64_t val_written = last.data.u32;
     uint8_t device = val_written >> HTIF_DEV_SHIFT;
     uint8_t cmd = val_written >> HTIF_CMD_SHIFT;
     uint64_t payload = val_written & 0xFFFFFFFFFFFFULL;

--- a/vadl/main/vadl/ast/AnnotationTable.java
+++ b/vadl/main/vadl/ast/AnnotationTable.java
@@ -1058,6 +1058,10 @@ class ExprAnnotation extends Annotation {
  * The {@code [ zero : <register>(<expr>) ]} annotation.
  * This is its own class, as the typechecking is rather complex and determines
  * new properties.
+ * <pre>{@code
+ * [ zero : X(0) ]
+ * register X: Bits<5> -> Bits<64>
+ * }</pre>
  */
 class ZeroConstraintAnnotation extends ExprAnnotation {
   @LazyInit
@@ -1072,7 +1076,7 @@ class ZeroConstraintAnnotation extends ExprAnnotation {
           .locationDescription(this, "Zero annotation must be of form %s.", usageString())
           .build();
     }
-    if (!(callExpr.computedTarget == def)) {
+    if (!(callExpr.computedTarget() == def)) {
       throw error("Invalid zero annotation", callExpr.target)
           .locationDescription(callExpr.target,
               "Zero annotation target must be the annotated register.")
@@ -1081,7 +1085,7 @@ class ZeroConstraintAnnotation extends ExprAnnotation {
     }
 
 
-    var args = callExpr.argIndicesFlatten();
+    var args = callExpr.argsIndices.stream().flatMap(a -> a.values.stream()).toList();
     // FIXME: Ones we have multi dimensional registers,
     //   we must loose this restriction, so that there can be multiple indices set.
     if (args.size() != 1) {

--- a/vadl/main/vadl/ast/BehaviorLowering.java
+++ b/vadl/main/vadl/ast/BehaviorLowering.java
@@ -567,8 +567,8 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
 
   @Override
   public ExpressionNode visit(IntegerLiteral expr) {
-    throw new RuntimeException(
-        "The behavior generator doesn't implement yet: " + expr.getClass().getSimpleName());
+    return new ConstantNode(Constant.Value.fromInteger(expr.number,
+        ((ConstantType) expr.type()).closestBits()));
   }
 
   @Override

--- a/vadl/main/vadl/ast/BehaviorLowering.java
+++ b/vadl/main/vadl/ast/BehaviorLowering.java
@@ -574,8 +574,8 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
 
   @Override
   public ExpressionNode visit(IntegerLiteral expr) {
-    return new ConstantNode(Constant.Value.fromInteger(expr.number,
-        ((ConstantType) expr.type()).closestBits()));
+    // IntegerLiteral should never be reached as it should always be substituted by the typechecker.
+    throw new IllegalStateException("IntegerLiteral should never be reached in the VIAM lowering.");
   }
 
   @Override

--- a/vadl/main/vadl/ast/BehaviorLowering.java
+++ b/vadl/main/vadl/ast/BehaviorLowering.java
@@ -367,6 +367,8 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
     var result = expr.accept(this);
     result.setSourceLocationIfNotSet(expr.location());
     expressionCache.put(expr, result);
+    result.ensure(!(result.type() instanceof ConstantType),
+        "Constant types must not exist in the VIAM");
     return result;
   }
 

--- a/vadl/main/vadl/ast/Definition.java
+++ b/vadl/main/vadl/ast/Definition.java
@@ -2045,12 +2045,16 @@ class AliasDefinition extends Definition implements IdentifiableNode, TypedNode 
   @Nullable
   Type type;
 
-
   /**
    * Set by the typechecker, the register file or register the alias points to.
    */
   @Nullable
   Definition computedTarget;
+  /**
+   * Set by the typechecker, the arguments used to pre-access the computedTarget.
+   */
+  @Nullable
+  List<Expr> computedFixedArgs;
 
   AliasDefinition(IdentifierOrPlaceholder id, AliasKind kind,
                   @Nullable TypeLiteral aliasType, @Nullable TypeLiteral targetType, Expr value,

--- a/vadl/main/vadl/ast/Expr.java
+++ b/vadl/main/vadl/ast/Expr.java
@@ -1757,10 +1757,6 @@ final class CallIndexExpr extends Expr implements IsCallExpr {
     args.values.addAll(newArgs);
   }
 
-  List<Expr> argIndicesFlatten() {
-    return argsIndices.stream().flatMap(a -> a.values.stream()).toList();
-  }
-
 
   @Override
   public IsId path() {

--- a/vadl/main/vadl/ast/Expr.java
+++ b/vadl/main/vadl/ast/Expr.java
@@ -1757,6 +1757,10 @@ final class CallIndexExpr extends Expr implements IsCallExpr {
     args.values.addAll(newArgs);
   }
 
+  List<Expr> argIndicesFlatten() {
+    return argsIndices.stream().flatMap(a -> a.values.stream()).toList();
+  }
+
 
   @Override
   public IsId path() {

--- a/vadl/main/vadl/ast/ParserUtils.java
+++ b/vadl/main/vadl/ast/ParserUtils.java
@@ -636,6 +636,12 @@ class ParserUtils {
       var macroOverrides = new HashMap<String, String>();
       for (StringLiteral arg : args) {
         var keyValue = arg.value.split("=", 2);
+        if (keyValue.length != 2) {
+          throw error("Invalid import", arg)
+              .locationDescription(arg,
+                  "Macro overrides must have the form `<macro-name>=<substitute>`.")
+              .build();
+        }
         macroOverrides.put(keyValue[0], keyValue[1]);
       }
       try {

--- a/vadl/main/vadl/ast/TypeChecker.java
+++ b/vadl/main/vadl/ast/TypeChecker.java
@@ -845,6 +845,12 @@ public class TypeChecker
       }
 
       var valType = check(definition.value);
+      definition.computedFixedArgs = List.of();
+      if (definition.value instanceof CallIndexExpr callIndexExpr) {
+        // If the target is a call index expression, we get all fixed arguments of the
+        // alias register call.
+        definition.computedFixedArgs = AstUtils.flatArguments(callIndexExpr.args());
+      }
 
       if (definition.aliasType != null) {
         definition.type = check(definition.aliasType);

--- a/vadl/main/vadl/ast/ViamLowering.java
+++ b/vadl/main/vadl/ast/ViamLowering.java
@@ -1387,16 +1387,6 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
     // now we add the dimensions of the form T<d0><d1>..
     dimensions.add(dimFromType(dimensions.size(), resultType));
 
-    // FIXME: Remove this and add it using the [zero: ..] annotation
-    var constraints = new ArrayList<RegisterTensor.Constraint>();
-    if (type instanceof ConcreteRelationType relType) {
-      var zeroConstraint = new RegisterTensor.Constraint(
-          List.of(Constant.Value.of(0, relType.argTypes().getFirst().asDataType())),
-          Constant.Value.of(0, resultType));
-      constraints.add(zeroConstraint);
-    }
-
-
     var reg = new RegisterTensor(
         generateIdentifier(definition.viamId, definition.identifier()),
         dimensions

--- a/vadl/main/vadl/ast/ViamLowering.java
+++ b/vadl/main/vadl/ast/ViamLowering.java
@@ -321,7 +321,7 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
 
       return Optional.of(new ArtificialResource(
           identifier,
-          ArtificialResource.Kind.REG_ALIAS,
+          ArtificialResource.Kind.REGISTER,
           innerResource,
           new BehaviorLowering(this).getRegisterAliasReadFunc(definition),
           new BehaviorLowering(this).getRegisterAliasWriteProc(definition)
@@ -1137,7 +1137,7 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
         .findFirst().orElse(null);
     var memories = filterAndCastToInstance(allDefinitions, Memory.class);
     // TODO: @flofriday compute artifical resources
-    var artificialResources = new ArrayList<ArtificialResource>();
+    var artificialResources = filterAndCastToInstance(allDefinitions, ArtificialResource.class);
 
     // Add programCounter to registers if it is a register.
     // The register list is the owner of the PC register itself.

--- a/vadl/main/vadl/ast/ViamLowering.java
+++ b/vadl/main/vadl/ast/ViamLowering.java
@@ -778,8 +778,7 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
 
     // FIXME: Further research for the parameters (probably don't apply to counter)
     var reg = new RegisterTensor(identifier,
-        List.of(dimFromType(0, resultType)),
-        new RegisterTensor.Constraint[] {}
+        List.of(dimFromType(0, resultType))
     );
 
     var counter = new Counter(identifier,
@@ -1400,8 +1399,7 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
 
     var reg = new RegisterTensor(
         generateIdentifier(definition.viamId, definition.identifier()),
-        dimensions,
-        constraints.toArray(new RegisterTensor.Constraint[0])
+        dimensions
     );
     return Optional.of(reg);
   }

--- a/vadl/main/vadl/cppCodeGen/context/CGenContext.java
+++ b/vadl/main/vadl/cppCodeGen/context/CGenContext.java
@@ -33,6 +33,7 @@ import vadl.types.Type;
 public abstract class CGenContext<T> {
 
   protected String prefix = "";
+  protected int tabSize = 3;
   private boolean newLine = true;
   protected final Consumer<String> writer;
 
@@ -64,7 +65,7 @@ public abstract class CGenContext<T> {
    * Enters tab mode and every following write is tabbed until {@code tabOut} is called.
    */
   public CGenContext<T> spacedIn() {
-    prefix = "   ";
+    prefix += " ".repeat(tabSize);
     return this;
   }
 
@@ -72,7 +73,10 @@ public abstract class CGenContext<T> {
    * Exits tab mode and every following write is not tabbed anymore.
    */
   public CGenContext<T> spaceOut() {
-    prefix = "";
+    if (!prefix.isEmpty()) {
+      prefix = prefix.substring(0, prefix.length() - tabSize);
+    }
+
     return this;
   }
 

--- a/vadl/main/vadl/cppCodeGen/mixins/CDefaultMixins.java
+++ b/vadl/main/vadl/cppCodeGen/mixins/CDefaultMixins.java
@@ -177,10 +177,10 @@ public interface CDefaultMixins {
     default void handle(CGenContext<Node> ctx, IfNode node) {
       ctx.wr("if (")
           .gen(node.condition())
-          .ln(") { ")
-          .gen(node.trueBranch())
-          .ln("} else {")
-          .gen(node.falseBranch())
+          .ln(") { ").spacedIn()
+          .gen(node.trueBranch()).spaceOut()
+          .ln("} else {").spacedIn()
+          .gen(node.falseBranch()).spaceOut()
           .ln("}");
     }
   }
@@ -340,7 +340,13 @@ public interface CDefaultMixins {
   interface Select {
     @Handler
     default void handle(CGenContext<Node> ctx, SelectNode toHandle) {
-      throw new UnsupportedOperationException("Type SelectNode not yet implemented");
+      ctx.wr("(")
+          .gen(toHandle.condition())
+          .wr(" ? ")
+          .gen(toHandle.trueCase())
+          .wr(": ")
+          .gen(toHandle.falseCase())
+          .wr(")");
     }
   }
 

--- a/vadl/main/vadl/cppCodeGen/mixins/CDefaultMixins.java
+++ b/vadl/main/vadl/cppCodeGen/mixins/CDefaultMixins.java
@@ -338,7 +338,9 @@ public interface CDefaultMixins {
 
   @SuppressWarnings("MissingJavadocType")
   interface Select {
+
     @Handler
+    @SuppressWarnings("MissingJavadocMethodCheck")
     default void handle(CGenContext<Node> ctx, SelectNode toHandle) {
       ctx.wr("(")
           .gen(toHandle.condition())

--- a/vadl/main/vadl/iss/codegen/IssCMixins.java
+++ b/vadl/main/vadl/iss/codegen/IssCMixins.java
@@ -22,6 +22,7 @@ import vadl.cppCodeGen.context.CGenContext;
 import vadl.iss.passes.nodes.IssConstExtractNode;
 import vadl.javaannotations.Handler;
 import vadl.viam.graph.Node;
+import vadl.viam.graph.dependency.WriteRegTensorNode;
 
 /**
  * The ISS C mixins for all ISS intermediate nodes added to behaviors.
@@ -75,6 +76,24 @@ public interface IssCMixins {
           .wr(")");
     }
 
+  }
+
+  /**
+   * Implements the register write in the {@code cpu.c}.
+   */
+  interface CpuSourceWriteRegTensor {
+
+    @Handler
+    @SuppressWarnings("MissingJavadocMethod")
+    default void handle(CGenContext<Node> ctx,
+                        WriteRegTensorNode node) {
+      var reg = node.regTensor();
+      ctx.wr("set_" + reg.simpleName().toLowerCase() + "(");
+      for (var i : node.indices()) {
+        ctx.gen(i).wr(",");
+      }
+      ctx.gen(node.value()).wr(")");
+    }
   }
 
 }

--- a/vadl/main/vadl/iss/codegen/IssMemoryRegionInitCodeGen.java
+++ b/vadl/main/vadl/iss/codegen/IssMemoryRegionInitCodeGen.java
@@ -61,7 +61,7 @@ public class IssMemoryRegionInitCodeGen extends IssProcGen {
 
   /**
    * Produces the {@code init_<memory_region_name>()} function setup the ROM, which correspond
-   * to the {@link Processor#firmware()} definition in the specification.
+   * to on of the {@link Processor#memoryRegions()} definitions in the specification.
    *
    * @return the full function code, including signature.
    */

--- a/vadl/main/vadl/iss/codegen/IssResetGen.java
+++ b/vadl/main/vadl/iss/codegen/IssResetGen.java
@@ -31,7 +31,7 @@ import vadl.viam.passes.sideEffectScheduling.nodes.InstrExitNode;
  * It runs in the {@code cpu.c#reset_hold} callback, which takes care of setting up the
  * CPU state after a reset.
  */
-public class IssResetGen extends IssProcGen {
+public class IssResetGen extends IssProcGen implements IssCMixins.CpuSourceWriteRegTensor {
 
   private final Procedure reset;
 
@@ -47,12 +47,7 @@ public class IssResetGen extends IssProcGen {
 
   @Override
   public void handle(CGenContext<Node> ctx, WriteRegTensorNode toHandle) {
-    var reg = toHandle.regTensor();
-    ctx().wr("set_" + reg.simpleName().toLowerCase() + "(");
-    for (var i : toHandle.indices()) {
-      ctx().gen(i).wr(",");
-    }
-    ctx().gen(toHandle.value()).wr(")");
+    IssCMixins.CpuSourceWriteRegTensor.super.handle(ctx, toHandle);
   }
 
   @Override

--- a/vadl/main/vadl/iss/passes/extensions/ExceptionInfo.java
+++ b/vadl/main/vadl/iss/passes/extensions/ExceptionInfo.java
@@ -143,7 +143,8 @@ public class ExceptionInfo extends DefinitionExtension<InstructionSetArchitectur
           // .map(p -> Tcg_32_64.nextFitting(p.type().asDataType().bitWidth()))
           .map(Enum::toString)
           .collect(Collectors.joining(", "));
-      return "DEF_HELPER_" + nrArgs + "(raise_" + name.toLowerCase() + ", noreturn, env, "
+      argTypes = argTypes.isEmpty() ? "" : ", " + argTypes;
+      return "DEF_HELPER_" + nrArgs + "(raise_" + name.toLowerCase() + ", noreturn, env"
           + argTypes + ")";
     }
 
@@ -165,11 +166,12 @@ public class ExceptionInfo extends DefinitionExtension<InstructionSetArchitectur
       var params = this.params.values().stream()
           .map(p -> "uint" + configuration.targetSize().width + "_t " + p.param.simpleName())
           .collect(Collectors.joining(", "));
+      params = params.isEmpty() ? "" : ", " + params;
       var targetUpper = configuration.targetName().toUpperCase();
       var targetLower = configuration.targetName().toLowerCase();
       var sb = new StringBuilder();
       sb.append("void helper_raise_" + name.toLowerCase())
-          .append("(CPU" + targetUpper + "State *env, " + params)
+          .append("(CPU" + targetUpper + "State *env" + params)
           .append(") {\n");
       for (Param p : this.params.values()) {
         sb.append("\tenv->" + p.nameInCpuState + " = (" + p.cType() + ") " + p.param.simpleName()

--- a/vadl/main/vadl/iss/passes/tcgLowering/TcgOpLoweringPass.java
+++ b/vadl/main/vadl/iss/passes/tcgLowering/TcgOpLoweringPass.java
@@ -869,7 +869,7 @@ class BuiltInTcgLoweringExecutor {
         //// Logical ////
 
         .set(BuiltInTable.NOT, (ctx) -> out(
-            new TcgNotNode(ctx.dest(), ctx.src(0), ctx.src(1))
+            new TcgNotNode(ctx.dest(), ctx.src(0))
         ))
 
         .set(BuiltInTable.AND, (ctx) -> out(

--- a/vadl/main/vadl/iss/passes/tcgLowering/nodes/TcgGenException.java
+++ b/vadl/main/vadl/iss/passes/tcgLowering/nodes/TcgGenException.java
@@ -50,10 +50,11 @@ public class TcgGenException extends TcgNode {
   @Override
   public String cCode(Function<Node, String> nodeToCCode) {
     // update PC before leaving TB and generate
+    var argStr = args.stream().map(nodeToCCode).collect(Collectors.joining(", "));
+    argStr = argStr.isEmpty() ? "" : ", " + argStr;
     return "gen_update_pc_diff(ctx, 0);\n\t"
-        + "gen_helper_raise_" + exception.simpleName().toLowerCase() + "(tcg_env, "
-        + args.stream().map(nodeToCCode).collect(Collectors.joining(", "))
-        + ")";
+        + "gen_helper_raise_" + exception.simpleName().toLowerCase()
+        + "(tcg_env" + argStr + ")";
   }
 
   @Override

--- a/vadl/main/vadl/iss/passes/tcgLowering/nodes/TcgNotNode.java
+++ b/vadl/main/vadl/iss/passes/tcgLowering/nodes/TcgNotNode.java
@@ -22,25 +22,24 @@ import vadl.viam.graph.Node;
 /**
  * Represents the {@code tcg_gen_not} TCG instruction in the TCG VIAM lowering.
  */
-public class TcgNotNode extends TcgBinaryOpNode {
+public class TcgNotNode extends TcgUnaryOpNode {
 
-  public TcgNotNode(TcgVRefNode resVar, TcgVRefNode arg1, TcgVRefNode arg2) {
-    super(resVar, arg1, arg2, resVar.width());
+  public TcgNotNode(TcgVRefNode resVar, TcgVRefNode arg1) {
+    super(resVar, arg1);
   }
 
   @Override
   public String tcgFunctionName() {
-    return "tcg_gen_not";
+    return "tcg_gen_not_" + firstDest().width();
   }
 
   @Override
   public Node copy() {
-    return new TcgNotNode(firstDest().copy(TcgVRefNode.class), arg1.copy(TcgVRefNode.class),
-        arg2.copy(TcgVRefNode.class));
+    return new TcgNotNode(firstDest().copy(TcgVRefNode.class), arg.copy(TcgVRefNode.class));
   }
 
   @Override
   public Node shallowCopy() {
-    return new TcgNotNode(firstDest(), arg1, arg2);
+    return new TcgNotNode(firstDest(), arg);
   }
 }

--- a/vadl/main/vadl/lcb/template/lib/Target/EmitISelLoweringCppFilePass.java
+++ b/vadl/main/vadl/lcb/template/lib/Target/EmitISelLoweringCppFilePass.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
 import vadl.configuration.LcbConfiguration;
@@ -78,8 +77,10 @@ public class EmitISelLoweringCppFilePass extends LcbTemplateRenderingPass {
      **/
     public LlvmRegisterFile(RegisterTensor registerFile) {
       super(registerFile.identifier,
-          registerFile.dimensions(),
-          registerFile.constraints());
+          registerFile.dimensions());
+      for (var c : registerFile.constraints()) {
+        addConstraint(c);
+      }
     }
 
     public String llvmResultType() {

--- a/vadl/main/vadl/pass/PassOrders.java
+++ b/vadl/main/vadl/pass/PassOrders.java
@@ -107,6 +107,7 @@ import vadl.viam.passes.algebraic_simplication.AlgebraicSimplificationPass;
 import vadl.viam.passes.behaviorRewrite.BehaviorRewritePass;
 import vadl.viam.passes.canonicalization.CanonicalizationPass;
 import vadl.viam.passes.dummyPasses.DummyMiaPass;
+import vadl.viam.passes.functionInliner.ArtificialResInlinerPass;
 import vadl.viam.passes.functionInliner.FieldAccessInlinerPass;
 import vadl.viam.passes.functionInliner.FunctionInlinerPass;
 import vadl.viam.passes.sideEffectScheduling.SideEffectSchedulingPass;
@@ -156,6 +157,7 @@ public class PassOrders {
     order.add(new StaticCounterAccessResolvingPass(configuration));
     order.add(new FunctionInlinerPass(configuration));
     order.add(new FieldAccessInlinerPass(configuration));
+    order.add(new ArtificialResInlinerPass(configuration));
     order.add(new SideEffectConditionResolvingPass(configuration));
     // requires SideEffectConditionResolvingPass to work
     order.add(new DuplicateWriteDetectionPass(configuration));

--- a/vadl/main/vadl/types/BuiltInTable.java
+++ b/vadl/main/vadl/types/BuiltInTable.java
@@ -593,7 +593,8 @@ public class BuiltInTable {
   public static final BuiltIn EQU =
       func("VADL::equ", "=", Type.relation(BitsType.class, BitsType.class, BoolType.class))
           .takesAllWithSameBitWidths()
-          .compute((a, b) -> Constant.Value.fromBoolean(a.equals(b)))
+          .compute(
+              (a, b) -> Constant.Value.fromBoolean(a.asVal().equalValue(b)))
           .returns(Type.bool())
           .build();
 

--- a/vadl/main/vadl/viam/ArtificialResource.java
+++ b/vadl/main/vadl/viam/ArtificialResource.java
@@ -39,7 +39,7 @@ public class ArtificialResource extends Resource {
    * A hint what the artificial resources were created from.
    */
   public enum Kind {
-    REG_ALIAS
+    REGISTER
   }
 
   private final Kind kind;
@@ -89,26 +89,24 @@ public class ArtificialResource extends Resource {
     var readParams = readFunction.parameters();
     var writeParams = writeProcedure.parameters();
     ensure(readFunction.returnType().isData(), "Read return type must be a data type");
-    ensure(readParams.length <= 1, "Read cannot have more than 1 parameter (address)");
     ensure(writeParams.length == readParams.length + 1,
         "Write must have one more param than read (because the last value is write)");
-    var readParam = readFunction.parameters()[0];
-    var writeAddrParam = writeProcedure.parameters()[0];
-    var writeValParam = writeProcedure.parameters()[1];
-    ensure(readParam.type().isData(), "Read type must be a data type");
-    ensure(writeAddrParam.type().isData(), "Write address type must be a data type");
+    for (int i = 0; i < readParams.length; i++) {
+      var readParam = readFunction.parameters()[i];
+      var writeAddrParam = writeProcedure.parameters()[i];
+      ensure(readParam.type().isData(), "Read type must be a data type");
+      ensure(writeAddrParam.type().isData(), "Write address type must be a data type");
+      ensure(readParam.type().isTrivialCastTo(writeAddrParam.type()),
+          "Write address type must be a data type");
+    }
+
+    var writeValParam = writeParams[writeParams.length - 1];
     ensure(writeValParam.type().isData(), "Write value type must be a data type");
 
     ensure(readFunction.returnType().isTrivialCastTo(resultType()),
         "Read return type must match result type");
     ensure(writeValParam.type().isTrivialCastTo(resultType()),
         "Write value type must match result type");
-    if (hasAddress()) {
-      ensure(readParam.type().isTrivialCastTo(addressType()),
-          "Read address type must match address type");
-      ensure(writeAddrParam.type().isTrivialCastTo(addressType()),
-          "Write address type must match address type");
-    }
   }
 
   @Override
@@ -146,5 +144,10 @@ public class ArtificialResource extends Resource {
   @Override
   public void accept(DefinitionVisitor visitor) {
     visitor.visit(this);
+  }
+
+  @Override
+  public String toString() {
+    return "alias " + kind().name().toLowerCase() + " " + identifier.simpleName() + ": " + type();
   }
 }

--- a/vadl/main/vadl/viam/Constant.java
+++ b/vadl/main/vadl/viam/Constant.java
@@ -748,6 +748,17 @@ public abstract class Constant {
       return fromInteger(BigInteger.ONE, type);
     }
 
+    /**
+     * Returns true if the memory value representation of this constant is equal to the
+     * other constant.
+     * This does not compare the types of the constants.
+     */
+    public boolean equalValue(Constant other) {
+      if (!(other instanceof Constant.Value otherValue)) {
+        return false;
+      }
+      return value.equals(otherValue.value);
+    }
 
     @Override
     public boolean equals(Object o) {

--- a/vadl/main/vadl/viam/Procedure.java
+++ b/vadl/main/vadl/viam/Procedure.java
@@ -45,6 +45,7 @@ public class Procedure extends Definition implements DefProp.WithBehavior {
     this.parameters = parameters;
     this.behavior = behavior;
     this.behavior.setParentDefinition(this);
+    Arrays.stream(parameters).forEach(p -> p.setParent(this));
   }
 
   public Parameter[] parameters() {

--- a/vadl/main/vadl/viam/RegisterTensor.java
+++ b/vadl/main/vadl/viam/RegisterTensor.java
@@ -17,6 +17,7 @@
 package vadl.viam;
 
 import com.google.common.collect.Streams;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -75,16 +76,16 @@ public class RegisterTensor extends Resource {
   }
 
   private final List<Dimension> dimensions;
-  private final Constraint[] constraints;
+  private final List<Constraint> constraints;
 
   /**
    * Constructs the register tensor.
    */
-  public RegisterTensor(Identifier identifier, List<Dimension> dimensions,
-                        Constraint[] constraints) {
+  public RegisterTensor(Identifier identifier,
+                        List<Dimension> dimensions) {
     super(identifier);
     this.dimensions = dimensions;
-    this.constraints = constraints;
+    this.constraints = new ArrayList<>();
   }
 
   public int dimCount() {
@@ -102,6 +103,7 @@ public class RegisterTensor extends Resource {
   public List<Dimension> indexDimensions() {
     return dimensions.subList(0, maxNumberOfAccessIndices());
   }
+
 
   public int maxNumberOfAccessIndices() {
     return dimCount() - 1;
@@ -131,8 +133,13 @@ public class RegisterTensor extends Resource {
     return dimensions.getLast();
   }
 
+  // TODO: Refactor this to return a list instead of an array
   public Constraint[] constraints() {
-    return constraints;
+    return constraints.toArray(new Constraint[0]);
+  }
+
+  public void addConstraint(Constraint constraint) {
+    constraints.add(constraint);
   }
 
   @Override

--- a/vadl/main/vadl/viam/RegisterTensor.java
+++ b/vadl/main/vadl/viam/RegisterTensor.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import vadl.types.BitsType;
 import vadl.types.ConcreteRelationType;
@@ -251,6 +252,12 @@ public class RegisterTensor extends Resource {
           "Provided index type does not match respective tensor image type: %s != %s",
           provided, actual);
     });
+  }
+
+  @Override
+  public String toString() {
+    var indices = dimensions.stream().map(d -> "<" + d.size() + ">").collect(Collectors.joining());
+    return "register " + simpleName() + ": Bits" + indices;
   }
 
   /**

--- a/vadl/main/vadl/viam/graph/Graph.java
+++ b/vadl/main/vadl/viam/graph/Graph.java
@@ -23,6 +23,8 @@ import com.google.errorprone.annotations.FormatMethod;
 import com.google.errorprone.annotations.FormatString;
 import com.google.errorprone.annotations.concurrent.LazyInit;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -453,9 +455,24 @@ public class Graph {
   /**
    * Copies the graph and returns it.
    *
-   * @param name the name of the copied graph
+   * @param name of the new graph
+   * @return the collection of nodes that were added
    */
   public Graph copy(String name) {
+    // create new empty graph instance
+    var graph = createEmptyInstance(name, this.parentDefinition());
+    copyInto(graph);
+    return graph;
+  }
+
+  /**
+   * Copy all nodes in this graph into the given graph and return all nodes
+   * that were added to the new graph.
+   *
+   * @param graph the graph all nodes should be copied to
+   * @return the collection of nodes that were added
+   */
+  public Collection<Node> copyInto(Graph graph) {
     // The process of coping a graph:
     // 1. Make a shallow copy of each node in the graph.
     //    This will return an uninitialized new node that is linked (input/successor) to
@@ -505,19 +522,17 @@ public class Graph {
       });
     });
 
-    // create new empty graph instance
-    var graph = createEmptyInstance(name, this.parentDefinition());
-
+    var added = new HashSet<Node>();
     // add all nodes to the graph
     cache.values().forEach(newNode -> {
       if (newNode.isUninitialized()) {
         // only if not yet initialized
         // might be initialized because of recursive input addition
-        graph.addWithInputs(newNode);
+        added.add(graph.addWithInputs(newNode));
       }
     });
 
-    return graph;
+    return added;
   }
 
   /**

--- a/vadl/main/vadl/viam/graph/control/AbstractEndNode.java
+++ b/vadl/main/vadl/viam/graph/control/AbstractEndNode.java
@@ -18,6 +18,7 @@ package vadl.viam.graph.control;
 
 import java.util.List;
 import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
 import vadl.javaannotations.viam.Input;
 import vadl.viam.graph.GraphVisitor;
 import vadl.viam.graph.Node;
@@ -41,6 +42,23 @@ public abstract class AbstractEndNode extends ControlNode {
 
   public NodeList<SideEffectNode> sideEffects() {
     return sideEffects;
+  }
+
+  /**
+   * Remove a side effect from this node.
+   * If the side effect is present multiple times, it will only remove the first occurrence.
+   */
+  public void removeSideEffect(SideEffectNode sideEffect) {
+    sideEffects.remove(sideEffect);
+    sideEffect.removeUsage(this);
+  }
+
+  @Nonnull
+  @Override
+  public DirectionalNode predecessor() {
+    var superNode = super.predecessor();
+    ensure(superNode instanceof DirectionalNode, "Invalid predecessor %s", superNode);
+    return (DirectionalNode) superNode;
   }
 
   @Override

--- a/vadl/main/vadl/viam/graph/control/BranchEndNode.java
+++ b/vadl/main/vadl/viam/graph/control/BranchEndNode.java
@@ -16,7 +16,6 @@
 
 package vadl.viam.graph.control;
 
-import javax.annotation.Nonnull;
 import vadl.viam.graph.GraphNodeVisitor;
 import vadl.viam.graph.Node;
 import vadl.viam.graph.NodeList;
@@ -29,14 +28,6 @@ public class BranchEndNode extends AbstractEndNode {
   public BranchEndNode(
       NodeList<SideEffectNode> sideEffects) {
     super(sideEffects);
-  }
-
-  @Override
-  @Nonnull
-  public DirectionalNode predecessor() {
-    var superNode = super.predecessor();
-    ensure(superNode instanceof DirectionalNode, "Invalid predecessor %s", superNode);
-    return (DirectionalNode) superNode;
   }
 
   @Override

--- a/vadl/main/vadl/viam/graph/control/DirectionalNode.java
+++ b/vadl/main/vadl/viam/graph/control/DirectionalNode.java
@@ -63,6 +63,20 @@ public abstract class DirectionalNode extends ControlNode {
   }
 
   /**
+   * Same as {@code setNext(null)}, unlinks this node from the next node.
+   *
+   * <p><b>Note:</b> This operation leaves the graph in an inconsistent state.
+   *
+   * @return unlinked node (previous next node)
+   */
+  public ControlNode unlinkNext() {
+    ensure(next != null, "Next node is already null (unlinked)");
+    var n = this.next;
+    setNext(null);
+    return n;
+  }
+
+  /**
    * Inserts a direction node between this and the next node.
    * If the new node is not yet active, it will be added to the graph.
    *

--- a/vadl/main/vadl/viam/passes/functionInliner/ArtificialResInlinerPass.java
+++ b/vadl/main/vadl/viam/passes/functionInliner/ArtificialResInlinerPass.java
@@ -1,0 +1,143 @@
+// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.viam.passes.functionInliner;
+
+import static java.util.Objects.requireNonNull;
+
+import com.google.common.collect.Streams;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import javax.annotation.Nullable;
+import vadl.configuration.GeneralConfiguration;
+import vadl.pass.Pass;
+import vadl.pass.PassName;
+import vadl.pass.PassResults;
+import vadl.utils.ViamUtils;
+import vadl.viam.DefProp;
+import vadl.viam.Parameter;
+import vadl.viam.Specification;
+import vadl.viam.graph.Graph;
+import vadl.viam.graph.control.AbstractEndNode;
+import vadl.viam.graph.control.ProcEndNode;
+import vadl.viam.graph.control.StartNode;
+import vadl.viam.graph.dependency.ExpressionNode;
+import vadl.viam.graph.dependency.FuncParamNode;
+import vadl.viam.graph.dependency.ReadArtificialResNode;
+import vadl.viam.graph.dependency.WriteArtificialResNode;
+
+/**
+ * Inlines all {@link ReadArtificialResNode} and {@link WriteArtificialResNode}s in every
+ * behavior hold by a {@link vadl.viam.DefProp.WithBehavior} definition.
+ */
+public class ArtificialResInlinerPass extends Pass {
+
+  public ArtificialResInlinerPass(GeneralConfiguration configuration) {
+    super(configuration);
+  }
+
+  @Override
+  public PassName getName() {
+    return new PassName("Artificial Resource Inliner");
+  }
+
+  @Nullable
+  @Override
+  public Object execute(PassResults passResults, Specification viam) throws IOException {
+    ViamUtils.findDefinitionsByFilter(viam, d -> d instanceof DefProp.WithBehavior)
+        .stream()
+        .flatMap(d -> ((DefProp.WithBehavior) d).behaviors().stream())
+        .forEach(behavior -> {
+          inlineReads(behavior);
+          inlineWrites(behavior);
+        });
+
+    return null;
+  }
+
+  private static void inlineReads(Graph behavior) {
+    behavior.getNodes(ReadArtificialResNode.class)
+        .toList()
+        .forEach(node -> {
+          node.replaceAndDelete(
+              FunctionInlinerPass.inline(node.resourceDefinition().readFunction(), node.indices()));
+        });
+  }
+
+  private static void inlineWrites(Graph behavior) {
+    behavior.getNodes(WriteArtificialResNode.class)
+        .toList()
+        .forEach(e -> {
+          e.usages()
+              .toList()
+              .forEach(usage ->
+                  inlineResWrite(e, (AbstractEndNode) usage));
+          e.safeDelete();
+        });
+  }
+
+  private static void inlineResWrite(WriteArtificialResNode write, AbstractEndNode endNode) {
+    var thisBehavior = requireNonNull(write.graph());
+
+    var proc = write.resourceDefinition().writeProcedure();
+    // copy all nodes from the artificial write procedure into this behavior
+    var addedNodes = proc.behavior().copyInto(thisBehavior);
+
+    final var copyEnd = addedNodes.stream().filter(ProcEndNode.class::isInstance)
+        .map(ProcEndNode.class::cast).findFirst().orElseThrow();
+    final var copyStart = addedNodes.stream().filter(StartNode.class::isInstance)
+        .map(StartNode.class::cast).findFirst().orElseThrow();
+
+    // map all params to passed argument expressions
+    var params = proc.parameters();
+    var paramToArg = new HashMap<Parameter, ExpressionNode>();
+    Streams.forEachPair(
+        Arrays.stream(params),
+        write.indices().stream(), paramToArg::put);
+    // last param is always the value to write
+    paramToArg.put(params[params.length - 1], write.value());
+    // replace used parameter (FuncParamNode) by the argument expression
+    addedNodes.stream().filter(FuncParamNode.class::isInstance)
+        .map(FuncParamNode.class::cast)
+        .forEach(usedParam ->
+            usedParam.replaceAndDelete(
+                requireNonNull(paramToArg.get(usedParam.parameter()))
+            ));
+
+    // move all side effects of the procedure end node to the current end node
+    for (var sideEffect : copyEnd.sideEffects()) {
+      endNode.addSideEffect(sideEffect);
+    }
+
+    // remove the copied end node
+    var copyEndPred = copyEnd.predecessor();
+    copyEndPred.unlinkNext();
+    copyEnd.replaceAndDelete(endNode);
+
+    if (copyStart != copyEndPred) {
+      // if there is control flow, we link it into this control flow
+      var copySucc = copyStart.unlinkNext();
+      var endPred = endNode.predecessor();
+      endPred.setNext(copySucc);
+      copyEndPred.setNext(endNode);
+    } else {
+      copyStart.safeDelete();
+    }
+
+    endNode.removeSideEffect(write);
+  }
+}

--- a/vadl/main/vadl/viam/passes/functionInliner/FunctionInlinerPass.java
+++ b/vadl/main/vadl/viam/passes/functionInliner/FunctionInlinerPass.java
@@ -22,7 +22,6 @@ import com.google.common.collect.Streams;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.IdentityHashMap;
-import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import vadl.configuration.GeneralConfiguration;
@@ -30,6 +29,8 @@ import vadl.pass.Pass;
 import vadl.pass.PassName;
 import vadl.pass.PassResults;
 import vadl.utils.Pair;
+import vadl.utils.ViamUtils;
+import vadl.viam.DefProp;
 import vadl.viam.Instruction;
 import vadl.viam.Relocation;
 import vadl.viam.Specification;
@@ -66,27 +67,33 @@ public class FunctionInlinerPass extends Pass {
   public Object execute(PassResults passResults, Specification viam) throws IOException {
     IdentityHashMap<Instruction, UninlinedGraph> behaviors = new IdentityHashMap<>();
 
-    instructions(viam, behaviors);
+    allWithBehavior(viam, behaviors);
 
     return new Output(behaviors);
   }
 
-  private void instructions(Specification viam,
-                            IdentityHashMap<Instruction, UninlinedGraph> behaviors) {
+  private void allWithBehavior(Specification viam,
+                               IdentityHashMap<Instruction, UninlinedGraph> behaviors) {
 
-    viam.isa().map(isa -> isa.ownInstructions().stream()).orElse(Stream.empty())
-        .forEach(instruction -> {
-          behaviors.put(instruction, handleMainBehavior(instruction));
+    ViamUtils.findDefinitionsByFilter(viam, d -> d instanceof DefProp.WithBehavior)
+        .stream()
+        .map(DefProp.WithBehavior.class::cast)
+        .forEach(withBehavior -> {
+          var uninlinedGraph = handleMainBehavior(withBehavior);
+          var def = withBehavior.asDefinition();
+          if (def instanceof Instruction instr) {
+            behaviors.put(instr, uninlinedGraph);
+          }
         });
   }
 
-  private UninlinedGraph handleMainBehavior(Instruction instruction) {
-    var copy = instruction.behavior().copy();
-    return inline(instruction, copy);
+  private UninlinedGraph handleMainBehavior(DefProp.WithBehavior def) {
+    var copy = def.behaviors().getFirst().copy();
+    return inline(def, copy);
   }
 
-  private @Nonnull UninlinedGraph inline(Instruction instruction, Graph copy) {
-    var functionCalls = instruction.behavior().getNodes(FuncCallNode.class)
+  private @Nonnull UninlinedGraph inline(DefProp.WithBehavior def, Graph copy) {
+    var functionCalls = def.behaviors().getFirst().getNodes(FuncCallNode.class)
         .filter(funcCallNode -> funcCallNode.function().behavior().isPureFunction())
         .filter(funcCallNode -> !(funcCallNode.function() instanceof Relocation))
         .toList();
@@ -110,6 +117,6 @@ public class FunctionInlinerPass extends Pass {
       functionCall.replaceAndDelete(returnNode.value().copy());
     });
 
-    return new UninlinedGraph(copy, instruction);
+    return new UninlinedGraph(copy, def.asDefinition());
   }
 }

--- a/vadl/test/resources/scripts/iss_qemu/compilers/riscv_compiler.py
+++ b/vadl/test/resources/scripts/iss_qemu/compilers/riscv_compiler.py
@@ -55,13 +55,14 @@ async def build_assembly(id: str, core: str) -> Path:
   # shutdown simulation with exit(0)
   addi x1, x0, 1
   la x2, tohost
-  sd x1, 0(x2)
-  
+  sw x1, 0(x2)
+  sw x0, 4(x2)
+
   .section .tohost, "aw", @progbits
-  .align 6; 
+  .align 6;
   .global tohost; 
   tohost: .dword 0; 
-  .size tohost, 8;    
+  .size tohost, 8;
   .align 6; 
   .global fromhost; 
   fromhost: .dword 0; 

--- a/vadl/test/resources/testSource/sys/risc-v/rvcsr.vadl
+++ b/vadl/test/resources/testSource/sys/risc-v/rvcsr.vadl
@@ -134,17 +134,19 @@ instruction set architecture RV32IZicsr extending RV3264Base = {
     // mstatus.mpp  := PRV::M // we only support machine mode at the moment
     // mstatus.mie  := 0
     // clear two lsb
-    PC := mtvec & ~0x3
+    PC := mtvec
   }
 
   //// INSTRUCTIONS ////
 
-  // Environment Breakpoint
-  instruction EBREAK : Itype =
-    raise Exc(ExcCode::BREAKPOINT)
+  model ECallInstr (name : Id, imm : Lit, excCode: Id) : IsaDefs = {
+    instruction $name : Itype = raise Exc(ExcCode::$excCode)                    // ecall / ebreak instructions
+    encoding $name = {opcode = 0b111'0011, funct3 = 0b000, rd = 0b0'0000, rs1 = 0b0'0000, imm = $imm}
+    assembly $name = (mnemonic)
+    }
 
-  encoding EBREAK = { opcode = 0b111'0011, funct3 = 0b000, imm = 0b0000'0000'0001, rs1 = 0b00000, rd = 0b00000 }
-  assembly EBREAK = mnemonic
+  $ECallInstr (ECALL ; 0; M_ECALL)        // environment (sys) call
+  $ECallInstr (EBREAK; 1; BREAKPOINT)     // environment (sys) break
 
   // return from trap
   instruction MRET: Itype = {
@@ -158,15 +160,6 @@ instruction set architecture RV32IZicsr extending RV3264Base = {
   assembly MRET = mnemonic
 
   //// CSR INSTRUCTIONS ////
-
-  model ECallInstr (name : Id, imm : Lit, excCode: Id) : IsaDefs = {
-    instruction $name : Itype = { /* TODO: raise instr */ }  // ecall / ebreak instructions
-    encoding $name = {opcode = 0b111'0011, funct3 = 0b000, rd = 0b0'0000, rs1 = 0b0'0000, imm = $imm}
-    assembly $name = (mnemonic)
-    }
-
-  $ECallInstr (ECALL ; 0; M_ECALL)        // environment (sys) call
-  $ECallInstr (EBREAK; 1; BREAKPOINT)     // environment (sys) break
 
   // name = instruction id, funct3 opcode, offset = 4 for immediate else 0, csrStat = behavior
   model CsrBaseInstr (name : Id, funct3 : Bin, offset : Int, csrStat : Stat) : IsaDefs = {

--- a/vadl/test/resources/testSource/sys/risc-v/rvcsr.vadl
+++ b/vadl/test/resources/testSource/sys/risc-v/rvcsr.vadl
@@ -8,15 +8,7 @@ import rv3264im::{RV3264Base, RV3264M}
 instruction set architecture RV32IZicsr extending RV3264Base = {
 
   enumeration CsrDef : Bits<12> = // defined control and status register indices
-    { ustatus  = 0x000  //   0 User mode restricted view of mstatus
-    , uie      = 0x004  //   4 User mode Interrupt Enable
-    , utvec    = 0x005  //   5 User mode Trap VECtor base address
-    , uscratch = 0x040  //  64 User mode SCRATCH
-    , uepc     = 0x041  //  65 User mode Exception Program Counter
-    , ucause   = 0x042  //  66 User mode exception CAUSE
-    , utval    = 0x043  //  67 User mode Trap VALue
-    , uip      = 0x044  //  68 User mode Interrupt Pending
-    , mstatus  = 0x300  // 768 Machine STATUS
+    { mstatus  = 0x300  // 768 Machine STATUS
     , misa     = 0x301  // 769 Machine ISA
     , mie      = 0x304  // 772 Machine Interrupt Enable register
     , mtvec    = 0x305  // 773 Machine Trap VECtor base address
@@ -32,15 +24,7 @@ instruction set architecture RV32IZicsr extending RV3264Base = {
   using    CsrImplIndex = Bits<CsrIndexSize>   // index type for implemented CSR registers
 
   enumeration CsrImpl : CsrImplIndex =  // implemented control and status register indices
-    { ustatus        // 0x000  User mode restricted view of mstatus
-    , uie            // 0x004  User mode Interrupt Enable
-    , utvec          // 0x005  User mode Trap VECtor base address
-    , uscratch       // 0x040  User mode SCRATCH
-    , uepc           // 0x041  User mode Exception Program Counter
-    , ucause         // 0x042  User mode exception CAUSE
-    , utval          // 0x043  User mode Trap VALue
-    , uip            // 0x044  User mode Interrupt Pending
-    , mstatus        // 0x300  Machine STATUS
+    { mstatus        // 0x300  Machine STATUS
     , misa           // 0x301  Machine ISA
     , mie            // 0x304  Machine Interrupt Enable
     , mtvec          // 0x305  Machine Trap VECtor base address
@@ -55,15 +39,7 @@ instruction set architecture RV32IZicsr extending RV3264Base = {
 
   function CsrDefToImpl (csr : Bits<12>) -> CsrImplIndex = // map defined CSR index to implemented CSR index
     match csr with
-      { CsrDef::ustatus  => CsrImpl::ustatus        // 0x000  User mode restricted view of mstatus
-      , CsrDef::uie      => CsrImpl::uie            // 0x004  User mode Interrupt Enable
-      , CsrDef::utvec    => CsrImpl::utvec          // 0x005  User mode Trap VECtor base address
-      , CsrDef::uscratch => CsrImpl::uscratch       // 0x040  User mode SCRATCH
-      , CsrDef::uepc     => CsrImpl::uepc           // 0x041  User mode Exception Program Counter
-      , CsrDef::ucause   => CsrImpl::ucause         // 0x042  User mode exception CAUSE
-      , CsrDef::utval    => CsrImpl::utval          // 0x043  User mode Trap VALue
-      , CsrDef::uip      => CsrImpl::uip            // 0x044  User mode Interrupt Pending
-      , CsrDef::mstatus  => CsrImpl::mstatus        // 0x300  Machine STATUS
+      { CsrDef::mstatus  => CsrImpl::mstatus        // 0x300  Machine STATUS
       , CsrDef::misa     => CsrImpl::misa           // 0x301  Machine ISA
       , CsrDef::mie      => CsrImpl::mie            // 0x304  Machine Interrupt Enable
       , CsrDef::mtvec    => CsrImpl::mtvec          // 0x305  Machine Trap VECtor base address
@@ -78,15 +54,7 @@ instruction set architecture RV32IZicsr extending RV3264Base = {
 
   function CsrName(index : Bits<12>) -> String = 
     match index with
-      { CsrDef::ustatus  => "ustatus"        // User mode restricted view of mstatus
-      , CsrDef::uie      => "uie"            // User mode Interrupt Enable
-      , CsrDef::utvec    => "utvec"          // User mode Trap VECtor base address
-      , CsrDef::uscratch => "uscratch"       // User mode SCRATCH
-      , CsrDef::uepc     => "uepc"           // User mode Exception Program Counter
-      , CsrDef::ucause   => "ucause"         // User mode exception CAUSE
-      , CsrDef::utval    => "utval"          // User mode Trap VALue
-      , CsrDef::uip      => "uip"            // User mode Interrupt Pending
-      , CsrDef::mstatus  => "mstatus"        // Machine STATUS
+      { CsrDef::mstatus  => "mstatus"        // Machine STATUS
       , CsrDef::misa     => "misa"           // Machine ISA
       , CsrDef::mie      => "mie"            // Machine Interrupt Enable
       , CsrDef::mtvec    => "mtvec"          // Machine Trap VECtor base address
@@ -99,13 +67,97 @@ instruction set architecture RV32IZicsr extending RV3264Base = {
       , _                => hex( index )   
       }
 
-//  register CSR : Regs<CsrImpl::ImplLength> change when implemented
+  //// REGISTERS AND ALIASES ////
+
+  // register CSR : Regs<CsrImpl::ImplLength> change when implemented
   register CSR : CsrImplIndex -> Regs
+  // register Priv : PRV when enum as type supported
 
+  alias register mstatus: MachineStatus = CSR(CsrDefToImpl(CsrDef::mstatus))
+  alias register mtvec                  = CSR(CsrDefToImpl(CsrDef::mtvec))
+  alias register mepc                   = CSR(CsrDefToImpl(CsrDef::mepc))
+  alias register mcause                 = CSR(CsrDefToImpl(CsrDef::mcause))
+  alias register mtval                  = CSR(CsrDefToImpl(CsrDef::mtval))
 
-  exception IllegalInstruction = {
-
+  // privilege modes (internal)
+  enumeration PRV =
+  { U = 0
+  , S = 1
+  , RESERVED = 2
+  , M = 3
   }
+
+  format MachineStatus : Regs =
+  { sd    [31]
+  , wpri  [30..23]      // RV64 , wpri -> [31..23]
+  , tsr   [22]          // Trap SRET (supports intercepting SRET instruction)
+  , tw    [21]          // Timeout Wait (supports interception WFI instruction)
+  , tvm   [20]          // Trap Virtual Memory
+  , mxr   [19]          // Make eXecutable Readable
+  , sum   [18]          // Supervisor User Memory access permit
+  , mprv  [17]          // Modify PRiVilege
+  , xs    [16..15]      // additional eXtension user-mode Status (RO)
+  , fs    [14..13]      // Floating-point unit Status (WARL)
+  , mpp   [12..11]      // Previous Privilege Machine (WARL)
+  , wpri2 [10..9]
+  , spp   [8]           // Previous Privilege Supervisor (WARL)
+  , mpie  [7]           // Prior To Trap Interrupt-Enable Machine
+  , wpri1 [6]
+  , spie  [5]           // Prior To Trap Interrupt-Enable Supervisor
+  , upie  [4]           // Prior To Trap Interrupt-Enable User
+  , mie   [3]           // Interrupt-Enable Machine
+  , wpri0 [2]
+  , sie   [1]           // Interrupt-Enable Supervisor
+  , uie   [0]           // Interrupt-Enable User
+  }
+
+  //// EXCEPTION DEFINITION ////
+
+  // highest is semi-hosting (0x3f)
+  using ExcCodeSize = Bits<6>
+  enumeration ExcCode: ExcCodeSize =
+  { ILLEGAL_INSTR = 0x02
+  , BREAKPOINT    = 0x03
+  , M_ECALL       = 0x0B
+  }
+
+  model wCSR(csr: Val, val: Ex) : Stat = {
+    CSR(CsrDefToImpl($csr)) := $val
+  }
+
+  exception Exc(cause: ExcCodeSize) = {
+    mepc := PC
+    mcause := cause as Regs
+    mtval := 0
+    // add when alias definition implemented
+    // mstatus.mpie := mstatus.mie
+    // mstatus.mpp  := PRV::M // we only support machine mode at the moment
+    // mstatus.mie  := 0
+    // clear two lsb
+    PC := mtvec & ~0x3
+  }
+
+  //// INSTRUCTIONS ////
+
+  // Environment Breakpoint
+  instruction EBREAK : Itype =
+    raise Exc(ExcCode::BREAKPOINT)
+
+  encoding EBREAK = { opcode = 0b111'0011, funct3 = 0b000, imm = 0b0000'0000'0001, rs1 = 0b00000, rd = 0b00000 }
+  assembly EBREAK = mnemonic
+
+  // return from trap
+  instruction MRET: Itype = {
+    // mstatus.mpp := 0
+    // mstatus.mie := mstatus.mpie
+    // mstatus.mpie := 1
+    // Priv := mstatus.mpp
+    PC := mepc
+  }
+  encoding MRET  = { opcode = 0b111'0011, funct3 = 0b000, imm = 0b0011'0000'0010, rs1 = 0b00000, rd = 0b00000 }
+  assembly MRET = mnemonic
+
+  //// CSR INSTRUCTIONS ////
 
   model ECallInstr (name : Id, imm : Lit, excCode: Id) : IsaDefs = {
     instruction $name : Itype = { /* TODO: raise instr */ }  // ecall / ebreak instructions
@@ -121,7 +173,7 @@ instruction set architecture RV32IZicsr extending RV3264Base = {
     instruction $name : Itype =
       let csridx = CsrDefToImpl(imm) in
         if csridx = CsrImpl::ImplLength then
-          raise IllegalInstruction
+          raise Exc(ExcCode::ILLEGAL_INSTR)
         else
           $csrStat
     encoding $name = { opcode = 0b111'0011, funct3 = $funct3 + $offset}

--- a/vadl/test/resources/testSource/sys/risc-v/rvcsr.vadl
+++ b/vadl/test/resources/testSource/sys/risc-v/rvcsr.vadl
@@ -163,3 +163,33 @@ instruction set architecture RV32IZicsr extending RV3264Base = {
 }
 
 instruction set architecture RV32IMZicsr extending RV32IZicsr, RV3264M = { }
+
+processor Spike implements RV32IMZicsr = {
+    constant reset_vec_addr = 0x1000
+
+    reset = {
+      PC := reset_vec_addr
+    }
+
+    [ firmware ]
+    [ base: 0x80000000 ]
+    memory region [RAM] DRAM in MEM
+
+    memory region [ROM] MROM in MEM = {
+        MEM<4>(0x1000) := 0x00000297  // auipc t0, 0x0
+        MEM<4>(0x1004) := 0x02828613  // addi a2, t0, 40
+        // TODO: Replace this NOP by the correct instruction
+        // this processor has no zicsr extension
+        MEM<4>(0x1008) := 0x00000013  // addi x0, x0, 0
+        MEM<4>(0x100c) := 0x0202b583  // ld   a1, 32(t0)
+        MEM<4>(0x1010) := 0x0182b283  // ld   t0, 24(t0)
+        MEM<4>(0x1014) := 0x00028067  // jr   t0
+        // store start_addr in memory (0x80000000)
+        MEM<4>(0x1018) := 0x80000000  // lo32(start_addr)
+        MEM<4>(0x101c) := 0x00000000  // hi32(start_addr)
+        // we do not yet support a fdt, but we set the address,
+        // to keep the registers consistent with upstream
+        MEM<4>(0x1020) := 0x87e00000  // lo32(fdt_addr)
+        MEM<4>(0x1024) := 0x00000000  // hi32(fdt_addr)
+    }
+}

--- a/vadl/test/resources/testSource/sys/risc-v/rvcsr.vadl
+++ b/vadl/test/resources/testSource/sys/risc-v/rvcsr.vadl
@@ -230,13 +230,9 @@ processor Spike implements RV32IMZicsr = {
         // this processor has no zicsr extension:   0xf1402573  csrr   a0, mhartid
         MEM<4>(0x1008) := 0x00000013  // addi x0, x0, 0
 
-        if MLen = 32 then {
-            MEM<4>(0x100c) := 0x0202a583  // lw   a1, 32(t0)
-            MEM<4>(0x1010) := 0x0182a283  // lw   t0, 24(t0)
-        } else {
-            MEM<4>(0x100c) := 0x0202b583  // ld   a1, 32(t0)
-            MEM<4>(0x1010) := 0x0182b283  // ld   t0, 24(t0)
-        }
+        // 32-bit reset version
+        MEM<4>(0x100c) := 0x0202a583  // lw   a1, 32(t0)
+        MEM<4>(0x1010) := 0x0182a283  // lw   t0, 24(t0)
 
         MEM<4>(0x1014) := 0x00028067  // jr   t0
         // store start_addr in memory (0x80000000)

--- a/vadl/test/resources/testSource/sys/risc-v/rvcsr.vadl
+++ b/vadl/test/resources/testSource/sys/risc-v/rvcsr.vadl
@@ -102,7 +102,10 @@ instruction set architecture RV32IZicsr extending RV3264Base = {
 //  register CSR : Regs<CsrImpl::ImplLength> change when implemented
   register CSR : CsrImplIndex -> Regs
 
-  exception IllegalInstruction = {}
+
+  exception IllegalInstruction = {
+
+  }
 
   model ECallInstr (name : Id, imm : Lit, excCode: Id) : IsaDefs = {
     instruction $name : Itype = { /* TODO: raise instr */ }  // ecall / ebreak instructions
@@ -179,10 +182,17 @@ processor Spike implements RV32IMZicsr = {
         MEM<4>(0x1000) := 0x00000297  // auipc t0, 0x0
         MEM<4>(0x1004) := 0x02828613  // addi a2, t0, 40
         // TODO: Replace this NOP by the correct instruction
-        // this processor has no zicsr extension
+        // this processor has no zicsr extension:   0xf1402573  csrr   a0, mhartid
         MEM<4>(0x1008) := 0x00000013  // addi x0, x0, 0
-        MEM<4>(0x100c) := 0x0202b583  // ld   a1, 32(t0)
-        MEM<4>(0x1010) := 0x0182b283  // ld   t0, 24(t0)
+
+        if MLen = 32 then {
+            MEM<4>(0x100c) := 0x0202a583  // lw   a1, 32(t0)
+            MEM<4>(0x1010) := 0x0182a283  // lw   t0, 24(t0)
+        } else {
+            MEM<4>(0x100c) := 0x0202b583  // ld   a1, 32(t0)
+            MEM<4>(0x1010) := 0x0182b283  // ld   t0, 24(t0)
+        }
+
         MEM<4>(0x1014) := 0x00028067  // jr   t0
         // store start_addr in memory (0x80000000)
         MEM<4>(0x1018) := 0x80000000  // lo32(start_addr)

--- a/vadl/test/vadl/ast/AnnotationTest.java
+++ b/vadl/test/vadl/ast/AnnotationTest.java
@@ -79,7 +79,7 @@ public class AnnotationTest {
           %s
         
           %s
-          register file X : Bits<5> -> Bits<32>
+          register X : Bits<5> -> Bits<32>
         }
         """.formatted(otherDefs == null ? "" : otherDefs, annotation);
   }
@@ -106,7 +106,7 @@ public class AnnotationTest {
 
   @Test
   void zeroAnnoInvalidTarget2() {
-    var prog = zeroExtendTest("[ zero : Y(1)]", "register file Y: Bits<5> -> Bits<64>");
+    var prog = zeroExtendTest("[ zero : Y(1)]", "register Y: Bits<5> -> Bits<64>");
     var ast = VadlParser.parse(prog);
     var typechecker = new TypeChecker();
     var diag = Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));

--- a/vadl/test/vadl/iss/AsmTestBuilder.java
+++ b/vadl/test/vadl/iss/AsmTestBuilder.java
@@ -61,8 +61,9 @@ public abstract class AsmTestBuilder {
     );
   }
 
-  public void addLabel(String label) {
+  public AsmTestBuilder addLabel(String label) {
     add("%s:", label);
+    return this;
   }
 
   @FormatMethod

--- a/vadl/test/vadl/iss/IssInstrTest.java
+++ b/vadl/test/vadl/iss/IssInstrTest.java
@@ -21,6 +21,7 @@ import static vadl.iss.IssTestUtils.yamlToTestResult;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -60,6 +61,12 @@ public abstract class IssInstrTest extends QemuIssTest {
   public abstract Tool reference();
 
   public abstract Tool compiler();
+
+
+  protected final Stream<DynamicTest> runTest(
+      IssTestUtils.TestCase test) throws IOException {
+    return runTestsWith(1, (i) -> test);
+  }
 
   @SafeVarargs
   protected final Stream<DynamicTest> runTestsWith(
@@ -148,7 +155,13 @@ public abstract class IssInstrTest extends QemuIssTest {
               System.out.println("Test " + e.id());
               System.out.println("ASM: \n" + testSpec.asmCore());
               System.out.println("\nRan stages: " + e.completedStages());
-              System.out.println("Register tests: \n" + e.regTests());
+              System.out.println("Register tests: ");
+              e.regTests().stream()
+                  .sorted(Comparator.comparing(IssTestUtils.TestResult.RegTestResult::reg))
+                  .forEachOrdered(r -> {
+                    System.out.println(
+                        "- " + r.reg() + " exp: " + r.expected() + " act: " + r.actual());
+                  });
               System.out.println("Duration: " + e.duration());
 
               if (!success) {

--- a/vadl/test/vadl/iss/QemuIssTest.java
+++ b/vadl/test/vadl/iss/QemuIssTest.java
@@ -18,12 +18,13 @@ package vadl.iss;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.images.builder.ImageFromDockerfile;
-import org.testcontainers.shaded.org.checkerframework.checker.nullness.qual.Nullable;
 import vadl.DockerExecutionTest;
 import vadl.configuration.IssConfiguration;
 import vadl.pass.PassOrders;
@@ -90,7 +91,7 @@ public abstract class QemuIssTest extends DockerExecutionTest {
         }
 
         // generate iss image from the output path
-        return getIssImage(issOutputPath, configuration, "riscv64-softmmu");
+        return getIssImage(issOutputPath, configuration, "riscv64-softmmu", "riscv32-softmmu");
       } catch (IOException | DuplicatedPassKeyException e) {
         throw new RuntimeException(e);
       }
@@ -102,13 +103,13 @@ public abstract class QemuIssTest extends DockerExecutionTest {
    * This will produce a new image for the given generated iss sources.
    *
    * @param generatedIssSources the path to the generated ISS/QEMU sources.
-   * @param referenceTarget     The reference target that should also be compiled
+   * @param referenceTargets    The reference targets that should also be build
    *                            (e.g. riscv64-softmmu)
    * @return a new image that builds the ISS at build time.
    */
   private ImageFromDockerfile getIssImage(Path generatedIssSources,
                                           IssConfiguration configuration,
-                                          @Nullable String referenceTarget
+                                          String... referenceTargets
   ) {
 
     // get redis cache for faster compilation using sccache
@@ -117,7 +118,8 @@ public abstract class QemuIssTest extends DockerExecutionTest {
     var targetName = configuration.targetName().toLowerCase();
     var softmmuTarget = targetName + "-softmmu";
     var qemuBin = "qemu-system-" + targetName;
-    var refTarget = referenceTarget == null ? "" : "," + referenceTarget;
+    var refTargetString = Arrays.stream(referenceTargets).collect(Collectors.joining(","));
+    var refTarget = refTargetString.isEmpty() ? "" : "," + refTargetString;
 
     var dockerImage = new ImageFromDockerfile()
         .withDockerfileFromBuilder(d -> {

--- a/vadl/test/vadl/iss/riscv/AbstractIssRiscv32InstrTest.java
+++ b/vadl/test/vadl/iss/riscv/AbstractIssRiscv32InstrTest.java
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.iss.riscv;
+
+import java.util.Map;
+import vadl.iss.IssInstrTest;
+
+public abstract class AbstractIssRiscv32InstrTest extends IssInstrTest {
+
+
+  @Override
+  public Map<String, String> gdbRegMap() {
+    return AbstractIssRiscv64InstrTest.GDB_REF_MAP;
+  }
+
+  @Override
+  public Tool simulator() {
+    return new Tool("/qemu/build/qemu-system-rv32imzicsr", "-bios");
+  }
+
+  @Override
+  public Tool reference() {
+    return new Tool("/qemu/build/qemu-system-riscv32", "-M spike -bios");
+  }
+
+  @Override
+  public Tool compiler() {
+    return new Tool("/scripts/compilers/riscv_compiler.py", "-march=rv32imzicsr -mabi=ilp32");
+  }
+
+}

--- a/vadl/test/vadl/iss/riscv/IssRV32ZicsrInstrTest.java
+++ b/vadl/test/vadl/iss/riscv/IssRV32ZicsrInstrTest.java
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.iss.riscv;
+
+import java.io.IOException;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+import vadl.iss.AsmTestBuilder;
+import vadl.iss.IssTestUtils;
+
+public class IssRV32ZicsrInstrTest extends AbstractIssRiscv32InstrTest {
+  private static final String VADL_SPEC = "sys/risc-v/rvcsr.vadl";
+  private static final int TESTS_PER_INSTRUCTION = 50;
+
+  @Override
+  public int getTestPerInstruction() {
+    return TESTS_PER_INSTRUCTION;
+  }
+
+  @Override
+  public String getVadlSpec() {
+    return VADL_SPEC;
+  }
+
+  @Override
+  public AsmTestBuilder getBuilder(String testNamePrefix, int id) {
+    return new RV64IMTestBuilder(testNamePrefix + "_" + id);
+  }
+
+  @TestFactory
+  Stream<DynamicTest> testSimpleTrap() throws IOException {
+    var asmCore = """
+        la t0, handler
+        csrw mtvec, t0
+        
+        li a2, 1
+        li a0, 1
+        li a1, 1
+        ebreak
+        li a0, 2
+        j exit
+        
+        handler:
+        csrr t1, mepc
+        addi t1, t1, 4
+        csrw mepc, t1
+        addi t2, x0, 5
+        csrr a3, mcause
+        mret
+        
+        li a2, 2 # should not reach this 
+        
+        exit:
+        """;
+    return runTest(new IssTestUtils.TestCase("Simple Trap", asmCore));
+  }
+
+
+}


### PR DESCRIPTION
This PR adds support for the `rv32csr.vadl` specification.

The most important change that was necessary was the implementation of the null register annotation.