### PR TITLE
lcb: Removed obsolete constant materialisation for i64

### DIFF
--- a/vadl/test/resources/snapshots/rv64im/InstrInfoTableGen.td
+++ b/vadl/test/resources/snapshots/rv64im/InstrInfoTableGen.td
@@ -4254,62 +4254,6 @@ def constMat2 : Instruction
 let Namespace = "processorNameValue";
 
 let OutOperandList = ( outs X:$rd );
-let InOperandList = ( ins bare_symbol:$symbol );
-
-let isTerminator  = 0;
-let isBranch      = 0;
-let isCall        = 0;
-let isReturn      = 0;
-let isPseudo      = 1;
-let isCodeGenOnly = 1;
-let mayLoad       = 0;
-let mayStore      = 0;
-let isBarrier     = 0;
-let isReMaterializable = 0;
-let isAsCheapAsAMove   = 0;
-
-let Constraints = "";
-let AddedComplexity = 0;
-
-let Uses = [  ];
-let Defs = [  ];
-}
-
-
-
-def constMat3 : Instruction
-{
-let Namespace = "processorNameValue";
-
-let OutOperandList = ( outs X:$rd );
-let InOperandList = ( ins bare_symbol:$symbol );
-
-let isTerminator  = 0;
-let isBranch      = 0;
-let isCall        = 0;
-let isReturn      = 0;
-let isPseudo      = 1;
-let isCodeGenOnly = 1;
-let mayLoad       = 0;
-let mayStore      = 0;
-let isBarrier     = 0;
-let isReMaterializable = 0;
-let isAsCheapAsAMove   = 0;
-
-let Constraints = "";
-let AddedComplexity = 0;
-
-let Uses = [  ];
-let Defs = [  ];
-}
-
-
-
-def constMat4 : Instruction
-{
-let Namespace = "processorNameValue";
-
-let OutOperandList = ( outs X:$rd );
 let InOperandList = ( ins bare_symbol:$imm );
 
 let isTerminator  = 0;

--- a/vadl/test/resources/testSource/sys/risc-v/rv64im.vadl
+++ b/vadl/test/resources/testSource/sys/risc-v/rv64im.vadl
@@ -95,26 +95,6 @@ application binary interface ABI for RV64IM = {
       ADDI { rd = rd, rs1 = rd, imm = lo( val ) }
    }
 
-   constant sequence( rd : Bits<5>, val : UInt<64> ) =
-   {
-      LUI { rd = rd, imm = to32AndHi( val ) }
-      ADDI { rd = rd, rs1 = rd, imm = to32AndLo ( val ) }
-      SLLI { rd = rd, rs1 = rd, sft = 16 }
-      ORI { rd = rd, rs1 = rd, imm = lowerHalfHi(val) }
-      SLLI { rd = rd, rs1 = rd, sft = 16 }
-      ORI { rd = rd, rs1 = rd, imm = lowerHalfLo(val) }
-   }
-
-  constant sequence( rd : Bits<5>, val : SInt<64> ) =
-   {
-      LUI { rd = rd, imm = to32AndHi( val ) }
-      ADDI { rd = rd, rs1 = rd, imm = to32AndLo ( val ) }
-      SLLI { rd = rd, rs1 = rd, sft = 16 }
-      ORI { rd = rd, rs1 = rd, imm = lowerHalfHi(val) }
-      SLLI { rd = rd, rs1 = rd, sft = 16 }
-      ORI { rd = rd, rs1 = rd, imm = lowerHalfLo(val) }
-   }
-
    constant sequence( rd : Bits<5>, imm : SInt<12> ) =
    {
       ADDI{ rd = rd, rs1 = 0, imm = imm }

--- a/vadl/test/vadl/lcb/riscv/riscv64/template/MCTargetDesc/EmitMCInstExpanderCppFilePassTest.java
+++ b/vadl/test/vadl/lcb/riscv/riscv64/template/MCTargetDesc/EmitMCInstExpanderCppFilePassTest.java
@@ -94,8 +94,6 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
             case processornamevalue::constMat0:
             case processornamevalue::constMat1:
             case processornamevalue::constMat2:
-            case processornamevalue::constMat3:
-            case processornamevalue::constMat4:
             case processornamevalue::registerAdjustment0:
             {
                 return true;
@@ -116,8 +114,6 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
             case processornamevalue::constMat0:
             case processornamevalue::constMat1:
             case processornamevalue::constMat2:
-            case processornamevalue::constMat3:
-            case processornamevalue::constMat4:
             case processornamevalue::registerAdjustment0:
             case processornamevalue::LA:
             case processornamevalue::LLA:
@@ -163,8 +159,6 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
             case processornamevalue::constMat0:
             case processornamevalue::constMat1:
             case processornamevalue::constMat2:
-            case processornamevalue::constMat3:
-            case processornamevalue::constMat4:
             case processornamevalue::registerAdjustment0:
             {
                 return true;
@@ -307,16 +301,6 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
               case processornamevalue::constMat2:
               {
                 constMat2_expand(MCI, callback, callbackSymbol );
-                return true;
-              }
-              case processornamevalue::constMat3:
-              {
-                constMat3_expand(MCI, callback, callbackSymbol );
-                return true;
-              }
-              case processornamevalue::constMat4:
-              {
-                constMat4_expand(MCI, callback, callbackSymbol );
                 return true;
               }
               case processornamevalue::registerAdjustment0:
@@ -873,136 +857,6 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
         
         
         std::vector<MCInst> processorNameValueMCInstExpander::constMat2_expand(const MCInst& instruction, std::function<void(const MCInst &)> callback, std::function<void(MCSymbol* )> callbackSymbol ) const
-        {
-           std::vector< MCInst > result;
-           MCInst a = MCInst();
-           a.setOpcode(processorNameValue::LUI);
-           a.addOperand(instruction.getOperand(0));
-           const MCExpr* b = MCOperandToMCExpr(instruction.getOperand(1));
-           const MCExpr* c = processorNameValueMCExpr::create(b, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264I_to32AndHi, Ctx);
-           const MCExpr* d = processorNameValueMCExpr::create(c, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264I_Utype_immUp, Ctx);
-           MCOperand e = MCOperand::createExpr(d);
-           a.addOperand(e);
-           result.push_back(a);
-           callback(a);
-           MCInst f = MCInst();
-           f.setOpcode(processorNameValue::ADDI);
-           f.addOperand(instruction.getOperand(0));
-           f.addOperand(instruction.getOperand(0));
-           const MCExpr* g = MCOperandToMCExpr(instruction.getOperand(1));
-           const MCExpr* h = processorNameValueMCExpr::create(g, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264I_to32AndLo, Ctx);
-           const MCExpr* i = processorNameValueMCExpr::create(h, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264I_Itype_immS, Ctx);
-           MCOperand j = MCOperand::createExpr(i);
-           f.addOperand(j);
-           result.push_back(f);
-           callback(f);
-           MCInst k = MCInst();
-           k.setOpcode(processorNameValue::SLLI);
-           k.addOperand(instruction.getOperand(0));
-           k.addOperand(instruction.getOperand(0));
-           k.addOperand(MCOperand::createImm(RV3264I_Ftype_shamt_decode(16)));
-           result.push_back(k);
-           callback(k);
-           MCInst l = MCInst();
-           l.setOpcode(processorNameValue::ORI);
-           l.addOperand(instruction.getOperand(0));
-           l.addOperand(instruction.getOperand(0));
-           const MCExpr* m = MCOperandToMCExpr(instruction.getOperand(1));
-           const MCExpr* n = processorNameValueMCExpr::create(m, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264I_lowerHalfHi, Ctx);
-           const MCExpr* o = processorNameValueMCExpr::create(n, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264I_Itype_immS, Ctx);
-           MCOperand p = MCOperand::createExpr(o);
-           l.addOperand(p);
-           result.push_back(l);
-           callback(l);
-           MCInst q = MCInst();
-           q.setOpcode(processorNameValue::SLLI);
-           q.addOperand(instruction.getOperand(0));
-           q.addOperand(instruction.getOperand(0));
-           q.addOperand(MCOperand::createImm(RV3264I_Ftype_shamt_decode(16)));
-           result.push_back(q);
-           callback(q);
-           MCInst r = MCInst();
-           r.setOpcode(processorNameValue::ORI);
-           r.addOperand(instruction.getOperand(0));
-           r.addOperand(instruction.getOperand(0));
-           const MCExpr* s = MCOperandToMCExpr(instruction.getOperand(1));
-           const MCExpr* t = processorNameValueMCExpr::create(s, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264I_lowerHalfLo, Ctx);
-           const MCExpr* u = processorNameValueMCExpr::create(t, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264I_Itype_immS, Ctx);
-           MCOperand v = MCOperand::createExpr(u);
-           r.addOperand(v);
-           result.push_back(r);
-           callback(r);
-           return result;
-        }
-        
-        
-        
-        std::vector<MCInst> processorNameValueMCInstExpander::constMat3_expand(const MCInst& instruction, std::function<void(const MCInst &)> callback, std::function<void(MCSymbol* )> callbackSymbol ) const
-        {
-           std::vector< MCInst > result;
-           MCInst a = MCInst();
-           a.setOpcode(processorNameValue::LUI);
-           a.addOperand(instruction.getOperand(0));
-           const MCExpr* b = MCOperandToMCExpr(instruction.getOperand(1));
-           const MCExpr* c = processorNameValueMCExpr::create(b, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264I_to32AndHi, Ctx);
-           const MCExpr* d = processorNameValueMCExpr::create(c, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264I_Utype_immUp, Ctx);
-           MCOperand e = MCOperand::createExpr(d);
-           a.addOperand(e);
-           result.push_back(a);
-           callback(a);
-           MCInst f = MCInst();
-           f.setOpcode(processorNameValue::ADDI);
-           f.addOperand(instruction.getOperand(0));
-           f.addOperand(instruction.getOperand(0));
-           const MCExpr* g = MCOperandToMCExpr(instruction.getOperand(1));
-           const MCExpr* h = processorNameValueMCExpr::create(g, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264I_to32AndLo, Ctx);
-           const MCExpr* i = processorNameValueMCExpr::create(h, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264I_Itype_immS, Ctx);
-           MCOperand j = MCOperand::createExpr(i);
-           f.addOperand(j);
-           result.push_back(f);
-           callback(f);
-           MCInst k = MCInst();
-           k.setOpcode(processorNameValue::SLLI);
-           k.addOperand(instruction.getOperand(0));
-           k.addOperand(instruction.getOperand(0));
-           k.addOperand(MCOperand::createImm(RV3264I_Ftype_shamt_decode(16)));
-           result.push_back(k);
-           callback(k);
-           MCInst l = MCInst();
-           l.setOpcode(processorNameValue::ORI);
-           l.addOperand(instruction.getOperand(0));
-           l.addOperand(instruction.getOperand(0));
-           const MCExpr* m = MCOperandToMCExpr(instruction.getOperand(1));
-           const MCExpr* n = processorNameValueMCExpr::create(m, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264I_lowerHalfHi, Ctx);
-           const MCExpr* o = processorNameValueMCExpr::create(n, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264I_Itype_immS, Ctx);
-           MCOperand p = MCOperand::createExpr(o);
-           l.addOperand(p);
-           result.push_back(l);
-           callback(l);
-           MCInst q = MCInst();
-           q.setOpcode(processorNameValue::SLLI);
-           q.addOperand(instruction.getOperand(0));
-           q.addOperand(instruction.getOperand(0));
-           q.addOperand(MCOperand::createImm(RV3264I_Ftype_shamt_decode(16)));
-           result.push_back(q);
-           callback(q);
-           MCInst r = MCInst();
-           r.setOpcode(processorNameValue::ORI);
-           r.addOperand(instruction.getOperand(0));
-           r.addOperand(instruction.getOperand(0));
-           const MCExpr* s = MCOperandToMCExpr(instruction.getOperand(1));
-           const MCExpr* t = processorNameValueMCExpr::create(s, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264I_lowerHalfLo, Ctx);
-           const MCExpr* u = processorNameValueMCExpr::create(t, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264I_Itype_immS, Ctx);
-           MCOperand v = MCOperand::createExpr(u);
-           r.addOperand(v);
-           result.push_back(r);
-           callback(r);
-           return result;
-        }
-        
-        
-        
-        std::vector<MCInst> processorNameValueMCInstExpander::constMat4_expand(const MCInst& instruction, std::function<void(const MCInst &)> callback, std::function<void(MCSymbol* )> callbackSymbol ) const
         {
            std::vector< MCInst > result;
            MCInst a = MCInst();


### PR DESCRIPTION
Follow-up of !213, since it added a method which checks whether the immediate fits into i32. If it does not then use the constant pool. This made the constant materialisation in the spec obsolete.