### PR TITLE
gcb: Added test for determining compiler kind

### DIFF
--- a/vadl/test/vadl/gcb/AbstractGcbTest.java
+++ b/vadl/test/vadl/gcb/AbstractGcbTest.java
@@ -17,6 +17,10 @@
 package vadl.gcb;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import vadl.configuration.GcbConfiguration;
 import vadl.cppCodeGen.AbstractCppCodeGenTest;
 import vadl.gcb.valuetypes.TargetName;
@@ -24,12 +28,16 @@ import vadl.pass.PassKey;
 import vadl.pass.PassOrder;
 import vadl.pass.PassOrders;
 import vadl.pass.exception.DuplicatedPassKeyException;
+import vadl.viam.Format;
+import vadl.viam.Instruction;
+import vadl.viam.Specification;
 
 public abstract class AbstractGcbTest extends AbstractCppCodeGenTest {
 
   @Override
   public GcbConfiguration getConfiguration(boolean doDump) {
-    return new GcbConfiguration(super.getConfiguration(doDump), new TargetName("processorNameValue"));
+    return new GcbConfiguration(super.getConfiguration(doDump),
+        new TargetName("processorNameValue"));
   }
 
   /**
@@ -45,5 +53,25 @@ public abstract class AbstractGcbTest extends AbstractCppCodeGenTest {
       throws IOException, DuplicatedPassKeyException {
     return setupPassManagerAndRunSpecUntil(specPath,
         PassOrders.gcbAndCppCodeGen(configuration), until);
+  }
+
+  /**
+   * Helper method to get an {@link Instruction} from a {@link Specification}.
+   */
+  @Nullable
+  protected Instruction getInstrByName(String instruction,
+                                       Specification specification) {
+    return specification.isa().stream().flatMap(x -> x.ownInstructions().stream())
+        .filter(x -> x.simpleName().equals(instruction))
+        .findFirst()
+        .get();
+  }
+
+  /**
+   * Helper method to extract an immediate.
+   */
+  protected @Nonnull Optional<Format.Field> getImmediate(String imm,
+                                                         List<Format.Field> immediates) {
+    return immediates.stream().filter(x -> x.identifier.simpleName().equals(imm)).findFirst();
   }
 }

--- a/vadl/test/vadl/gcb/riscv/riscv64/GenerateValueRangeImmediatePassTest.java
+++ b/vadl/test/vadl/gcb/riscv/riscv64/GenerateValueRangeImmediatePassTest.java
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-package vadl.gcb.passes;
+package vadl.gcb.riscv.riscv64;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -29,6 +29,9 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.shaded.org.checkerframework.checker.nullness.qual.Nullable;
 import vadl.gcb.AbstractGcbTest;
+import vadl.gcb.passes.GenerateValueRangeImmediatePass;
+import vadl.gcb.passes.ValueRange;
+import vadl.gcb.passes.ValueRangeCtx;
 import vadl.pass.PassKey;
 import vadl.pass.exception.DuplicatedPassKeyException;
 import vadl.utils.Pair;

--- a/vadl/test/vadl/gcb/riscv/riscv64/GenerateValueRangeImmediatePassTest.java
+++ b/vadl/test/vadl/gcb/riscv/riscv64/GenerateValueRangeImmediatePassTest.java
@@ -162,18 +162,4 @@ public class GenerateValueRangeImmediatePassTest extends AbstractGcbTest {
         .filter(x -> x.identifier.simpleName().equals(field))
         .findFirst().get();
   }
-
-  private static @Nonnull Optional<Format.Field> getImmediate(String imm,
-                                                              List<Format.Field> immediates) {
-    return immediates.stream().filter(x -> x.identifier.simpleName().equals(imm)).findFirst();
-  }
-
-  @Nullable
-  private Instruction getInstrByName(String instruction,
-                                     Specification specification) {
-    return specification.isa().map(x -> x.ownInstructions().stream()).orElse(Stream.empty())
-        .filter(x -> x.simpleName().equals(instruction))
-        .findFirst()
-        .get();
-  }
 }

--- a/vadl/test/vadl/gcb/riscv/riscv64/IdentifyFieldUsagePassTest.java
+++ b/vadl/test/vadl/gcb/riscv/riscv64/IdentifyFieldUsagePassTest.java
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-package vadl.gcb.passes;
+package vadl.gcb.riscv.riscv64;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
@@ -31,6 +31,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.shaded.org.checkerframework.checker.nullness.qual.Nullable;
 import vadl.gcb.AbstractGcbTest;
+import vadl.gcb.passes.IdentifyFieldUsagePass;
 import vadl.pass.PassKey;
 import vadl.pass.exception.DuplicatedPassKeyException;
 import vadl.viam.Format;

--- a/vadl/test/vadl/gcb/riscv/riscv64/IdentifyFieldUsagePassTest.java
+++ b/vadl/test/vadl/gcb/riscv/riscv64/IdentifyFieldUsagePassTest.java
@@ -275,18 +275,4 @@ public class IdentifyFieldUsagePassTest extends AbstractGcbTest {
             registerUsageAggregate -> registerUsageAggregate.identifier.simpleName().equals(reg))
         .findFirst();
   }
