### PR TITLE
sys:var-risc Fix opcode encoding of SYS insn

### DIFF
--- a/sys/v-risc/VarRisc.vadl
+++ b/sys/v-risc/VarRisc.vadl
@@ -20,7 +20,7 @@
  * distinguish 16 ("_S") and 48 bit ("_L") from 32 bit instructions. Short
  * instructions are available only as instructions with 2 operands, one source
  * operand is identical to the destination operand. Word instructions always
- * have 3 operands, long instructions can have 2 or 3 operands. 
+ * have 3 operands, long instructions can have 2 or 3 operands.
  * VarRISC32 is a simple load/store architecture similar to RISC-V 32IM, but
  * supports longer immediate values. All integer operations which are necessary
  * for compiler generation are available.
@@ -34,7 +34,7 @@ instruction set architecture VarRISC32 = {
   constant Size      = 32                // register size
   constant LinkIdx   = 31                // index of link register
 
-  using Regs         = Bits<Size>        // type for integer register 
+  using Regs         = Bits<Size>        // type for integer register
   using SIntR        = SInt<Size>        // register sized signed integer
   using UIntR        = UInt<Size>        // register sized unsigned integer
   using UIntM        = UInt<5>           // type for masking shift amounts
@@ -139,7 +139,7 @@ instruction set architecture VarRISC32 = {
 
   model SysCallInstr (name : Id, code : Val) : IsaDefs = {
     instruction $name : TYPE_I = {}
-    encoding $name = { opcode = ImmCode, func5 = $code }
+    encoding $name = { opcode = MemCode, func5 = $code }
     assembly $name = ( mnemonic, ' ', register(rd), ',', register(rs1), ',', decimal(imm) )
   }
 
@@ -177,7 +177,7 @@ instruction set architecture VarRISC32 = {
     instruction $name : TYPE_S =
       let retaddr = PC.next in {
         PC := R(rd)
-        R(rs1) := retaddr         
+        R(rs1) := retaddr
       }
     encoding $name = { opcode = $code }
     assembly $name = ( mnemonic, ' ', register(rd), ',', register(rs1) )
@@ -257,7 +257,7 @@ instruction set architecture VarRISC32 = {
 
 /* instruction encoding and opcode space of opcode and func5/func9
 TYPE_S opcode              0      1      2      3      4      5      6      7      8      9     10
-                         ADD_S  SUB_S  MUL_S  DIV_S  REM_S  AND_S   OR_S  XOR_S  ASR_S  LRS_S  LSL_S 
+                         ADD_S  SUB_S  MUL_S  DIV_S  REM_S  AND_S   OR_S  XOR_S  ASR_S  LRS_S  LSL_S
 TYPE_S opcode             11     12     13     14     15     16     17     18     19     20     21
                         ADDI_S SUBI_S MULI_S DIVI_S REMI_S ANDI_S  ORI_S XORI_S ASRI_S LSRI_S LSLI_S
 TYPE_S opcode             22     23     24     25
@@ -266,7 +266,7 @@ TYPE_S opcode             26     27     28     29     30     31
                          LDB_S  LDH_S  LDW_S  STB_S  STH_S  STW_S
 TYPE_L opcode             32     33     34     35     36     37     38     39     res   res   res    res  res    res
                          LDB_L  LDH_L  LDW_L  STB_L  STH_L  STW_L  LBU_L  LHU_L  Long Double Float  Long Double Float
-TYPE_L opcode             46     47     48     49     50     51   
+TYPE_L opcode             46     47     48     49     50     51
                          BEQ_L  BNE_L  BLT_L  BLE_L BULT_L BULE_L
 TYPE_L opcode             52     53     54     55     56     57     58     59
                         ADDI_L SUBI_L MULI_L DIVI_L REMI_L ANDI_L  ORI_L XORI_L


### PR DESCRIPTION
The instruction set has a conflict for the `BAL` and `SYS` instruction (`opcode: 62`, `func5: 31`) which currently have the same instruction patterns

This looks to me like a mistake in the macro definition of `SysCallInstr`, which should use `opcode 61` (`MemCode`) according to the op/fun-code table in the comment.

I fixed it, but please check if that's the correct replacement opcode.