### PR TITLE
parser: Improve error message

### DIFF
--- a/buildSrc/src/main/kotlin/vadl/CocoR.gradle.kts
+++ b/buildSrc/src/main/kotlin/vadl/CocoR.gradle.kts
@@ -26,6 +26,10 @@ open class GenerateCocoParserTask @Inject constructor(
     @InputFile
     val cocoJar = project.objects.fileProperty()
 
+    @InputFile
+    @Optional
+    val parserFrame = project.objects.fileProperty()
+
     @OutputDirectory
     val outputDir =
         project.objects.directoryProperty().convention(
@@ -40,10 +44,21 @@ open class GenerateCocoParserTask @Inject constructor(
             outputDirFile.mkdirs()
         }
 
+        val opts = mutableListOf<String>()
+        if (parserFrame.isPresent) {
+            opts.add("-P")
+            opts.add(parserFrame.get().asFile.absolutePath)
+        }
+
         inputFiles.files.forEach {
             println("Generating from $it...")
             execOps.exec {
-                commandLine("java", "-jar", cocoJar.get().asFile.absolutePath, "-o", outputDirFile.path, it)
+                commandLine(
+                    "java", "-jar", cocoJar.get().asFile.absolutePath,
+                    "-o", outputDirFile.path,
+                    *opts.toTypedArray(),
+                    it
+                )
             }
             println("------")
         }

--- a/vadl/build.gradle.kts
+++ b/vadl/build.gradle.kts
@@ -75,7 +75,7 @@ tasks.withType<Checkstyle> {
 tasks.register<CocoR_gradle.GenerateCocoParserTask>("generateCocoParser") {
     group = "build"
     inputFiles.from("main/vadl/ast/vadl.ATG")
-    parserFrame.set(project.file("main/vadl/ast/parser.frame"))
+    parserFrame.set(project.file("main/vadl/ast/Parser.frame"))
     outputDir.set(outputDir.get().dir("vadl/ast"))
     cocoJar.set(project.file("libs/Coco.jar"))
 }

--- a/vadl/build.gradle.kts
+++ b/vadl/build.gradle.kts
@@ -75,6 +75,7 @@ tasks.withType<Checkstyle> {
 tasks.register<CocoR_gradle.GenerateCocoParserTask>("generateCocoParser") {
     group = "build"
     inputFiles.from("main/vadl/ast/vadl.ATG")
+    parserFrame.set(project.file("main/vadl/ast/parser.frame"))
     outputDir.set(outputDir.get().dir("vadl/ast"))
     cocoJar.set(project.file("libs/Coco.jar"))
 }

--- a/vadl/main/vadl/ast/Parser.frame
+++ b/vadl/main/vadl/ast/Parser.frame
@@ -144,10 +144,15 @@ class Errors {
 	}
 	
 	public void SynErr (int line, int col, int n) {
-		String s;
-		switch (n) {-->errors
-			default: s = "error " + n; break;
-		}
+		String s = ParserUtils.EXPECTED_STRS.length > n
+		  ? ParserUtils.EXPECTED_STRS[n] : null;
+		if (s != null) {
+		  s = "`" + s + "` expected";
+		} else {
+      switch (n) {-->errors
+        default: s = "error " + n; break;
+      }
+    }
 		printMsg(line, col, s);
 		count++;
 	}

--- a/vadl/main/vadl/ast/ParserUtils.java
+++ b/vadl/main/vadl/ast/ParserUtils.java
@@ -45,6 +45,9 @@ class ParserUtils {
   static boolean[] BIN_OPS_EXCEPT_GT;
   static boolean[] BIN_OPS_EXCEPT_IN;
   static boolean[] UN_OPS;
+  // an array of literal and symbol representations that are used for a
+  // good parse error message such as "`(` expected".
+  static String[] EXPECTED_STRS;
 
   // Must be kept in sync with allowedIdentifierKeywords
   static boolean[] ID_TOKENS;
@@ -164,6 +167,62 @@ class ParserUtils {
     AUX_FIELD_TOKENS = NO_OPS.clone();
     AUX_FIELD_TOKENS[Parser._PREDICATE] = true;
     AUX_FIELD_TOKENS[Parser._ENCODE] = true;
+
+
+    EXPECTED_STRS = new String[NO_OPS.length];
+    EXPECTED_STRS[Parser._SYM_ARROW] = "->";
+    EXPECTED_STRS[Parser._SYM_ASSIGN] = ":=";
+    EXPECTED_STRS[Parser._SYM_AT] = "@";
+    EXPECTED_STRS[Parser._SYM_BIGARROW] = "=>";
+    EXPECTED_STRS[Parser._SYM_BINAND] = "&";
+    EXPECTED_STRS[Parser._SYM_BINOR] = "|";
+    EXPECTED_STRS[Parser._SYM_BRACE_CLOSE] = "}";
+    EXPECTED_STRS[Parser._SYM_BRACE_OPEN] = "{";
+    EXPECTED_STRS[Parser._SYM_BRACK_CLOSE] = "]";
+    EXPECTED_STRS[Parser._SYM_BRACK_OPEN] = "[";
+    EXPECTED_STRS[Parser._SYM_CARET] = "^";
+    EXPECTED_STRS[Parser._SYM_COLON] = ":";
+    EXPECTED_STRS[Parser._SYM_COMMA] = ",";
+    EXPECTED_STRS[Parser._SYM_DIV] = "/";
+    EXPECTED_STRS[Parser._SYM_DOLLAR] = "$";
+    EXPECTED_STRS[Parser._SYM_DOT] = ".";
+    EXPECTED_STRS[Parser._SYM_ELEM_OF] = "∈";
+    EXPECTED_STRS[Parser._SYM_EQ] = "=";
+    EXPECTED_STRS[Parser._SYM_EXCL] = "!";
+    EXPECTED_STRS[Parser._SYM_GT] = ">";
+    EXPECTED_STRS[Parser._SYM_GTE] = ">=";
+    EXPECTED_STRS[Parser._SYM_IN] = "in";
+    EXPECTED_STRS[Parser._SYM_LOGAND] = "&&";
+    EXPECTED_STRS[Parser._SYM_LOGOR] = "||";
+    EXPECTED_STRS[Parser._SYM_LONG_MUL] = "*#";
+    EXPECTED_STRS[Parser._SYM_LT] = "<";
+    EXPECTED_STRS[Parser._SYM_LTE] = "<=";
+    EXPECTED_STRS[Parser._SYM_MINUS] = "-";
+    EXPECTED_STRS[Parser._SYM_MOD] = "%";
+    EXPECTED_STRS[Parser._SYM_MUL] = "*";
+    EXPECTED_STRS[Parser._SYM_NAMESPACE] = "::";
+    EXPECTED_STRS[Parser._SYM_NEQ] = "!=";
+    EXPECTED_STRS[Parser._SYM_NIN] = "!in";
+    EXPECTED_STRS[Parser._SYM_NOT_ELEM_OF] = "∉";
+    EXPECTED_STRS[Parser._SYM_PAREN_CLOSE] = ")";
+    EXPECTED_STRS[Parser._SYM_PAREN_OPEN] = "(";
+    EXPECTED_STRS[Parser._SYM_PLUS] = "+";
+    EXPECTED_STRS[Parser._SYM_PLUS_EQ] = "+=";
+    EXPECTED_STRS[Parser._SYM_QUESTION] = "?";
+    EXPECTED_STRS[Parser._SYM_RANGE] = "..";
+    EXPECTED_STRS[Parser._SYM_ROTL] = "<<>";
+    EXPECTED_STRS[Parser._SYM_ROTR] = "<>>";
+    EXPECTED_STRS[Parser._SYM_SAT_ADD] = "+|";
+    EXPECTED_STRS[Parser._SYM_SAT_SUB] = "-|";
+    EXPECTED_STRS[Parser._SYM_SEMICOLON] = ";";
+    EXPECTED_STRS[Parser._SYM_SHL] = "<<";
+    EXPECTED_STRS[Parser._SYM_SHR] = ">>";
+    EXPECTED_STRS[Parser._SYM_TILDE] = "~";
+    EXPECTED_STRS[Parser._SYM_UNDERSCORE] = "_";
+    // set literals produced by scanner
+    for (var l : Scanner.literals.entrySet()) {
+      EXPECTED_STRS[l.getValue()] = l.getKey();
+    }
   }
 
   /**


### PR DESCRIPTION
Improves several error messages and refactors code duplication in the `ParserUtils`

If one wants to invoke a none defined macro, the parser states this now. Instead of
```
error: Parsing Error
     ╭──[file:///Users/jozott/development/uni/dipl/iss-dev/code/open-vadl/out/test.vadl:1:24]
     │
   1 │ model outer() : Id = { $inner() }
     │                        ^ Expected node of type Id, received InvalidType - PlaceholderNode
     │ 
     The parser got confused at this point, probably because of a syntax error in your code.
```
we print
```
error: Parsing Error
     ╭──[file:///Users/jozott/development/uni/dipl/iss-dev/code/open-vadl/out/test.vadl:1:24]
     │
   1 │ model outer() : Id = { $inner() }
     │                        ^ Macro $inner used but not yet defined
     │ 
     The parser got confused at this point, probably because of a syntax error in your code.
```

In the event of syntax errors, literals and most symbols are no longer output according to their terminal rule name, but according to their actual representation.
Instead of 
```
error: Parsing Error
     ╭──[file:///Users/jozott/development/uni/dipl/iss-dev/code/open-vadl/out/test.vadl:3:7]
     │
   3 │ micro Test = {}
     │       ^ ARCHITECTURE expected
     │ 
     The parser got confused at this point, probably because of a syntax error in your code.
```
we now print
```
error: Parsing Error
     ╭──[file:///Users/jozott/development/uni/dipl/iss-dev/code/open-vadl/out/test.vadl:3:7]
     │
   3 │ micro Test = {}
     │       ^ `architecture` expected
     │ 
     The parser got confused at this point, probably because of a syntax error in your code.
```

and instead of
```
error: Parsing Error
     ╭──[file:///Users/jozott/development/uni/dipl/iss-dev/code/open-vadl/out/test.vadl:1:30]
     │
   1 │ model outer() : Id = { $inner() }
     │                              ^ SYM_BRACE_CLOSE expected
     │ 
     The parser got confused at this point, probably because of a syntax error in your code.
```
we print
```
error: Parsing Error
     ╭──[file:///Users/jozott/development/uni/dipl/iss-dev/code/open-vadl/out/test.vadl:1:30]
     │
   1 │ model outer() : Id = { $inner() }
     │                              ^ `)` expected
     │ 
     The parser got confused at this point, probably because of a syntax error in your code.
```