-
-  private static @Nonnull Optional<Format.Field> getImmediate(String imm,
-                                                              List<Format.Field> immediates) {
-    return immediates.stream().filter(x -> x.identifier.simpleName().equals(imm)).findFirst();
-  }
-
-  @Nullable
-  private Instruction getInstrByName(String instruction,
-                                     Specification specification) {
-    return specification.isa().map(x -> x.ownInstructions().stream()).orElse(Stream.empty())
-        .filter(x -> x.simpleName().equals(instruction))
-        .findFirst()
-        .get();
-  }
 }

--- a/vadl/test/vadl/gcb/riscv/riscv64/passes/DetermineRelocationTypeForFieldPassTest.java
+++ b/vadl/test/vadl/gcb/riscv/riscv64/passes/DetermineRelocationTypeForFieldPassTest.java
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.gcb.riscv.riscv64.passes;
+
+import java.io.IOException;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import vadl.gcb.AbstractGcbTest;
+import vadl.gcb.passes.IdentifyFieldUsagePass;
+import vadl.gcb.passes.RelocationKindCtx;
+import vadl.gcb.passes.relocation.model.CompilerRelocation;
+import vadl.pass.PassKey;
+import vadl.pass.exception.DuplicatedPassKeyException;
+
+class DetermineRelocationTypeForFieldPassTest extends AbstractGcbTest {
+
+  private static Stream<Arguments> interestingInstructions() {
+    return Stream.of(
+        Arguments.of("BEQ", "imm", CompilerRelocation.Kind.RELATIVE),
+        Arguments.of("BNE", "imm", CompilerRelocation.Kind.RELATIVE),
+        Arguments.of("BGE", "imm", CompilerRelocation.Kind.RELATIVE),
+        Arguments.of("BLT", "imm", CompilerRelocation.Kind.RELATIVE),
+        Arguments.of("BLTU", "imm", CompilerRelocation.Kind.RELATIVE)
+    );
+  }
+
+  /**
+   * We are using {@link #interestingInstructions()} and extracting only the instruction name
+   * so Intellij only shows the name as test parameter. Otherwise, it will show all three, however,
+   * field and compiler relocation kind are irrelevant.
+   */
+  private static Stream<Arguments> interestingInstructionsForRegisterTest() {
+    return interestingInstructions()
+        .map(arguments -> Arguments.of(arguments.get()[0]));
+  }
+
+  @MethodSource(value = "interestingInstructions")
+  @ParameterizedTest
+  void shouldDetermineCompilerRelocationKind(String instructionName,
+                                             String field,
+                                             CompilerRelocation.Kind kind)
+      throws IOException, DuplicatedPassKeyException {
+    // Given
+    var setup = runGcb(getConfiguration(false), "sys/risc-v/rv64im.vadl",
+        new PassKey(DetermineRelocationTypeForFieldPassTest.class.getName()));
+    var passManager = setup.passManager();
+
+    var container =
+        (IdentifyFieldUsagePass.ImmediateDetectionContainer) passManager.getPassResults()
+            .lastResultOf(IdentifyFieldUsagePass.class);
+
+    // When
+    // Pass no direct result
+
+    // Then
+    var instruction = getInstrByName(instructionName, setup.specification());
+    Assertions.assertNotNull(instruction);
+
+    var ctx = instruction.expectExtension(RelocationKindCtx.class);
+    Assertions.assertNotNull(ctx);
+
+    var immediates = container.getImmediates(instruction);
+    Assertions.assertNotNull(immediates);
+
+    var formatField = getImmediate(field, immediates);
+    Assertions.assertTrue(formatField.isPresent(), "Tested field is not an immediate field");
+
+    // The actual test is here.
+    Assertions.assertTrue(ctx.getFieldToKind().containsKey(formatField.get()),
+        "Tested field is not a relocation field");
+    Assertions.assertEquals(kind, ctx.getFieldToKind().get(formatField.get()));
+  }
+
+  @MethodSource(value = "interestingInstructionsForRegisterTest")
+  @ParameterizedTest
+  void shouldNotDetermineCompilerRelocationKindForRegisters(String instructionName)
+      throws IOException, DuplicatedPassKeyException {
+    // Given
+    var setup = runGcb(getConfiguration(false), "sys/risc-v/rv64im.vadl",
+        new PassKey(DetermineRelocationTypeForFieldPassTest.class.getName()));
+    var passManager = setup.passManager();
+
+    var container =
+        (IdentifyFieldUsagePass.ImmediateDetectionContainer) passManager.getPassResults()
+            .lastResultOf(IdentifyFieldUsagePass.class);
+
+    // When
+    // Pass no direct result
+
+    // Then
+    var instruction = getInstrByName(instructionName, setup.specification());
+    Assertions.assertNotNull(instruction);
+
+    var ctx = instruction.expectExtension(RelocationKindCtx.class);
+    Assertions.assertNotNull(ctx);
+
+    var registers = container.getRegisterUsages(instruction);
+    Assertions.assertNotNull(registers);
+
+    // The actual test is here.
+    for (var register : registers.keySet()) {
+      Assertions.assertFalse(ctx.getFieldToKind().containsKey(register),
+          "Register has relocation kind but must not");
+    }
+  }
+
+}


### PR DESCRIPTION
We already had a test with LLVM file check. However, this requires to compile LLVM. The test in this PR is faster and faster to execute. Additionally, it checks whether register fields have no compiler kind relocation.