### PR TITLE
frontend: Fix pretty print

### DIFF
--- a/vadl/main/vadl/ast/Definition.java
+++ b/vadl/main/vadl/ast/Definition.java
@@ -19,6 +19,7 @@ package vadl.ast;
 import com.google.errorprone.annotations.concurrent.LazyInit;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -4979,6 +4980,7 @@ class AsmDescriptionDefinition extends Definition implements IdentifiableNode {
     if (!commonDefinitions.isEmpty()) {
       for (var def : commonDefinitions) {
         def.prettyPrint(indent, builder);
+        builder.append("\n");
       }
     }
 
@@ -4992,11 +4994,11 @@ class AsmDescriptionDefinition extends Definition implements IdentifiableNode {
         }
         builder.append("\n");
       }
-      builder.append(prettyIndentString(--indent)).append("}\n");
+      builder.append(prettyIndentString(--indent)).append("}\n\n");
     }
 
     if (!directives.isEmpty()) {
-      builder.append(prettyIndentString(indent)).append("directives = {\n");
+      builder.append(prettyIndentString(indent)).append("directives = {\n\n");
       indent++;
       for (var dir : directives) {
         dir.prettyPrint(indent, builder);
@@ -5010,12 +5012,10 @@ class AsmDescriptionDefinition extends Definition implements IdentifiableNode {
 
     builder.append(prettyIndentString(indent)).append("grammar = {\n");
     indent++;
-    for (var rule : rules) {
+    var printableRules = rules.stream().filter(r -> !r.isBuiltinRule && !r.isTerminalRule).toList();
+    for (var rule : printableRules) {
       builder.append(prettyIndentString(indent));
       rule.prettyPrint(indent, builder);
-      if (!Objects.equals(rules.get(rules.size() - 1), rule)) {
-        builder.append("\n");
-      }
     }
     builder.append(prettyIndentString(--indent)).append("}\n");
 
@@ -5030,9 +5030,11 @@ class AsmDescriptionDefinition extends Definition implements IdentifiableNode {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
+
     AsmDescriptionDefinition that = (AsmDescriptionDefinition) o;
     return Objects.equals(id, that.id) && Objects.equals(abi, that.abi)
-        && Objects.equals(rules, that.rules);
+        && new HashSet<>(that.rules).containsAll(rules)
+        && new HashSet<>(rules).containsAll(that.rules);
   }
 
   @Override
@@ -5247,7 +5249,7 @@ class AsmGrammarRuleDefinition extends Definition implements IdentifiableNode {
     alternatives.prettyPrint(indent, builder);
     indent--;
 
-    builder.append("\n").append(prettyIndentString(indent)).append(";\n");
+    builder.append("\n").append(prettyIndentString(indent)).append(";\n\n");
   }
 
   @Override

--- a/vadl/main/vadl/ast/Definition.java
+++ b/vadl/main/vadl/ast/Definition.java
@@ -24,6 +24,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.StringJoiner;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
@@ -3434,9 +3435,9 @@ class AbiPseudoInstructionDefinition extends Definition {
   void prettyPrint(int indent, StringBuilder builder) {
     prettyPrintAnnotations(indent, builder);
     builder.append(prettyIndentString(indent));
-    builder.append(kind.keyword);
-    builder.append(" = ");
-    builder.append(target).append("}\n");
+    builder.append("pseudo ").append(kind.keyword).append(" instruction = ");
+    target.prettyPrint(indent + 1, builder);
+    builder.append("\n");
   }
 
   @Override
@@ -3551,7 +3552,7 @@ class AbiSequenceDefinition extends InstructionSequenceDefinition {
 
   enum SeqKind {
     CONSTANT("constant"),
-    REGISTER("register");
+    REGISTER("register adjustment");
 
     private final String keyword;
 
@@ -3596,10 +3597,15 @@ class SpecialPurposeRegisterDefinition extends Definition {
     prettyPrintAnnotations(indent, builder);
     builder.append(prettyIndentString(indent));
     builder.append(purpose.keyword);
-    builder.append(" = ");
-    exprs.forEach(e -> {
-      e.prettyPrint(indent + 1, builder);
-    });
+    builder.append(" = [");
+    var joiner = new StringJoiner(", ");
+    for (var expr : exprs) {
+      StringBuilder tempBuilder = new StringBuilder();
+      expr.prettyPrint(indent + 1, tempBuilder);
+      joiner.add(tempBuilder.toString());
+    }
+    builder.append(joiner.toString());
+    builder.append("]\n");
   }
 
   @Override
@@ -3705,10 +3711,16 @@ class AbiClangNumericTypeDefinition extends Definition {
   }
 
   enum TypeName {
-    POINTER_WIDTH,
-    POINTER_ALIGN,
-    LONG_WIDTH,
-    LONG_ALIGN
+    POINTER_WIDTH("pointer width"),
+    POINTER_ALIGN("pointer align"),
+    LONG_WIDTH("long width"),
+    LONG_ALIGN("long align");
+
+    final String keyword;
+
+    TypeName(String keyword) {
+      this.keyword = keyword;
+    }
   }
 
   public AbiClangNumericTypeDefinition(AbiClangNumericTypeDefinition.TypeName typeName,
@@ -3736,8 +3748,8 @@ class AbiClangNumericTypeDefinition extends Definition {
 
   @Override
   void prettyPrint(int indent, StringBuilder builder) {
-    builder.append(prettyIndentString(indent)).append("clang numeric type: ").append(typeName)
-        .append(" with");
+    builder.append(prettyIndentString(indent))
+        .append(typeName.keyword).append(" = ");
     size.prettyPrint(indent + 1, builder);
   }
 }
@@ -3773,15 +3785,27 @@ class AbiClangTypeDefinition extends Definition {
 
   enum TypeName {
     // Type of the size_t in C.
-    SIZE_TYPE,
-    INT_MAX_TYPE
+    SIZE_TYPE("size_t type"),
+    INT_MAX_TYPE("int max type");
+
+    final String keyword;
+
+    TypeName(String keyword) {
+      this.keyword = keyword;
+    }
   }
 
   enum TypeSize {
-    UNSIGNED_INT,
-    SIGNED_INT,
-    UNSIGNED_LONG,
-    SIGNED_LONG
+    UNSIGNED_INT("unsigned int"),
+    SIGNED_INT("signed int"),
+    UNSIGNED_LONG("unsigned long"),
+    SIGNED_LONG("signed  long");
+
+    final String keyword;
+
+    TypeSize(String keyword) {
+      this.keyword = keyword;
+    }
   }
 
   public AbiClangTypeDefinition(AbiClangTypeDefinition.TypeName typeName,
@@ -3809,8 +3833,8 @@ class AbiClangTypeDefinition extends Definition {
 
   @Override
   void prettyPrint(int indent, StringBuilder builder) {
-    builder.append(prettyIndentString(indent)).append("clang type: ")
-        .append(typeName).append(" with ").append(typeSize);
+    builder.append(prettyIndentString(indent)).append(typeName.keyword)
+        .append(" = ").append(typeSize.keyword);
   }
 }
 

--- a/vadl/main/vadl/ast/Definition.java
+++ b/vadl/main/vadl/ast/Definition.java
@@ -4978,10 +4978,7 @@ class AsmDescriptionDefinition extends Definition implements IdentifiableNode {
     indent++;
 
     if (!commonDefinitions.isEmpty()) {
-      for (var def : commonDefinitions) {
-        def.prettyPrint(indent, builder);
-        builder.append("\n");
-      }
+      prettyPrintDefinitions(indent, builder, commonDefinitions);
     }
 
     if (!modifiers.isEmpty()) {

--- a/vadl/main/vadl/ast/Expr.java
+++ b/vadl/main/vadl/ast/Expr.java
@@ -459,7 +459,7 @@ class UnaryExpr extends Expr {
   @Override
   void prettyPrint(int indent, StringBuilder builder) {
     operator.prettyPrint(indent, builder);
-    builder.append(" (");
+    builder.append("(");
     operand.prettyPrint(indent, builder);
     builder.append(")");
   }

--- a/vadl/main/vadl/ast/Expr.java
+++ b/vadl/main/vadl/ast/Expr.java
@@ -459,13 +459,9 @@ class UnaryExpr extends Expr {
   @Override
   void prettyPrint(int indent, StringBuilder builder) {
     operator.prettyPrint(indent, builder);
-    if (operator instanceof UnOp) {
-      operand.prettyPrint(indent, builder);
-    } else {
-      builder.append(" (");
-      operand.prettyPrint(indent, builder);
-      builder.append(")");
-    }
+    builder.append(" (");
+    operand.prettyPrint(indent, builder);
+    builder.append(")");
   }
 
   @Override
@@ -1937,7 +1933,7 @@ class LetExpr extends Expr {
   @Override
   void prettyPrint(int indent, StringBuilder builder) {
     builder.append(prettyIndentString(indent));
-    builder.append("let ");
+    builder.append("(let ");
     var isFirst = true;
     for (var identifier : identifiers) {
       if (!isFirst) {
@@ -1953,6 +1949,7 @@ class LetExpr extends Expr {
       builder.append(prettyIndentString(indent + 1));
     }
     body.prettyPrint(indent + 1, builder);
+    builder.append(")");
   }
 
   @Override

--- a/vadl/main/vadl/ast/Ungrouper.java
+++ b/vadl/main/vadl/ast/Ungrouper.java
@@ -421,6 +421,7 @@ public class Ungrouper
 
   @Override
   public Void visit(ImportDefinition importDefinition) {
+    ungroup(importDefinition.moduleAst);
     return null;
   }
 

--- a/vadl/main/vadl/ast/vadl.ATG
+++ b/vadl/main/vadl/ast/vadl.ATG
@@ -885,18 +885,19 @@ PRODUCTIONS
   )
   .
 
-  clangNumericTypeDefinition<out Definition def>                     (. def = DUMMY_DEF; var startLoc = nextTokenLoc(); .)
+  clangNumericTypeDefinition<out Definition def>    (. def = DUMMY_DEF; var startLoc = nextTokenLoc(); AbiClangNumericTypeDefinition.TypeName typeName = null; .)
   =
   (
     POINTER (
-      WIDTH SYM_EQ expression<out Expr expr1, BIN_OPS>               (. def = new AbiClangNumericTypeDefinition(AbiClangNumericTypeDefinition.TypeName.POINTER_WIDTH, expr1, startLoc.join(lastTokenLoc())); .)
-      |  ALIGN SYM_EQ expression<out Expr expr2, BIN_OPS>            (. def = new AbiClangNumericTypeDefinition(AbiClangNumericTypeDefinition.TypeName.POINTER_ALIGN, expr2, startLoc.join(lastTokenLoc())); .)
+         WIDTH                                      (. typeName = AbiClangNumericTypeDefinition.TypeName.POINTER_WIDTH; .)
+      |  ALIGN                                      (. typeName = AbiClangNumericTypeDefinition.TypeName.POINTER_ALIGN; .)
     )
     | LONG (
-      WIDTH SYM_EQ expression<out Expr expr3, BIN_OPS>               (. def = new AbiClangNumericTypeDefinition(AbiClangNumericTypeDefinition.TypeName.LONG_WIDTH, expr3, startLoc.join(lastTokenLoc())); .)
-      |  ALIGN SYM_EQ expression<out Expr expr4, BIN_OPS>            (. def = new AbiClangNumericTypeDefinition(AbiClangNumericTypeDefinition.TypeName.LONG_ALIGN, expr4, startLoc.join(lastTokenLoc())); .)
+         WIDTH                                      (. typeName = AbiClangNumericTypeDefinition.TypeName.LONG_WIDTH; .)
+      |  ALIGN                                      (. typeName = AbiClangNumericTypeDefinition.TypeName.LONG_ALIGN; .)
     )
   )
+  SYM_EQ expression<out Expr expr, BIN_OPS>         (. def = new AbiClangNumericTypeDefinition(typeName, expr, startLoc.join(lastTokenLoc())); .)
   .
 
   // See https://clang.llvm.org/doxygen/structclang_1_1TransferrableTargetInfo.html#a30e275c7308708d1b55cd9d009265e33

--- a/vadl/test/resources/dumps/rv64im.dump
+++ b/vadl/test/resources/dumps/rv64im.dump
@@ -15,10 +15,9 @@ ImportDefinition
 . : ' | Identifier name: "Arch64" type: null
 . : ' ConstantDefinition name: "SftLen"
 . : ' | BinaryExpr operator: + type: null
-. : ' | . GroupedExpr type: null
-. : ' | . : BinaryExpr operator: / type: null
-. : ' | . : ' Identifier name: "MLen" type: null
-. : ' | . : ' IntegerLiteral literal: 32 (32) type: null
+. : ' | . BinaryExpr operator: / type: null
+. : ' | . : Identifier name: "MLen" type: null
+. : ' | . : IntegerLiteral literal: 32 (32) type: null
 . : ' | . IntegerLiteral literal: 4 (4) type: null
 . : ' ConstantDefinition name: "WLen"
 . : ' | IntegerLiteral literal: 32 (32) type: null
@@ -181,11 +180,10 @@ ImportDefinition
 . : ' | . : Identifier name: "Bits7" type: null
 . : ' | DerivedFormatField name: "immUp"
 . : ' | . BinaryExpr operator: << type: null
-. : ' | . : GroupedExpr type: null
-. : ' | . : ' CastExpr type: null
-. : ' | . : ' | Identifier name: "imm" type: null
-. : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . Identifier name: "SIntR" type: null
+. : ' | . : CastExpr type: null
+. : ' | . : ' Identifier name: "imm" type: null
+. : ' | . : ' TypeLiteral type: null
+. : ' | . : ' | Identifier name: "SIntR" type: null
 . : ' | . : IntegerLiteral literal: 12 (12) type: null
 . : ' FormatDefinition name: "Stype"
 . : ' | TypeLiteral type: null
@@ -248,11 +246,10 @@ ImportDefinition
 . : ' | . : IntegerLiteral literal: 0 (0) type: null
 . : ' | DerivedFormatField name: "immS"
 . : ' | . BinaryExpr operator: << type: null
-. : ' | . : GroupedExpr type: null
-. : ' | . : ' CastExpr type: null
-. : ' | . : ' | Identifier name: "imm" type: null
-. : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . Identifier name: "SIntR" type: null
+. : ' | . : CastExpr type: null
+. : ' | . : ' Identifier name: "imm" type: null
+. : ' | . : ' TypeLiteral type: null
+. : ' | . : ' | Identifier name: "SIntR" type: null
 . : ' | . : IntegerLiteral literal: 1 (1) type: null
 . : ' FormatDefinition name: "Jtype"
 . : ' | TypeLiteral type: null
@@ -276,11 +273,10 @@ ImportDefinition
 . : ' | . : IntegerLiteral literal: 0 (0) type: null
 . : ' | DerivedFormatField name: "immS"
 . : ' | . BinaryExpr operator: << type: null
-. : ' | . : GroupedExpr type: null
-. : ' | . : ' CastExpr type: null
-. : ' | . : ' | Identifier name: "imm" type: null
-. : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . Identifier name: "SIntR" type: null
+. : ' | . : CastExpr type: null
+. : ' | . : ' Identifier name: "imm" type: null
+. : ' | . : ' TypeLiteral type: null
+. : ' | . : ' | Identifier name: "SIntR" type: null
 . : ' | . : IntegerLiteral literal: 1 (1) type: null
 . : ' InstructionDefinition name: "ADD"
 . : ' | Identifier name: "Rtype" type: null
@@ -290,24 +286,21 @@ ImportDefinition
 . : ' | . : ArgsIndices
 . : ' | . : ' Identifier name: "rd" type: null
 . : ' | . CastExpr type: null
-. : ' | . : GroupedExpr type: null
-. : ' | . : ' BinaryExpr operator: + type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . CastExpr type: null
-. : ' | . : ' | . : CallIndexExpr type: null
-. : ' | . : ' | . : ' Identifier name: "X" type: null
-. : ' | . : ' | . : ' ArgsIndices
-. : ' | . : ' | . : ' | Identifier name: "rs1" type: null
-. : ' | . : ' | . : TypeLiteral type: null
-. : ' | . : ' | . : ' Identifier name: "Bits" type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . CastExpr type: null
-. : ' | . : ' | . : CallIndexExpr type: null
-. : ' | . : ' | . : ' Identifier name: "X" type: null
-. : ' | . : ' | . : ' ArgsIndices
-. : ' | . : ' | . : ' | Identifier name: "rs2" type: null
-. : ' | . : ' | . : TypeLiteral type: null
-. : ' | . : ' | . : ' Identifier name: "Bits" type: null
+. : ' | . : BinaryExpr operator: + type: null
+. : ' | . : ' CastExpr type: null
+. : ' | . : ' | CallIndexExpr type: null
+. : ' | . : ' | . Identifier name: "X" type: null
+. : ' | . : ' | . ArgsIndices
+. : ' | . : ' | . : Identifier name: "rs1" type: null
+. : ' | . : ' | TypeLiteral type: null
+. : ' | . : ' | . Identifier name: "Bits" type: null
+. : ' | . : ' CastExpr type: null
+. : ' | . : ' | CallIndexExpr type: null
+. : ' | . : ' | . Identifier name: "X" type: null
+. : ' | . : ' | . ArgsIndices
+. : ' | . : ' | . : Identifier name: "rs2" type: null
+. : ' | . : ' | TypeLiteral type: null
+. : ' | . : ' | . Identifier name: "Bits" type: null
 . : ' | . : TypeLiteral type: null
 . : ' | . : ' Identifier name: "Regs" type: null
 . : ' EncodingDefinition
@@ -344,24 +337,21 @@ ImportDefinition
 . : ' | . : ArgsIndices
 . : ' | . : ' Identifier name: "rd" type: null
 . : ' | . CastExpr type: null
-. : ' | . : GroupedExpr type: null
-. : ' | . : ' BinaryExpr operator: - type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . CastExpr type: null
-. : ' | . : ' | . : CallIndexExpr type: null
-. : ' | . : ' | . : ' Identifier name: "X" type: null
-. : ' | . : ' | . : ' ArgsIndices
-. : ' | . : ' | . : ' | Identifier name: "rs1" type: null
-. : ' | . : ' | . : TypeLiteral type: null
-. : ' | . : ' | . : ' Identifier name: "Bits" type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . CastExpr type: null
-. : ' | . : ' | . : CallIndexExpr type: null
-. : ' | . : ' | . : ' Identifier name: "X" type: null
-. : ' | . : ' | . : ' ArgsIndices
-. : ' | . : ' | . : ' | Identifier name: "rs2" type: null
-. : ' | . : ' | . : TypeLiteral type: null
-. : ' | . : ' | . : ' Identifier name: "Bits" type: null
+. : ' | . : BinaryExpr operator: - type: null
+. : ' | . : ' CastExpr type: null
+. : ' | . : ' | CallIndexExpr type: null
+. : ' | . : ' | . Identifier name: "X" type: null
+. : ' | . : ' | . ArgsIndices
+. : ' | . : ' | . : Identifier name: "rs1" type: null
+. : ' | . : ' | TypeLiteral type: null
+. : ' | . : ' | . Identifier name: "Bits" type: null
+. : ' | . : ' CastExpr type: null
+. : ' | . : ' | CallIndexExpr type: null
+. : ' | . : ' | . Identifier name: "X" type: null
+. : ' | . : ' | . ArgsIndices
+. : ' | . : ' | . : Identifier name: "rs2" type: null
+. : ' | . : ' | TypeLiteral type: null
+. : ' | . : ' | . Identifier name: "Bits" type: null
 . : ' | . : TypeLiteral type: null
 . : ' | . : ' Identifier name: "Regs" type: null
 . : ' EncodingDefinition
@@ -398,24 +388,21 @@ ImportDefinition
 . : ' | . : ArgsIndices
 . : ' | . : ' Identifier name: "rd" type: null
 . : ' | . CastExpr type: null
-. : ' | . : GroupedExpr type: null
-. : ' | . : ' BinaryExpr operator: & type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . CastExpr type: null
-. : ' | . : ' | . : CallIndexExpr type: null
-. : ' | . : ' | . : ' Identifier name: "X" type: null
-. : ' | . : ' | . : ' ArgsIndices
-. : ' | . : ' | . : ' | Identifier name: "rs1" type: null
-. : ' | . : ' | . : TypeLiteral type: null
-. : ' | . : ' | . : ' Identifier name: "Bits" type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . CastExpr type: null
-. : ' | . : ' | . : CallIndexExpr type: null
-. : ' | . : ' | . : ' Identifier name: "X" type: null
-. : ' | . : ' | . : ' ArgsIndices
-. : ' | . : ' | . : ' | Identifier name: "rs2" type: null
-. : ' | . : ' | . : TypeLiteral type: null
-. : ' | . : ' | . : ' Identifier name: "Bits" type: null
+. : ' | . : BinaryExpr operator: & type: null
+. : ' | . : ' CastExpr type: null
+. : ' | . : ' | CallIndexExpr type: null
+. : ' | . : ' | . Identifier name: "X" type: null
+. : ' | . : ' | . ArgsIndices
+. : ' | . : ' | . : Identifier name: "rs1" type: null
+. : ' | . : ' | TypeLiteral type: null
+. : ' | . : ' | . Identifier name: "Bits" type: null
+. : ' | . : ' CastExpr type: null
+. : ' | . : ' | CallIndexExpr type: null
+. : ' | . : ' | . Identifier name: "X" type: null
+. : ' | . : ' | . ArgsIndices
+. : ' | . : ' | . : Identifier name: "rs2" type: null
+. : ' | . : ' | TypeLiteral type: null
+. : ' | . : ' | . Identifier name: "Bits" type: null
 . : ' | . : TypeLiteral type: null
 . : ' | . : ' Identifier name: "Regs" type: null
 . : ' EncodingDefinition
@@ -452,24 +439,21 @@ ImportDefinition
 . : ' | . : ArgsIndices
 . : ' | . : ' Identifier name: "rd" type: null
 . : ' | . CastExpr type: null
-. : ' | . : GroupedExpr type: null
-. : ' | . : ' BinaryExpr operator: | type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . CastExpr type: null
-. : ' | . : ' | . : CallIndexExpr type: null
-. : ' | . : ' | . : ' Identifier name: "X" type: null
-. : ' | . : ' | . : ' ArgsIndices
-. : ' | . : ' | . : ' | Identifier name: "rs1" type: null
-. : ' | . : ' | . : TypeLiteral type: null
-. : ' | . : ' | . : ' Identifier name: "Bits" type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . CastExpr type: null
-. : ' | . : ' | . : CallIndexExpr type: null
-. : ' | . : ' | . : ' Identifier name: "X" type: null
-. : ' | . : ' | . : ' ArgsIndices
-. : ' | . : ' | . : ' | Identifier name: "rs2" type: null
-. : ' | . : ' | . : TypeLiteral type: null
-. : ' | . : ' | . : ' Identifier name: "Bits" type: null
+. : ' | . : BinaryExpr operator: | type: null
+. : ' | . : ' CastExpr type: null
+. : ' | . : ' | CallIndexExpr type: null
+. : ' | . : ' | . Identifier name: "X" type: null
+. : ' | . : ' | . ArgsIndices
+. : ' | . : ' | . : Identifier name: "rs1" type: null
+. : ' | . : ' | TypeLiteral type: null
+. : ' | . : ' | . Identifier name: "Bits" type: null
+. : ' | . : ' CastExpr type: null
+. : ' | . : ' | CallIndexExpr type: null
+. : ' | . : ' | . Identifier name: "X" type: null
+. : ' | . : ' | . ArgsIndices
+. : ' | . : ' | . : Identifier name: "rs2" type: null
+. : ' | . : ' | TypeLiteral type: null
+. : ' | . : ' | . Identifier name: "Bits" type: null
 . : ' | . : TypeLiteral type: null
 . : ' | . : ' Identifier name: "Regs" type: null
 . : ' EncodingDefinition
@@ -506,24 +490,21 @@ ImportDefinition
 . : ' | . : ArgsIndices
 . : ' | . : ' Identifier name: "rd" type: null
 . : ' | . CastExpr type: null
-. : ' | . : GroupedExpr type: null
-. : ' | . : ' BinaryExpr operator: ^ type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . CastExpr type: null
-. : ' | . : ' | . : CallIndexExpr type: null
-. : ' | . : ' | . : ' Identifier name: "X" type: null
-. : ' | . : ' | . : ' ArgsIndices
-. : ' | . : ' | . : ' | Identifier name: "rs1" type: null
-. : ' | . : ' | . : TypeLiteral type: null
-. : ' | . : ' | . : ' Identifier name: "Bits" type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . CastExpr type: null
-. : ' | . : ' | . : CallIndexExpr type: null
-. : ' | . : ' | . : ' Identifier name: "X" type: null
-. : ' | . : ' | . : ' ArgsIndices
-. : ' | . : ' | . : ' | Identifier name: "rs2" type: null
-. : ' | . : ' | . : TypeLiteral type: null
-. : ' | . : ' | . : ' Identifier name: "Bits" type: null
+. : ' | . : BinaryExpr operator: ^ type: null
+. : ' | . : ' CastExpr type: null
+. : ' | . : ' | CallIndexExpr type: null
+. : ' | . : ' | . Identifier name: "X" type: null
+. : ' | . : ' | . ArgsIndices
+. : ' | . : ' | . : Identifier name: "rs1" type: null
+. : ' | . : ' | TypeLiteral type: null
+. : ' | . : ' | . Identifier name: "Bits" type: null
+. : ' | . : ' CastExpr type: null
+. : ' | . : ' | CallIndexExpr type: null
+. : ' | . : ' | . Identifier name: "X" type: null
+. : ' | . : ' | . ArgsIndices
+. : ' | . : ' | . : Identifier name: "rs2" type: null
+. : ' | . : ' | TypeLiteral type: null
+. : ' | . : ' | . Identifier name: "Bits" type: null
 . : ' | . : TypeLiteral type: null
 . : ' | . : ' Identifier name: "Regs" type: null
 . : ' EncodingDefinition
@@ -560,24 +541,21 @@ ImportDefinition
 . : ' | . : ArgsIndices
 . : ' | . : ' Identifier name: "rd" type: null
 . : ' | . CastExpr type: null
-. : ' | . : GroupedExpr type: null
-. : ' | . : ' BinaryExpr operator: < type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . CastExpr type: null
-. : ' | . : ' | . : CallIndexExpr type: null
-. : ' | . : ' | . : ' Identifier name: "X" type: null
-. : ' | . : ' | . : ' ArgsIndices
-. : ' | . : ' | . : ' | Identifier name: "rs1" type: null
-. : ' | . : ' | . : TypeLiteral type: null
-. : ' | . : ' | . : ' Identifier name: "SInt" type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . CastExpr type: null
-. : ' | . : ' | . : CallIndexExpr type: null
-. : ' | . : ' | . : ' Identifier name: "X" type: null
-. : ' | . : ' | . : ' ArgsIndices
-. : ' | . : ' | . : ' | Identifier name: "rs2" type: null
-. : ' | . : ' | . : TypeLiteral type: null
-. : ' | . : ' | . : ' Identifier name: "SInt" type: null
+. : ' | . : BinaryExpr operator: < type: null
+. : ' | . : ' CastExpr type: null
+. : ' | . : ' | CallIndexExpr type: null
+. : ' | . : ' | . Identifier name: "X" type: null
+. : ' | . : ' | . ArgsIndices
+. : ' | . : ' | . : Identifier name: "rs1" type: null
+. : ' | . : ' | TypeLiteral type: null
+. : ' | . : ' | . Identifier name: "SInt" type: null
+. : ' | . : ' CastExpr type: null
+. : ' | . : ' | CallIndexExpr type: null
+. : ' | . : ' | . Identifier name: "X" type: null
+. : ' | . : ' | . ArgsIndices
+. : ' | . : ' | . : Identifier name: "rs2" type: null
+. : ' | . : ' | TypeLiteral type: null
+. : ' | . : ' | . Identifier name: "SInt" type: null
 . : ' | . : TypeLiteral type: null
 . : ' | . : ' Identifier name: "Regs" type: null
 . : ' EncodingDefinition
@@ -614,24 +592,21 @@ ImportDefinition
 . : ' | . : ArgsIndices
 . : ' | . : ' Identifier name: "rd" type: null
 . : ' | . CastExpr type: null
-. : ' | . : GroupedExpr type: null
-. : ' | . : ' BinaryExpr operator: < type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . CastExpr type: null
-. : ' | . : ' | . : CallIndexExpr type: null
-. : ' | . : ' | . : ' Identifier name: "X" type: null
-. : ' | . : ' | . : ' ArgsIndices
-. : ' | . : ' | . : ' | Identifier name: "rs1" type: null
-. : ' | . : ' | . : TypeLiteral type: null
-. : ' | . : ' | . : ' Identifier name: "UInt" type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . CastExpr type: null
-. : ' | . : ' | . : CallIndexExpr type: null
-. : ' | . : ' | . : ' Identifier name: "X" type: null
-. : ' | . : ' | . : ' ArgsIndices
-. : ' | . : ' | . : ' | Identifier name: "rs2" type: null
-. : ' | . : ' | . : TypeLiteral type: null
-. : ' | . : ' | . : ' Identifier name: "UInt" type: null
+. : ' | . : BinaryExpr operator: < type: null
+. : ' | . : ' CastExpr type: null
+. : ' | . : ' | CallIndexExpr type: null
+. : ' | . : ' | . Identifier name: "X" type: null
+. : ' | . : ' | . ArgsIndices
+. : ' | . : ' | . : Identifier name: "rs1" type: null
+. : ' | . : ' | TypeLiteral type: null
+. : ' | . : ' | . Identifier name: "UInt" type: null
+. : ' | . : ' CastExpr type: null
+. : ' | . : ' | CallIndexExpr type: null
+. : ' | . : ' | . Identifier name: "X" type: null
+. : ' | . : ' | . ArgsIndices
+. : ' | . : ' | . : Identifier name: "rs2" type: null
+. : ' | . : ' | TypeLiteral type: null
+. : ' | . : ' | . Identifier name: "UInt" type: null
 . : ' | . : TypeLiteral type: null
 . : ' | . : ' Identifier name: "Regs" type: null
 . : ' EncodingDefinition
@@ -668,24 +643,21 @@ ImportDefinition
 . : ' | . : ArgsIndices
 . : ' | . : ' Identifier name: "rd" type: null
 . : ' | . CastExpr type: null
-. : ' | . : GroupedExpr type: null
-. : ' | . : ' BinaryExpr operator: << type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . CastExpr type: null
-. : ' | . : ' | . : CallIndexExpr type: null
-. : ' | . : ' | . : ' Identifier name: "X" type: null
-. : ' | . : ' | . : ' ArgsIndices
-. : ' | . : ' | . : ' | Identifier name: "rs1" type: null
-. : ' | . : ' | . : TypeLiteral type: null
-. : ' | . : ' | . : ' Identifier name: "UInt" type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . CastExpr type: null
-. : ' | . : ' | . : CallIndexExpr type: null
-. : ' | . : ' | . : ' Identifier name: "X" type: null
-. : ' | . : ' | . : ' ArgsIndices
-. : ' | . : ' | . : ' | Identifier name: "rs2" type: null
-. : ' | . : ' | . : TypeLiteral type: null
-. : ' | . : ' | . : ' Identifier name: "UShft" type: null
+. : ' | . : BinaryExpr operator: << type: null
+. : ' | . : ' CastExpr type: null
+. : ' | . : ' | CallIndexExpr type: null
+. : ' | . : ' | . Identifier name: "X" type: null
+. : ' | . : ' | . ArgsIndices
+. : ' | . : ' | . : Identifier name: "rs1" type: null
+. : ' | . : ' | TypeLiteral type: null
+. : ' | . : ' | . Identifier name: "UInt" type: null
+. : ' | . : ' CastExpr type: null
+. : ' | . : ' | CallIndexExpr type: null
+. : ' | . : ' | . Identifier name: "X" type: null
+. : ' | . : ' | . ArgsIndices
+. : ' | . : ' | . : Identifier name: "rs2" type: null
+. : ' | . : ' | TypeLiteral type: null
+. : ' | . : ' | . Identifier name: "UShft" type: null
 . : ' | . : TypeLiteral type: null
 . : ' | . : ' Identifier name: "Regs" type: null
 . : ' EncodingDefinition
@@ -722,24 +694,21 @@ ImportDefinition
 . : ' | . : ArgsIndices
 . : ' | . : ' Identifier name: "rd" type: null
 . : ' | . CastExpr type: null
-. : ' | . : GroupedExpr type: null
-. : ' | . : ' BinaryExpr operator: >> type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . CastExpr type: null
-. : ' | . : ' | . : CallIndexExpr type: null
-. : ' | . : ' | . : ' Identifier name: "X" type: null
-. : ' | . : ' | . : ' ArgsIndices
-. : ' | . : ' | . : ' | Identifier name: "rs1" type: null
-. : ' | . : ' | . : TypeLiteral type: null
-. : ' | . : ' | . : ' Identifier name: "UInt" type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . CastExpr type: null
-. : ' | . : ' | . : CallIndexExpr type: null
-. : ' | . : ' | . : ' Identifier name: "X" type: null
-. : ' | . : ' | . : ' ArgsIndices
-. : ' | . : ' | . : ' | Identifier name: "rs2" type: null
-. : ' | . : ' | . : TypeLiteral type: null
-. : ' | . : ' | . : ' Identifier name: "UShft" type: null
+. : ' | . : BinaryExpr operator: >> type: null
+. : ' | . : ' CastExpr type: null
+. : ' | . : ' | CallIndexExpr type: null
+. : ' | . : ' | . Identifier name: "X" type: null
+. : ' | . : ' | . ArgsIndices
+. : ' | . : ' | . : Identifier name: "rs1" type: null
+. : ' | . : ' | TypeLiteral type: null
+. : ' | . : ' | . Identifier name: "UInt" type: null
+. : ' | . : ' CastExpr type: null
+. : ' | . : ' | CallIndexExpr type: null
+. : ' | . : ' | . Identifier name: "X" type: null
+. : ' | . : ' | . ArgsIndices
+. : ' | . : ' | . : Identifier name: "rs2" type: null
+. : ' | . : ' | TypeLiteral type: null
+. : ' | . : ' | . Identifier name: "UShft" type: null
 . : ' | . : TypeLiteral type: null
 . : ' | . : ' Identifier name: "Regs" type: null
 . : ' EncodingDefinition
@@ -776,24 +745,21 @@ ImportDefinition
 . : ' | . : ArgsIndices
 . : ' | . : ' Identifier name: "rd" type: null
 . : ' | . CastExpr type: null
-. : ' | . : GroupedExpr type: null
-. : ' | . : ' BinaryExpr operator: >> type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . CastExpr type: null
-. : ' | . : ' | . : CallIndexExpr type: null
-. : ' | . : ' | . : ' Identifier name: "X" type: null
-. : ' | . : ' | . : ' ArgsIndices
-. : ' | . : ' | . : ' | Identifier name: "rs1" type: null
-. : ' | . : ' | . : TypeLiteral type: null
-. : ' | . : ' | . : ' Identifier name: "SInt" type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . CastExpr type: null
-. : ' | . : ' | . : CallIndexExpr type: null
-. : ' | . : ' | . : ' Identifier name: "X" type: null
-. : ' | . : ' | . : ' ArgsIndices
-. : ' | . : ' | . : ' | Identifier name: "rs2" type: null
-. : ' | . : ' | . : TypeLiteral type: null
-. : ' | . : ' | . : ' Identifier name: "UShft" type: null
+. : ' | . : BinaryExpr operator: >> type: null
+. : ' | . : ' CastExpr type: null
+. : ' | . : ' | CallIndexExpr type: null
+. : ' | . : ' | . Identifier name: "X" type: null
+. : ' | . : ' | . ArgsIndices
+. : ' | . : ' | . : Identifier name: "rs1" type: null
+. : ' | . : ' | TypeLiteral type: null
+. : ' | . : ' | . Identifier name: "SInt" type: null
+. : ' | . : ' CastExpr type: null
+. : ' | . : ' | CallIndexExpr type: null
+. : ' | . : ' | . Identifier name: "X" type: null
+. : ' | . : ' | . ArgsIndices
+. : ' | . : ' | . : Identifier name: "rs2" type: null
+. : ' | . : ' | TypeLiteral type: null
+. : ' | . : ' | . Identifier name: "UShft" type: null
 . : ' | . : TypeLiteral type: null
 . : ' | . : ' Identifier name: "Regs" type: null
 . : ' EncodingDefinition
@@ -830,21 +796,18 @@ ImportDefinition
 . : ' | . : ArgsIndices
 . : ' | . : ' Identifier name: "rd" type: null
 . : ' | . CastExpr type: null
-. : ' | . : GroupedExpr type: null
-. : ' | . : ' BinaryExpr operator: + type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . CastExpr type: null
-. : ' | . : ' | . : CallIndexExpr type: null
-. : ' | . : ' | . : ' Identifier name: "X" type: null
-. : ' | . : ' | . : ' ArgsIndices
-. : ' | . : ' | . : ' | Identifier name: "rs1" type: null
-. : ' | . : ' | . : TypeLiteral type: null
-. : ' | . : ' | . : ' Identifier name: "SInt" type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . CastExpr type: null
-. : ' | . : ' | . : Identifier name: "immS" type: null
-. : ' | . : ' | . : TypeLiteral type: null
-. : ' | . : ' | . : ' Identifier name: "SInt" type: null
+. : ' | . : BinaryExpr operator: + type: null
+. : ' | . : ' CastExpr type: null
+. : ' | . : ' | CallIndexExpr type: null
+. : ' | . : ' | . Identifier name: "X" type: null
+. : ' | . : ' | . ArgsIndices
+. : ' | . : ' | . : Identifier name: "rs1" type: null
+. : ' | . : ' | TypeLiteral type: null
+. : ' | . : ' | . Identifier name: "SInt" type: null
+. : ' | . : ' CastExpr type: null
+. : ' | . : ' | Identifier name: "immS" type: null
+. : ' | . : ' | TypeLiteral type: null
+. : ' | . : ' | . Identifier name: "SInt" type: null
 . : ' | . : TypeLiteral type: null
 . : ' | . : ' Identifier name: "Regs" type: null
 . : ' EncodingDefinition
@@ -879,21 +842,18 @@ ImportDefinition
 . : ' | . : ArgsIndices
 . : ' | . : ' Identifier name: "rd" type: null
 . : ' | . CastExpr type: null
-. : ' | . : GroupedExpr type: null
-. : ' | . : ' BinaryExpr operator: & type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . CastExpr type: null
-. : ' | . : ' | . : CallIndexExpr type: null
-. : ' | . : ' | . : ' Identifier name: "X" type: null
-. : ' | . : ' | . : ' ArgsIndices
-. : ' | . : ' | . : ' | Identifier name: "rs1" type: null
-. : ' | . : ' | . : TypeLiteral type: null
-. : ' | . : ' | . : ' Identifier name: "SInt" type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . CastExpr type: null
-. : ' | . : ' | . : Identifier name: "immS" type: null
-. : ' | . : ' | . : TypeLiteral type: null
-. : ' | . : ' | . : ' Identifier name: "SInt" type: null
+. : ' | . : BinaryExpr operator: & type: null
+. : ' | . : ' CastExpr type: null
+. : ' | . : ' | CallIndexExpr type: null
+. : ' | . : ' | . Identifier name: "X" type: null
+. : ' | . : ' | . ArgsIndices
+. : ' | . : ' | . : Identifier name: "rs1" type: null
+. : ' | . : ' | TypeLiteral type: null
+. : ' | . : ' | . Identifier name: "SInt" type: null
+. : ' | . : ' CastExpr type: null
+. : ' | . : ' | Identifier name: "immS" type: null
+. : ' | . : ' | TypeLiteral type: null
+. : ' | . : ' | . Identifier name: "SInt" type: null
 . : ' | . : TypeLiteral type: null
 . : ' | . : ' Identifier name: "Regs" type: null
 . : ' EncodingDefinition
@@ -928,21 +888,18 @@ ImportDefinition
 . : ' | . : ArgsIndices
 . : ' | . : ' Identifier name: "rd" type: null
 . : ' | . CastExpr type: null
-. : ' | . : GroupedExpr type: null
-. : ' | . : ' BinaryExpr operator: | type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . CastExpr type: null
-. : ' | . : ' | . : CallIndexExpr type: null
-. : ' | . : ' | . : ' Identifier name: "X" type: null
-. : ' | . : ' | . : ' ArgsIndices
-. : ' | . : ' | . : ' | Identifier name: "rs1" type: null
-. : ' | . : ' | . : TypeLiteral type: null
-. : ' | . : ' | . : ' Identifier name: "SInt" type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . CastExpr type: null
-. : ' | . : ' | . : Identifier name: "immS" type: null
-. : ' | . : ' | . : TypeLiteral type: null
-. : ' | . : ' | . : ' Identifier name: "SInt" type: null
+. : ' | . : BinaryExpr operator: | type: null
+. : ' | . : ' CastExpr type: null
+. : ' | . : ' | CallIndexExpr type: null
+. : ' | . : ' | . Identifier name: "X" type: null
+. : ' | . : ' | . ArgsIndices
+. : ' | . : ' | . : Identifier name: "rs1" type: null
+. : ' | . : ' | TypeLiteral type: null
+. : ' | . : ' | . Identifier name: "SInt" type: null
+. : ' | . : ' CastExpr type: null
+. : ' | . : ' | Identifier name: "immS" type: null
+. : ' | . : ' | TypeLiteral type: null
+. : ' | . : ' | . Identifier name: "SInt" type: null
 . : ' | . : TypeLiteral type: null
 . : ' | . : ' Identifier name: "Regs" type: null
 . : ' EncodingDefinition
@@ -977,21 +934,18 @@ ImportDefinition
 . : ' | . : ArgsIndices
 . : ' | . : ' Identifier name: "rd" type: null
 . : ' | . CastExpr type: null
-. : ' | . : GroupedExpr type: null
-. : ' | . : ' BinaryExpr operator: ^ type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . CastExpr type: null
-. : ' | . : ' | . : CallIndexExpr type: null
-. : ' | . : ' | . : ' Identifier name: "X" type: null
-. : ' | . : ' | . : ' ArgsIndices
-. : ' | . : ' | . : ' | Identifier name: "rs1" type: null
-. : ' | . : ' | . : TypeLiteral type: null
-. : ' | . : ' | . : ' Identifier name: "SInt" type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . CastExpr type: null
-. : ' | . : ' | . : Identifier name: "immS" type: null
-. : ' | . : ' | . : TypeLiteral type: null
-. : ' | . : ' | . : ' Identifier name: "SInt" type: null
+. : ' | . : BinaryExpr operator: ^ type: null
+. : ' | . : ' CastExpr type: null
+. : ' | . : ' | CallIndexExpr type: null
+. : ' | . : ' | . Identifier name: "X" type: null
+. : ' | . : ' | . ArgsIndices
+. : ' | . : ' | . : Identifier name: "rs1" type: null
+. : ' | . : ' | TypeLiteral type: null
+. : ' | . : ' | . Identifier name: "SInt" type: null
+. : ' | . : ' CastExpr type: null
+. : ' | . : ' | Identifier name: "immS" type: null
+. : ' | . : ' | TypeLiteral type: null
+. : ' | . : ' | . Identifier name: "SInt" type: null
 . : ' | . : TypeLiteral type: null
 . : ' | . : ' Identifier name: "Regs" type: null
 . : ' EncodingDefinition
@@ -1026,21 +980,18 @@ ImportDefinition
 . : ' | . : ArgsIndices
 . : ' | . : ' Identifier name: "rd" type: null
 . : ' | . CastExpr type: null
-. : ' | . : GroupedExpr type: null
-. : ' | . : ' BinaryExpr operator: < type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . CastExpr type: null
-. : ' | . : ' | . : CallIndexExpr type: null
-. : ' | . : ' | . : ' Identifier name: "X" type: null
-. : ' | . : ' | . : ' ArgsIndices
-. : ' | . : ' | . : ' | Identifier name: "rs1" type: null
-. : ' | . : ' | . : TypeLiteral type: null
-. : ' | . : ' | . : ' Identifier name: "SInt" type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . CastExpr type: null
-. : ' | . : ' | . : Identifier name: "immS" type: null
-. : ' | . : ' | . : TypeLiteral type: null
-. : ' | . : ' | . : ' Identifier name: "SInt" type: null
+. : ' | . : BinaryExpr operator: < type: null
+. : ' | . : ' CastExpr type: null
+. : ' | . : ' | CallIndexExpr type: null
+. : ' | . : ' | . Identifier name: "X" type: null
+. : ' | . : ' | . ArgsIndices
+. : ' | . : ' | . : Identifier name: "rs1" type: null
+. : ' | . : ' | TypeLiteral type: null
+. : ' | . : ' | . Identifier name: "SInt" type: null
+. : ' | . : ' CastExpr type: null
+. : ' | . : ' | Identifier name: "immS" type: null
+. : ' | . : ' | TypeLiteral type: null
+. : ' | . : ' | . Identifier name: "SInt" type: null
 . : ' | . : TypeLiteral type: null
 . : ' | . : ' Identifier name: "Regs" type: null
 . : ' EncodingDefinition
@@ -1075,21 +1026,18 @@ ImportDefinition
 . : ' | . : ArgsIndices
 . : ' | . : ' Identifier name: "rd" type: null
 . : ' | . CastExpr type: null
-. : ' | . : GroupedExpr type: null
-. : ' | . : ' BinaryExpr operator: < type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . CastExpr type: null
-. : ' | . : ' | . : CallIndexExpr type: null
-. : ' | . : ' | . : ' Identifier name: "X" type: null
-. : ' | . : ' | . : ' ArgsIndices
-. : ' | . : ' | . : ' | Identifier name: "rs1" type: null
-. : ' | . : ' | . : TypeLiteral type: null
-. : ' | . : ' | . : ' Identifier name: "UInt" type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . CastExpr type: null
-. : ' | . : ' | . : Identifier name: "immS" type: null
-. : ' | . : ' | . : TypeLiteral type: null
-. : ' | . : ' | . : ' Identifier name: "UInt" type: null
+. : ' | . : BinaryExpr operator: < type: null
+. : ' | . : ' CastExpr type: null
+. : ' | . : ' | CallIndexExpr type: null
+. : ' | . : ' | . Identifier name: "X" type: null
+. : ' | . : ' | . ArgsIndices
+. : ' | . : ' | . : Identifier name: "rs1" type: null
+. : ' | . : ' | TypeLiteral type: null
+. : ' | . : ' | . Identifier name: "UInt" type: null
+. : ' | . : ' CastExpr type: null
+. : ' | . : ' | Identifier name: "immS" type: null
+. : ' | . : ' | TypeLiteral type: null
+. : ' | . : ' | . Identifier name: "UInt" type: null
 . : ' | . : TypeLiteral type: null
 . : ' | . : ' Identifier name: "Regs" type: null
 . : ' EncodingDefinition
@@ -1558,14 +1506,13 @@ ImportDefinition
 . : ' | Identifier name: "Btype" type: null
 . : ' | IfStatement
 . : ' | . BinaryExpr operator: = type: null
-. : ' | . : GroupedExpr type: null
-. : ' | . : ' CastExpr type: null
-. : ' | . : ' | CallIndexExpr type: null
-. : ' | . : ' | . Identifier name: "X" type: null
-. : ' | . : ' | . ArgsIndices
-. : ' | . : ' | . : Identifier name: "rs1" type: null
-. : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . Identifier name: "Bits" type: null
+. : ' | . : CastExpr type: null
+. : ' | . : ' CallIndexExpr type: null
+. : ' | . : ' | Identifier name: "X" type: null
+. : ' | . : ' | ArgsIndices
+. : ' | . : ' | . Identifier name: "rs1" type: null
+. : ' | . : ' TypeLiteral type: null
+. : ' | . : ' | Identifier name: "Bits" type: null
 . : ' | . : CallIndexExpr type: null
 . : ' | . : ' Identifier name: "X" type: null
 . : ' | . : ' ArgsIndices
@@ -1603,14 +1550,13 @@ ImportDefinition
 . : ' | Identifier name: "Btype" type: null
 . : ' | IfStatement
 . : ' | . BinaryExpr operator: != type: null
-. : ' | . : GroupedExpr type: null
-. : ' | . : ' CastExpr type: null
-. : ' | . : ' | CallIndexExpr type: null
-. : ' | . : ' | . Identifier name: "X" type: null
-. : ' | . : ' | . ArgsIndices
-. : ' | . : ' | . : Identifier name: "rs1" type: null
-. : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . Identifier name: "Bits" type: null
+. : ' | . : CastExpr type: null
+. : ' | . : ' CallIndexExpr type: null
+. : ' | . : ' | Identifier name: "X" type: null
+. : ' | . : ' | ArgsIndices
+. : ' | . : ' | . Identifier name: "rs1" type: null
+. : ' | . : ' TypeLiteral type: null
+. : ' | . : ' | Identifier name: "Bits" type: null
 . : ' | . : CallIndexExpr type: null
 . : ' | . : ' Identifier name: "X" type: null
 . : ' | . : ' ArgsIndices
@@ -1648,14 +1594,13 @@ ImportDefinition
 . : ' | Identifier name: "Btype" type: null
 . : ' | IfStatement
 . : ' | . BinaryExpr operator: >= type: null
-. : ' | . : GroupedExpr type: null
-. : ' | . : ' CastExpr type: null
-. : ' | . : ' | CallIndexExpr type: null
-. : ' | . : ' | . Identifier name: "X" type: null
-. : ' | . : ' | . ArgsIndices
-. : ' | . : ' | . : Identifier name: "rs1" type: null
-. : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . Identifier name: "SInt" type: null
+. : ' | . : CastExpr type: null
+. : ' | . : ' CallIndexExpr type: null
+. : ' | . : ' | Identifier name: "X" type: null
+. : ' | . : ' | ArgsIndices
+. : ' | . : ' | . Identifier name: "rs1" type: null
+. : ' | . : ' TypeLiteral type: null
+. : ' | . : ' | Identifier name: "SInt" type: null
 . : ' | . : CallIndexExpr type: null
 . : ' | . : ' Identifier name: "X" type: null
 . : ' | . : ' ArgsIndices
@@ -1693,14 +1638,13 @@ ImportDefinition
 . : ' | Identifier name: "Btype" type: null
 . : ' | IfStatement
 . : ' | . BinaryExpr operator: >= type: null
-. : ' | . : GroupedExpr type: null
-. : ' | . : ' CastExpr type: null
-. : ' | . : ' | CallIndexExpr type: null
-. : ' | . : ' | . Identifier name: "X" type: null
-. : ' | . : ' | . ArgsIndices
-. : ' | . : ' | . : Identifier name: "rs1" type: null
-. : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . Identifier name: "UInt" type: null
+. : ' | . : CastExpr type: null
+. : ' | . : ' CallIndexExpr type: null
+. : ' | . : ' | Identifier name: "X" type: null
+. : ' | . : ' | ArgsIndices
+. : ' | . : ' | . Identifier name: "rs1" type: null
+. : ' | . : ' TypeLiteral type: null
+. : ' | . : ' | Identifier name: "UInt" type: null
 . : ' | . : CallIndexExpr type: null
 . : ' | . : ' Identifier name: "X" type: null
 . : ' | . : ' ArgsIndices
@@ -1738,14 +1682,13 @@ ImportDefinition
 . : ' | Identifier name: "Btype" type: null
 . : ' | IfStatement
 . : ' | . BinaryExpr operator: < type: null
-. : ' | . : GroupedExpr type: null
-. : ' | . : ' CastExpr type: null
-. : ' | . : ' | CallIndexExpr type: null
-. : ' | . : ' | . Identifier name: "X" type: null
-. : ' | . : ' | . ArgsIndices
-. : ' | . : ' | . : Identifier name: "rs1" type: null
-. : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . Identifier name: "SInt" type: null
+. : ' | . : CastExpr type: null
+. : ' | . : ' CallIndexExpr type: null
+. : ' | . : ' | Identifier name: "X" type: null
+. : ' | . : ' | ArgsIndices
+. : ' | . : ' | . Identifier name: "rs1" type: null
+. : ' | . : ' TypeLiteral type: null
+. : ' | . : ' | Identifier name: "SInt" type: null
 . : ' | . : CallIndexExpr type: null
 . : ' | . : ' Identifier name: "X" type: null
 . : ' | . : ' ArgsIndices
@@ -1783,14 +1726,13 @@ ImportDefinition
 . : ' | Identifier name: "Btype" type: null
 . : ' | IfStatement
 . : ' | . BinaryExpr operator: < type: null
-. : ' | . : GroupedExpr type: null
-. : ' | . : ' CastExpr type: null
-. : ' | . : ' | CallIndexExpr type: null
-. : ' | . : ' | . Identifier name: "X" type: null
-. : ' | . : ' | . ArgsIndices
-. : ' | . : ' | . : Identifier name: "rs1" type: null
-. : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . Identifier name: "UInt" type: null
+. : ' | . : CastExpr type: null
+. : ' | . : ' CallIndexExpr type: null
+. : ' | . : ' | Identifier name: "X" type: null
+. : ' | . : ' | ArgsIndices
+. : ' | . : ' | . Identifier name: "rs1" type: null
+. : ' | . : ' TypeLiteral type: null
+. : ' | . : ' | Identifier name: "UInt" type: null
 . : ' | . : CallIndexExpr type: null
 . : ' | . : ' Identifier name: "X" type: null
 . : ' | . : ' ArgsIndices
@@ -1836,17 +1778,14 @@ ImportDefinition
 . : ' | . : AssignmentStatement
 . : ' | . : ' Identifier name: "PC" type: null
 . : ' | . : ' BinaryExpr operator: & type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . BinaryExpr operator: + type: null
-. : ' | . : ' | . : Identifier name: "PC" type: null
-. : ' | . : ' | . : Identifier name: "immS" type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . UnaryExpr operator: UnOp - type: null
-. : ' | . : ' | . : GroupedExpr type: null
-. : ' | . : ' | . : ' CastExpr type: null
-. : ' | . : ' | . : ' | IntegerLiteral literal: 2 (2) type: null
-. : ' | . : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . : ' | . Identifier name: "SIntR" type: null
+. : ' | . : ' | BinaryExpr operator: + type: null
+. : ' | . : ' | . Identifier name: "PC" type: null
+. : ' | . : ' | . Identifier name: "immS" type: null
+. : ' | . : ' | UnaryExpr operator: UnOp - type: null
+. : ' | . : ' | . CastExpr type: null
+. : ' | . : ' | . : IntegerLiteral literal: 2 (2) type: null
+. : ' | . : ' | . : TypeLiteral type: null
+. : ' | . : ' | . : ' Identifier name: "SIntR" type: null
 . : ' | . : AssignmentStatement
 . : ' | . : ' CallIndexExpr type: null
 . : ' | . : ' | Identifier name: "X" type: null
@@ -1883,20 +1822,17 @@ ImportDefinition
 . : ' | . : AssignmentStatement
 . : ' | . : ' Identifier name: "PC" type: null
 . : ' | . : ' BinaryExpr operator: & type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . BinaryExpr operator: + type: null
-. : ' | . : ' | . : CallIndexExpr type: null
-. : ' | . : ' | . : ' Identifier name: "X" type: null
-. : ' | . : ' | . : ' ArgsIndices
-. : ' | . : ' | . : ' | Identifier name: "rs1" type: null
-. : ' | . : ' | . : Identifier name: "immS" type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . UnaryExpr operator: UnOp - type: null
-. : ' | . : ' | . : GroupedExpr type: null
-. : ' | . : ' | . : ' CastExpr type: null
-. : ' | . : ' | . : ' | IntegerLiteral literal: 2 (2) type: null
-. : ' | . : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . : ' | . Identifier name: "SIntR" type: null
+. : ' | . : ' | BinaryExpr operator: + type: null
+. : ' | . : ' | . CallIndexExpr type: null
+. : ' | . : ' | . : Identifier name: "X" type: null
+. : ' | . : ' | . : ArgsIndices
+. : ' | . : ' | . : ' Identifier name: "rs1" type: null
+. : ' | . : ' | . Identifier name: "immS" type: null
+. : ' | . : ' | UnaryExpr operator: UnOp - type: null
+. : ' | . : ' | . CastExpr type: null
+. : ' | . : ' | . : IntegerLiteral literal: 2 (2) type: null
+. : ' | . : ' | . : TypeLiteral type: null
+. : ' | . : ' | . : ' Identifier name: "SIntR" type: null
 . : ' | . : AssignmentStatement
 . : ' | . : ' CallIndexExpr type: null
 . : ' | . : ' | Identifier name: "X" type: null
@@ -2150,25 +2086,21 @@ ImportDefinition
 . : ' | . : ArgsIndices
 . : ' | . : ' Identifier name: "rd" type: null
 . : ' | . CastExpr type: null
-. : ' | . : GroupedExpr type: null
-. : ' | . : ' CastExpr type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . BinaryExpr operator: + type: null
-. : ' | . : ' | . : GroupedExpr type: null
-. : ' | . : ' | . : ' CastExpr type: null
-. : ' | . : ' | . : ' | CallIndexExpr type: null
-. : ' | . : ' | . : ' | . Identifier name: "X" type: null
-. : ' | . : ' | . : ' | . ArgsIndices
-. : ' | . : ' | . : ' | . : Identifier name: "rs1" type: null
-. : ' | . : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . : ' | . Identifier name: "SIntW" type: null
-. : ' | . : ' | . : GroupedExpr type: null
-. : ' | . : ' | . : ' CastExpr type: null
-. : ' | . : ' | . : ' | Identifier name: "immS" type: null
-. : ' | . : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . : ' | . Identifier name: "SIntW" type: null
-. : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . Identifier name: "SInt" type: null
+. : ' | . : CastExpr type: null
+. : ' | . : ' BinaryExpr operator: + type: null
+. : ' | . : ' | CastExpr type: null
+. : ' | . : ' | . CallIndexExpr type: null
+. : ' | . : ' | . : Identifier name: "X" type: null
+. : ' | . : ' | . : ArgsIndices
+. : ' | . : ' | . : ' Identifier name: "rs1" type: null
+. : ' | . : ' | . TypeLiteral type: null
+. : ' | . : ' | . : Identifier name: "SIntW" type: null
+. : ' | . : ' | CastExpr type: null
+. : ' | . : ' | . Identifier name: "immS" type: null
+. : ' | . : ' | . TypeLiteral type: null
+. : ' | . : ' | . : Identifier name: "SIntW" type: null
+. : ' | . : ' TypeLiteral type: null
+. : ' | . : ' | Identifier name: "SInt" type: null
 . : ' | . : TypeLiteral type: null
 . : ' | . : ' Identifier name: "SIntR" type: null
 . : ' EncodingDefinition
@@ -2203,21 +2135,18 @@ ImportDefinition
 . : ' | . : ArgsIndices
 . : ' | . : ' Identifier name: "rd" type: null
 . : ' | . CastExpr type: null
-. : ' | . : GroupedExpr type: null
-. : ' | . : ' CastExpr type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . BinaryExpr operator: << type: null
-. : ' | . : ' | . : GroupedExpr type: null
-. : ' | . : ' | . : ' CastExpr type: null
-. : ' | . : ' | . : ' | CallIndexExpr type: null
-. : ' | . : ' | . : ' | . Identifier name: "X" type: null
-. : ' | . : ' | . : ' | . ArgsIndices
-. : ' | . : ' | . : ' | . : Identifier name: "rs1" type: null
-. : ' | . : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . : ' | . Identifier name: "UIntW" type: null
-. : ' | . : ' | . : Identifier name: "shamt" type: null
-. : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . Identifier name: "SInt" type: null
+. : ' | . : CastExpr type: null
+. : ' | . : ' BinaryExpr operator: << type: null
+. : ' | . : ' | CastExpr type: null
+. : ' | . : ' | . CallIndexExpr type: null
+. : ' | . : ' | . : Identifier name: "X" type: null
+. : ' | . : ' | . : ArgsIndices
+. : ' | . : ' | . : ' Identifier name: "rs1" type: null
+. : ' | . : ' | . TypeLiteral type: null
+. : ' | . : ' | . : Identifier name: "UIntW" type: null
+. : ' | . : ' | Identifier name: "shamt" type: null
+. : ' | . : ' TypeLiteral type: null
+. : ' | . : ' | Identifier name: "SInt" type: null
 . : ' | . : TypeLiteral type: null
 . : ' | . : ' Identifier name: "SIntR" type: null
 . : ' EncodingDefinition
@@ -2254,21 +2183,18 @@ ImportDefinition
 . : ' | . : ArgsIndices
 . : ' | . : ' Identifier name: "rd" type: null
 . : ' | . CastExpr type: null
-. : ' | . : GroupedExpr type: null
-. : ' | . : ' CastExpr type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . BinaryExpr operator: >> type: null
-. : ' | . : ' | . : GroupedExpr type: null
-. : ' | . : ' | . : ' CastExpr type: null
-. : ' | . : ' | . : ' | CallIndexExpr type: null
-. : ' | . : ' | . : ' | . Identifier name: "X" type: null
-. : ' | . : ' | . : ' | . ArgsIndices
-. : ' | . : ' | . : ' | . : Identifier name: "rs1" type: null
-. : ' | . : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . : ' | . Identifier name: "UIntW" type: null
-. : ' | . : ' | . : Identifier name: "shamt" type: null
-. : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . Identifier name: "SInt" type: null
+. : ' | . : CastExpr type: null
+. : ' | . : ' BinaryExpr operator: >> type: null
+. : ' | . : ' | CastExpr type: null
+. : ' | . : ' | . CallIndexExpr type: null
+. : ' | . : ' | . : Identifier name: "X" type: null
+. : ' | . : ' | . : ArgsIndices
+. : ' | . : ' | . : ' Identifier name: "rs1" type: null
+. : ' | . : ' | . TypeLiteral type: null
+. : ' | . : ' | . : Identifier name: "UIntW" type: null
+. : ' | . : ' | Identifier name: "shamt" type: null
+. : ' | . : ' TypeLiteral type: null
+. : ' | . : ' | Identifier name: "SInt" type: null
 . : ' | . : TypeLiteral type: null
 . : ' | . : ' Identifier name: "SIntR" type: null
 . : ' EncodingDefinition
@@ -2305,21 +2231,18 @@ ImportDefinition
 . : ' | . : ArgsIndices
 . : ' | . : ' Identifier name: "rd" type: null
 . : ' | . CastExpr type: null
-. : ' | . : GroupedExpr type: null
-. : ' | . : ' CastExpr type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . BinaryExpr operator: >> type: null
-. : ' | . : ' | . : GroupedExpr type: null
-. : ' | . : ' | . : ' CastExpr type: null
-. : ' | . : ' | . : ' | CallIndexExpr type: null
-. : ' | . : ' | . : ' | . Identifier name: "X" type: null
-. : ' | . : ' | . : ' | . ArgsIndices
-. : ' | . : ' | . : ' | . : Identifier name: "rs1" type: null
-. : ' | . : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . : ' | . Identifier name: "SIntW" type: null
-. : ' | . : ' | . : Identifier name: "shamt" type: null
-. : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . Identifier name: "SInt" type: null
+. : ' | . : CastExpr type: null
+. : ' | . : ' BinaryExpr operator: >> type: null
+. : ' | . : ' | CastExpr type: null
+. : ' | . : ' | . CallIndexExpr type: null
+. : ' | . : ' | . : Identifier name: "X" type: null
+. : ' | . : ' | . : ArgsIndices
+. : ' | . : ' | . : ' Identifier name: "rs1" type: null
+. : ' | . : ' | . TypeLiteral type: null
+. : ' | . : ' | . : Identifier name: "SIntW" type: null
+. : ' | . : ' | Identifier name: "shamt" type: null
+. : ' | . : ' TypeLiteral type: null
+. : ' | . : ' | Identifier name: "SInt" type: null
 . : ' | . : TypeLiteral type: null
 . : ' | . : ' Identifier name: "SIntR" type: null
 . : ' EncodingDefinition
@@ -2356,28 +2279,24 @@ ImportDefinition
 . : ' | . : ArgsIndices
 . : ' | . : ' Identifier name: "rd" type: null
 . : ' | . CastExpr type: null
-. : ' | . : GroupedExpr type: null
-. : ' | . : ' CastExpr type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . BinaryExpr operator: + type: null
-. : ' | . : ' | . : GroupedExpr type: null
-. : ' | . : ' | . : ' CastExpr type: null
-. : ' | . : ' | . : ' | CallIndexExpr type: null
-. : ' | . : ' | . : ' | . Identifier name: "X" type: null
-. : ' | . : ' | . : ' | . ArgsIndices
-. : ' | . : ' | . : ' | . : Identifier name: "rs1" type: null
-. : ' | . : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . : ' | . Identifier name: "Word" type: null
-. : ' | . : ' | . : GroupedExpr type: null
-. : ' | . : ' | . : ' CastExpr type: null
-. : ' | . : ' | . : ' | CallIndexExpr type: null
-. : ' | . : ' | . : ' | . Identifier name: "X" type: null
-. : ' | . : ' | . : ' | . ArgsIndices
-. : ' | . : ' | . : ' | . : Identifier name: "rs2" type: null
-. : ' | . : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . : ' | . Identifier name: "Word" type: null
-. : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . Identifier name: "SInt" type: null
+. : ' | . : CastExpr type: null
+. : ' | . : ' BinaryExpr operator: + type: null
+. : ' | . : ' | CastExpr type: null
+. : ' | . : ' | . CallIndexExpr type: null
+. : ' | . : ' | . : Identifier name: "X" type: null
+. : ' | . : ' | . : ArgsIndices
+. : ' | . : ' | . : ' Identifier name: "rs1" type: null
+. : ' | . : ' | . TypeLiteral type: null
+. : ' | . : ' | . : Identifier name: "Word" type: null
+. : ' | . : ' | CastExpr type: null
+. : ' | . : ' | . CallIndexExpr type: null
+. : ' | . : ' | . : Identifier name: "X" type: null
+. : ' | . : ' | . : ArgsIndices
+. : ' | . : ' | . : ' Identifier name: "rs2" type: null
+. : ' | . : ' | . TypeLiteral type: null
+. : ' | . : ' | . : Identifier name: "Word" type: null
+. : ' | . : ' TypeLiteral type: null
+. : ' | . : ' | Identifier name: "SInt" type: null
 . : ' | . : TypeLiteral type: null
 . : ' | . : ' Identifier name: "SIntR" type: null
 . : ' EncodingDefinition
@@ -2414,28 +2333,24 @@ ImportDefinition
 . : ' | . : ArgsIndices
 . : ' | . : ' Identifier name: "rd" type: null
 . : ' | . CastExpr type: null
-. : ' | . : GroupedExpr type: null
-. : ' | . : ' CastExpr type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . BinaryExpr operator: - type: null
-. : ' | . : ' | . : GroupedExpr type: null
-. : ' | . : ' | . : ' CastExpr type: null
-. : ' | . : ' | . : ' | CallIndexExpr type: null
-. : ' | . : ' | . : ' | . Identifier name: "X" type: null
-. : ' | . : ' | . : ' | . ArgsIndices
-. : ' | . : ' | . : ' | . : Identifier name: "rs1" type: null
-. : ' | . : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . : ' | . Identifier name: "Word" type: null
-. : ' | . : ' | . : GroupedExpr type: null
-. : ' | . : ' | . : ' CastExpr type: null
-. : ' | . : ' | . : ' | CallIndexExpr type: null
-. : ' | . : ' | . : ' | . Identifier name: "X" type: null
-. : ' | . : ' | . : ' | . ArgsIndices
-. : ' | . : ' | . : ' | . : Identifier name: "rs2" type: null
-. : ' | . : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . : ' | . Identifier name: "Word" type: null
-. : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . Identifier name: "SInt" type: null
+. : ' | . : CastExpr type: null
+. : ' | . : ' BinaryExpr operator: - type: null
+. : ' | . : ' | CastExpr type: null
+. : ' | . : ' | . CallIndexExpr type: null
+. : ' | . : ' | . : Identifier name: "X" type: null
+. : ' | . : ' | . : ArgsIndices
+. : ' | . : ' | . : ' Identifier name: "rs1" type: null
+. : ' | . : ' | . TypeLiteral type: null
+. : ' | . : ' | . : Identifier name: "Word" type: null
+. : ' | . : ' | CastExpr type: null
+. : ' | . : ' | . CallIndexExpr type: null
+. : ' | . : ' | . : Identifier name: "X" type: null
+. : ' | . : ' | . : ArgsIndices
+. : ' | . : ' | . : ' Identifier name: "rs2" type: null
+. : ' | . : ' | . TypeLiteral type: null
+. : ' | . : ' | . : Identifier name: "Word" type: null
+. : ' | . : ' TypeLiteral type: null
+. : ' | . : ' | Identifier name: "SInt" type: null
 . : ' | . : TypeLiteral type: null
 . : ' | . : ' Identifier name: "SIntR" type: null
 . : ' EncodingDefinition
@@ -2472,28 +2387,24 @@ ImportDefinition
 . : ' | . : ArgsIndices
 . : ' | . : ' Identifier name: "rd" type: null
 . : ' | . CastExpr type: null
-. : ' | . : GroupedExpr type: null
-. : ' | . : ' CastExpr type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . BinaryExpr operator: << type: null
-. : ' | . : ' | . : GroupedExpr type: null
-. : ' | . : ' | . : ' CastExpr type: null
-. : ' | . : ' | . : ' | CallIndexExpr type: null
-. : ' | . : ' | . : ' | . Identifier name: "X" type: null
-. : ' | . : ' | . : ' | . ArgsIndices
-. : ' | . : ' | . : ' | . : Identifier name: "rs1" type: null
-. : ' | . : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . : ' | . Identifier name: "UIntW" type: null
-. : ' | . : ' | . : GroupedExpr type: null
-. : ' | . : ' | . : ' CastExpr type: null
-. : ' | . : ' | . : ' | CallIndexExpr type: null
-. : ' | . : ' | . : ' | . Identifier name: "X" type: null
-. : ' | . : ' | . : ' | . ArgsIndices
-. : ' | . : ' | . : ' | . : Identifier name: "rs2" type: null
-. : ' | . : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . : ' | . Identifier name: "UInt5" type: null
-. : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . Identifier name: "SInt" type: null
+. : ' | . : CastExpr type: null
+. : ' | . : ' BinaryExpr operator: << type: null
+. : ' | . : ' | CastExpr type: null
+. : ' | . : ' | . CallIndexExpr type: null
+. : ' | . : ' | . : Identifier name: "X" type: null
+. : ' | . : ' | . : ArgsIndices
+. : ' | . : ' | . : ' Identifier name: "rs1" type: null
+. : ' | . : ' | . TypeLiteral type: null
+. : ' | . : ' | . : Identifier name: "UIntW" type: null
+. : ' | . : ' | CastExpr type: null
+. : ' | . : ' | . CallIndexExpr type: null
+. : ' | . : ' | . : Identifier name: "X" type: null
+. : ' | . : ' | . : ArgsIndices
+. : ' | . : ' | . : ' Identifier name: "rs2" type: null
+. : ' | . : ' | . TypeLiteral type: null
+. : ' | . : ' | . : Identifier name: "UInt5" type: null
+. : ' | . : ' TypeLiteral type: null
+. : ' | . : ' | Identifier name: "SInt" type: null
 . : ' | . : TypeLiteral type: null
 . : ' | . : ' Identifier name: "SIntR" type: null
 . : ' EncodingDefinition
@@ -2530,28 +2441,24 @@ ImportDefinition
 . : ' | . : ArgsIndices
 . : ' | . : ' Identifier name: "rd" type: null
 . : ' | . CastExpr type: null
-. : ' | . : GroupedExpr type: null
-. : ' | . : ' CastExpr type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . BinaryExpr operator: >> type: null
-. : ' | . : ' | . : GroupedExpr type: null
-. : ' | . : ' | . : ' CastExpr type: null
-. : ' | . : ' | . : ' | CallIndexExpr type: null
-. : ' | . : ' | . : ' | . Identifier name: "X" type: null
-. : ' | . : ' | . : ' | . ArgsIndices
-. : ' | . : ' | . : ' | . : Identifier name: "rs1" type: null
-. : ' | . : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . : ' | . Identifier name: "UIntW" type: null
-. : ' | . : ' | . : GroupedExpr type: null
-. : ' | . : ' | . : ' CastExpr type: null
-. : ' | . : ' | . : ' | CallIndexExpr type: null
-. : ' | . : ' | . : ' | . Identifier name: "X" type: null
-. : ' | . : ' | . : ' | . ArgsIndices
-. : ' | . : ' | . : ' | . : Identifier name: "rs2" type: null
-. : ' | . : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . : ' | . Identifier name: "UInt5" type: null
-. : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . Identifier name: "SInt" type: null
+. : ' | . : CastExpr type: null
+. : ' | . : ' BinaryExpr operator: >> type: null
+. : ' | . : ' | CastExpr type: null
+. : ' | . : ' | . CallIndexExpr type: null
+. : ' | . : ' | . : Identifier name: "X" type: null
+. : ' | . : ' | . : ArgsIndices
+. : ' | . : ' | . : ' Identifier name: "rs1" type: null
+. : ' | . : ' | . TypeLiteral type: null
+. : ' | . : ' | . : Identifier name: "UIntW" type: null
+. : ' | . : ' | CastExpr type: null
+. : ' | . : ' | . CallIndexExpr type: null
+. : ' | . : ' | . : Identifier name: "X" type: null
+. : ' | . : ' | . : ArgsIndices
+. : ' | . : ' | . : ' Identifier name: "rs2" type: null
+. : ' | . : ' | . TypeLiteral type: null
+. : ' | . : ' | . : Identifier name: "UInt5" type: null
+. : ' | . : ' TypeLiteral type: null
+. : ' | . : ' | Identifier name: "SInt" type: null
 . : ' | . : TypeLiteral type: null
 . : ' | . : ' Identifier name: "SIntR" type: null
 . : ' EncodingDefinition
@@ -2588,28 +2495,24 @@ ImportDefinition
 . : ' | . : ArgsIndices
 . : ' | . : ' Identifier name: "rd" type: null
 . : ' | . CastExpr type: null
-. : ' | . : GroupedExpr type: null
-. : ' | . : ' CastExpr type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . BinaryExpr operator: >> type: null
-. : ' | . : ' | . : GroupedExpr type: null
-. : ' | . : ' | . : ' CastExpr type: null
-. : ' | . : ' | . : ' | CallIndexExpr type: null
-. : ' | . : ' | . : ' | . Identifier name: "X" type: null
-. : ' | . : ' | . : ' | . ArgsIndices
-. : ' | . : ' | . : ' | . : Identifier name: "rs1" type: null
-. : ' | . : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . : ' | . Identifier name: "SIntW" type: null
-. : ' | . : ' | . : GroupedExpr type: null
-. : ' | . : ' | . : ' CastExpr type: null
-. : ' | . : ' | . : ' | CallIndexExpr type: null
-. : ' | . : ' | . : ' | . Identifier name: "X" type: null
-. : ' | . : ' | . : ' | . ArgsIndices
-. : ' | . : ' | . : ' | . : Identifier name: "rs2" type: null
-. : ' | . : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . : ' | . Identifier name: "UInt5" type: null
-. : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . Identifier name: "SInt" type: null
+. : ' | . : CastExpr type: null
+. : ' | . : ' BinaryExpr operator: >> type: null
+. : ' | . : ' | CastExpr type: null
+. : ' | . : ' | . CallIndexExpr type: null
+. : ' | . : ' | . : Identifier name: "X" type: null
+. : ' | . : ' | . : ArgsIndices
+. : ' | . : ' | . : ' Identifier name: "rs1" type: null
+. : ' | . : ' | . TypeLiteral type: null
+. : ' | . : ' | . : Identifier name: "SIntW" type: null
+. : ' | . : ' | CastExpr type: null
+. : ' | . : ' | . CallIndexExpr type: null
+. : ' | . : ' | . : Identifier name: "X" type: null
+. : ' | . : ' | . : ArgsIndices
+. : ' | . : ' | . : ' Identifier name: "rs2" type: null
+. : ' | . : ' | . TypeLiteral type: null
+. : ' | . : ' | . : Identifier name: "UInt5" type: null
+. : ' | . : ' TypeLiteral type: null
+. : ' | . : ' | Identifier name: "SInt" type: null
 . : ' | . : TypeLiteral type: null
 . : ' | . : ' Identifier name: "SIntR" type: null
 . : ' EncodingDefinition
@@ -2686,17 +2589,15 @@ ImportDefinition
 . : ' | . : ArgsIndices
 . : ' | . : ' Identifier name: "rd" type: null
 . : ' | . CastExpr type: null
-. : ' | . : GroupedExpr type: null
-. : ' | . : ' BinaryExpr operator: << type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . CastExpr type: null
-. : ' | . : ' | . : CallIndexExpr type: null
-. : ' | . : ' | . : ' Identifier name: "X" type: null
-. : ' | . : ' | . : ' ArgsIndices
-. : ' | . : ' | . : ' | Identifier name: "rs1" type: null
-. : ' | . : ' | . : TypeLiteral type: null
-. : ' | . : ' | . : ' Identifier name: "UInt" type: null
-. : ' | . : ' | Identifier name: "shamt" type: null
+. : ' | . : BinaryExpr operator: << type: null
+. : ' | . : ' CastExpr type: null
+. : ' | . : ' | CallIndexExpr type: null
+. : ' | . : ' | . Identifier name: "X" type: null
+. : ' | . : ' | . ArgsIndices
+. : ' | . : ' | . : Identifier name: "rs1" type: null
+. : ' | . : ' | TypeLiteral type: null
+. : ' | . : ' | . Identifier name: "UInt" type: null
+. : ' | . : ' Identifier name: "shamt" type: null
 . : ' | . : TypeLiteral type: null
 . : ' | . : ' Identifier name: "Regs" type: null
 . : ' EncodingDefinition
@@ -2735,17 +2636,15 @@ ImportDefinition
 . : ' | . : ArgsIndices
 . : ' | . : ' Identifier name: "rd" type: null
 . : ' | . CastExpr type: null
-. : ' | . : GroupedExpr type: null
-. : ' | . : ' BinaryExpr operator: >> type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . CastExpr type: null
-. : ' | . : ' | . : CallIndexExpr type: null
-. : ' | . : ' | . : ' Identifier name: "X" type: null
-. : ' | . : ' | . : ' ArgsIndices
-. : ' | . : ' | . : ' | Identifier name: "rs1" type: null
-. : ' | . : ' | . : TypeLiteral type: null
-. : ' | . : ' | . : ' Identifier name: "UInt" type: null
-. : ' | . : ' | Identifier name: "shamt" type: null
+. : ' | . : BinaryExpr operator: >> type: null
+. : ' | . : ' CastExpr type: null
+. : ' | . : ' | CallIndexExpr type: null
+. : ' | . : ' | . Identifier name: "X" type: null
+. : ' | . : ' | . ArgsIndices
+. : ' | . : ' | . : Identifier name: "rs1" type: null
+. : ' | . : ' | TypeLiteral type: null
+. : ' | . : ' | . Identifier name: "UInt" type: null
+. : ' | . : ' Identifier name: "shamt" type: null
 . : ' | . : TypeLiteral type: null
 . : ' | . : ' Identifier name: "Regs" type: null
 . : ' EncodingDefinition
@@ -2784,17 +2683,15 @@ ImportDefinition
 . : ' | . : ArgsIndices
 . : ' | . : ' Identifier name: "rd" type: null
 . : ' | . CastExpr type: null
-. : ' | . : GroupedExpr type: null
-. : ' | . : ' BinaryExpr operator: >> type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . CastExpr type: null
-. : ' | . : ' | . : CallIndexExpr type: null
-. : ' | . : ' | . : ' Identifier name: "X" type: null
-. : ' | . : ' | . : ' ArgsIndices
-. : ' | . : ' | . : ' | Identifier name: "rs1" type: null
-. : ' | . : ' | . : TypeLiteral type: null
-. : ' | . : ' | . : ' Identifier name: "SInt" type: null
-. : ' | . : ' | Identifier name: "shamt" type: null
+. : ' | . : BinaryExpr operator: >> type: null
+. : ' | . : ' CastExpr type: null
+. : ' | . : ' | CallIndexExpr type: null
+. : ' | . : ' | . Identifier name: "X" type: null
+. : ' | . : ' | . ArgsIndices
+. : ' | . : ' | . : Identifier name: "rs1" type: null
+. : ' | . : ' | TypeLiteral type: null
+. : ' | . : ' | . Identifier name: "SInt" type: null
+. : ' | . : ' Identifier name: "shamt" type: null
 . : ' | . : TypeLiteral type: null
 . : ' | . : ' Identifier name: "Regs" type: null
 . : ' EncodingDefinition
@@ -2834,17 +2731,15 @@ ImportDefinition
 . : ' | . Identifier name: "UInt" type: null
 . : ' | . IntegerLiteral literal: 20 (20) type: null
 . : ' | CastExpr type: null
-. : ' | . GroupedExpr type: null
-. : ' | . : BinaryExpr operator: >> type: null
-. : ' | . : ' GroupedExpr type: null
-. : ' | . : ' | BinaryExpr operator: + type: null
-. : ' | . : ' | . Identifier name: "symbol" type: null
-. : ' | . : ' | . CastExpr type: null
-. : ' | . : ' | . : BinaryLiteral literal: 0x800 (2048) type: null
-. : ' | . : ' | . : TypeLiteral type: null
-. : ' | . : ' | . : ' Identifier name: "Bits" type: null
-. : ' | . : ' | . : ' IntegerLiteral literal: 32 (32) type: null
-. : ' | . : ' IntegerLiteral literal: 12 (12) type: null
+. : ' | . BinaryExpr operator: >> type: null
+. : ' | . : BinaryExpr operator: + type: null
+. : ' | . : ' Identifier name: "symbol" type: null
+. : ' | . : ' CastExpr type: null
+. : ' | . : ' | BinaryLiteral literal: 0x800 (2048) type: null
+. : ' | . : ' | TypeLiteral type: null
+. : ' | . : ' | . Identifier name: "Bits" type: null
+. : ' | . : ' | . IntegerLiteral literal: 32 (32) type: null
+. : ' | . : IntegerLiteral literal: 12 (12) type: null
 . : ' | . TypeLiteral type: null
 . : ' | . : Identifier name: "UInt" type: null
 . : ' | . : IntegerLiteral literal: 20 (20) type: null
@@ -2870,13 +2765,11 @@ ImportDefinition
 . : ' | . Identifier name: "UInt" type: null
 . : ' | . IntegerLiteral literal: 20 (20) type: null
 . : ' | CastExpr type: null
-. : ' | . GroupedExpr type: null
+. : ' | . BinaryExpr operator: >> type: null
 . : ' | . : BinaryExpr operator: >> type: null
-. : ' | . : ' GroupedExpr type: null
-. : ' | . : ' | BinaryExpr operator: >> type: null
-. : ' | . : ' | . Identifier name: "symbol" type: null
-. : ' | . : ' | . IntegerLiteral literal: 32 (32) type: null
-. : ' | . : ' IntegerLiteral literal: 12 (12) type: null
+. : ' | . : ' Identifier name: "symbol" type: null
+. : ' | . : ' IntegerLiteral literal: 32 (32) type: null
+. : ' | . : IntegerLiteral literal: 12 (12) type: null
 . : ' | . TypeLiteral type: null
 . : ' | . : Identifier name: "UInt" type: null
 . : ' | . : IntegerLiteral literal: 20 (20) type: null
@@ -2889,10 +2782,9 @@ ImportDefinition
 . : ' | . Identifier name: "SInt" type: null
 . : ' | . IntegerLiteral literal: 12 (12) type: null
 . : ' | CastExpr type: null
-. : ' | . GroupedExpr type: null
-. : ' | . : BinaryExpr operator: >> type: null
-. : ' | . : ' Identifier name: "symbol" type: null
-. : ' | . : ' IntegerLiteral literal: 32 (32) type: null
+. : ' | . BinaryExpr operator: >> type: null
+. : ' | . : Identifier name: "symbol" type: null
+. : ' | . : IntegerLiteral literal: 32 (32) type: null
 . : ' | . TypeLiteral type: null
 . : ' | . : Identifier name: "SInt" type: null
 . : ' | . : IntegerLiteral literal: 12 (12) type: null
@@ -2905,10 +2797,9 @@ ImportDefinition
 . : ' | . Identifier name: "SInt" type: null
 . : ' | . IntegerLiteral literal: 12 (12) type: null
 . : ' | CastExpr type: null
-. : ' | . GroupedExpr type: null
-. : ' | . : BinaryExpr operator: >> type: null
-. : ' | . : ' Identifier name: "symbol" type: null
-. : ' | . : ' IntegerLiteral literal: 52 (52) type: null
+. : ' | . BinaryExpr operator: >> type: null
+. : ' | . : Identifier name: "symbol" type: null
+. : ' | . : IntegerLiteral literal: 52 (52) type: null
 . : ' | . TypeLiteral type: null
 . : ' | . : Identifier name: "SInt" type: null
 . : ' | . : IntegerLiteral literal: 12 (12) type: null
@@ -2936,17 +2827,15 @@ ImportDefinition
 . : ' | . Identifier name: "UInt" type: null
 . : ' | . IntegerLiteral literal: 20 (20) type: null
 . : ' | CastExpr type: null
-. : ' | . GroupedExpr type: null
-. : ' | . : BinaryExpr operator: >> type: null
-. : ' | . : ' GroupedExpr type: null
-. : ' | . : ' | BinaryExpr operator: + type: null
-. : ' | . : ' | . Identifier name: "symbol" type: null
-. : ' | . : ' | . CastExpr type: null
-. : ' | . : ' | . : BinaryLiteral literal: 0x800 (2048) type: null
-. : ' | . : ' | . : TypeLiteral type: null
-. : ' | . : ' | . : ' Identifier name: "Bits" type: null
-. : ' | . : ' | . : ' IntegerLiteral literal: 32 (32) type: null
-. : ' | . : ' IntegerLiteral literal: 12 (12) type: null
+. : ' | . BinaryExpr operator: >> type: null
+. : ' | . : BinaryExpr operator: + type: null
+. : ' | . : ' Identifier name: "symbol" type: null
+. : ' | . : ' CastExpr type: null
+. : ' | . : ' | BinaryLiteral literal: 0x800 (2048) type: null
+. : ' | . : ' | TypeLiteral type: null
+. : ' | . : ' | . Identifier name: "Bits" type: null
+. : ' | . : ' | . IntegerLiteral literal: 32 (32) type: null
+. : ' | . : IntegerLiteral literal: 12 (12) type: null
 . : ' | . TypeLiteral type: null
 . : ' | . : Identifier name: "UInt" type: null
 . : ' | . : IntegerLiteral literal: 20 (20) type: null
@@ -2977,17 +2866,15 @@ ImportDefinition
 . : ' | . Identifier name: "UInt" type: null
 . : ' | . IntegerLiteral literal: 20 (20) type: null
 . : ' | CastExpr type: null
-. : ' | . GroupedExpr type: null
-. : ' | . : BinaryExpr operator: >> type: null
-. : ' | . : ' GroupedExpr type: null
-. : ' | . : ' | BinaryExpr operator: + type: null
-. : ' | . : ' | . Identifier name: "symbol" type: null
-. : ' | . : ' | . CastExpr type: null
-. : ' | . : ' | . : BinaryLiteral literal: 0x800 (2048) type: null
-. : ' | . : ' | . : TypeLiteral type: null
-. : ' | . : ' | . : ' Identifier name: "Bits" type: null
-. : ' | . : ' | . : ' IntegerLiteral literal: 32 (32) type: null
-. : ' | . : ' IntegerLiteral literal: 12 (12) type: null
+. : ' | . BinaryExpr operator: >> type: null
+. : ' | . : BinaryExpr operator: + type: null
+. : ' | . : ' Identifier name: "symbol" type: null
+. : ' | . : ' CastExpr type: null
+. : ' | . : ' | BinaryLiteral literal: 0x800 (2048) type: null
+. : ' | . : ' | TypeLiteral type: null
+. : ' | . : ' | . Identifier name: "Bits" type: null
+. : ' | . : ' | . IntegerLiteral literal: 32 (32) type: null
+. : ' | . : IntegerLiteral literal: 12 (12) type: null
 . : ' | . TypeLiteral type: null
 . : ' | . : Identifier name: "UInt" type: null
 . : ' | . : IntegerLiteral literal: 20 (20) type: null
@@ -3691,24 +3578,21 @@ ImportDefinition
 . : ' | . : ArgsIndices
 . : ' | . : ' Identifier name: "rd" type: null
 . : ' | . CastExpr type: null
-. : ' | . : GroupedExpr type: null
-. : ' | . : ' BinaryExpr operator: * type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . CastExpr type: null
-. : ' | . : ' | . : CallIndexExpr type: null
-. : ' | . : ' | . : ' Identifier name: "X" type: null
-. : ' | . : ' | . : ' ArgsIndices
-. : ' | . : ' | . : ' | Identifier name: "rs1" type: null
-. : ' | . : ' | . : TypeLiteral type: null
-. : ' | . : ' | . : ' Identifier name: "Bits" type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . CastExpr type: null
-. : ' | . : ' | . : CallIndexExpr type: null
-. : ' | . : ' | . : ' Identifier name: "X" type: null
-. : ' | . : ' | . : ' ArgsIndices
-. : ' | . : ' | . : ' | Identifier name: "rs2" type: null
-. : ' | . : ' | . : TypeLiteral type: null
-. : ' | . : ' | . : ' Identifier name: "Bits" type: null
+. : ' | . : BinaryExpr operator: * type: null
+. : ' | . : ' CastExpr type: null
+. : ' | . : ' | CallIndexExpr type: null
+. : ' | . : ' | . Identifier name: "X" type: null
+. : ' | . : ' | . ArgsIndices
+. : ' | . : ' | . : Identifier name: "rs1" type: null
+. : ' | . : ' | TypeLiteral type: null
+. : ' | . : ' | . Identifier name: "Bits" type: null
+. : ' | . : ' CastExpr type: null
+. : ' | . : ' | CallIndexExpr type: null
+. : ' | . : ' | . Identifier name: "X" type: null
+. : ' | . : ' | . ArgsIndices
+. : ' | . : ' | . : Identifier name: "rs2" type: null
+. : ' | . : ' | TypeLiteral type: null
+. : ' | . : ' | . Identifier name: "Bits" type: null
 . : ' | . : TypeLiteral type: null
 . : ' | . : ' Identifier name: "Regs" type: null
 . : ' EncodingDefinition
@@ -3742,22 +3626,20 @@ ImportDefinition
 . : ' | LetStatement
 . : ' | . Identifier name: "result" type: null
 . : ' | . BinaryExpr operator: *# type: null
-. : ' | . : GroupedExpr type: null
-. : ' | . : ' CastExpr type: null
-. : ' | . : ' | CallIndexExpr type: null
-. : ' | . : ' | . Identifier name: "X" type: null
-. : ' | . : ' | . ArgsIndices
-. : ' | . : ' | . : Identifier name: "rs1" type: null
-. : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . Identifier name: "SInt" type: null
-. : ' | . : GroupedExpr type: null
-. : ' | . : ' CastExpr type: null
-. : ' | . : ' | CallIndexExpr type: null
-. : ' | . : ' | . Identifier name: "X" type: null
-. : ' | . : ' | . ArgsIndices
-. : ' | . : ' | . : Identifier name: "rs2" type: null
-. : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . Identifier name: "SInt" type: null
+. : ' | . : CastExpr type: null
+. : ' | . : ' CallIndexExpr type: null
+. : ' | . : ' | Identifier name: "X" type: null
+. : ' | . : ' | ArgsIndices
+. : ' | . : ' | . Identifier name: "rs1" type: null
+. : ' | . : ' TypeLiteral type: null
+. : ' | . : ' | Identifier name: "SInt" type: null
+. : ' | . : CastExpr type: null
+. : ' | . : ' CallIndexExpr type: null
+. : ' | . : ' | Identifier name: "X" type: null
+. : ' | . : ' | ArgsIndices
+. : ' | . : ' | . Identifier name: "rs2" type: null
+. : ' | . : ' TypeLiteral type: null
+. : ' | . : ' | Identifier name: "SInt" type: null
 . : ' | . AssignmentStatement
 . : ' | . : CallIndexExpr type: null
 . : ' | . : ' Identifier name: "X" type: null
@@ -3800,22 +3682,20 @@ ImportDefinition
 . : ' | LetStatement
 . : ' | . Identifier name: "result" type: null
 . : ' | . BinaryExpr operator: *# type: null
-. : ' | . : GroupedExpr type: null
-. : ' | . : ' CastExpr type: null
-. : ' | . : ' | CallIndexExpr type: null
-. : ' | . : ' | . Identifier name: "X" type: null
-. : ' | . : ' | . ArgsIndices
-. : ' | . : ' | . : Identifier name: "rs1" type: null
-. : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . Identifier name: "SInt" type: null
-. : ' | . : GroupedExpr type: null
-. : ' | . : ' CastExpr type: null
-. : ' | . : ' | CallIndexExpr type: null
-. : ' | . : ' | . Identifier name: "X" type: null
-. : ' | . : ' | . ArgsIndices
-. : ' | . : ' | . : Identifier name: "rs2" type: null
-. : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . Identifier name: "UInt" type: null
+. : ' | . : CastExpr type: null
+. : ' | . : ' CallIndexExpr type: null
+. : ' | . : ' | Identifier name: "X" type: null
+. : ' | . : ' | ArgsIndices
+. : ' | . : ' | . Identifier name: "rs1" type: null
+. : ' | . : ' TypeLiteral type: null
+. : ' | . : ' | Identifier name: "SInt" type: null
+. : ' | . : CastExpr type: null
+. : ' | . : ' CallIndexExpr type: null
+. : ' | . : ' | Identifier name: "X" type: null
+. : ' | . : ' | ArgsIndices
+. : ' | . : ' | . Identifier name: "rs2" type: null
+. : ' | . : ' TypeLiteral type: null
+. : ' | . : ' | Identifier name: "UInt" type: null
 . : ' | . AssignmentStatement
 . : ' | . : CallIndexExpr type: null
 . : ' | . : ' Identifier name: "X" type: null
@@ -3858,22 +3738,20 @@ ImportDefinition
 . : ' | LetStatement
 . : ' | . Identifier name: "result" type: null
 . : ' | . BinaryExpr operator: *# type: null
-. : ' | . : GroupedExpr type: null
-. : ' | . : ' CastExpr type: null
-. : ' | . : ' | CallIndexExpr type: null
-. : ' | . : ' | . Identifier name: "X" type: null
-. : ' | . : ' | . ArgsIndices
-. : ' | . : ' | . : Identifier name: "rs1" type: null
-. : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . Identifier name: "UInt" type: null
-. : ' | . : GroupedExpr type: null
-. : ' | . : ' CastExpr type: null
-. : ' | . : ' | CallIndexExpr type: null
-. : ' | . : ' | . Identifier name: "X" type: null
-. : ' | . : ' | . ArgsIndices
-. : ' | . : ' | . : Identifier name: "rs2" type: null
-. : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . Identifier name: "UInt" type: null
+. : ' | . : CastExpr type: null
+. : ' | . : ' CallIndexExpr type: null
+. : ' | . : ' | Identifier name: "X" type: null
+. : ' | . : ' | ArgsIndices
+. : ' | . : ' | . Identifier name: "rs1" type: null
+. : ' | . : ' TypeLiteral type: null
+. : ' | . : ' | Identifier name: "UInt" type: null
+. : ' | . : CastExpr type: null
+. : ' | . : ' CallIndexExpr type: null
+. : ' | . : ' | Identifier name: "X" type: null
+. : ' | . : ' | ArgsIndices
+. : ' | . : ' | . Identifier name: "rs2" type: null
+. : ' | . : ' TypeLiteral type: null
+. : ' | . : ' | Identifier name: "UInt" type: null
 . : ' | . AssignmentStatement
 . : ' | . : CallIndexExpr type: null
 . : ' | . : ' Identifier name: "X" type: null
@@ -3934,13 +3812,11 @@ ImportDefinition
 . : ' | . : LetStatement
 . : ' | . : ' Identifier name: "AllOnes" type: null
 . : ' | . : ' CastExpr type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . UnaryExpr operator: UnOp - type: null
-. : ' | . : ' | . : GroupedExpr type: null
-. : ' | . : ' | . : ' CastExpr type: null
-. : ' | . : ' | . : ' | IntegerLiteral literal: 1 (1) type: null
-. : ' | . : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . : ' | . Identifier name: "SIntR" type: null
+. : ' | . : ' | UnaryExpr operator: UnOp - type: null
+. : ' | . : ' | . CastExpr type: null
+. : ' | . : ' | . : IntegerLiteral literal: 1 (1) type: null
+. : ' | . : ' | . : TypeLiteral type: null
+. : ' | . : ' | . : ' Identifier name: "SIntR" type: null
 . : ' | . : ' | TypeLiteral type: null
 . : ' | . : ' | . Identifier name: "SIntR" type: null
 . : ' | . : ' LetStatement
@@ -3948,39 +3824,32 @@ ImportDefinition
 . : ' | . : ' | IfExpr type: null
 . : ' | . : ' | . BinaryExpr operator: = type: null
 . : ' | . : ' | . : Identifier name: "divisor" type: null
-. : ' | . : ' | . : GroupedExpr type: null
-. : ' | . : ' | . : ' CastExpr type: null
-. : ' | . : ' | . : ' | IntegerLiteral literal: 0 (0) type: null
-. : ' | . : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . : ' | . Identifier name: "SIntR" type: null
+. : ' | . : ' | . : CastExpr type: null
+. : ' | . : ' | . : ' IntegerLiteral literal: 0 (0) type: null
+. : ' | . : ' | . : ' TypeLiteral type: null
+. : ' | . : ' | . : ' | Identifier name: "SIntR" type: null
 . : ' | . : ' | . Identifier name: "AllOnes" type: null
 . : ' | . : ' | . LetExpr type: null
 . : ' | . : ' | . : Identifier name: "MinInt" type: null
 . : ' | . : ' | . : CastExpr type: null
-. : ' | . : ' | . : ' GroupedExpr type: null
-. : ' | . : ' | . : ' | BinaryExpr operator: << type: null
-. : ' | . : ' | . : ' | . GroupedExpr type: null
-. : ' | . : ' | . : ' | . : CastExpr type: null
-. : ' | . : ' | . : ' | . : ' IntegerLiteral literal: 1 (1) type: null
-. : ' | . : ' | . : ' | . : ' TypeLiteral type: null
-. : ' | . : ' | . : ' | . : ' | Identifier name: "Regs" type: null
-. : ' | . : ' | . : ' | . GroupedExpr type: null
-. : ' | . : ' | . : ' | . : BinaryExpr operator: - type: null
-. : ' | . : ' | . : ' | . : ' GroupedExpr type: null
-. : ' | . : ' | . : ' | . : ' | Identifier name: "MLen" type: null
-. : ' | . : ' | . : ' | . : ' IntegerLiteral literal: 1 (1) type: null
+. : ' | . : ' | . : ' BinaryExpr operator: << type: null
+. : ' | . : ' | . : ' | CastExpr type: null
+. : ' | . : ' | . : ' | . IntegerLiteral literal: 1 (1) type: null
+. : ' | . : ' | . : ' | . TypeLiteral type: null
+. : ' | . : ' | . : ' | . : Identifier name: "Regs" type: null
+. : ' | . : ' | . : ' | BinaryExpr operator: - type: null
+. : ' | . : ' | . : ' | . Identifier name: "MLen" type: null
+. : ' | . : ' | . : ' | . IntegerLiteral literal: 1 (1) type: null
 . : ' | . : ' | . : ' TypeLiteral type: null
 . : ' | . : ' | . : ' | Identifier name: "SIntR" type: null
 . : ' | . : ' | . : IfExpr type: null
 . : ' | . : ' | . : ' BinaryExpr operator: & type: null
-. : ' | . : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . : ' | . BinaryExpr operator: = type: null
-. : ' | . : ' | . : ' | . : Identifier name: "dividend" type: null
-. : ' | . : ' | . : ' | . : Identifier name: "MinInt" type: null
-. : ' | . : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . : ' | . BinaryExpr operator: = type: null
-. : ' | . : ' | . : ' | . : Identifier name: "divisor" type: null
-. : ' | . : ' | . : ' | . : Identifier name: "AllOnes" type: null
+. : ' | . : ' | . : ' | BinaryExpr operator: = type: null
+. : ' | . : ' | . : ' | . Identifier name: "dividend" type: null
+. : ' | . : ' | . : ' | . Identifier name: "MinInt" type: null
+. : ' | . : ' | . : ' | BinaryExpr operator: = type: null
+. : ' | . : ' | . : ' | . Identifier name: "divisor" type: null
+. : ' | . : ' | . : ' | . Identifier name: "AllOnes" type: null
 . : ' | . : ' | . : ' Identifier name: "MinInt" type: null
 . : ' | . : ' | . : ' BinaryExpr operator: / type: null
 . : ' | . : ' | . : ' | Identifier name: "dividend" type: null
@@ -3991,11 +3860,10 @@ ImportDefinition
 . : ' | . : ' | . : ArgsIndices
 . : ' | . : ' | . : ' Identifier name: "rd" type: null
 . : ' | . : ' | . CastExpr type: null
-. : ' | . : ' | . : GroupedExpr type: null
-. : ' | . : ' | . : ' CastExpr type: null
-. : ' | . : ' | . : ' | Identifier name: "result" type: null
-. : ' | . : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . : ' | . Identifier name: "SInt" type: null
+. : ' | . : ' | . : CastExpr type: null
+. : ' | . : ' | . : ' Identifier name: "result" type: null
+. : ' | . : ' | . : ' TypeLiteral type: null
+. : ' | . : ' | . : ' | Identifier name: "SInt" type: null
 . : ' | . : ' | . : TypeLiteral type: null
 . : ' | . : ' | . : ' Identifier name: "Regs" type: null
 . : ' EncodingDefinition
@@ -4047,13 +3915,11 @@ ImportDefinition
 . : ' | . : LetStatement
 . : ' | . : ' Identifier name: "AllOnes" type: null
 . : ' | . : ' CastExpr type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . UnaryExpr operator: UnOp - type: null
-. : ' | . : ' | . : GroupedExpr type: null
-. : ' | . : ' | . : ' CastExpr type: null
-. : ' | . : ' | . : ' | IntegerLiteral literal: 1 (1) type: null
-. : ' | . : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . : ' | . Identifier name: "SIntR" type: null
+. : ' | . : ' | UnaryExpr operator: UnOp - type: null
+. : ' | . : ' | . CastExpr type: null
+. : ' | . : ' | . : IntegerLiteral literal: 1 (1) type: null
+. : ' | . : ' | . : TypeLiteral type: null
+. : ' | . : ' | . : ' Identifier name: "SIntR" type: null
 . : ' | . : ' | TypeLiteral type: null
 . : ' | . : ' | . Identifier name: "UIntR" type: null
 . : ' | . : ' LetStatement
@@ -4061,11 +3927,10 @@ ImportDefinition
 . : ' | . : ' | IfExpr type: null
 . : ' | . : ' | . BinaryExpr operator: = type: null
 . : ' | . : ' | . : Identifier name: "divisor" type: null
-. : ' | . : ' | . : GroupedExpr type: null
-. : ' | . : ' | . : ' CastExpr type: null
-. : ' | . : ' | . : ' | IntegerLiteral literal: 0 (0) type: null
-. : ' | . : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . : ' | . Identifier name: "UIntR" type: null
+. : ' | . : ' | . : CastExpr type: null
+. : ' | . : ' | . : ' IntegerLiteral literal: 0 (0) type: null
+. : ' | . : ' | . : ' TypeLiteral type: null
+. : ' | . : ' | . : ' | Identifier name: "UIntR" type: null
 . : ' | . : ' | . Identifier name: "AllOnes" type: null
 . : ' | . : ' | . BinaryExpr operator: / type: null
 . : ' | . : ' | . : Identifier name: "dividend" type: null
@@ -4076,11 +3941,10 @@ ImportDefinition
 . : ' | . : ' | . : ArgsIndices
 . : ' | . : ' | . : ' Identifier name: "rd" type: null
 . : ' | . : ' | . CastExpr type: null
-. : ' | . : ' | . : GroupedExpr type: null
-. : ' | . : ' | . : ' CastExpr type: null
-. : ' | . : ' | . : ' | Identifier name: "result" type: null
-. : ' | . : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . : ' | . Identifier name: "SInt" type: null
+. : ' | . : ' | . : CastExpr type: null
+. : ' | . : ' | . : ' Identifier name: "result" type: null
+. : ' | . : ' | . : ' TypeLiteral type: null
+. : ' | . : ' | . : ' | Identifier name: "SInt" type: null
 . : ' | . : ' | . : TypeLiteral type: null
 . : ' | . : ' | . : ' Identifier name: "Regs" type: null
 . : ' EncodingDefinition
@@ -4132,13 +3996,11 @@ ImportDefinition
 . : ' | . : LetStatement
 . : ' | . : ' Identifier name: "AllOnes" type: null
 . : ' | . : ' CastExpr type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . UnaryExpr operator: UnOp - type: null
-. : ' | . : ' | . : GroupedExpr type: null
-. : ' | . : ' | . : ' CastExpr type: null
-. : ' | . : ' | . : ' | IntegerLiteral literal: 1 (1) type: null
-. : ' | . : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . : ' | . Identifier name: "SIntR" type: null
+. : ' | . : ' | UnaryExpr operator: UnOp - type: null
+. : ' | . : ' | . CastExpr type: null
+. : ' | . : ' | . : IntegerLiteral literal: 1 (1) type: null
+. : ' | . : ' | . : TypeLiteral type: null
+. : ' | . : ' | . : ' Identifier name: "SIntR" type: null
 . : ' | . : ' | TypeLiteral type: null
 . : ' | . : ' | . Identifier name: "SIntR" type: null
 . : ' | . : ' LetStatement
@@ -4146,39 +4008,32 @@ ImportDefinition
 . : ' | . : ' | IfExpr type: null
 . : ' | . : ' | . BinaryExpr operator: = type: null
 . : ' | . : ' | . : Identifier name: "divisor" type: null
-. : ' | . : ' | . : GroupedExpr type: null
-. : ' | . : ' | . : ' CastExpr type: null
-. : ' | . : ' | . : ' | IntegerLiteral literal: 0 (0) type: null
-. : ' | . : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . : ' | . Identifier name: "SIntR" type: null
+. : ' | . : ' | . : CastExpr type: null
+. : ' | . : ' | . : ' IntegerLiteral literal: 0 (0) type: null
+. : ' | . : ' | . : ' TypeLiteral type: null
+. : ' | . : ' | . : ' | Identifier name: "SIntR" type: null
 . : ' | . : ' | . Identifier name: "dividend" type: null
 . : ' | . : ' | . LetExpr type: null
 . : ' | . : ' | . : Identifier name: "MinInt" type: null
 . : ' | . : ' | . : CastExpr type: null
-. : ' | . : ' | . : ' GroupedExpr type: null
-. : ' | . : ' | . : ' | BinaryExpr operator: << type: null
-. : ' | . : ' | . : ' | . GroupedExpr type: null
-. : ' | . : ' | . : ' | . : CastExpr type: null
-. : ' | . : ' | . : ' | . : ' IntegerLiteral literal: 1 (1) type: null
-. : ' | . : ' | . : ' | . : ' TypeLiteral type: null
-. : ' | . : ' | . : ' | . : ' | Identifier name: "Regs" type: null
-. : ' | . : ' | . : ' | . GroupedExpr type: null
-. : ' | . : ' | . : ' | . : BinaryExpr operator: - type: null
-. : ' | . : ' | . : ' | . : ' GroupedExpr type: null
-. : ' | . : ' | . : ' | . : ' | Identifier name: "MLen" type: null
-. : ' | . : ' | . : ' | . : ' IntegerLiteral literal: 1 (1) type: null
+. : ' | . : ' | . : ' BinaryExpr operator: << type: null
+. : ' | . : ' | . : ' | CastExpr type: null
+. : ' | . : ' | . : ' | . IntegerLiteral literal: 1 (1) type: null
+. : ' | . : ' | . : ' | . TypeLiteral type: null
+. : ' | . : ' | . : ' | . : Identifier name: "Regs" type: null
+. : ' | . : ' | . : ' | BinaryExpr operator: - type: null
+. : ' | . : ' | . : ' | . Identifier name: "MLen" type: null
+. : ' | . : ' | . : ' | . IntegerLiteral literal: 1 (1) type: null
 . : ' | . : ' | . : ' TypeLiteral type: null
 . : ' | . : ' | . : ' | Identifier name: "SIntR" type: null
 . : ' | . : ' | . : IfExpr type: null
 . : ' | . : ' | . : ' BinaryExpr operator: & type: null
-. : ' | . : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . : ' | . BinaryExpr operator: = type: null
-. : ' | . : ' | . : ' | . : Identifier name: "dividend" type: null
-. : ' | . : ' | . : ' | . : Identifier name: "MinInt" type: null
-. : ' | . : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . : ' | . BinaryExpr operator: = type: null
-. : ' | . : ' | . : ' | . : Identifier name: "divisor" type: null
-. : ' | . : ' | . : ' | . : Identifier name: "AllOnes" type: null
+. : ' | . : ' | . : ' | BinaryExpr operator: = type: null
+. : ' | . : ' | . : ' | . Identifier name: "dividend" type: null
+. : ' | . : ' | . : ' | . Identifier name: "MinInt" type: null
+. : ' | . : ' | . : ' | BinaryExpr operator: = type: null
+. : ' | . : ' | . : ' | . Identifier name: "divisor" type: null
+. : ' | . : ' | . : ' | . Identifier name: "AllOnes" type: null
 . : ' | . : ' | . : ' IntegerLiteral literal: 0 (0) type: null
 . : ' | . : ' | . : ' BinaryExpr operator: % type: null
 . : ' | . : ' | . : ' | Identifier name: "dividend" type: null
@@ -4189,11 +4044,10 @@ ImportDefinition
 . : ' | . : ' | . : ArgsIndices
 . : ' | . : ' | . : ' Identifier name: "rd" type: null
 . : ' | . : ' | . CastExpr type: null
-. : ' | . : ' | . : GroupedExpr type: null
-. : ' | . : ' | . : ' CastExpr type: null
-. : ' | . : ' | . : ' | Identifier name: "result" type: null
-. : ' | . : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . : ' | . Identifier name: "SInt" type: null
+. : ' | . : ' | . : CastExpr type: null
+. : ' | . : ' | . : ' Identifier name: "result" type: null
+. : ' | . : ' | . : ' TypeLiteral type: null
+. : ' | . : ' | . : ' | Identifier name: "SInt" type: null
 . : ' | . : ' | . : TypeLiteral type: null
 . : ' | . : ' | . : ' Identifier name: "Regs" type: null
 . : ' EncodingDefinition
@@ -4245,13 +4099,11 @@ ImportDefinition
 . : ' | . : LetStatement
 . : ' | . : ' Identifier name: "AllOnes" type: null
 . : ' | . : ' CastExpr type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . UnaryExpr operator: UnOp - type: null
-. : ' | . : ' | . : GroupedExpr type: null
-. : ' | . : ' | . : ' CastExpr type: null
-. : ' | . : ' | . : ' | IntegerLiteral literal: 1 (1) type: null
-. : ' | . : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . : ' | . Identifier name: "SIntR" type: null
+. : ' | . : ' | UnaryExpr operator: UnOp - type: null
+. : ' | . : ' | . CastExpr type: null
+. : ' | . : ' | . : IntegerLiteral literal: 1 (1) type: null
+. : ' | . : ' | . : TypeLiteral type: null
+. : ' | . : ' | . : ' Identifier name: "SIntR" type: null
 . : ' | . : ' | TypeLiteral type: null
 . : ' | . : ' | . Identifier name: "UIntR" type: null
 . : ' | . : ' LetStatement
@@ -4259,11 +4111,10 @@ ImportDefinition
 . : ' | . : ' | IfExpr type: null
 . : ' | . : ' | . BinaryExpr operator: = type: null
 . : ' | . : ' | . : Identifier name: "divisor" type: null
-. : ' | . : ' | . : GroupedExpr type: null
-. : ' | . : ' | . : ' CastExpr type: null
-. : ' | . : ' | . : ' | IntegerLiteral literal: 0 (0) type: null
-. : ' | . : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . : ' | . Identifier name: "UIntR" type: null
+. : ' | . : ' | . : CastExpr type: null
+. : ' | . : ' | . : ' IntegerLiteral literal: 0 (0) type: null
+. : ' | . : ' | . : ' TypeLiteral type: null
+. : ' | . : ' | . : ' | Identifier name: "UIntR" type: null
 . : ' | . : ' | . Identifier name: "dividend" type: null
 . : ' | . : ' | . BinaryExpr operator: % type: null
 . : ' | . : ' | . : Identifier name: "dividend" type: null
@@ -4274,11 +4125,10 @@ ImportDefinition
 . : ' | . : ' | . : ArgsIndices
 . : ' | . : ' | . : ' Identifier name: "rd" type: null
 . : ' | . : ' | . CastExpr type: null
-. : ' | . : ' | . : GroupedExpr type: null
-. : ' | . : ' | . : ' CastExpr type: null
-. : ' | . : ' | . : ' | Identifier name: "result" type: null
-. : ' | . : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . : ' | . Identifier name: "SInt" type: null
+. : ' | . : ' | . : CastExpr type: null
+. : ' | . : ' | . : ' Identifier name: "result" type: null
+. : ' | . : ' | . : ' TypeLiteral type: null
+. : ' | . : ' | . : ' | Identifier name: "SInt" type: null
 . : ' | . : ' | . : TypeLiteral type: null
 . : ' | . : ' | . : ' Identifier name: "Regs" type: null
 . : ' EncodingDefinition
@@ -4315,28 +4165,24 @@ ImportDefinition
 . : ' | . : ArgsIndices
 . : ' | . : ' Identifier name: "rd" type: null
 . : ' | . CastExpr type: null
-. : ' | . : GroupedExpr type: null
-. : ' | . : ' CastExpr type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . BinaryExpr operator: * type: null
-. : ' | . : ' | . : GroupedExpr type: null
-. : ' | . : ' | . : ' CastExpr type: null
-. : ' | . : ' | . : ' | CallIndexExpr type: null
-. : ' | . : ' | . : ' | . Identifier name: "X" type: null
-. : ' | . : ' | . : ' | . ArgsIndices
-. : ' | . : ' | . : ' | . : Identifier name: "rs1" type: null
-. : ' | . : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . : ' | . Identifier name: "SIntW" type: null
-. : ' | . : ' | . : GroupedExpr type: null
-. : ' | . : ' | . : ' CastExpr type: null
-. : ' | . : ' | . : ' | CallIndexExpr type: null
-. : ' | . : ' | . : ' | . Identifier name: "X" type: null
-. : ' | . : ' | . : ' | . ArgsIndices
-. : ' | . : ' | . : ' | . : Identifier name: "rs2" type: null
-. : ' | . : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . : ' | . Identifier name: "SIntW" type: null
-. : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . Identifier name: "SInt" type: null
+. : ' | . : CastExpr type: null
+. : ' | . : ' BinaryExpr operator: * type: null
+. : ' | . : ' | CastExpr type: null
+. : ' | . : ' | . CallIndexExpr type: null
+. : ' | . : ' | . : Identifier name: "X" type: null
+. : ' | . : ' | . : ArgsIndices
+. : ' | . : ' | . : ' Identifier name: "rs1" type: null
+. : ' | . : ' | . TypeLiteral type: null
+. : ' | . : ' | . : Identifier name: "SIntW" type: null
+. : ' | . : ' | CastExpr type: null
+. : ' | . : ' | . CallIndexExpr type: null
+. : ' | . : ' | . : Identifier name: "X" type: null
+. : ' | . : ' | . : ArgsIndices
+. : ' | . : ' | . : ' Identifier name: "rs2" type: null
+. : ' | . : ' | . TypeLiteral type: null
+. : ' | . : ' | . : Identifier name: "SIntW" type: null
+. : ' | . : ' TypeLiteral type: null
+. : ' | . : ' | Identifier name: "SInt" type: null
 . : ' | . : TypeLiteral type: null
 . : ' | . : ' Identifier name: "SIntR" type: null
 . : ' EncodingDefinition
@@ -4388,13 +4234,11 @@ ImportDefinition
 . : ' | . : LetStatement
 . : ' | . : ' Identifier name: "AllOnes" type: null
 . : ' | . : ' CastExpr type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . UnaryExpr operator: UnOp - type: null
-. : ' | . : ' | . : GroupedExpr type: null
-. : ' | . : ' | . : ' CastExpr type: null
-. : ' | . : ' | . : ' | IntegerLiteral literal: 1 (1) type: null
-. : ' | . : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . : ' | . Identifier name: "SIntR" type: null
+. : ' | . : ' | UnaryExpr operator: UnOp - type: null
+. : ' | . : ' | . CastExpr type: null
+. : ' | . : ' | . : IntegerLiteral literal: 1 (1) type: null
+. : ' | . : ' | . : TypeLiteral type: null
+. : ' | . : ' | . : ' Identifier name: "SIntR" type: null
 . : ' | . : ' | TypeLiteral type: null
 . : ' | . : ' | . Identifier name: "SIntW" type: null
 . : ' | . : ' LetStatement
@@ -4402,39 +4246,32 @@ ImportDefinition
 . : ' | . : ' | IfExpr type: null
 . : ' | . : ' | . BinaryExpr operator: = type: null
 . : ' | . : ' | . : Identifier name: "divisor" type: null
-. : ' | . : ' | . : GroupedExpr type: null
-. : ' | . : ' | . : ' CastExpr type: null
-. : ' | . : ' | . : ' | IntegerLiteral literal: 0 (0) type: null
-. : ' | . : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . : ' | . Identifier name: "SIntW" type: null
+. : ' | . : ' | . : CastExpr type: null
+. : ' | . : ' | . : ' IntegerLiteral literal: 0 (0) type: null
+. : ' | . : ' | . : ' TypeLiteral type: null
+. : ' | . : ' | . : ' | Identifier name: "SIntW" type: null
 . : ' | . : ' | . Identifier name: "AllOnes" type: null
 . : ' | . : ' | . LetExpr type: null
 . : ' | . : ' | . : Identifier name: "MinInt" type: null
 . : ' | . : ' | . : CastExpr type: null
-. : ' | . : ' | . : ' GroupedExpr type: null
-. : ' | . : ' | . : ' | BinaryExpr operator: << type: null
-. : ' | . : ' | . : ' | . GroupedExpr type: null
-. : ' | . : ' | . : ' | . : CastExpr type: null
-. : ' | . : ' | . : ' | . : ' IntegerLiteral literal: 1 (1) type: null
-. : ' | . : ' | . : ' | . : ' TypeLiteral type: null
-. : ' | . : ' | . : ' | . : ' | Identifier name: "Regs" type: null
-. : ' | . : ' | . : ' | . GroupedExpr type: null
-. : ' | . : ' | . : ' | . : BinaryExpr operator: - type: null
-. : ' | . : ' | . : ' | . : ' GroupedExpr type: null
-. : ' | . : ' | . : ' | . : ' | Identifier name: "WLen" type: null
-. : ' | . : ' | . : ' | . : ' IntegerLiteral literal: 1 (1) type: null
+. : ' | . : ' | . : ' BinaryExpr operator: << type: null
+. : ' | . : ' | . : ' | CastExpr type: null
+. : ' | . : ' | . : ' | . IntegerLiteral literal: 1 (1) type: null
+. : ' | . : ' | . : ' | . TypeLiteral type: null
+. : ' | . : ' | . : ' | . : Identifier name: "Regs" type: null
+. : ' | . : ' | . : ' | BinaryExpr operator: - type: null
+. : ' | . : ' | . : ' | . Identifier name: "WLen" type: null
+. : ' | . : ' | . : ' | . IntegerLiteral literal: 1 (1) type: null
 . : ' | . : ' | . : ' TypeLiteral type: null
 . : ' | . : ' | . : ' | Identifier name: "SIntW" type: null
 . : ' | . : ' | . : IfExpr type: null
 . : ' | . : ' | . : ' BinaryExpr operator: & type: null
-. : ' | . : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . : ' | . BinaryExpr operator: = type: null
-. : ' | . : ' | . : ' | . : Identifier name: "dividend" type: null
-. : ' | . : ' | . : ' | . : Identifier name: "MinInt" type: null
-. : ' | . : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . : ' | . BinaryExpr operator: = type: null
-. : ' | . : ' | . : ' | . : Identifier name: "divisor" type: null
-. : ' | . : ' | . : ' | . : Identifier name: "AllOnes" type: null
+. : ' | . : ' | . : ' | BinaryExpr operator: = type: null
+. : ' | . : ' | . : ' | . Identifier name: "dividend" type: null
+. : ' | . : ' | . : ' | . Identifier name: "MinInt" type: null
+. : ' | . : ' | . : ' | BinaryExpr operator: = type: null
+. : ' | . : ' | . : ' | . Identifier name: "divisor" type: null
+. : ' | . : ' | . : ' | . Identifier name: "AllOnes" type: null
 . : ' | . : ' | . : ' Identifier name: "MinInt" type: null
 . : ' | . : ' | . : ' BinaryExpr operator: / type: null
 . : ' | . : ' | . : ' | Identifier name: "dividend" type: null
@@ -4445,11 +4282,10 @@ ImportDefinition
 . : ' | . : ' | . : ArgsIndices
 . : ' | . : ' | . : ' Identifier name: "rd" type: null
 . : ' | . : ' | . CastExpr type: null
-. : ' | . : ' | . : GroupedExpr type: null
-. : ' | . : ' | . : ' CastExpr type: null
-. : ' | . : ' | . : ' | Identifier name: "result" type: null
-. : ' | . : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . : ' | . Identifier name: "SInt" type: null
+. : ' | . : ' | . : CastExpr type: null
+. : ' | . : ' | . : ' Identifier name: "result" type: null
+. : ' | . : ' | . : ' TypeLiteral type: null
+. : ' | . : ' | . : ' | Identifier name: "SInt" type: null
 . : ' | . : ' | . : TypeLiteral type: null
 . : ' | . : ' | . : ' Identifier name: "Regs" type: null
 . : ' EncodingDefinition
@@ -4501,13 +4337,11 @@ ImportDefinition
 . : ' | . : LetStatement
 . : ' | . : ' Identifier name: "AllOnes" type: null
 . : ' | . : ' CastExpr type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . UnaryExpr operator: UnOp - type: null
-. : ' | . : ' | . : GroupedExpr type: null
-. : ' | . : ' | . : ' CastExpr type: null
-. : ' | . : ' | . : ' | IntegerLiteral literal: 1 (1) type: null
-. : ' | . : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . : ' | . Identifier name: "SIntR" type: null
+. : ' | . : ' | UnaryExpr operator: UnOp - type: null
+. : ' | . : ' | . CastExpr type: null
+. : ' | . : ' | . : IntegerLiteral literal: 1 (1) type: null
+. : ' | . : ' | . : TypeLiteral type: null
+. : ' | . : ' | . : ' Identifier name: "SIntR" type: null
 . : ' | . : ' | TypeLiteral type: null
 . : ' | . : ' | . Identifier name: "UIntW" type: null
 . : ' | . : ' LetStatement
@@ -4515,11 +4349,10 @@ ImportDefinition
 . : ' | . : ' | IfExpr type: null
 . : ' | . : ' | . BinaryExpr operator: = type: null
 . : ' | . : ' | . : Identifier name: "divisor" type: null
-. : ' | . : ' | . : GroupedExpr type: null
-. : ' | . : ' | . : ' CastExpr type: null
-. : ' | . : ' | . : ' | IntegerLiteral literal: 0 (0) type: null
-. : ' | . : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . : ' | . Identifier name: "UIntW" type: null
+. : ' | . : ' | . : CastExpr type: null
+. : ' | . : ' | . : ' IntegerLiteral literal: 0 (0) type: null
+. : ' | . : ' | . : ' TypeLiteral type: null
+. : ' | . : ' | . : ' | Identifier name: "UIntW" type: null
 . : ' | . : ' | . Identifier name: "AllOnes" type: null
 . : ' | . : ' | . BinaryExpr operator: / type: null
 . : ' | . : ' | . : Identifier name: "dividend" type: null
@@ -4530,11 +4363,10 @@ ImportDefinition
 . : ' | . : ' | . : ArgsIndices
 . : ' | . : ' | . : ' Identifier name: "rd" type: null
 . : ' | . : ' | . CastExpr type: null
-. : ' | . : ' | . : GroupedExpr type: null
-. : ' | . : ' | . : ' CastExpr type: null
-. : ' | . : ' | . : ' | Identifier name: "result" type: null
-. : ' | . : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . : ' | . Identifier name: "SInt" type: null
+. : ' | . : ' | . : CastExpr type: null
+. : ' | . : ' | . : ' Identifier name: "result" type: null
+. : ' | . : ' | . : ' TypeLiteral type: null
+. : ' | . : ' | . : ' | Identifier name: "SInt" type: null
 . : ' | . : ' | . : TypeLiteral type: null
 . : ' | . : ' | . : ' Identifier name: "Regs" type: null
 . : ' EncodingDefinition
@@ -4586,13 +4418,11 @@ ImportDefinition
 . : ' | . : LetStatement
 . : ' | . : ' Identifier name: "AllOnes" type: null
 . : ' | . : ' CastExpr type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . UnaryExpr operator: UnOp - type: null
-. : ' | . : ' | . : GroupedExpr type: null
-. : ' | . : ' | . : ' CastExpr type: null
-. : ' | . : ' | . : ' | IntegerLiteral literal: 1 (1) type: null
-. : ' | . : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . : ' | . Identifier name: "SIntR" type: null
+. : ' | . : ' | UnaryExpr operator: UnOp - type: null
+. : ' | . : ' | . CastExpr type: null
+. : ' | . : ' | . : IntegerLiteral literal: 1 (1) type: null
+. : ' | . : ' | . : TypeLiteral type: null
+. : ' | . : ' | . : ' Identifier name: "SIntR" type: null
 . : ' | . : ' | TypeLiteral type: null
 . : ' | . : ' | . Identifier name: "SIntW" type: null
 . : ' | . : ' LetStatement
@@ -4600,39 +4430,32 @@ ImportDefinition
 . : ' | . : ' | IfExpr type: null
 . : ' | . : ' | . BinaryExpr operator: = type: null
 . : ' | . : ' | . : Identifier name: "divisor" type: null
-. : ' | . : ' | . : GroupedExpr type: null
-. : ' | . : ' | . : ' CastExpr type: null
-. : ' | . : ' | . : ' | IntegerLiteral literal: 0 (0) type: null
-. : ' | . : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . : ' | . Identifier name: "SIntW" type: null
+. : ' | . : ' | . : CastExpr type: null
+. : ' | . : ' | . : ' IntegerLiteral literal: 0 (0) type: null
+. : ' | . : ' | . : ' TypeLiteral type: null
+. : ' | . : ' | . : ' | Identifier name: "SIntW" type: null
 . : ' | . : ' | . Identifier name: "dividend" type: null
 . : ' | . : ' | . LetExpr type: null
 . : ' | . : ' | . : Identifier name: "MinInt" type: null
 . : ' | . : ' | . : CastExpr type: null
-. : ' | . : ' | . : ' GroupedExpr type: null
-. : ' | . : ' | . : ' | BinaryExpr operator: << type: null
-. : ' | . : ' | . : ' | . GroupedExpr type: null
-. : ' | . : ' | . : ' | . : CastExpr type: null
-. : ' | . : ' | . : ' | . : ' IntegerLiteral literal: 1 (1) type: null
-. : ' | . : ' | . : ' | . : ' TypeLiteral type: null
-. : ' | . : ' | . : ' | . : ' | Identifier name: "Regs" type: null
-. : ' | . : ' | . : ' | . GroupedExpr type: null
-. : ' | . : ' | . : ' | . : BinaryExpr operator: - type: null
-. : ' | . : ' | . : ' | . : ' GroupedExpr type: null
-. : ' | . : ' | . : ' | . : ' | Identifier name: "WLen" type: null
-. : ' | . : ' | . : ' | . : ' IntegerLiteral literal: 1 (1) type: null
+. : ' | . : ' | . : ' BinaryExpr operator: << type: null
+. : ' | . : ' | . : ' | CastExpr type: null
+. : ' | . : ' | . : ' | . IntegerLiteral literal: 1 (1) type: null
+. : ' | . : ' | . : ' | . TypeLiteral type: null
+. : ' | . : ' | . : ' | . : Identifier name: "Regs" type: null
+. : ' | . : ' | . : ' | BinaryExpr operator: - type: null
+. : ' | . : ' | . : ' | . Identifier name: "WLen" type: null
+. : ' | . : ' | . : ' | . IntegerLiteral literal: 1 (1) type: null
 . : ' | . : ' | . : ' TypeLiteral type: null
 . : ' | . : ' | . : ' | Identifier name: "SIntW" type: null
 . : ' | . : ' | . : IfExpr type: null
 . : ' | . : ' | . : ' BinaryExpr operator: & type: null
-. : ' | . : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . : ' | . BinaryExpr operator: = type: null
-. : ' | . : ' | . : ' | . : Identifier name: "dividend" type: null
-. : ' | . : ' | . : ' | . : Identifier name: "MinInt" type: null
-. : ' | . : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . : ' | . BinaryExpr operator: = type: null
-. : ' | . : ' | . : ' | . : Identifier name: "divisor" type: null
-. : ' | . : ' | . : ' | . : Identifier name: "AllOnes" type: null
+. : ' | . : ' | . : ' | BinaryExpr operator: = type: null
+. : ' | . : ' | . : ' | . Identifier name: "dividend" type: null
+. : ' | . : ' | . : ' | . Identifier name: "MinInt" type: null
+. : ' | . : ' | . : ' | BinaryExpr operator: = type: null
+. : ' | . : ' | . : ' | . Identifier name: "divisor" type: null
+. : ' | . : ' | . : ' | . Identifier name: "AllOnes" type: null
 . : ' | . : ' | . : ' IntegerLiteral literal: 0 (0) type: null
 . : ' | . : ' | . : ' BinaryExpr operator: % type: null
 . : ' | . : ' | . : ' | Identifier name: "dividend" type: null
@@ -4643,11 +4466,10 @@ ImportDefinition
 . : ' | . : ' | . : ArgsIndices
 . : ' | . : ' | . : ' Identifier name: "rd" type: null
 . : ' | . : ' | . CastExpr type: null
-. : ' | . : ' | . : GroupedExpr type: null
-. : ' | . : ' | . : ' CastExpr type: null
-. : ' | . : ' | . : ' | Identifier name: "result" type: null
-. : ' | . : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . : ' | . Identifier name: "SInt" type: null
+. : ' | . : ' | . : CastExpr type: null
+. : ' | . : ' | . : ' Identifier name: "result" type: null
+. : ' | . : ' | . : ' TypeLiteral type: null
+. : ' | . : ' | . : ' | Identifier name: "SInt" type: null
 . : ' | . : ' | . : TypeLiteral type: null
 . : ' | . : ' | . : ' Identifier name: "Regs" type: null
 . : ' EncodingDefinition
@@ -4699,13 +4521,11 @@ ImportDefinition
 . : ' | . : LetStatement
 . : ' | . : ' Identifier name: "AllOnes" type: null
 . : ' | . : ' CastExpr type: null
-. : ' | . : ' | GroupedExpr type: null
-. : ' | . : ' | . UnaryExpr operator: UnOp - type: null
-. : ' | . : ' | . : GroupedExpr type: null
-. : ' | . : ' | . : ' CastExpr type: null
-. : ' | . : ' | . : ' | IntegerLiteral literal: 1 (1) type: null
-. : ' | . : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . : ' | . Identifier name: "SIntR" type: null
+. : ' | . : ' | UnaryExpr operator: UnOp - type: null
+. : ' | . : ' | . CastExpr type: null
+. : ' | . : ' | . : IntegerLiteral literal: 1 (1) type: null
+. : ' | . : ' | . : TypeLiteral type: null
+. : ' | . : ' | . : ' Identifier name: "SIntR" type: null
 . : ' | . : ' | TypeLiteral type: null
 . : ' | . : ' | . Identifier name: "UIntW" type: null
 . : ' | . : ' LetStatement
@@ -4713,11 +4533,10 @@ ImportDefinition
 . : ' | . : ' | IfExpr type: null
 . : ' | . : ' | . BinaryExpr operator: = type: null
 . : ' | . : ' | . : Identifier name: "divisor" type: null
-. : ' | . : ' | . : GroupedExpr type: null
-. : ' | . : ' | . : ' CastExpr type: null
-. : ' | . : ' | . : ' | IntegerLiteral literal: 0 (0) type: null
-. : ' | . : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . : ' | . Identifier name: "UIntW" type: null
+. : ' | . : ' | . : CastExpr type: null
+. : ' | . : ' | . : ' IntegerLiteral literal: 0 (0) type: null
+. : ' | . : ' | . : ' TypeLiteral type: null
+. : ' | . : ' | . : ' | Identifier name: "UIntW" type: null
 . : ' | . : ' | . Identifier name: "dividend" type: null
 . : ' | . : ' | . BinaryExpr operator: % type: null
 . : ' | . : ' | . : Identifier name: "dividend" type: null
@@ -4728,11 +4547,10 @@ ImportDefinition
 . : ' | . : ' | . : ArgsIndices
 . : ' | . : ' | . : ' Identifier name: "rd" type: null
 . : ' | . : ' | . CastExpr type: null
-. : ' | . : ' | . : GroupedExpr type: null
-. : ' | . : ' | . : ' CastExpr type: null
-. : ' | . : ' | . : ' | Identifier name: "result" type: null
-. : ' | . : ' | . : ' | TypeLiteral type: null
-. : ' | . : ' | . : ' | . Identifier name: "SInt" type: null
+. : ' | . : ' | . : CastExpr type: null
+. : ' | . : ' | . : ' Identifier name: "result" type: null
+. : ' | . : ' | . : ' TypeLiteral type: null
+. : ' | . : ' | . : ' | Identifier name: "SInt" type: null
 . : ' | . : ' | . : TypeLiteral type: null
 . : ' | . : ' | . : ' Identifier name: "Regs" type: null
 . : ' EncodingDefinition

--- a/vadl/test/resources/macros/complex-types.expanded.vadl
+++ b/vadl/test/resources/macros/complex-types.expanded.vadl
@@ -1,5 +1,5 @@
 constant a = 5
 constant b = 3
-constant c = (a + b)
-constant d = (a / b)
-constant e = (a * b)
+constant c = a + b
+constant d = a / b
+constant e = a * b

--- a/vadl/test/resources/macros/hexagon.expanded.vadl
+++ b/vadl/test/resources/macros/hexagon.expanded.vadl
@@ -57,9 +57,9 @@ instruction set architecture QDSP6 = {
   group counter PC: Address
 
   function AsmR(reg : Index) -> String = ("R", decimal(reg))
-  function AsmRR(reg : Index) -> String = ("R", decimal((reg + 1)), ":", decimal(reg))
+  function AsmRR(reg : Index) -> String = ("R", decimal(reg + 1), ":", decimal(reg))
   function AsmC(reg : Index) -> String = ("C", decimal(reg))
-  function AsmCC(reg : Index) -> String = ("C", decimal((reg + 1)), ":", decimal(reg))
+  function AsmCC(reg : Index) -> String = ("C", decimal(reg + 1), ":", decimal(reg))
   function AsmP(reg : PredicateIndex) -> String = ("P", decimal(reg))
   function AsmImmU(v : UWord) -> String = ("#", decimal(v), ")")
   function AsmImmUX(v : UWord) -> String = ("##", decimal(v), ")")
@@ -89,10 +89,10 @@ else
 
   function testpred(reg : PredicateIndex) -> Bool =
     match reg with
-      { 0 => (P.P0(0) = 1)
-      , 1 => (P.P1(0) = 1)
-      , 2 => (P.P2(0) = 1)
-      , _ => (P.P3(0) = 1)
+      { 0 => P.P0(0) = 1
+      , 1 => P.P1(0) = 1
+      , 2 => P.P2(0) = 1
+      , _ => P.P3(0) = 1
       }
 
 
@@ -130,10 +130,10 @@ match reg with
       0xff
     else
       0x00
-  function align32(v : SWord) -> SWord = ((v >> 2) << 2)
-  function scaledImmR2(imm : SWord) -> SWord = (imm << 2)
-  function scaledImmU(imm : SWord, scale : UInt<2>) -> SWord = (imm << scale)
-  function scaledImmS(imm : SWord, scale : UInt<2>) -> SWord = (imm << scale)
+  function align32(v : SWord) -> SWord = (v >> 2) << 2
+  function scaledImmR2(imm : SWord) -> SWord = imm << 2
+  function scaledImmU(imm : SWord, scale : UInt<2>) -> SWord = imm << scale
+  function scaledImmS(imm : SWord, scale : UInt<2>) -> SWord = imm << scale
   function frameScramble(addr : Address) -> Address = VADL::xor(addr, FRAMEKEY)
   function frameUnscramble(addr : Address) -> Address = VADL::xor(addr, FRAMEKEY)
 
@@ -189,7 +189,7 @@ match reg with
   }
 
   instruction TransferImmLow : TransferImmHalfFormat =   {
-    R(x5) := ((R(x5) & 0xFFFF0000) | immU as UInt<32>)
+    R(x5) := R(x5) & 0xFFFF0000 | immU as UInt<32>
   }
 
 
@@ -203,7 +203,7 @@ match reg with
   assembly TransferImmLow = ("", AsmR(x5), ".L", " = ", ("#", decimal(immU)))
 
   instruction TransferImmHigh : TransferImmHalfFormat =   {
-    R(x5) := ((R(x5) & 0x0000FFFF) | (immU as UInt<32> << 16))
+    R(x5) := R(x5) & 0x0000FFFF | immU as UInt<32> << 16
   }
 
 
@@ -478,7 +478,7 @@ match reg with
   }
 
   instruction CmpImmEq : CmpImmFormat =   {
-    let val = toPValue((R(s5) = extendS(immS))) in
+    let val = toPValue(R(s5) = extendS(immS)) in
       {
         Pset(d2, val)      }
   }
@@ -496,7 +496,7 @@ match reg with
   assembly CmpImmEq = (AsmP(d2), "=", ("cmp.eq(", AsmR(s5), ",#", decimal(immS), ")"))
 
   instruction CmpImmNeq : CmpImmFormat =   {
-    let val = toPValue(!((R(s5) = extendS(immS)))) in
+    let val = toPValue(!(R(s5) = extendS(immS))) in
       {
         Pset(d2, val)      }
   }
@@ -514,7 +514,7 @@ match reg with
   assembly CmpImmNeq = (AsmP(d2), "=", ("!cmp.eq(", AsmR(s5), ",#", decimal(immS), ")"))
 
   instruction CmpImmGt : CmpImmFormat =   {
-    let val = toPValue((R(s5) as SInt > extendS(immS))) in
+    let val = toPValue(R(s5) as SInt > extendS(immS)) in
       {
         Pset(d2, val)      }
   }
@@ -532,7 +532,7 @@ match reg with
   assembly CmpImmGt = (AsmP(d2), "=", ("cmp.gt(", AsmR(s5), ",#", decimal(immS), ")"))
 
   instruction CmpImmLte : CmpImmFormat =   {
-    let val = toPValue((!(R(s5) as SInt) > extendS(immS))) in
+    let val = toPValue(!(R(s5) as SInt) > extendS(immS)) in
       {
         Pset(d2, val)      }
   }
@@ -550,7 +550,7 @@ match reg with
   assembly CmpImmLte = (AsmP(d2), "=", ("!cmp.gt(", AsmR(s5), ",#", decimal(immS), ")"))
 
   instruction CmpImmGtu : CmpImmUFormat =   {
-    let val = toPValue((R(s5) as UInt > extendU(immU))) in
+    let val = toPValue(R(s5) as UInt > extendU(immU)) in
       {
         Pset(d2, val)      }
   }
@@ -568,7 +568,7 @@ match reg with
   assembly CmpImmGtu = (AsmP(d2), "=", ("cmp.gtu(", AsmR(s5), ",#", decimal(immU), ")"))
 
   instruction CmpImmLteu : CmpImmUFormat =   {
-    let val = toPValue((R(s5) as UInt > extendU(immU))) in
+    let val = toPValue(R(s5) as UInt > extendU(immU)) in
       {
         Pset(d2, val)      }
   }
@@ -586,7 +586,7 @@ match reg with
   assembly CmpImmLteu = (AsmP(d2), "=", ("!cmp.gtu(", AsmR(s5), ",#", decimal(immU), ")"))
 
   instruction CmpRegEq : CmpRegFormat =   {
-    let val = toPValue((R(s5) = R(t5))) in
+    let val = toPValue(R(s5) = R(t5)) in
       {
         Pset(d2, val)      }
   }
@@ -604,7 +604,7 @@ match reg with
   assembly CmpRegEq = (AsmP(d2), "=", ("cmp.eq(", AsmR(s5), ",", AsmR(t5), ")"))
 
   instruction CmpRegNeq : CmpRegFormat =   {
-    let val = toPValue(!((R(s5) = R(t5)))) in
+    let val = toPValue(!(R(s5) = R(t5))) in
       {
         Pset(d2, val)      }
   }
@@ -622,7 +622,7 @@ match reg with
   assembly CmpRegNeq = (AsmP(d2), "=", ("!cmp.eq(", AsmR(s5), ",", AsmR(t5), ")"))
 
   instruction CmpRegGt : CmpRegFormat =   {
-    let val = toPValue((R(s5) as SInt > R(t5) as SInt)) in
+    let val = toPValue(R(s5) as SInt > R(t5) as SInt) in
       {
         Pset(d2, val)      }
   }
@@ -640,7 +640,7 @@ match reg with
   assembly CmpRegGt = (AsmP(d2), "=", ("cmp.gt(", AsmR(s5), ",", AsmR(t5), ")"))
 
   instruction CmpRegLte : CmpRegFormat =   {
-    let val = toPValue(!((R(s5) as SInt > R(t5) as SInt))) in
+    let val = toPValue(!(R(s5) as SInt > R(t5) as SInt)) in
       {
         Pset(d2, val)      }
   }
@@ -658,7 +658,7 @@ match reg with
   assembly CmpRegLte = (AsmP(d2), "=", ("!cmp.gt(", AsmR(s5), ",", AsmR(t5), ")"))
 
   instruction CmpRegGtu : CmpRegFormat =   {
-    let val = toPValue((R(s5) as UInt > R(t5) as UInt)) in
+    let val = toPValue(R(s5) as UInt > R(t5) as UInt) in
       {
         Pset(d2, val)      }
   }
@@ -676,7 +676,7 @@ match reg with
   assembly CmpRegGtu = (AsmP(d2), "=", ("cmp.gtu(", AsmR(s5), ",", AsmR(t5), ")"))
 
   instruction CmpRegLteu : CmpRegFormat =   {
-    let val = toPValue(!((R(s5) as UInt > R(t5) as UInt))) in
+    let val = toPValue(!(R(s5) as UInt > R(t5) as UInt)) in
       {
         Pset(d2, val)      }
   }
@@ -731,7 +731,7 @@ match reg with
 
   instruction CombineDoubleRegImm : CombineRegImmFormat =   {
     R(d5) := extendS(immS)
-    R((d5 + 1)) := R(rs)
+    R(d5 + 1) := R(rs)
   }
 
 
@@ -747,7 +747,7 @@ match reg with
 
   instruction CombineDoubleImmReg : CombineRegImmFormat =   {
     R(d5) := R(rs)
-    R((d5 + 1)) := extendS(immS)
+    R(d5 + 1) := extendS(immS)
   }
 
 
@@ -763,7 +763,7 @@ match reg with
 
   instruction CombineDoubleImmSS : CombineImmFormat =   {
     R(d5) := immlowS
-    R((d5 + 1)) := extendS(immhighS)
+    R(d5 + 1) := extendS(immhighS)
   }
 
 
@@ -778,7 +778,7 @@ match reg with
 
   instruction CombineDoubleImmSU : CombineImmFormat =   {
     R(d5) := immlowU
-    R((d5 + 1)) := extendS(immhighS)
+    R(d5 + 1) := extendS(immhighS)
   }
 
 
@@ -979,13 +979,13 @@ match reg with
   instruction TransferCR : StandardFormat =   {
     {
       let val = R(s5) in
-        if (d5 = C_INDEX_P) then
+        if d5 = C_INDEX_P then
           {
             P := val
           }
 
         else
-          if (d5 != C_INDEX_PC) then
+          if d5 != C_INDEX_PC then
             C(d5) := val
 
 
@@ -1004,18 +1004,18 @@ match reg with
   instruction TransferCCRR : StandardFormat =   {
     {
       let valLo = R(s5) in
-        let valHi = R((s5 + 1)) in
-          if (d5 = C_INDEX_P) then
+        let valHi = R(s5 + 1) in
+          if d5 = C_INDEX_P then
             {
               P := valLo
-              C((d5 + 1)) := valHi
+              C(d5 + 1) := valHi
             }
 
           else
-            if ((d5 + 1) != C_INDEX_PC) then
+            if d5 + 1 != C_INDEX_PC then
               {
                 C(d5) := valLo
-                C((d5 + 1)) := valHi
+                C(d5 + 1) := valHi
               }
 
 
@@ -1033,7 +1033,7 @@ match reg with
 
   instruction TransferRRCC : StandardFormat =   {
     R(d5) := getCIsa(s5)
-    R((d5 + 1)) := getCIsa((s5 + 1))
+    R(d5 + 1) := getCIsa(s5 + 1)
   }
 
 
@@ -1079,7 +1079,7 @@ match reg with
   }
 
   instruction AddRegPC : AddRegPCFormat =   {
-    R(d5) := (PC.current + immU)
+    R(d5) := PC.current + immU
   }
 
 
@@ -1092,7 +1092,7 @@ match reg with
   assembly AddRegPC = ("", AsmR(d5), "=add(pc,", AsmImmU(immU), ")")
 
   instruction AddRegPCX : AddRegPCXFormat =   {
-    R(d5) := (PC.current + immU)
+    R(d5) := PC.current + immU
   }
 
 
@@ -1188,7 +1188,7 @@ match reg with
   assembly LogicalPredOrAnd = (AsmP(d2), "=", ("or(", AsmP(s2), ",and(", AsmP(t2), ",", AsmP(u2), "))"))
 
   instruction LogicalPredAndNot : LogicalPredFormat =   {
-    Pset(d2, VADL::and(Pget(t2), !(Pget(s2))))  }
+    Pset(d2, VADL::and(Pget(t2), !Pget(s2)))  }
 
 
   encoding LogicalPredAndNot =
@@ -1260,7 +1260,7 @@ match reg with
   assembly LogicalPredOrAndNot = (AsmP(d2), "=", ("or(", AsmP(s2), ",and(", AsmP(t2), ",!", AsmP(u2), "))"))
 
   instruction LogicalPredOrNot : LogicalPredFormat =   {
-    Pset(d2, VADL::or(Pget(t2), !(Pget(s2))))  }
+    Pset(d2, VADL::or(Pget(t2), !Pget(s2)))  }
 
 
   encoding LogicalPredOrNot =
@@ -1327,7 +1327,7 @@ match reg with
   assembly CallRegPredPos = (AsmPred(u2, false, false), "callr ", AsmR(s5))
 
   instruction CallRegPredNeg : BranchRegFormat =   {
-    if !(testpred(u2)) then
+    if !testpred(u2) then
       {
         LR := PC.next
         PC := R(s5)
@@ -1394,7 +1394,7 @@ match reg with
   assembly JumpRegPredPosT = (AsmPred(u2, false, false), "jumpr", ":t ", " ", AsmR(s5))
 
   instruction JumpRegPredNegNT : BranchRegFormat =   {
-    if !(testpred(u2)) then
+    if !testpred(u2) then
       {
         PC := R(s5)
       }
@@ -1411,7 +1411,7 @@ match reg with
   assembly JumpRegPredNegNT = (AsmPred(u2, true, false), "jumpr", ":nt ", " ", AsmR(s5))
 
   instruction JumpRegPredNegT : BranchRegFormat =   {
-    if !(testpred(u2)) then
+    if !testpred(u2) then
       {
         PC := R(s5)
       }
@@ -1447,7 +1447,7 @@ match reg with
   instruction JumpImm : JumpImmFormat =   {
     if true then
       {
-        PC := (PC.current + extendR2(imm))
+        PC := PC.current + extendR2(imm)
       }
 
   }
@@ -1463,7 +1463,7 @@ match reg with
   instruction JumpImmPredPosNT : JumpImmPredFormat =   {
     if testpred(u2) then
       {
-        PC := (PC.current + extendR2(imm))
+        PC := PC.current + extendR2(imm)
       }
 
   }
@@ -1480,7 +1480,7 @@ match reg with
   instruction JumpImmPredPosT : JumpImmPredFormat =   {
     if testpred(u2) then
       {
-        PC := (PC.current + extendR2(imm))
+        PC := PC.current + extendR2(imm)
       }
 
   }
@@ -1495,9 +1495,9 @@ match reg with
   assembly JumpImmPredPosT = (AsmPred(u2, false, false), "jump", ":t ", " ", decimal(immS))
 
   instruction JumpImmPredNegNT : JumpImmPredFormat =   {
-    if !(testpred(u2)) then
+    if !testpred(u2) then
       {
-        PC := (PC.current + extendR2(imm))
+        PC := PC.current + extendR2(imm)
       }
 
   }
@@ -1512,9 +1512,9 @@ match reg with
   assembly JumpImmPredNegNT = (AsmPred(u2, true, false), "jump", ":nt ", " ", decimal(immS))
 
   instruction JumpImmPredNegT : JumpImmPredFormat =   {
-    if !(testpred(u2)) then
+    if !testpred(u2) then
       {
-        PC := (PC.current + extendR2(imm))
+        PC := PC.current + extendR2(imm)
       }
 
   }
@@ -1547,7 +1547,7 @@ match reg with
     if true then
       {
         LR := PC.next
-        PC := (PC.current + extendR2(imm))
+        PC := PC.current + extendR2(imm)
       }
 
   }
@@ -1564,7 +1564,7 @@ match reg with
     if testpred(pred) then
       {
         LR := PC.next
-        PC := (PC.current + extendR2(imm))
+        PC := PC.current + extendR2(imm)
       }
 
   }
@@ -1579,10 +1579,10 @@ match reg with
   assembly CallImmPredPos = (AsmPred(pred, false, false), "call #", decimal(imm))
 
   instruction CallImmPredNeg : CallImmPredFormat =   {
-    if !(testpred(pred)) then
+    if !testpred(pred) then
       {
         LR := PC.next
-        PC := (PC.current + extendR2(imm))
+        PC := PC.current + extendR2(imm)
       }
 
   }
@@ -1606,10 +1606,10 @@ match reg with
   , s4	 [19..16]
   , disp	 [21..20, 7..1]
   , dispS = scaledImmR2(disp)
-  , s5 =   if (s4 <= 7) then
+  , s5 =   if s4 <= 7 then
     s4 as Index
   else
-    (s4 as Index + 8)
+    s4 as Index + 8
   , d2 = d1 as PredicateIndex
   }
   format CmpJumpImmFormat: Word =
@@ -1624,10 +1624,10 @@ match reg with
   , disp	 [21..20, 7..1]
   , immU = imm as UWord
   , dispS = scaledImmR2(disp)
-  , s5 =   if (s4 <= 7) then
+  , s5 =   if s4 <= 7 then
     s4 as Index
   else
-    (s4 as Index + 8)
+    s4 as Index + 8
   , d2 = d1 as PredicateIndex
   }
   format CmpJumpRegFormat: Word =
@@ -1641,24 +1641,24 @@ match reg with
   , t4	 [11..8]
   , disp	 [21..20, 7..1]
   , dispS = scaledImmR2(disp)
-  , s5 =   if (s4 <= 7) then
+  , s5 =   if s4 <= 7 then
     s4 as Index
   else
-    (s4 as Index + 8)
-  , t5 =   if (t4 <= 7) then
+    s4 as Index + 8
+  , t5 =   if t4 <= 7 then
     t4 as Index
   else
-    (t4 as Index + 8)
+    t4 as Index + 8
   , d2 = d1 as PredicateIndex
   }
 
   instruction CmpJumpEqMinus1P0PosNT : CmpJumpFormat =   {
-    let pred = (R(s5) = -(1)) in
-      let pvalue = toPValue((R(s5) = -(1))) in
+    let pred = R(s5) = -1 in
+      let pvalue = toPValue(R(s5) = -1) in
         {
           Pset(0, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -1676,12 +1676,12 @@ match reg with
   assembly CmpJumpEqMinus1P0PosNT = (AsmP(0), "=", ("cmp.eq(", AsmR(s5), "#-1)"), "; ", AsmPred(0, 0, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpEqMinus1P1PosNT : CmpJumpFormat =   {
-    let pred = (R(s5) = -(1)) in
-      let pvalue = toPValue((R(s5) = -(1))) in
+    let pred = R(s5) = -1 in
+      let pvalue = toPValue(R(s5) = -1) in
         {
           Pset(1, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -1699,12 +1699,12 @@ match reg with
   assembly CmpJumpEqMinus1P1PosNT = (AsmP(1), "=", ("cmp.eq(", AsmR(s5), "#-1)"), "; ", AsmPred(1, 0, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpEqMinus1P0NegNT : CmpJumpFormat =   {
-    let pred = !((R(s5) = -(1))) in
-      let pvalue = toPValue(!((R(s5) = -(1)))) in
+    let pred = !(R(s5) = -1) in
+      let pvalue = toPValue(!(R(s5) = -1)) in
         {
           Pset(0, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -1722,12 +1722,12 @@ match reg with
   assembly CmpJumpEqMinus1P0NegNT = (AsmP(0), "=", ("cmp.eq(", AsmR(s5), "#-1)"), "; ", AsmPred(0, 1, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpEqMinus1P1NegNT : CmpJumpFormat =   {
-    let pred = !((R(s5) = -(1))) in
-      let pvalue = toPValue(!((R(s5) = -(1)))) in
+    let pred = !(R(s5) = -1) in
+      let pvalue = toPValue(!(R(s5) = -1)) in
         {
           Pset(1, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -1745,12 +1745,12 @@ match reg with
   assembly CmpJumpEqMinus1P1NegNT = (AsmP(1), "=", ("cmp.eq(", AsmR(s5), "#-1)"), "; ", AsmPred(1, 1, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpEqMinus1P0PosT : CmpJumpFormat =   {
-    let pred = (R(s5) = -(1)) in
-      let pvalue = toPValue((R(s5) = -(1))) in
+    let pred = R(s5) = -1 in
+      let pvalue = toPValue(R(s5) = -1) in
         {
           Pset(0, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -1768,12 +1768,12 @@ match reg with
   assembly CmpJumpEqMinus1P0PosT = (AsmP(0), "=", ("cmp.eq(", AsmR(s5), "#-1)"), "; ", AsmPred(0, 0, true), " jump:", "t", " #", decimal(dispS))
 
   instruction CmpJumpEqMinus1P1PosT : CmpJumpFormat =   {
-    let pred = (R(s5) = -(1)) in
-      let pvalue = toPValue((R(s5) = -(1))) in
+    let pred = R(s5) = -1 in
+      let pvalue = toPValue(R(s5) = -1) in
         {
           Pset(1, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -1791,12 +1791,12 @@ match reg with
   assembly CmpJumpEqMinus1P1PosT = (AsmP(1), "=", ("cmp.eq(", AsmR(s5), "#-1)"), "; ", AsmPred(1, 0, true), " jump:", "t", " #", decimal(dispS))
 
   instruction CmpJumpEqMinus1P0NegT : CmpJumpFormat =   {
-    let pred = !((R(s5) = -(1))) in
-      let pvalue = toPValue(!((R(s5) = -(1)))) in
+    let pred = !(R(s5) = -1) in
+      let pvalue = toPValue(!(R(s5) = -1)) in
         {
           Pset(0, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -1814,12 +1814,12 @@ match reg with
   assembly CmpJumpEqMinus1P0NegT = (AsmP(0), "=", ("cmp.eq(", AsmR(s5), "#-1)"), "; ", AsmPred(0, 1, true), " jump:", "t", " #", decimal(dispS))
 
   instruction CmpJumpEqMinus1P1NegT : CmpJumpFormat =   {
-    let pred = !((R(s5) = -(1))) in
-      let pvalue = toPValue(!((R(s5) = -(1)))) in
+    let pred = !(R(s5) = -1) in
+      let pvalue = toPValue(!(R(s5) = -1)) in
         {
           Pset(1, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -1837,12 +1837,12 @@ match reg with
   assembly CmpJumpEqMinus1P1NegT = (AsmP(1), "=", ("cmp.eq(", AsmR(s5), "#-1)"), "; ", AsmPred(1, 1, true), " jump:", "t", " #", decimal(dispS))
 
   instruction CmpJumpGtMinus1P0PosNT : CmpJumpFormat =   {
-    let pred = (R(s5) as SInt > -(1) as SInt) in
-      let pvalue = toPValue((R(s5) as SInt > -(1) as SInt)) in
+    let pred = R(s5) as SInt > -1 as SInt in
+      let pvalue = toPValue(R(s5) as SInt > -1 as SInt) in
         {
           Pset(0, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -1860,12 +1860,12 @@ match reg with
   assembly CmpJumpGtMinus1P0PosNT = (AsmP(0), "=", ("cmp.gt(", AsmR(s5), "#-1)"), "; ", AsmPred(0, 0, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpGtMinus1P1PosNT : CmpJumpFormat =   {
-    let pred = (R(s5) as SInt > -(1) as SInt) in
-      let pvalue = toPValue((R(s5) as SInt > -(1) as SInt)) in
+    let pred = R(s5) as SInt > -1 as SInt in
+      let pvalue = toPValue(R(s5) as SInt > -1 as SInt) in
         {
           Pset(1, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -1883,12 +1883,12 @@ match reg with
   assembly CmpJumpGtMinus1P1PosNT = (AsmP(1), "=", ("cmp.gt(", AsmR(s5), "#-1)"), "; ", AsmPred(1, 0, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpGtMinus1P0NegNT : CmpJumpFormat =   {
-    let pred = !((R(s5) as SInt > -(1) as SInt)) in
-      let pvalue = toPValue(!((R(s5) as SInt > -(1) as SInt))) in
+    let pred = !(R(s5) as SInt > -1 as SInt) in
+      let pvalue = toPValue(!(R(s5) as SInt > -1 as SInt)) in
         {
           Pset(0, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -1906,12 +1906,12 @@ match reg with
   assembly CmpJumpGtMinus1P0NegNT = (AsmP(0), "=", ("cmp.gt(", AsmR(s5), "#-1)"), "; ", AsmPred(0, 1, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpGtMinus1P1NegNT : CmpJumpFormat =   {
-    let pred = !((R(s5) as SInt > -(1) as SInt)) in
-      let pvalue = toPValue(!((R(s5) as SInt > -(1) as SInt))) in
+    let pred = !(R(s5) as SInt > -1 as SInt) in
+      let pvalue = toPValue(!(R(s5) as SInt > -1 as SInt)) in
         {
           Pset(1, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -1929,12 +1929,12 @@ match reg with
   assembly CmpJumpGtMinus1P1NegNT = (AsmP(1), "=", ("cmp.gt(", AsmR(s5), "#-1)"), "; ", AsmPred(1, 1, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpGtMinus1P0PosT : CmpJumpFormat =   {
-    let pred = (R(s5) as SInt > -(1) as SInt) in
-      let pvalue = toPValue((R(s5) as SInt > -(1) as SInt)) in
+    let pred = R(s5) as SInt > -1 as SInt in
+      let pvalue = toPValue(R(s5) as SInt > -1 as SInt) in
         {
           Pset(0, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -1952,12 +1952,12 @@ match reg with
   assembly CmpJumpGtMinus1P0PosT = (AsmP(0), "=", ("cmp.gt(", AsmR(s5), "#-1)"), "; ", AsmPred(0, 0, true), " jump:", "t", " #", decimal(dispS))
 
   instruction CmpJumpGtMinus1P1PosT : CmpJumpFormat =   {
-    let pred = (R(s5) as SInt > -(1) as SInt) in
-      let pvalue = toPValue((R(s5) as SInt > -(1) as SInt)) in
+    let pred = R(s5) as SInt > -1 as SInt in
+      let pvalue = toPValue(R(s5) as SInt > -1 as SInt) in
         {
           Pset(1, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -1975,12 +1975,12 @@ match reg with
   assembly CmpJumpGtMinus1P1PosT = (AsmP(1), "=", ("cmp.gt(", AsmR(s5), "#-1)"), "; ", AsmPred(1, 0, true), " jump:", "t", " #", decimal(dispS))
 
   instruction CmpJumpGtMinus1P0NegT : CmpJumpFormat =   {
-    let pred = !((R(s5) as SInt > -(1) as SInt)) in
-      let pvalue = toPValue(!((R(s5) as SInt > -(1) as SInt))) in
+    let pred = !(R(s5) as SInt > -1 as SInt) in
+      let pvalue = toPValue(!(R(s5) as SInt > -1 as SInt)) in
         {
           Pset(0, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -1998,12 +1998,12 @@ match reg with
   assembly CmpJumpGtMinus1P0NegT = (AsmP(0), "=", ("cmp.gt(", AsmR(s5), "#-1)"), "; ", AsmPred(0, 1, true), " jump:", "t", " #", decimal(dispS))
 
   instruction CmpJumpGtMinus1P1NegT : CmpJumpFormat =   {
-    let pred = !((R(s5) as SInt > -(1) as SInt)) in
-      let pvalue = toPValue(!((R(s5) as SInt > -(1) as SInt))) in
+    let pred = !(R(s5) as SInt > -1 as SInt) in
+      let pvalue = toPValue(!(R(s5) as SInt > -1 as SInt)) in
         {
           Pset(1, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -2021,12 +2021,12 @@ match reg with
   assembly CmpJumpGtMinus1P1NegT = (AsmP(1), "=", ("cmp.gt(", AsmR(s5), "#-1)"), "; ", AsmPred(1, 1, true), " jump:", "t", " #", decimal(dispS))
 
   instruction CmpJumpTstBit0P0PosNT : CmpJumpFormat =   {
-    let pred = ((R(s5) & 0b1) = 1) in
-      let pvalue = toPValue(((R(s5) & 0b1) = 1)) in
+    let pred = (R(s5) & 0b1) = 1 in
+      let pvalue = toPValue((R(s5) & 0b1) = 1) in
         {
           Pset(0, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -2044,12 +2044,12 @@ match reg with
   assembly CmpJumpTstBit0P0PosNT = (AsmP(0), "=", ("tstbit(", AsmR(s5), "#0)"), "; ", AsmPred(0, 0, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpTstBit0P1PosNT : CmpJumpFormat =   {
-    let pred = ((R(s5) & 0b1) = 1) in
-      let pvalue = toPValue(((R(s5) & 0b1) = 1)) in
+    let pred = (R(s5) & 0b1) = 1 in
+      let pvalue = toPValue((R(s5) & 0b1) = 1) in
         {
           Pset(1, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -2067,12 +2067,12 @@ match reg with
   assembly CmpJumpTstBit0P1PosNT = (AsmP(1), "=", ("tstbit(", AsmR(s5), "#0)"), "; ", AsmPred(1, 0, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpTstBit0P0NegNT : CmpJumpFormat =   {
-    let pred = !(((R(s5) & 0b1) = 1)) in
-      let pvalue = toPValue(!(((R(s5) & 0b1) = 1))) in
+    let pred = !((R(s5) & 0b1) = 1) in
+      let pvalue = toPValue(!((R(s5) & 0b1) = 1)) in
         {
           Pset(0, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -2090,12 +2090,12 @@ match reg with
   assembly CmpJumpTstBit0P0NegNT = (AsmP(0), "=", ("tstbit(", AsmR(s5), "#0)"), "; ", AsmPred(0, 1, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpTstBit0P1NegNT : CmpJumpFormat =   {
-    let pred = !(((R(s5) & 0b1) = 1)) in
-      let pvalue = toPValue(!(((R(s5) & 0b1) = 1))) in
+    let pred = !((R(s5) & 0b1) = 1) in
+      let pvalue = toPValue(!((R(s5) & 0b1) = 1)) in
         {
           Pset(1, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -2113,12 +2113,12 @@ match reg with
   assembly CmpJumpTstBit0P1NegNT = (AsmP(1), "=", ("tstbit(", AsmR(s5), "#0)"), "; ", AsmPred(1, 1, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpTstBit0P0PosT : CmpJumpFormat =   {
-    let pred = ((R(s5) & 0b1) = 1) in
-      let pvalue = toPValue(((R(s5) & 0b1) = 1)) in
+    let pred = (R(s5) & 0b1) = 1 in
+      let pvalue = toPValue((R(s5) & 0b1) = 1) in
         {
           Pset(0, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -2136,12 +2136,12 @@ match reg with
   assembly CmpJumpTstBit0P0PosT = (AsmP(0), "=", ("tstbit(", AsmR(s5), "#0)"), "; ", AsmPred(0, 0, true), " jump:", "t", " #", decimal(dispS))
 
   instruction CmpJumpTstBit0P1PosT : CmpJumpFormat =   {
-    let pred = ((R(s5) & 0b1) = 1) in
-      let pvalue = toPValue(((R(s5) & 0b1) = 1)) in
+    let pred = (R(s5) & 0b1) = 1 in
+      let pvalue = toPValue((R(s5) & 0b1) = 1) in
         {
           Pset(1, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -2159,12 +2159,12 @@ match reg with
   assembly CmpJumpTstBit0P1PosT = (AsmP(1), "=", ("tstbit(", AsmR(s5), "#0)"), "; ", AsmPred(1, 0, true), " jump:", "t", " #", decimal(dispS))
 
   instruction CmpJumpTstBit0P0NegT : CmpJumpFormat =   {
-    let pred = !(((R(s5) & 0b1) = 1)) in
-      let pvalue = toPValue(!(((R(s5) & 0b1) = 1))) in
+    let pred = !((R(s5) & 0b1) = 1) in
+      let pvalue = toPValue(!((R(s5) & 0b1) = 1)) in
         {
           Pset(0, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -2182,12 +2182,12 @@ match reg with
   assembly CmpJumpTstBit0P0NegT = (AsmP(0), "=", ("tstbit(", AsmR(s5), "#0)"), "; ", AsmPred(0, 1, true), " jump:", "t", " #", decimal(dispS))
 
   instruction CmpJumpTstBit0P1NegT : CmpJumpFormat =   {
-    let pred = !(((R(s5) & 0b1) = 1)) in
-      let pvalue = toPValue(!(((R(s5) & 0b1) = 1))) in
+    let pred = !((R(s5) & 0b1) = 1) in
+      let pvalue = toPValue(!((R(s5) & 0b1) = 1)) in
         {
           Pset(1, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -2205,12 +2205,12 @@ match reg with
   assembly CmpJumpTstBit0P1NegT = (AsmP(1), "=", ("tstbit(", AsmR(s5), "#0)"), "; ", AsmPred(1, 1, true), " jump:", "t", " #", decimal(dispS))
 
   instruction CmpJumpEqImmP0PosNT : CmpJumpImmFormat =   {
-    let pred = (R(s5) = immU) in
-      let pvalue = toPValue((R(s5) = immU)) in
+    let pred = R(s5) = immU in
+      let pvalue = toPValue(R(s5) = immU) in
         {
           Pset(0, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -2228,12 +2228,12 @@ match reg with
   assembly CmpJumpEqImmP0PosNT = (AsmP(0), "=", ("cmp.eq(", AsmR(s5), "#", decimal(immU), ")"), "; ", AsmPred(0, 0, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpEqImmP1PosNT : CmpJumpImmFormat =   {
-    let pred = (R(s5) = immU) in
-      let pvalue = toPValue((R(s5) = immU)) in
+    let pred = R(s5) = immU in
+      let pvalue = toPValue(R(s5) = immU) in
         {
           Pset(1, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -2251,12 +2251,12 @@ match reg with
   assembly CmpJumpEqImmP1PosNT = (AsmP(1), "=", ("cmp.eq(", AsmR(s5), "#", decimal(immU), ")"), "; ", AsmPred(1, 0, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpEqImmP0NegNT : CmpJumpImmFormat =   {
-    let pred = !((R(s5) = immU)) in
-      let pvalue = toPValue(!((R(s5) = immU))) in
+    let pred = !(R(s5) = immU) in
+      let pvalue = toPValue(!(R(s5) = immU)) in
         {
           Pset(0, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -2274,12 +2274,12 @@ match reg with
   assembly CmpJumpEqImmP0NegNT = (AsmP(0), "=", ("cmp.eq(", AsmR(s5), "#", decimal(immU), ")"), "; ", AsmPred(0, 1, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpEqImmP1NegNT : CmpJumpImmFormat =   {
-    let pred = !((R(s5) = immU)) in
-      let pvalue = toPValue(!((R(s5) = immU))) in
+    let pred = !(R(s5) = immU) in
+      let pvalue = toPValue(!(R(s5) = immU)) in
         {
           Pset(1, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -2297,12 +2297,12 @@ match reg with
   assembly CmpJumpEqImmP1NegNT = (AsmP(1), "=", ("cmp.eq(", AsmR(s5), "#", decimal(immU), ")"), "; ", AsmPred(1, 1, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpEqImmP0PosT : CmpJumpImmFormat =   {
-    let pred = (R(s5) = immU) in
-      let pvalue = toPValue((R(s5) = immU)) in
+    let pred = R(s5) = immU in
+      let pvalue = toPValue(R(s5) = immU) in
         {
           Pset(0, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -2320,12 +2320,12 @@ match reg with
   assembly CmpJumpEqImmP0PosT = (AsmP(0), "=", ("cmp.eq(", AsmR(s5), "#", decimal(immU), ")"), "; ", AsmPred(0, 0, true), " jump:", "t", " #", decimal(dispS))
 
   instruction CmpJumpEqImmP1PosT : CmpJumpImmFormat =   {
-    let pred = (R(s5) = immU) in
-      let pvalue = toPValue((R(s5) = immU)) in
+    let pred = R(s5) = immU in
+      let pvalue = toPValue(R(s5) = immU) in
         {
           Pset(1, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -2343,12 +2343,12 @@ match reg with
   assembly CmpJumpEqImmP1PosT = (AsmP(1), "=", ("cmp.eq(", AsmR(s5), "#", decimal(immU), ")"), "; ", AsmPred(1, 0, true), " jump:", "t", " #", decimal(dispS))
 
   instruction CmpJumpEqImmP0NegT : CmpJumpImmFormat =   {
-    let pred = !((R(s5) = immU)) in
-      let pvalue = toPValue(!((R(s5) = immU))) in
+    let pred = !(R(s5) = immU) in
+      let pvalue = toPValue(!(R(s5) = immU)) in
         {
           Pset(0, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -2366,12 +2366,12 @@ match reg with
   assembly CmpJumpEqImmP0NegT = (AsmP(0), "=", ("cmp.eq(", AsmR(s5), "#", decimal(immU), ")"), "; ", AsmPred(0, 1, true), " jump:", "t", " #", decimal(dispS))
 
   instruction CmpJumpEqImmP1NegT : CmpJumpImmFormat =   {
-    let pred = !((R(s5) = immU)) in
-      let pvalue = toPValue(!((R(s5) = immU))) in
+    let pred = !(R(s5) = immU) in
+      let pvalue = toPValue(!(R(s5) = immU)) in
         {
           Pset(1, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -2389,12 +2389,12 @@ match reg with
   assembly CmpJumpEqImmP1NegT = (AsmP(1), "=", ("cmp.eq(", AsmR(s5), "#", decimal(immU), ")"), "; ", AsmPred(1, 1, true), " jump:", "t", " #", decimal(dispS))
 
   instruction CmpJumpGtImmP0PosNT : CmpJumpImmFormat =   {
-    let pred = (R(s5)(15..0) as UWord > immU) in
-      let pvalue = toPValue((R(s5)(15..0) as UWord > immU)) in
+    let pred = R(s5)(15..0) as UWord > immU in
+      let pvalue = toPValue(R(s5)(15..0) as UWord > immU) in
         {
           Pset(0, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -2412,12 +2412,12 @@ match reg with
   assembly CmpJumpGtImmP0PosNT = (AsmP(0), "=", ("cmp.gt(", AsmR(s5), "#", decimal(immU), ")"), "; ", AsmPred(0, 0, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpGtImmP1PosNT : CmpJumpImmFormat =   {
-    let pred = (R(s5)(15..0) as UWord > immU) in
-      let pvalue = toPValue((R(s5)(15..0) as UWord > immU)) in
+    let pred = R(s5)(15..0) as UWord > immU in
+      let pvalue = toPValue(R(s5)(15..0) as UWord > immU) in
         {
           Pset(1, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -2435,12 +2435,12 @@ match reg with
   assembly CmpJumpGtImmP1PosNT = (AsmP(1), "=", ("cmp.gt(", AsmR(s5), "#", decimal(immU), ")"), "; ", AsmPred(1, 0, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpGtImmP0NegNT : CmpJumpImmFormat =   {
-    let pred = !((R(s5)(15..0) as UWord > immU)) in
-      let pvalue = toPValue(!((R(s5)(15..0) as UWord > immU))) in
+    let pred = !(R(s5)(15..0) as UWord > immU) in
+      let pvalue = toPValue(!(R(s5)(15..0) as UWord > immU)) in
         {
           Pset(0, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -2458,12 +2458,12 @@ match reg with
   assembly CmpJumpGtImmP0NegNT = (AsmP(0), "=", ("cmp.gt(", AsmR(s5), "#", decimal(immU), ")"), "; ", AsmPred(0, 1, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpGtImmP1NegNT : CmpJumpImmFormat =   {
-    let pred = !((R(s5)(15..0) as UWord > immU)) in
-      let pvalue = toPValue(!((R(s5)(15..0) as UWord > immU))) in
+    let pred = !(R(s5)(15..0) as UWord > immU) in
+      let pvalue = toPValue(!(R(s5)(15..0) as UWord > immU)) in
         {
           Pset(1, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -2481,12 +2481,12 @@ match reg with
   assembly CmpJumpGtImmP1NegNT = (AsmP(1), "=", ("cmp.gt(", AsmR(s5), "#", decimal(immU), ")"), "; ", AsmPred(1, 1, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpGtImmP0PosT : CmpJumpImmFormat =   {
-    let pred = (R(s5)(15..0) as UWord > immU) in
-      let pvalue = toPValue((R(s5)(15..0) as UWord > immU)) in
+    let pred = R(s5)(15..0) as UWord > immU in
+      let pvalue = toPValue(R(s5)(15..0) as UWord > immU) in
         {
           Pset(0, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -2504,12 +2504,12 @@ match reg with
   assembly CmpJumpGtImmP0PosT = (AsmP(0), "=", ("cmp.gt(", AsmR(s5), "#", decimal(immU), ")"), "; ", AsmPred(0, 0, true), " jump:", "t", " #", decimal(dispS))
 
   instruction CmpJumpGtImmP1PosT : CmpJumpImmFormat =   {
-    let pred = (R(s5)(15..0) as UWord > immU) in
-      let pvalue = toPValue((R(s5)(15..0) as UWord > immU)) in
+    let pred = R(s5)(15..0) as UWord > immU in
+      let pvalue = toPValue(R(s5)(15..0) as UWord > immU) in
         {
           Pset(1, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -2527,12 +2527,12 @@ match reg with
   assembly CmpJumpGtImmP1PosT = (AsmP(1), "=", ("cmp.gt(", AsmR(s5), "#", decimal(immU), ")"), "; ", AsmPred(1, 0, true), " jump:", "t", " #", decimal(dispS))
 
   instruction CmpJumpGtImmP0NegT : CmpJumpImmFormat =   {
-    let pred = !((R(s5)(15..0) as UWord > immU)) in
-      let pvalue = toPValue(!((R(s5)(15..0) as UWord > immU))) in
+    let pred = !(R(s5)(15..0) as UWord > immU) in
+      let pvalue = toPValue(!(R(s5)(15..0) as UWord > immU)) in
         {
           Pset(0, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -2550,12 +2550,12 @@ match reg with
   assembly CmpJumpGtImmP0NegT = (AsmP(0), "=", ("cmp.gt(", AsmR(s5), "#", decimal(immU), ")"), "; ", AsmPred(0, 1, true), " jump:", "t", " #", decimal(dispS))
 
   instruction CmpJumpGtImmP1NegT : CmpJumpImmFormat =   {
-    let pred = !((R(s5)(15..0) as UWord > immU)) in
-      let pvalue = toPValue(!((R(s5)(15..0) as UWord > immU))) in
+    let pred = !(R(s5)(15..0) as UWord > immU) in
+      let pvalue = toPValue(!(R(s5)(15..0) as UWord > immU)) in
         {
           Pset(1, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -2573,12 +2573,12 @@ match reg with
   assembly CmpJumpGtImmP1NegT = (AsmP(1), "=", ("cmp.gt(", AsmR(s5), "#", decimal(immU), ")"), "; ", AsmPred(1, 1, true), " jump:", "t", " #", decimal(dispS))
 
   instruction CmpJumpGtuImmP0PosNT : CmpJumpImmFormat =   {
-    let pred = (R(s5) as UInt > immU) in
-      let pvalue = toPValue((R(s5) as UInt > immU)) in
+    let pred = R(s5) as UInt > immU in
+      let pvalue = toPValue(R(s5) as UInt > immU) in
         {
           Pset(0, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -2596,12 +2596,12 @@ match reg with
   assembly CmpJumpGtuImmP0PosNT = (AsmP(0), "=", ("cmp.gtu(", AsmR(s5), "#", decimal(immU), ")"), "; ", AsmPred(0, 0, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpGtuImmP1PosNT : CmpJumpImmFormat =   {
-    let pred = (R(s5) as UInt > immU) in
-      let pvalue = toPValue((R(s5) as UInt > immU)) in
+    let pred = R(s5) as UInt > immU in
+      let pvalue = toPValue(R(s5) as UInt > immU) in
         {
           Pset(1, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -2619,12 +2619,12 @@ match reg with
   assembly CmpJumpGtuImmP1PosNT = (AsmP(1), "=", ("cmp.gtu(", AsmR(s5), "#", decimal(immU), ")"), "; ", AsmPred(1, 0, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpGtuImmP0NegNT : CmpJumpImmFormat =   {
-    let pred = !((R(s5) as UInt > immU)) in
-      let pvalue = toPValue(!((R(s5) as UInt > immU))) in
+    let pred = !(R(s5) as UInt > immU) in
+      let pvalue = toPValue(!(R(s5) as UInt > immU)) in
         {
           Pset(0, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -2642,12 +2642,12 @@ match reg with
   assembly CmpJumpGtuImmP0NegNT = (AsmP(0), "=", ("cmp.gtu(", AsmR(s5), "#", decimal(immU), ")"), "; ", AsmPred(0, 1, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpGtuImmP1NegNT : CmpJumpImmFormat =   {
-    let pred = !((R(s5) as UInt > immU)) in
-      let pvalue = toPValue(!((R(s5) as UInt > immU))) in
+    let pred = !(R(s5) as UInt > immU) in
+      let pvalue = toPValue(!(R(s5) as UInt > immU)) in
         {
           Pset(1, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -2665,12 +2665,12 @@ match reg with
   assembly CmpJumpGtuImmP1NegNT = (AsmP(1), "=", ("cmp.gtu(", AsmR(s5), "#", decimal(immU), ")"), "; ", AsmPred(1, 1, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpGtuImmP0PosT : CmpJumpImmFormat =   {
-    let pred = (R(s5) as UInt > immU) in
-      let pvalue = toPValue((R(s5) as UInt > immU)) in
+    let pred = R(s5) as UInt > immU in
+      let pvalue = toPValue(R(s5) as UInt > immU) in
         {
           Pset(0, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -2688,12 +2688,12 @@ match reg with
   assembly CmpJumpGtuImmP0PosT = (AsmP(0), "=", ("cmp.gtu(", AsmR(s5), "#", decimal(immU), ")"), "; ", AsmPred(0, 0, true), " jump:", "t", " #", decimal(dispS))
 
   instruction CmpJumpGtuImmP1PosT : CmpJumpImmFormat =   {
-    let pred = (R(s5) as UInt > immU) in
-      let pvalue = toPValue((R(s5) as UInt > immU)) in
+    let pred = R(s5) as UInt > immU in
+      let pvalue = toPValue(R(s5) as UInt > immU) in
         {
           Pset(1, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -2711,12 +2711,12 @@ match reg with
   assembly CmpJumpGtuImmP1PosT = (AsmP(1), "=", ("cmp.gtu(", AsmR(s5), "#", decimal(immU), ")"), "; ", AsmPred(1, 0, true), " jump:", "t", " #", decimal(dispS))
 
   instruction CmpJumpGtuImmP0NegT : CmpJumpImmFormat =   {
-    let pred = !((R(s5) as UInt > immU)) in
-      let pvalue = toPValue(!((R(s5) as UInt > immU))) in
+    let pred = !(R(s5) as UInt > immU) in
+      let pvalue = toPValue(!(R(s5) as UInt > immU)) in
         {
           Pset(0, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -2734,12 +2734,12 @@ match reg with
   assembly CmpJumpGtuImmP0NegT = (AsmP(0), "=", ("cmp.gtu(", AsmR(s5), "#", decimal(immU), ")"), "; ", AsmPred(0, 1, true), " jump:", "t", " #", decimal(dispS))
 
   instruction CmpJumpGtuImmP1NegT : CmpJumpImmFormat =   {
-    let pred = !((R(s5) as UInt > immU)) in
-      let pvalue = toPValue(!((R(s5) as UInt > immU))) in
+    let pred = !(R(s5) as UInt > immU) in
+      let pvalue = toPValue(!(R(s5) as UInt > immU)) in
         {
           Pset(1, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -2757,12 +2757,12 @@ match reg with
   assembly CmpJumpGtuImmP1NegT = (AsmP(1), "=", ("cmp.gtu(", AsmR(s5), "#", decimal(immU), ")"), "; ", AsmPred(1, 1, true), " jump:", "t", " #", decimal(dispS))
 
   instruction CmpJumpEqRegP0PosNT : CmpJumpRegFormat =   {
-    let pred = (R(s5) = R(t5)) in
-      let pvalue = toPValue((R(s5) = R(t5))) in
+    let pred = R(s5) = R(t5) in
+      let pvalue = toPValue(R(s5) = R(t5)) in
         {
           Pset(0, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -2780,12 +2780,12 @@ match reg with
   assembly CmpJumpEqRegP0PosNT = (AsmP(0), "=", ("cmp.eq(", AsmR(s5), "", AsmR(t5), ")"), "; ", AsmPred(0, 0, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpEqRegP1PosNT : CmpJumpRegFormat =   {
-    let pred = (R(s5) = R(t5)) in
-      let pvalue = toPValue((R(s5) = R(t5))) in
+    let pred = R(s5) = R(t5) in
+      let pvalue = toPValue(R(s5) = R(t5)) in
         {
           Pset(1, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -2803,12 +2803,12 @@ match reg with
   assembly CmpJumpEqRegP1PosNT = (AsmP(1), "=", ("cmp.eq(", AsmR(s5), "", AsmR(t5), ")"), "; ", AsmPred(1, 0, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpEqRegP0NegNT : CmpJumpRegFormat =   {
-    let pred = !((R(s5) = R(t5))) in
-      let pvalue = toPValue(!((R(s5) = R(t5)))) in
+    let pred = !(R(s5) = R(t5)) in
+      let pvalue = toPValue(!(R(s5) = R(t5))) in
         {
           Pset(0, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -2826,12 +2826,12 @@ match reg with
   assembly CmpJumpEqRegP0NegNT = (AsmP(0), "=", ("cmp.eq(", AsmR(s5), "", AsmR(t5), ")"), "; ", AsmPred(0, 1, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpEqRegP1NegNT : CmpJumpRegFormat =   {
-    let pred = !((R(s5) = R(t5))) in
-      let pvalue = toPValue(!((R(s5) = R(t5)))) in
+    let pred = !(R(s5) = R(t5)) in
+      let pvalue = toPValue(!(R(s5) = R(t5))) in
         {
           Pset(1, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -2849,12 +2849,12 @@ match reg with
   assembly CmpJumpEqRegP1NegNT = (AsmP(1), "=", ("cmp.eq(", AsmR(s5), "", AsmR(t5), ")"), "; ", AsmPred(1, 1, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpEqRegP0PosT : CmpJumpRegFormat =   {
-    let pred = (R(s5) = R(t5)) in
-      let pvalue = toPValue((R(s5) = R(t5))) in
+    let pred = R(s5) = R(t5) in
+      let pvalue = toPValue(R(s5) = R(t5)) in
         {
           Pset(0, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -2872,12 +2872,12 @@ match reg with
   assembly CmpJumpEqRegP0PosT = (AsmP(0), "=", ("cmp.eq(", AsmR(s5), "", AsmR(t5), ")"), "; ", AsmPred(0, 0, true), " jump:", "t", " #", decimal(dispS))
 
   instruction CmpJumpEqRegP1PosT : CmpJumpRegFormat =   {
-    let pred = (R(s5) = R(t5)) in
-      let pvalue = toPValue((R(s5) = R(t5))) in
+    let pred = R(s5) = R(t5) in
+      let pvalue = toPValue(R(s5) = R(t5)) in
         {
           Pset(1, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -2895,12 +2895,12 @@ match reg with
   assembly CmpJumpEqRegP1PosT = (AsmP(1), "=", ("cmp.eq(", AsmR(s5), "", AsmR(t5), ")"), "; ", AsmPred(1, 0, true), " jump:", "t", " #", decimal(dispS))
 
   instruction CmpJumpEqRegP0NegT : CmpJumpRegFormat =   {
-    let pred = !((R(s5) = R(t5))) in
-      let pvalue = toPValue(!((R(s5) = R(t5)))) in
+    let pred = !(R(s5) = R(t5)) in
+      let pvalue = toPValue(!(R(s5) = R(t5))) in
         {
           Pset(0, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -2918,12 +2918,12 @@ match reg with
   assembly CmpJumpEqRegP0NegT = (AsmP(0), "=", ("cmp.eq(", AsmR(s5), "", AsmR(t5), ")"), "; ", AsmPred(0, 1, true), " jump:", "t", " #", decimal(dispS))
 
   instruction CmpJumpEqRegP1NegT : CmpJumpRegFormat =   {
-    let pred = !((R(s5) = R(t5))) in
-      let pvalue = toPValue(!((R(s5) = R(t5)))) in
+    let pred = !(R(s5) = R(t5)) in
+      let pvalue = toPValue(!(R(s5) = R(t5))) in
         {
           Pset(1, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -2941,12 +2941,12 @@ match reg with
   assembly CmpJumpEqRegP1NegT = (AsmP(1), "=", ("cmp.eq(", AsmR(s5), "", AsmR(t5), ")"), "; ", AsmPred(1, 1, true), " jump:", "t", " #", decimal(dispS))
 
   instruction CmpJumpGtRegP0PosNT : CmpJumpRegFormat =   {
-    let pred = (R(s5) as SInt > R(t5) as SInt) in
-      let pvalue = toPValue((R(s5) as SInt > R(t5) as SInt)) in
+    let pred = R(s5) as SInt > R(t5) as SInt in
+      let pvalue = toPValue(R(s5) as SInt > R(t5) as SInt) in
         {
           Pset(0, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -2964,12 +2964,12 @@ match reg with
   assembly CmpJumpGtRegP0PosNT = (AsmP(0), "=", ("cmp.gt(", AsmR(s5), "", AsmR(t5), ")"), "; ", AsmPred(0, 0, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpGtRegP1PosNT : CmpJumpRegFormat =   {
-    let pred = (R(s5) as SInt > R(t5) as SInt) in
-      let pvalue = toPValue((R(s5) as SInt > R(t5) as SInt)) in
+    let pred = R(s5) as SInt > R(t5) as SInt in
+      let pvalue = toPValue(R(s5) as SInt > R(t5) as SInt) in
         {
           Pset(1, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -2987,12 +2987,12 @@ match reg with
   assembly CmpJumpGtRegP1PosNT = (AsmP(1), "=", ("cmp.gt(", AsmR(s5), "", AsmR(t5), ")"), "; ", AsmPred(1, 0, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpGtRegP0NegNT : CmpJumpRegFormat =   {
-    let pred = !((R(s5) as SInt > R(t5) as SInt)) in
-      let pvalue = toPValue(!((R(s5) as SInt > R(t5) as SInt))) in
+    let pred = !(R(s5) as SInt > R(t5) as SInt) in
+      let pvalue = toPValue(!(R(s5) as SInt > R(t5) as SInt)) in
         {
           Pset(0, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -3010,12 +3010,12 @@ match reg with
   assembly CmpJumpGtRegP0NegNT = (AsmP(0), "=", ("cmp.gt(", AsmR(s5), "", AsmR(t5), ")"), "; ", AsmPred(0, 1, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpGtRegP1NegNT : CmpJumpRegFormat =   {
-    let pred = !((R(s5) as SInt > R(t5) as SInt)) in
-      let pvalue = toPValue(!((R(s5) as SInt > R(t5) as SInt))) in
+    let pred = !(R(s5) as SInt > R(t5) as SInt) in
+      let pvalue = toPValue(!(R(s5) as SInt > R(t5) as SInt)) in
         {
           Pset(1, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -3033,12 +3033,12 @@ match reg with
   assembly CmpJumpGtRegP1NegNT = (AsmP(1), "=", ("cmp.gt(", AsmR(s5), "", AsmR(t5), ")"), "; ", AsmPred(1, 1, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpGtRegP0PosT : CmpJumpRegFormat =   {
-    let pred = (R(s5) as SInt > R(t5) as SInt) in
-      let pvalue = toPValue((R(s5) as SInt > R(t5) as SInt)) in
+    let pred = R(s5) as SInt > R(t5) as SInt in
+      let pvalue = toPValue(R(s5) as SInt > R(t5) as SInt) in
         {
           Pset(0, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -3056,12 +3056,12 @@ match reg with
   assembly CmpJumpGtRegP0PosT = (AsmP(0), "=", ("cmp.gt(", AsmR(s5), "", AsmR(t5), ")"), "; ", AsmPred(0, 0, true), " jump:", "t", " #", decimal(dispS))
 
   instruction CmpJumpGtRegP1PosT : CmpJumpRegFormat =   {
-    let pred = (R(s5) as SInt > R(t5) as SInt) in
-      let pvalue = toPValue((R(s5) as SInt > R(t5) as SInt)) in
+    let pred = R(s5) as SInt > R(t5) as SInt in
+      let pvalue = toPValue(R(s5) as SInt > R(t5) as SInt) in
         {
           Pset(1, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -3079,12 +3079,12 @@ match reg with
   assembly CmpJumpGtRegP1PosT = (AsmP(1), "=", ("cmp.gt(", AsmR(s5), "", AsmR(t5), ")"), "; ", AsmPred(1, 0, true), " jump:", "t", " #", decimal(dispS))
 
   instruction CmpJumpGtRegP0NegT : CmpJumpRegFormat =   {
-    let pred = !((R(s5) as SInt > R(t5) as SInt)) in
-      let pvalue = toPValue(!((R(s5) as SInt > R(t5) as SInt))) in
+    let pred = !(R(s5) as SInt > R(t5) as SInt) in
+      let pvalue = toPValue(!(R(s5) as SInt > R(t5) as SInt)) in
         {
           Pset(0, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -3102,12 +3102,12 @@ match reg with
   assembly CmpJumpGtRegP0NegT = (AsmP(0), "=", ("cmp.gt(", AsmR(s5), "", AsmR(t5), ")"), "; ", AsmPred(0, 1, true), " jump:", "t", " #", decimal(dispS))
 
   instruction CmpJumpGtRegP1NegT : CmpJumpRegFormat =   {
-    let pred = !((R(s5) as SInt > R(t5) as SInt)) in
-      let pvalue = toPValue(!((R(s5) as SInt > R(t5) as SInt))) in
+    let pred = !(R(s5) as SInt > R(t5) as SInt) in
+      let pvalue = toPValue(!(R(s5) as SInt > R(t5) as SInt)) in
         {
           Pset(1, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -3125,12 +3125,12 @@ match reg with
   assembly CmpJumpGtRegP1NegT = (AsmP(1), "=", ("cmp.gt(", AsmR(s5), "", AsmR(t5), ")"), "; ", AsmPred(1, 1, true), " jump:", "t", " #", decimal(dispS))
 
   instruction CmpJumpGtuRegP0PosNT : CmpJumpRegFormat =   {
-    let pred = (R(s5)(15..0) as UWord > R(t5)) in
-      let pvalue = toPValue((R(s5)(15..0) as UWord > R(t5))) in
+    let pred = R(s5)(15..0) as UWord > R(t5) in
+      let pvalue = toPValue(R(s5)(15..0) as UWord > R(t5)) in
         {
           Pset(0, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -3148,12 +3148,12 @@ match reg with
   assembly CmpJumpGtuRegP0PosNT = (AsmP(0), "=", ("cmp.gtu(", AsmR(s5), "", AsmR(t5), ")"), "; ", AsmPred(0, 0, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpGtuRegP1PosNT : CmpJumpRegFormat =   {
-    let pred = (R(s5)(15..0) as UWord > R(t5)) in
-      let pvalue = toPValue((R(s5)(15..0) as UWord > R(t5))) in
+    let pred = R(s5)(15..0) as UWord > R(t5) in
+      let pvalue = toPValue(R(s5)(15..0) as UWord > R(t5)) in
         {
           Pset(1, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -3171,12 +3171,12 @@ match reg with
   assembly CmpJumpGtuRegP1PosNT = (AsmP(1), "=", ("cmp.gtu(", AsmR(s5), "", AsmR(t5), ")"), "; ", AsmPred(1, 0, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpGtuRegP0NegNT : CmpJumpRegFormat =   {
-    let pred = !((R(s5)(15..0) as UWord > R(t5))) in
-      let pvalue = toPValue(!((R(s5)(15..0) as UWord > R(t5)))) in
+    let pred = !(R(s5)(15..0) as UWord > R(t5)) in
+      let pvalue = toPValue(!(R(s5)(15..0) as UWord > R(t5))) in
         {
           Pset(0, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -3194,12 +3194,12 @@ match reg with
   assembly CmpJumpGtuRegP0NegNT = (AsmP(0), "=", ("cmp.gtu(", AsmR(s5), "", AsmR(t5), ")"), "; ", AsmPred(0, 1, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpGtuRegP1NegNT : CmpJumpRegFormat =   {
-    let pred = !((R(s5)(15..0) as UWord > R(t5))) in
-      let pvalue = toPValue(!((R(s5)(15..0) as UWord > R(t5)))) in
+    let pred = !(R(s5)(15..0) as UWord > R(t5)) in
+      let pvalue = toPValue(!(R(s5)(15..0) as UWord > R(t5))) in
         {
           Pset(1, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -3217,12 +3217,12 @@ match reg with
   assembly CmpJumpGtuRegP1NegNT = (AsmP(1), "=", ("cmp.gtu(", AsmR(s5), "", AsmR(t5), ")"), "; ", AsmPred(1, 1, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpGtuRegP0PosT : CmpJumpRegFormat =   {
-    let pred = (R(s5)(15..0) as UWord > R(t5)) in
-      let pvalue = toPValue((R(s5)(15..0) as UWord > R(t5))) in
+    let pred = R(s5)(15..0) as UWord > R(t5) in
+      let pvalue = toPValue(R(s5)(15..0) as UWord > R(t5)) in
         {
           Pset(0, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -3240,12 +3240,12 @@ match reg with
   assembly CmpJumpGtuRegP0PosT = (AsmP(0), "=", ("cmp.gtu(", AsmR(s5), "", AsmR(t5), ")"), "; ", AsmPred(0, 0, true), " jump:", "t", " #", decimal(dispS))
 
   instruction CmpJumpGtuRegP1PosT : CmpJumpRegFormat =   {
-    let pred = (R(s5)(15..0) as UWord > R(t5)) in
-      let pvalue = toPValue((R(s5)(15..0) as UWord > R(t5))) in
+    let pred = R(s5)(15..0) as UWord > R(t5) in
+      let pvalue = toPValue(R(s5)(15..0) as UWord > R(t5)) in
         {
           Pset(1, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -3263,12 +3263,12 @@ match reg with
   assembly CmpJumpGtuRegP1PosT = (AsmP(1), "=", ("cmp.gtu(", AsmR(s5), "", AsmR(t5), ")"), "; ", AsmPred(1, 0, true), " jump:", "t", " #", decimal(dispS))
 
   instruction CmpJumpGtuRegP0NegT : CmpJumpRegFormat =   {
-    let pred = !((R(s5)(15..0) as UWord > R(t5))) in
-      let pvalue = toPValue(!((R(s5)(15..0) as UWord > R(t5)))) in
+    let pred = !(R(s5)(15..0) as UWord > R(t5)) in
+      let pvalue = toPValue(!(R(s5)(15..0) as UWord > R(t5))) in
         {
           Pset(0, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -3286,12 +3286,12 @@ match reg with
   assembly CmpJumpGtuRegP0NegT = (AsmP(0), "=", ("cmp.gtu(", AsmR(s5), "", AsmR(t5), ")"), "; ", AsmPred(0, 1, true), " jump:", "t", " #", decimal(dispS))
 
   instruction CmpJumpGtuRegP1NegT : CmpJumpRegFormat =   {
-    let pred = !((R(s5)(15..0) as UWord > R(t5))) in
-      let pvalue = toPValue(!((R(s5)(15..0) as UWord > R(t5)))) in
+    let pred = !(R(s5)(15..0) as UWord > R(t5)) in
+      let pvalue = toPValue(!(R(s5)(15..0) as UWord > R(t5))) in
         {
           Pset(1, pvalue)          if pred then
             {
-              PC := (PC.current + extendR2(disp))
+              PC := PC.current + extendR2(disp)
             }
 
         }
@@ -3339,7 +3339,7 @@ match reg with
   instruction LoadByteGPRel : LoadFormat =   {
     if true then
       {
-        R(d5) := MEM< 1 >((GP + scaledImmU(immGPRel, 0))) as SByte
+        R(d5) := MEM< 1 >(GP + scaledImmU(immGPRel, 0)) as SByte
       }
 
   }
@@ -3358,7 +3358,7 @@ match reg with
   instruction LoadByteRegRel : LoadFormat =   {
     if true then
       {
-        R(d5) := MEM< 1 >((R(s5) + scaledImmS(immRegRel, 0))) as SByte
+        R(d5) := MEM< 1 >(R(s5) + scaledImmS(immRegRel, 0)) as SByte
       }
 
   }
@@ -3377,7 +3377,7 @@ match reg with
   instruction LoadBytePredPosRegRel : LoadRegRelPredFormat =   {
     if testpred(t2) then
       {
-        R(d5) := MEM< 1 >((R(s5) + scaledImmS(immRegRel, 0))) as SByte
+        R(d5) := MEM< 1 >(R(s5) + scaledImmS(immRegRel, 0)) as SByte
       }
 
   }
@@ -3395,9 +3395,9 @@ match reg with
   assembly LoadBytePredPosRegRel = (AsmPred(t2, false, false), AsmR(d5), "=", ("memb", AsmAddrRegRel(s5, immRegRel)))
 
   instruction LoadBytePredNegRegRel : LoadRegRelPredFormat =   {
-    if !(testpred(t2)) then
+    if !testpred(t2) then
       {
-        R(d5) := MEM< 1 >((R(s5) + scaledImmS(immRegRel, 0))) as SByte
+        R(d5) := MEM< 1 >(R(s5) + scaledImmS(immRegRel, 0)) as SByte
       }
 
   }
@@ -3417,7 +3417,7 @@ match reg with
   instruction LoadUByteGPRel : LoadFormat =   {
     if true then
       {
-        R(d5) := MEM< 1 >((GP + scaledImmU(immGPRel, 0))) as UByte
+        R(d5) := MEM< 1 >(GP + scaledImmU(immGPRel, 0)) as UByte
       }
 
   }
@@ -3436,7 +3436,7 @@ match reg with
   instruction LoadUByteRegRel : LoadFormat =   {
     if true then
       {
-        R(d5) := MEM< 1 >((R(s5) + scaledImmS(immRegRel, 0))) as UByte
+        R(d5) := MEM< 1 >(R(s5) + scaledImmS(immRegRel, 0)) as UByte
       }
 
   }
@@ -3455,7 +3455,7 @@ match reg with
   instruction LoadHalfGPRel : LoadFormat =   {
     if true then
       {
-        R(d5) := MEM< 2 >((GP + scaledImmU(immGPRel, 1))) as SHalf
+        R(d5) := MEM< 2 >(GP + scaledImmU(immGPRel, 1)) as SHalf
       }
 
   }
@@ -3474,7 +3474,7 @@ match reg with
   instruction LoadHalfRegRel : LoadFormat =   {
     if true then
       {
-        R(d5) := MEM< 2 >((R(s5) + scaledImmS(immRegRel, 1))) as SHalf
+        R(d5) := MEM< 2 >(R(s5) + scaledImmS(immRegRel, 1)) as SHalf
       }
 
   }
@@ -3493,7 +3493,7 @@ match reg with
   instruction LoadHalfPredPosRegRel : LoadRegRelPredFormat =   {
     if testpred(t2) then
       {
-        R(d5) := MEM< 2 >((R(s5) + scaledImmS(immRegRel, 1))) as SHalf
+        R(d5) := MEM< 2 >(R(s5) + scaledImmS(immRegRel, 1)) as SHalf
       }
 
   }
@@ -3511,9 +3511,9 @@ match reg with
   assembly LoadHalfPredPosRegRel = (AsmPred(t2, false, false), AsmR(d5), "=", ("memh", AsmAddrRegRel(s5, immRegRel)))
 
   instruction LoadHalfPredNegRegRel : LoadRegRelPredFormat =   {
-    if !(testpred(t2)) then
+    if !testpred(t2) then
       {
-        R(d5) := MEM< 2 >((R(s5) + scaledImmS(immRegRel, 1))) as SHalf
+        R(d5) := MEM< 2 >(R(s5) + scaledImmS(immRegRel, 1)) as SHalf
       }
 
   }
@@ -3533,7 +3533,7 @@ match reg with
   instruction LoadUHalfGPRel : LoadFormat =   {
     if true then
       {
-        R(d5) := MEM< 2 >((GP + scaledImmU(immGPRel, 1))) as UHalf
+        R(d5) := MEM< 2 >(GP + scaledImmU(immGPRel, 1)) as UHalf
       }
 
   }
@@ -3552,7 +3552,7 @@ match reg with
   instruction LoadUHalfRegRel : LoadFormat =   {
     if true then
       {
-        R(d5) := MEM< 2 >((R(s5) + scaledImmS(immRegRel, 1))) as UHalf
+        R(d5) := MEM< 2 >(R(s5) + scaledImmS(immRegRel, 1)) as UHalf
       }
 
   }
@@ -3571,7 +3571,7 @@ match reg with
   instruction LoadWordGPRel : LoadFormat =   {
     if true then
       {
-        R(d5) := MEM< 4 >((GP + scaledImmU(immGPRel, 2))) as SWord
+        R(d5) := MEM< 4 >(GP + scaledImmU(immGPRel, 2)) as SWord
       }
 
   }
@@ -3590,7 +3590,7 @@ match reg with
   instruction LoadWordRegRel : LoadFormat =   {
     if true then
       {
-        R(d5) := MEM< 4 >((R(s5) + scaledImmS(immRegRel, 2))) as SWord
+        R(d5) := MEM< 4 >(R(s5) + scaledImmS(immRegRel, 2)) as SWord
       }
 
   }
@@ -3609,7 +3609,7 @@ match reg with
   instruction LoadWordPredPosRegRel : LoadRegRelPredFormat =   {
     if testpred(t2) then
       {
-        R(d5) := MEM< 4 >((R(s5) + scaledImmS(immRegRel, 2))) as SWord
+        R(d5) := MEM< 4 >(R(s5) + scaledImmS(immRegRel, 2)) as SWord
       }
 
   }
@@ -3627,9 +3627,9 @@ match reg with
   assembly LoadWordPredPosRegRel = (AsmPred(t2, false, false), AsmR(d5), "=", ("memw", AsmAddrRegRel(s5, immRegRel)))
 
   instruction LoadWordPredNegRegRel : LoadRegRelPredFormat =   {
-    if !(testpred(t2)) then
+    if !testpred(t2) then
       {
-        R(d5) := MEM< 4 >((R(s5) + scaledImmS(immRegRel, 2))) as SWord
+        R(d5) := MEM< 4 >(R(s5) + scaledImmS(immRegRel, 2)) as SWord
       }
 
   }
@@ -3649,10 +3649,10 @@ match reg with
   instruction LoadDoubleGPRel : LoadFormat =   {
     if true then
       {
-        let result = MEM< 8 >((GP + scaledImmU(immGPRel, 3))) as SDouble in
+        let result = MEM< 8 >(GP + scaledImmU(immGPRel, 3)) as SDouble in
           {
             R(d5) := result(31..0)
-            R((d5 + 1)) := result(63..32)
+            R(d5 + 1) := result(63..32)
           }
       }
 
@@ -3672,10 +3672,10 @@ match reg with
   instruction LoadDoubleRegRel : LoadFormat =   {
     if true then
       {
-        let result = MEM< 8 >((R(s5) + scaledImmS(immRegRel, 3))) as SDouble in
+        let result = MEM< 8 >(R(s5) + scaledImmS(immRegRel, 3)) as SDouble in
           {
             R(d5) := result(31..0)
-            R((d5 + 1)) := result(63..32)
+            R(d5 + 1) := result(63..32)
           }
       }
 
@@ -3695,10 +3695,10 @@ match reg with
   instruction LoadDoublePredPosRegRel : LoadRegRelPredFormat =   {
     if testpred(t2) then
       {
-        let result = MEM< 8 >((R(s5) + scaledImmS(immRegRel, 3))) as SDouble in
+        let result = MEM< 8 >(R(s5) + scaledImmS(immRegRel, 3)) as SDouble in
           {
             R(d5) := result(31..0)
-            R((d5 + 1)) := result(63..32)
+            R(d5 + 1) := result(63..32)
           }
       }
 
@@ -3717,12 +3717,12 @@ match reg with
   assembly LoadDoublePredPosRegRel = (AsmPred(t2, false, false), AsmRR(d5), "=", ("memd", AsmAddrRegRel(s5, immRegRel)))
 
   instruction LoadDoublePredNegRegRel : LoadRegRelPredFormat =   {
-    if !(testpred(t2)) then
+    if !testpred(t2) then
       {
-        let result = MEM< 8 >((R(s5) + scaledImmS(immRegRel, 3))) as SDouble in
+        let result = MEM< 8 >(R(s5) + scaledImmS(immRegRel, 3)) as SDouble in
           {
             R(d5) := result(31..0)
-            R((d5 + 1)) := result(63..32)
+            R(d5 + 1) := result(63..32)
           }
       }
 
@@ -3758,7 +3758,7 @@ match reg with
     let restored = MEM< 8 >(FP) as Double in
       let LRnew = frameUnscramble(restored(63..32)) in
         {
-          SP := (FP + 8)
+          SP := FP + 8
           LR := LRnew
           FP := restored(31..0)
         }
@@ -3783,7 +3783,7 @@ match reg with
         let restored = MEM< 8 >(FP) as Double in
           let LRnew = frameUnscramble(restored(63..32)) in
             {
-              SP := (FP + 8)
+              SP := FP + 8
               LR := LRnew
               FP := restored(31..0)
               PC := LRnew
@@ -3813,7 +3813,7 @@ match reg with
         let restored = MEM< 8 >(FP) as Double in
           let LRnew = frameUnscramble(restored(63..32)) in
             {
-              SP := (FP + 8)
+              SP := FP + 8
               LR := LRnew
               FP := restored(31..0)
               PC := LRnew
@@ -3838,12 +3838,12 @@ match reg with
   assembly DecallocReturnPredPos = (AsmPred(pred, false, false), "dealloc_return", "")
 
   instruction DecallocReturnPredNeg : DeallocFrameFormat =   {
-    if !(testpred(pred)) then
+    if !testpred(pred) then
       {
         let restored = MEM< 8 >(FP) as Double in
           let LRnew = frameUnscramble(restored(63..32)) in
             {
-              SP := (FP + 8)
+              SP := FP + 8
               LR := LRnew
               FP := restored(31..0)
               PC := LRnew
@@ -3882,7 +3882,7 @@ match reg with
   }
 
   instruction StoreByteGPRel : StoreFormat =   {
-    MEM< 1 >((GP + scaledImmU(immGPRel, 0))) := (R(t5) >> 0 as UInt<6>) as Byte
+    MEM< 1 >(GP + scaledImmU(immGPRel, 0)) := (R(t5) >> 0 as UInt<6>) as Byte
   }
 
 
@@ -3897,7 +3897,7 @@ match reg with
   assembly StoreByteGPRel = (("memb", AsmAddrGPRel(immGPRel)), "=", AsmR(t5), "")
 
   instruction StoreByteRegRel : StoreFormat =   {
-    MEM< 1 >((R(s5) + scaledImmS(immRegRel, 0))) := (R(t5) >> 0 as UInt<6>) as Byte
+    MEM< 1 >(R(s5) + scaledImmS(immRegRel, 0)) := (R(t5) >> 0 as UInt<6>) as Byte
   }
 
 
@@ -3912,7 +3912,7 @@ match reg with
   assembly StoreByteRegRel = (("memb", AsmAddrRegRel(s5, immRegRel)), "=", AsmR(t5), "")
 
   instruction StoreHalfGPRel : StoreFormat =   {
-    MEM< 2 >((GP + scaledImmU(immGPRel, 1))) := (R(t5) >> 0 as UInt<6>) as Half
+    MEM< 2 >(GP + scaledImmU(immGPRel, 1)) := (R(t5) >> 0 as UInt<6>) as Half
   }
 
 
@@ -3927,7 +3927,7 @@ match reg with
   assembly StoreHalfGPRel = (("memh", AsmAddrGPRel(immGPRel)), "=", AsmR(t5), "")
 
   instruction StoreHalfRegRel : StoreFormat =   {
-    MEM< 2 >((R(s5) + scaledImmS(immRegRel, 1))) := (R(t5) >> 0 as UInt<6>) as Half
+    MEM< 2 >(R(s5) + scaledImmS(immRegRel, 1)) := (R(t5) >> 0 as UInt<6>) as Half
   }
 
 
@@ -3942,7 +3942,7 @@ match reg with
   assembly StoreHalfRegRel = (("memh", AsmAddrRegRel(s5, immRegRel)), "=", AsmR(t5), "")
 
   instruction StoreHHalfGPRel : StoreFormat =   {
-    MEM< 2 >((GP + scaledImmU(immGPRel, 1))) := (R(t5) >> (2 * 8) as UInt<6>) as Half
+    MEM< 2 >(GP + scaledImmU(immGPRel, 1)) := (R(t5) >> (2 * 8) as UInt<6>) as Half
   }
 
 
@@ -3957,7 +3957,7 @@ match reg with
   assembly StoreHHalfGPRel = (("memh", AsmAddrGPRel(immGPRel)), "=", AsmR(t5), ".H")
 
   instruction StoreHHalfRegRel : StoreFormat =   {
-    MEM< 2 >((R(s5) + scaledImmS(immRegRel, 1))) := (R(t5) >> (2 * 8) as UInt<6>) as Half
+    MEM< 2 >(R(s5) + scaledImmS(immRegRel, 1)) := (R(t5) >> (2 * 8) as UInt<6>) as Half
   }
 
 
@@ -3972,7 +3972,7 @@ match reg with
   assembly StoreHHalfRegRel = (("memh", AsmAddrRegRel(s5, immRegRel)), "=", AsmR(t5), ".H")
 
   instruction StoreWordGPRel : StoreFormat =   {
-    MEM< 4 >((GP + scaledImmU(immGPRel, 2))) := (R(t5) >> 0 as UInt<6>) as Word
+    MEM< 4 >(GP + scaledImmU(immGPRel, 2)) := (R(t5) >> 0 as UInt<6>) as Word
   }
 
 
@@ -3987,7 +3987,7 @@ match reg with
   assembly StoreWordGPRel = (("memw", AsmAddrGPRel(immGPRel)), "=", AsmR(t5), "")
 
   instruction StoreWordRegRel : StoreFormat =   {
-    MEM< 4 >((R(s5) + scaledImmS(immRegRel, 2))) := (R(t5) >> 0 as UInt<6>) as Word
+    MEM< 4 >(R(s5) + scaledImmS(immRegRel, 2)) := (R(t5) >> 0 as UInt<6>) as Word
   }
 
 
@@ -4002,7 +4002,7 @@ match reg with
   assembly StoreWordRegRel = (("memw", AsmAddrRegRel(s5, immRegRel)), "=", AsmR(t5), "")
 
   instruction StoreDoubleGPRel : StoreFormat =   {
-    MEM< 8 >((GP + scaledImmU(immGPRel, 3))) := (R((t5 + 1)), R(t5)) as Double
+    MEM< 8 >(GP + scaledImmU(immGPRel, 3)) := (R(t5 + 1), R(t5)) as Double
   }
 
 
@@ -4017,7 +4017,7 @@ match reg with
   assembly StoreDoubleGPRel = (("memd", AsmAddrGPRel(immGPRel)), "=", AsmR(t5), "")
 
   instruction StoreDoubleRegRel : StoreFormat =   {
-    MEM< 8 >((R(s5) + scaledImmS(immRegRel, 3))) := (R((t5 + 1)), R(t5)) as Double
+    MEM< 8 >(R(s5) + scaledImmS(immRegRel, 3)) := (R(t5 + 1), R(t5)) as Double
   }
 
 
@@ -4059,7 +4059,7 @@ match reg with
 
   instruction StoreImmByte : StoreImmFormat =   {
     if true then
-      MEM< 1 >((R(s5) + scaledImmU(immOffsetU, 0))) := immS as SByte
+      MEM< 1 >(R(s5) + scaledImmU(immOffsetU, 0)) := immS as SByte
 
   }
 
@@ -4074,7 +4074,7 @@ match reg with
 
   instruction StoreImmHalf : StoreImmFormat =   {
     if true then
-      MEM< 2 >((R(s5) + scaledImmU(immOffsetU, 1))) := immS as SHalf
+      MEM< 2 >(R(s5) + scaledImmU(immOffsetU, 1)) := immS as SHalf
 
   }
 
@@ -4089,7 +4089,7 @@ match reg with
 
   instruction StoreImmWord : StoreImmFormat =   {
     if true then
-      MEM< 4 >((R(s5) + scaledImmU(immOffsetU, 2))) := immS as SWord
+      MEM< 4 >(R(s5) + scaledImmU(immOffsetU, 2)) := immS as SWord
 
   }
 
@@ -4104,7 +4104,7 @@ match reg with
 
   instruction StoreImmByteX : StoreImmXFormat =   {
     if true then
-      MEM< 1 >((R(s5) + scaledImmU(immOffsetU, 0))) := immS as SByte
+      MEM< 1 >(R(s5) + scaledImmU(immOffsetU, 0)) := immS as SByte
 
   }
 
@@ -4120,7 +4120,7 @@ match reg with
 
   instruction StoreImmHalfX : StoreImmXFormat =   {
     if true then
-      MEM< 2 >((R(s5) + scaledImmU(immOffsetU, 1))) := immS as SHalf
+      MEM< 2 >(R(s5) + scaledImmU(immOffsetU, 1)) := immS as SHalf
 
   }
 
@@ -4136,7 +4136,7 @@ match reg with
 
   instruction StoreImmWordX : StoreImmXFormat =   {
     if true then
-      MEM< 4 >((R(s5) + scaledImmU(immOffsetU, 2))) := immS as SWord
+      MEM< 4 >(R(s5) + scaledImmU(immOffsetU, 2)) := immS as SWord
 
   }
 
@@ -4158,15 +4158,15 @@ match reg with
   , unsigned	 [21]
   , opc	 [20..16, 13..11]
   , imm	 [10..0]
-  , immU = (imm as UInt<11> * 8 as UInt<4>)
+  , immU = imm as UInt<11> * 8 as UInt<4>
   }
 
   instruction AllocFrame : AllocFrameFormat =   {
-    let SPnew = (SP - 8) in
+    let SPnew = SP - 8 in
       {
         MEM< 8 >(SPnew) := (frameScramble(LR), FP)
         FP := SPnew
-        SP := (SPnew - immU)
+        SP := SPnew - immU
       }
   }
 
@@ -4287,7 +4287,7 @@ match reg with
   }
 
   instruction BitSetImm : BitOpImmFormat =   {
-    R(d5) := (R(s5) | (1 as Word << imm))
+    R(d5) := R(s5) | 1 as Word << imm
   }
 
 
@@ -4302,7 +4302,7 @@ match reg with
   assembly BitSetImm = (AsmR(d5), " = ", "setbit", "(", AsmR(s5), ",", ("#", decimal(imm)), ")")
 
   instruction BitClrImm : BitOpImmFormat =   {
-    R(d5) := (R(s5) & VADL::not((1 as Word << imm)))
+    R(d5) := R(s5) & VADL::not(1 as Word << imm)
   }
 
 
@@ -4317,7 +4317,7 @@ match reg with
   assembly BitClrImm = (AsmR(d5), " = ", "clrbit", "(", AsmR(s5), ",", ("#", decimal(imm)), ")")
 
   instruction BitToggleImm : BitOpImmFormat =   {
-    R(d5) := (R(s5) ^ (1 as Word << imm))
+    R(d5) := R(s5) ^ 1 as Word << imm
   }
 
 
@@ -4388,8 +4388,8 @@ match reg with
   }
 
   instruction AddDoubleCarry : ALUDoubleCarryFormat =   {
-    let a = (R((s5 + 1)), R(s5)) in
-      let b = (R((t5 + 1)), R(t5)) in
+    let a = (R(s5 + 1), R(s5)) in
+      let b = (R(t5 + 1), R(t5)) in
         let c = P(x2) as Bits<1> as Word in
           let temp, tempstatus = VADL::adds(a, if false then
   VADL::not(b)
@@ -4398,8 +4398,8 @@ else
             let result, status = VADL::adds(temp, c) in
               {
                 R(d5) := result(31..0)
-                R((d5 + 1)) := result(63..32)
-                Pset(x2, (tempstatus.carry | status.carry))              }
+                R(d5 + 1) := result(63..32)
+                Pset(x2, tempstatus.carry | status.carry)              }
   }
 
 
@@ -4416,8 +4416,8 @@ else
   "add", "(", AsmRR(s5), ",", AsmRR(t5), ",", AsmP(x2), "):carry")
 
   instruction SubDoubleCarry : ALUDoubleCarryFormat =   {
-    let a = (R((s5 + 1)), R(s5)) in
-      let b = (R((t5 + 1)), R(t5)) in
+    let a = (R(s5 + 1), R(s5)) in
+      let b = (R(t5 + 1), R(t5)) in
         let c = P(x2) as Bits<1> as Word in
           let temp, tempstatus = VADL::adds(a, if true then
   VADL::not(b)
@@ -4426,8 +4426,8 @@ else
             let result, status = VADL::adds(temp, c) in
               {
                 R(d5) := result(31..0)
-                R((d5 + 1)) := result(63..32)
-                Pset(x2, (tempstatus.carry | status.carry))              }
+                R(d5 + 1) := result(63..32)
+                Pset(x2, tempstatus.carry | status.carry)              }
   }
 
 
@@ -4519,7 +4519,7 @@ else
   , XTYPE_PRED_WRITING
   }
 
-  function implies(a : Bool, b : Bool) -> Bool = (!(a) | b)
+  function implies(a : Bool, b : Bool) -> Bool = !a | b
 
   group VLIW = (((XTYPE<0..1> | ALU32<0..1> | J<0..1> | CR<0..1>).(XTYPE<0..1> | ALU32<0..1> | J<0..1> | JR<0..1> | CR23<0..1>).(LD<0..1> | ST<0..1> | ALU32<0..1>).(LD<0..1> | ST<0..1> | ALU32<0..1>)) | SYSTEMSolo)
 }
@@ -4528,7 +4528,7 @@ application binary interface ABI for QDSP6 = {
 }
 
 processor CPU implements QDSP6 with ABI = {
-  stop with @Brkpt = (PC = 0xeeee'eeee)
+  stop with @Brkpt = PC = 0xeeee'eeee
 
   reset =
     {

--- a/vadl/test/resources/macros/hexagon.expanded.vadl
+++ b/vadl/test/resources/macros/hexagon.expanded.vadl
@@ -496,7 +496,7 @@ match reg with
   assembly CmpImmEq = (AsmP(d2), "=", ("cmp.eq(", AsmR(s5), ",#", decimal(immS), ")"))
 
   instruction CmpImmNeq : CmpImmFormat =   {
-    let val = toPValue(!(R(s5) = extendS(immS))) in
+    let val = toPValue(!((R(s5) = extendS(immS)))) in
       {
         Pset(d2, val)      }
   }
@@ -532,7 +532,7 @@ match reg with
   assembly CmpImmGt = (AsmP(d2), "=", ("cmp.gt(", AsmR(s5), ",#", decimal(immS), ")"))
 
   instruction CmpImmLte : CmpImmFormat =   {
-    let val = toPValue((!R(s5) as SInt > extendS(immS))) in
+    let val = toPValue((!(R(s5) as SInt) > extendS(immS))) in
       {
         Pset(d2, val)      }
   }
@@ -604,7 +604,7 @@ match reg with
   assembly CmpRegEq = (AsmP(d2), "=", ("cmp.eq(", AsmR(s5), ",", AsmR(t5), ")"))
 
   instruction CmpRegNeq : CmpRegFormat =   {
-    let val = toPValue(!(R(s5) = R(t5))) in
+    let val = toPValue(!((R(s5) = R(t5)))) in
       {
         Pset(d2, val)      }
   }
@@ -640,7 +640,7 @@ match reg with
   assembly CmpRegGt = (AsmP(d2), "=", ("cmp.gt(", AsmR(s5), ",", AsmR(t5), ")"))
 
   instruction CmpRegLte : CmpRegFormat =   {
-    let val = toPValue(!(R(s5) as SInt > R(t5) as SInt)) in
+    let val = toPValue(!((R(s5) as SInt > R(t5) as SInt))) in
       {
         Pset(d2, val)      }
   }
@@ -676,7 +676,7 @@ match reg with
   assembly CmpRegGtu = (AsmP(d2), "=", ("cmp.gtu(", AsmR(s5), ",", AsmR(t5), ")"))
 
   instruction CmpRegLteu : CmpRegFormat =   {
-    let val = toPValue(!(R(s5) as UInt > R(t5) as UInt)) in
+    let val = toPValue(!((R(s5) as UInt > R(t5) as UInt))) in
       {
         Pset(d2, val)      }
   }
@@ -1188,7 +1188,7 @@ match reg with
   assembly LogicalPredOrAnd = (AsmP(d2), "=", ("or(", AsmP(s2), ",and(", AsmP(t2), ",", AsmP(u2), "))"))
 
   instruction LogicalPredAndNot : LogicalPredFormat =   {
-    Pset(d2, VADL::and(Pget(t2), !Pget(s2)))  }
+    Pset(d2, VADL::and(Pget(t2), !(Pget(s2))))  }
 
 
   encoding LogicalPredAndNot =
@@ -1260,7 +1260,7 @@ match reg with
   assembly LogicalPredOrAndNot = (AsmP(d2), "=", ("or(", AsmP(s2), ",and(", AsmP(t2), ",!", AsmP(u2), "))"))
 
   instruction LogicalPredOrNot : LogicalPredFormat =   {
-    Pset(d2, VADL::or(Pget(t2), !Pget(s2)))  }
+    Pset(d2, VADL::or(Pget(t2), !(Pget(s2))))  }
 
 
   encoding LogicalPredOrNot =
@@ -1327,7 +1327,7 @@ match reg with
   assembly CallRegPredPos = (AsmPred(u2, false, false), "callr ", AsmR(s5))
 
   instruction CallRegPredNeg : BranchRegFormat =   {
-    if !testpred(u2) then
+    if !(testpred(u2)) then
       {
         LR := PC.next
         PC := R(s5)
@@ -1394,7 +1394,7 @@ match reg with
   assembly JumpRegPredPosT = (AsmPred(u2, false, false), "jumpr", ":t ", " ", AsmR(s5))
 
   instruction JumpRegPredNegNT : BranchRegFormat =   {
-    if !testpred(u2) then
+    if !(testpred(u2)) then
       {
         PC := R(s5)
       }
@@ -1411,7 +1411,7 @@ match reg with
   assembly JumpRegPredNegNT = (AsmPred(u2, true, false), "jumpr", ":nt ", " ", AsmR(s5))
 
   instruction JumpRegPredNegT : BranchRegFormat =   {
-    if !testpred(u2) then
+    if !(testpred(u2)) then
       {
         PC := R(s5)
       }
@@ -1495,7 +1495,7 @@ match reg with
   assembly JumpImmPredPosT = (AsmPred(u2, false, false), "jump", ":t ", " ", decimal(immS))
 
   instruction JumpImmPredNegNT : JumpImmPredFormat =   {
-    if !testpred(u2) then
+    if !(testpred(u2)) then
       {
         PC := (PC.current + extendR2(imm))
       }
@@ -1512,7 +1512,7 @@ match reg with
   assembly JumpImmPredNegNT = (AsmPred(u2, true, false), "jump", ":nt ", " ", decimal(immS))
 
   instruction JumpImmPredNegT : JumpImmPredFormat =   {
-    if !testpred(u2) then
+    if !(testpred(u2)) then
       {
         PC := (PC.current + extendR2(imm))
       }
@@ -1579,7 +1579,7 @@ match reg with
   assembly CallImmPredPos = (AsmPred(pred, false, false), "call #", decimal(imm))
 
   instruction CallImmPredNeg : CallImmPredFormat =   {
-    if !testpred(pred) then
+    if !(testpred(pred)) then
       {
         LR := PC.next
         PC := (PC.current + extendR2(imm))
@@ -1653,8 +1653,8 @@ match reg with
   }
 
   instruction CmpJumpEqMinus1P0PosNT : CmpJumpFormat =   {
-    let pred = (R(s5) = -1) in
-      let pvalue = toPValue((R(s5) = -1)) in
+    let pred = (R(s5) = -(1)) in
+      let pvalue = toPValue((R(s5) = -(1))) in
         {
           Pset(0, pvalue)          if pred then
             {
@@ -1676,8 +1676,8 @@ match reg with
   assembly CmpJumpEqMinus1P0PosNT = (AsmP(0), "=", ("cmp.eq(", AsmR(s5), "#-1)"), "; ", AsmPred(0, 0, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpEqMinus1P1PosNT : CmpJumpFormat =   {
-    let pred = (R(s5) = -1) in
-      let pvalue = toPValue((R(s5) = -1)) in
+    let pred = (R(s5) = -(1)) in
+      let pvalue = toPValue((R(s5) = -(1))) in
         {
           Pset(1, pvalue)          if pred then
             {
@@ -1699,8 +1699,8 @@ match reg with
   assembly CmpJumpEqMinus1P1PosNT = (AsmP(1), "=", ("cmp.eq(", AsmR(s5), "#-1)"), "; ", AsmPred(1, 0, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpEqMinus1P0NegNT : CmpJumpFormat =   {
-    let pred = !(R(s5) = -1) in
-      let pvalue = toPValue(!(R(s5) = -1)) in
+    let pred = !((R(s5) = -(1))) in
+      let pvalue = toPValue(!((R(s5) = -(1)))) in
         {
           Pset(0, pvalue)          if pred then
             {
@@ -1722,8 +1722,8 @@ match reg with
   assembly CmpJumpEqMinus1P0NegNT = (AsmP(0), "=", ("cmp.eq(", AsmR(s5), "#-1)"), "; ", AsmPred(0, 1, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpEqMinus1P1NegNT : CmpJumpFormat =   {
-    let pred = !(R(s5) = -1) in
-      let pvalue = toPValue(!(R(s5) = -1)) in
+    let pred = !((R(s5) = -(1))) in
+      let pvalue = toPValue(!((R(s5) = -(1)))) in
         {
           Pset(1, pvalue)          if pred then
             {
@@ -1745,8 +1745,8 @@ match reg with
   assembly CmpJumpEqMinus1P1NegNT = (AsmP(1), "=", ("cmp.eq(", AsmR(s5), "#-1)"), "; ", AsmPred(1, 1, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpEqMinus1P0PosT : CmpJumpFormat =   {
-    let pred = (R(s5) = -1) in
-      let pvalue = toPValue((R(s5) = -1)) in
+    let pred = (R(s5) = -(1)) in
+      let pvalue = toPValue((R(s5) = -(1))) in
         {
           Pset(0, pvalue)          if pred then
             {
@@ -1768,8 +1768,8 @@ match reg with
   assembly CmpJumpEqMinus1P0PosT = (AsmP(0), "=", ("cmp.eq(", AsmR(s5), "#-1)"), "; ", AsmPred(0, 0, true), " jump:", "t", " #", decimal(dispS))
 
   instruction CmpJumpEqMinus1P1PosT : CmpJumpFormat =   {
-    let pred = (R(s5) = -1) in
-      let pvalue = toPValue((R(s5) = -1)) in
+    let pred = (R(s5) = -(1)) in
+      let pvalue = toPValue((R(s5) = -(1))) in
         {
           Pset(1, pvalue)          if pred then
             {
@@ -1791,8 +1791,8 @@ match reg with
   assembly CmpJumpEqMinus1P1PosT = (AsmP(1), "=", ("cmp.eq(", AsmR(s5), "#-1)"), "; ", AsmPred(1, 0, true), " jump:", "t", " #", decimal(dispS))
 
   instruction CmpJumpEqMinus1P0NegT : CmpJumpFormat =   {
-    let pred = !(R(s5) = -1) in
-      let pvalue = toPValue(!(R(s5) = -1)) in
+    let pred = !((R(s5) = -(1))) in
+      let pvalue = toPValue(!((R(s5) = -(1)))) in
         {
           Pset(0, pvalue)          if pred then
             {
@@ -1814,8 +1814,8 @@ match reg with
   assembly CmpJumpEqMinus1P0NegT = (AsmP(0), "=", ("cmp.eq(", AsmR(s5), "#-1)"), "; ", AsmPred(0, 1, true), " jump:", "t", " #", decimal(dispS))
 
   instruction CmpJumpEqMinus1P1NegT : CmpJumpFormat =   {
-    let pred = !(R(s5) = -1) in
-      let pvalue = toPValue(!(R(s5) = -1)) in
+    let pred = !((R(s5) = -(1))) in
+      let pvalue = toPValue(!((R(s5) = -(1)))) in
         {
           Pset(1, pvalue)          if pred then
             {
@@ -1837,8 +1837,8 @@ match reg with
   assembly CmpJumpEqMinus1P1NegT = (AsmP(1), "=", ("cmp.eq(", AsmR(s5), "#-1)"), "; ", AsmPred(1, 1, true), " jump:", "t", " #", decimal(dispS))
 
   instruction CmpJumpGtMinus1P0PosNT : CmpJumpFormat =   {
-    let pred = (R(s5) as SInt > -1 as SInt) in
-      let pvalue = toPValue((R(s5) as SInt > -1 as SInt)) in
+    let pred = (R(s5) as SInt > -(1) as SInt) in
+      let pvalue = toPValue((R(s5) as SInt > -(1) as SInt)) in
         {
           Pset(0, pvalue)          if pred then
             {
@@ -1860,8 +1860,8 @@ match reg with
   assembly CmpJumpGtMinus1P0PosNT = (AsmP(0), "=", ("cmp.gt(", AsmR(s5), "#-1)"), "; ", AsmPred(0, 0, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpGtMinus1P1PosNT : CmpJumpFormat =   {
-    let pred = (R(s5) as SInt > -1 as SInt) in
-      let pvalue = toPValue((R(s5) as SInt > -1 as SInt)) in
+    let pred = (R(s5) as SInt > -(1) as SInt) in
+      let pvalue = toPValue((R(s5) as SInt > -(1) as SInt)) in
         {
           Pset(1, pvalue)          if pred then
             {
@@ -1883,8 +1883,8 @@ match reg with
   assembly CmpJumpGtMinus1P1PosNT = (AsmP(1), "=", ("cmp.gt(", AsmR(s5), "#-1)"), "; ", AsmPred(1, 0, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpGtMinus1P0NegNT : CmpJumpFormat =   {
-    let pred = !(R(s5) as SInt > -1 as SInt) in
-      let pvalue = toPValue(!(R(s5) as SInt > -1 as SInt)) in
+    let pred = !((R(s5) as SInt > -(1) as SInt)) in
+      let pvalue = toPValue(!((R(s5) as SInt > -(1) as SInt))) in
         {
           Pset(0, pvalue)          if pred then
             {
@@ -1906,8 +1906,8 @@ match reg with
   assembly CmpJumpGtMinus1P0NegNT = (AsmP(0), "=", ("cmp.gt(", AsmR(s5), "#-1)"), "; ", AsmPred(0, 1, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpGtMinus1P1NegNT : CmpJumpFormat =   {
-    let pred = !(R(s5) as SInt > -1 as SInt) in
-      let pvalue = toPValue(!(R(s5) as SInt > -1 as SInt)) in
+    let pred = !((R(s5) as SInt > -(1) as SInt)) in
+      let pvalue = toPValue(!((R(s5) as SInt > -(1) as SInt))) in
         {
           Pset(1, pvalue)          if pred then
             {
@@ -1929,8 +1929,8 @@ match reg with
   assembly CmpJumpGtMinus1P1NegNT = (AsmP(1), "=", ("cmp.gt(", AsmR(s5), "#-1)"), "; ", AsmPred(1, 1, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpGtMinus1P0PosT : CmpJumpFormat =   {
-    let pred = (R(s5) as SInt > -1 as SInt) in
-      let pvalue = toPValue((R(s5) as SInt > -1 as SInt)) in
+    let pred = (R(s5) as SInt > -(1) as SInt) in
+      let pvalue = toPValue((R(s5) as SInt > -(1) as SInt)) in
         {
           Pset(0, pvalue)          if pred then
             {
@@ -1952,8 +1952,8 @@ match reg with
   assembly CmpJumpGtMinus1P0PosT = (AsmP(0), "=", ("cmp.gt(", AsmR(s5), "#-1)"), "; ", AsmPred(0, 0, true), " jump:", "t", " #", decimal(dispS))
 
   instruction CmpJumpGtMinus1P1PosT : CmpJumpFormat =   {
-    let pred = (R(s5) as SInt > -1 as SInt) in
-      let pvalue = toPValue((R(s5) as SInt > -1 as SInt)) in
+    let pred = (R(s5) as SInt > -(1) as SInt) in
+      let pvalue = toPValue((R(s5) as SInt > -(1) as SInt)) in
         {
           Pset(1, pvalue)          if pred then
             {
@@ -1975,8 +1975,8 @@ match reg with
   assembly CmpJumpGtMinus1P1PosT = (AsmP(1), "=", ("cmp.gt(", AsmR(s5), "#-1)"), "; ", AsmPred(1, 0, true), " jump:", "t", " #", decimal(dispS))
 
   instruction CmpJumpGtMinus1P0NegT : CmpJumpFormat =   {
-    let pred = !(R(s5) as SInt > -1 as SInt) in
-      let pvalue = toPValue(!(R(s5) as SInt > -1 as SInt)) in
+    let pred = !((R(s5) as SInt > -(1) as SInt)) in
+      let pvalue = toPValue(!((R(s5) as SInt > -(1) as SInt))) in
         {
           Pset(0, pvalue)          if pred then
             {
@@ -1998,8 +1998,8 @@ match reg with
   assembly CmpJumpGtMinus1P0NegT = (AsmP(0), "=", ("cmp.gt(", AsmR(s5), "#-1)"), "; ", AsmPred(0, 1, true), " jump:", "t", " #", decimal(dispS))
 
   instruction CmpJumpGtMinus1P1NegT : CmpJumpFormat =   {
-    let pred = !(R(s5) as SInt > -1 as SInt) in
-      let pvalue = toPValue(!(R(s5) as SInt > -1 as SInt)) in
+    let pred = !((R(s5) as SInt > -(1) as SInt)) in
+      let pvalue = toPValue(!((R(s5) as SInt > -(1) as SInt))) in
         {
           Pset(1, pvalue)          if pred then
             {
@@ -2067,8 +2067,8 @@ match reg with
   assembly CmpJumpTstBit0P1PosNT = (AsmP(1), "=", ("tstbit(", AsmR(s5), "#0)"), "; ", AsmPred(1, 0, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpTstBit0P0NegNT : CmpJumpFormat =   {
-    let pred = !((R(s5) & 0b1) = 1) in
-      let pvalue = toPValue(!((R(s5) & 0b1) = 1)) in
+    let pred = !(((R(s5) & 0b1) = 1)) in
+      let pvalue = toPValue(!(((R(s5) & 0b1) = 1))) in
         {
           Pset(0, pvalue)          if pred then
             {
@@ -2090,8 +2090,8 @@ match reg with
   assembly CmpJumpTstBit0P0NegNT = (AsmP(0), "=", ("tstbit(", AsmR(s5), "#0)"), "; ", AsmPred(0, 1, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpTstBit0P1NegNT : CmpJumpFormat =   {
-    let pred = !((R(s5) & 0b1) = 1) in
-      let pvalue = toPValue(!((R(s5) & 0b1) = 1)) in
+    let pred = !(((R(s5) & 0b1) = 1)) in
+      let pvalue = toPValue(!(((R(s5) & 0b1) = 1))) in
         {
           Pset(1, pvalue)          if pred then
             {
@@ -2159,8 +2159,8 @@ match reg with
   assembly CmpJumpTstBit0P1PosT = (AsmP(1), "=", ("tstbit(", AsmR(s5), "#0)"), "; ", AsmPred(1, 0, true), " jump:", "t", " #", decimal(dispS))
 
   instruction CmpJumpTstBit0P0NegT : CmpJumpFormat =   {
-    let pred = !((R(s5) & 0b1) = 1) in
-      let pvalue = toPValue(!((R(s5) & 0b1) = 1)) in
+    let pred = !(((R(s5) & 0b1) = 1)) in
+      let pvalue = toPValue(!(((R(s5) & 0b1) = 1))) in
         {
           Pset(0, pvalue)          if pred then
             {
@@ -2182,8 +2182,8 @@ match reg with
   assembly CmpJumpTstBit0P0NegT = (AsmP(0), "=", ("tstbit(", AsmR(s5), "#0)"), "; ", AsmPred(0, 1, true), " jump:", "t", " #", decimal(dispS))
 
   instruction CmpJumpTstBit0P1NegT : CmpJumpFormat =   {
-    let pred = !((R(s5) & 0b1) = 1) in
-      let pvalue = toPValue(!((R(s5) & 0b1) = 1)) in
+    let pred = !(((R(s5) & 0b1) = 1)) in
+      let pvalue = toPValue(!(((R(s5) & 0b1) = 1))) in
         {
           Pset(1, pvalue)          if pred then
             {
@@ -2251,8 +2251,8 @@ match reg with
   assembly CmpJumpEqImmP1PosNT = (AsmP(1), "=", ("cmp.eq(", AsmR(s5), "#", decimal(immU), ")"), "; ", AsmPred(1, 0, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpEqImmP0NegNT : CmpJumpImmFormat =   {
-    let pred = !(R(s5) = immU) in
-      let pvalue = toPValue(!(R(s5) = immU)) in
+    let pred = !((R(s5) = immU)) in
+      let pvalue = toPValue(!((R(s5) = immU))) in
         {
           Pset(0, pvalue)          if pred then
             {
@@ -2274,8 +2274,8 @@ match reg with
   assembly CmpJumpEqImmP0NegNT = (AsmP(0), "=", ("cmp.eq(", AsmR(s5), "#", decimal(immU), ")"), "; ", AsmPred(0, 1, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpEqImmP1NegNT : CmpJumpImmFormat =   {
-    let pred = !(R(s5) = immU) in
-      let pvalue = toPValue(!(R(s5) = immU)) in
+    let pred = !((R(s5) = immU)) in
+      let pvalue = toPValue(!((R(s5) = immU))) in
         {
           Pset(1, pvalue)          if pred then
             {
@@ -2343,8 +2343,8 @@ match reg with
   assembly CmpJumpEqImmP1PosT = (AsmP(1), "=", ("cmp.eq(", AsmR(s5), "#", decimal(immU), ")"), "; ", AsmPred(1, 0, true), " jump:", "t", " #", decimal(dispS))
 
   instruction CmpJumpEqImmP0NegT : CmpJumpImmFormat =   {
-    let pred = !(R(s5) = immU) in
-      let pvalue = toPValue(!(R(s5) = immU)) in
+    let pred = !((R(s5) = immU)) in
+      let pvalue = toPValue(!((R(s5) = immU))) in
         {
           Pset(0, pvalue)          if pred then
             {
@@ -2366,8 +2366,8 @@ match reg with
   assembly CmpJumpEqImmP0NegT = (AsmP(0), "=", ("cmp.eq(", AsmR(s5), "#", decimal(immU), ")"), "; ", AsmPred(0, 1, true), " jump:", "t", " #", decimal(dispS))
 
   instruction CmpJumpEqImmP1NegT : CmpJumpImmFormat =   {
-    let pred = !(R(s5) = immU) in
-      let pvalue = toPValue(!(R(s5) = immU)) in
+    let pred = !((R(s5) = immU)) in
+      let pvalue = toPValue(!((R(s5) = immU))) in
         {
           Pset(1, pvalue)          if pred then
             {
@@ -2435,8 +2435,8 @@ match reg with
   assembly CmpJumpGtImmP1PosNT = (AsmP(1), "=", ("cmp.gt(", AsmR(s5), "#", decimal(immU), ")"), "; ", AsmPred(1, 0, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpGtImmP0NegNT : CmpJumpImmFormat =   {
-    let pred = !(R(s5)(15..0) as UWord > immU) in
-      let pvalue = toPValue(!(R(s5)(15..0) as UWord > immU)) in
+    let pred = !((R(s5)(15..0) as UWord > immU)) in
+      let pvalue = toPValue(!((R(s5)(15..0) as UWord > immU))) in
         {
           Pset(0, pvalue)          if pred then
             {
@@ -2458,8 +2458,8 @@ match reg with
   assembly CmpJumpGtImmP0NegNT = (AsmP(0), "=", ("cmp.gt(", AsmR(s5), "#", decimal(immU), ")"), "; ", AsmPred(0, 1, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpGtImmP1NegNT : CmpJumpImmFormat =   {
-    let pred = !(R(s5)(15..0) as UWord > immU) in
-      let pvalue = toPValue(!(R(s5)(15..0) as UWord > immU)) in
+    let pred = !((R(s5)(15..0) as UWord > immU)) in
+      let pvalue = toPValue(!((R(s5)(15..0) as UWord > immU))) in
         {
           Pset(1, pvalue)          if pred then
             {
@@ -2527,8 +2527,8 @@ match reg with
   assembly CmpJumpGtImmP1PosT = (AsmP(1), "=", ("cmp.gt(", AsmR(s5), "#", decimal(immU), ")"), "; ", AsmPred(1, 0, true), " jump:", "t", " #", decimal(dispS))
 
   instruction CmpJumpGtImmP0NegT : CmpJumpImmFormat =   {
-    let pred = !(R(s5)(15..0) as UWord > immU) in
-      let pvalue = toPValue(!(R(s5)(15..0) as UWord > immU)) in
+    let pred = !((R(s5)(15..0) as UWord > immU)) in
+      let pvalue = toPValue(!((R(s5)(15..0) as UWord > immU))) in
         {
           Pset(0, pvalue)          if pred then
             {
@@ -2550,8 +2550,8 @@ match reg with
   assembly CmpJumpGtImmP0NegT = (AsmP(0), "=", ("cmp.gt(", AsmR(s5), "#", decimal(immU), ")"), "; ", AsmPred(0, 1, true), " jump:", "t", " #", decimal(dispS))
 
   instruction CmpJumpGtImmP1NegT : CmpJumpImmFormat =   {
-    let pred = !(R(s5)(15..0) as UWord > immU) in
-      let pvalue = toPValue(!(R(s5)(15..0) as UWord > immU)) in
+    let pred = !((R(s5)(15..0) as UWord > immU)) in
+      let pvalue = toPValue(!((R(s5)(15..0) as UWord > immU))) in
         {
           Pset(1, pvalue)          if pred then
             {
@@ -2619,8 +2619,8 @@ match reg with
   assembly CmpJumpGtuImmP1PosNT = (AsmP(1), "=", ("cmp.gtu(", AsmR(s5), "#", decimal(immU), ")"), "; ", AsmPred(1, 0, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpGtuImmP0NegNT : CmpJumpImmFormat =   {
-    let pred = !(R(s5) as UInt > immU) in
-      let pvalue = toPValue(!(R(s5) as UInt > immU)) in
+    let pred = !((R(s5) as UInt > immU)) in
+      let pvalue = toPValue(!((R(s5) as UInt > immU))) in
         {
           Pset(0, pvalue)          if pred then
             {
@@ -2642,8 +2642,8 @@ match reg with
   assembly CmpJumpGtuImmP0NegNT = (AsmP(0), "=", ("cmp.gtu(", AsmR(s5), "#", decimal(immU), ")"), "; ", AsmPred(0, 1, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpGtuImmP1NegNT : CmpJumpImmFormat =   {
-    let pred = !(R(s5) as UInt > immU) in
-      let pvalue = toPValue(!(R(s5) as UInt > immU)) in
+    let pred = !((R(s5) as UInt > immU)) in
+      let pvalue = toPValue(!((R(s5) as UInt > immU))) in
         {
           Pset(1, pvalue)          if pred then
             {
@@ -2711,8 +2711,8 @@ match reg with
   assembly CmpJumpGtuImmP1PosT = (AsmP(1), "=", ("cmp.gtu(", AsmR(s5), "#", decimal(immU), ")"), "; ", AsmPred(1, 0, true), " jump:", "t", " #", decimal(dispS))
 
   instruction CmpJumpGtuImmP0NegT : CmpJumpImmFormat =   {
-    let pred = !(R(s5) as UInt > immU) in
-      let pvalue = toPValue(!(R(s5) as UInt > immU)) in
+    let pred = !((R(s5) as UInt > immU)) in
+      let pvalue = toPValue(!((R(s5) as UInt > immU))) in
         {
           Pset(0, pvalue)          if pred then
             {
@@ -2734,8 +2734,8 @@ match reg with
   assembly CmpJumpGtuImmP0NegT = (AsmP(0), "=", ("cmp.gtu(", AsmR(s5), "#", decimal(immU), ")"), "; ", AsmPred(0, 1, true), " jump:", "t", " #", decimal(dispS))
 
   instruction CmpJumpGtuImmP1NegT : CmpJumpImmFormat =   {
-    let pred = !(R(s5) as UInt > immU) in
-      let pvalue = toPValue(!(R(s5) as UInt > immU)) in
+    let pred = !((R(s5) as UInt > immU)) in
+      let pvalue = toPValue(!((R(s5) as UInt > immU))) in
         {
           Pset(1, pvalue)          if pred then
             {
@@ -2803,8 +2803,8 @@ match reg with
   assembly CmpJumpEqRegP1PosNT = (AsmP(1), "=", ("cmp.eq(", AsmR(s5), "", AsmR(t5), ")"), "; ", AsmPred(1, 0, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpEqRegP0NegNT : CmpJumpRegFormat =   {
-    let pred = !(R(s5) = R(t5)) in
-      let pvalue = toPValue(!(R(s5) = R(t5))) in
+    let pred = !((R(s5) = R(t5))) in
+      let pvalue = toPValue(!((R(s5) = R(t5)))) in
         {
           Pset(0, pvalue)          if pred then
             {
@@ -2826,8 +2826,8 @@ match reg with
   assembly CmpJumpEqRegP0NegNT = (AsmP(0), "=", ("cmp.eq(", AsmR(s5), "", AsmR(t5), ")"), "; ", AsmPred(0, 1, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpEqRegP1NegNT : CmpJumpRegFormat =   {
-    let pred = !(R(s5) = R(t5)) in
-      let pvalue = toPValue(!(R(s5) = R(t5))) in
+    let pred = !((R(s5) = R(t5))) in
+      let pvalue = toPValue(!((R(s5) = R(t5)))) in
         {
           Pset(1, pvalue)          if pred then
             {
@@ -2895,8 +2895,8 @@ match reg with
   assembly CmpJumpEqRegP1PosT = (AsmP(1), "=", ("cmp.eq(", AsmR(s5), "", AsmR(t5), ")"), "; ", AsmPred(1, 0, true), " jump:", "t", " #", decimal(dispS))
 
   instruction CmpJumpEqRegP0NegT : CmpJumpRegFormat =   {
-    let pred = !(R(s5) = R(t5)) in
-      let pvalue = toPValue(!(R(s5) = R(t5))) in
+    let pred = !((R(s5) = R(t5))) in
+      let pvalue = toPValue(!((R(s5) = R(t5)))) in
         {
           Pset(0, pvalue)          if pred then
             {
@@ -2918,8 +2918,8 @@ match reg with
   assembly CmpJumpEqRegP0NegT = (AsmP(0), "=", ("cmp.eq(", AsmR(s5), "", AsmR(t5), ")"), "; ", AsmPred(0, 1, true), " jump:", "t", " #", decimal(dispS))
 
   instruction CmpJumpEqRegP1NegT : CmpJumpRegFormat =   {
-    let pred = !(R(s5) = R(t5)) in
-      let pvalue = toPValue(!(R(s5) = R(t5))) in
+    let pred = !((R(s5) = R(t5))) in
+      let pvalue = toPValue(!((R(s5) = R(t5)))) in
         {
           Pset(1, pvalue)          if pred then
             {
@@ -2987,8 +2987,8 @@ match reg with
   assembly CmpJumpGtRegP1PosNT = (AsmP(1), "=", ("cmp.gt(", AsmR(s5), "", AsmR(t5), ")"), "; ", AsmPred(1, 0, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpGtRegP0NegNT : CmpJumpRegFormat =   {
-    let pred = !(R(s5) as SInt > R(t5) as SInt) in
-      let pvalue = toPValue(!(R(s5) as SInt > R(t5) as SInt)) in
+    let pred = !((R(s5) as SInt > R(t5) as SInt)) in
+      let pvalue = toPValue(!((R(s5) as SInt > R(t5) as SInt))) in
         {
           Pset(0, pvalue)          if pred then
             {
@@ -3010,8 +3010,8 @@ match reg with
   assembly CmpJumpGtRegP0NegNT = (AsmP(0), "=", ("cmp.gt(", AsmR(s5), "", AsmR(t5), ")"), "; ", AsmPred(0, 1, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpGtRegP1NegNT : CmpJumpRegFormat =   {
-    let pred = !(R(s5) as SInt > R(t5) as SInt) in
-      let pvalue = toPValue(!(R(s5) as SInt > R(t5) as SInt)) in
+    let pred = !((R(s5) as SInt > R(t5) as SInt)) in
+      let pvalue = toPValue(!((R(s5) as SInt > R(t5) as SInt))) in
         {
           Pset(1, pvalue)          if pred then
             {
@@ -3079,8 +3079,8 @@ match reg with
   assembly CmpJumpGtRegP1PosT = (AsmP(1), "=", ("cmp.gt(", AsmR(s5), "", AsmR(t5), ")"), "; ", AsmPred(1, 0, true), " jump:", "t", " #", decimal(dispS))
 
   instruction CmpJumpGtRegP0NegT : CmpJumpRegFormat =   {
-    let pred = !(R(s5) as SInt > R(t5) as SInt) in
-      let pvalue = toPValue(!(R(s5) as SInt > R(t5) as SInt)) in
+    let pred = !((R(s5) as SInt > R(t5) as SInt)) in
+      let pvalue = toPValue(!((R(s5) as SInt > R(t5) as SInt))) in
         {
           Pset(0, pvalue)          if pred then
             {
@@ -3102,8 +3102,8 @@ match reg with
   assembly CmpJumpGtRegP0NegT = (AsmP(0), "=", ("cmp.gt(", AsmR(s5), "", AsmR(t5), ")"), "; ", AsmPred(0, 1, true), " jump:", "t", " #", decimal(dispS))
 
   instruction CmpJumpGtRegP1NegT : CmpJumpRegFormat =   {
-    let pred = !(R(s5) as SInt > R(t5) as SInt) in
-      let pvalue = toPValue(!(R(s5) as SInt > R(t5) as SInt)) in
+    let pred = !((R(s5) as SInt > R(t5) as SInt)) in
+      let pvalue = toPValue(!((R(s5) as SInt > R(t5) as SInt))) in
         {
           Pset(1, pvalue)          if pred then
             {
@@ -3171,8 +3171,8 @@ match reg with
   assembly CmpJumpGtuRegP1PosNT = (AsmP(1), "=", ("cmp.gtu(", AsmR(s5), "", AsmR(t5), ")"), "; ", AsmPred(1, 0, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpGtuRegP0NegNT : CmpJumpRegFormat =   {
-    let pred = !(R(s5)(15..0) as UWord > R(t5)) in
-      let pvalue = toPValue(!(R(s5)(15..0) as UWord > R(t5))) in
+    let pred = !((R(s5)(15..0) as UWord > R(t5))) in
+      let pvalue = toPValue(!((R(s5)(15..0) as UWord > R(t5)))) in
         {
           Pset(0, pvalue)          if pred then
             {
@@ -3194,8 +3194,8 @@ match reg with
   assembly CmpJumpGtuRegP0NegNT = (AsmP(0), "=", ("cmp.gtu(", AsmR(s5), "", AsmR(t5), ")"), "; ", AsmPred(0, 1, true), " jump:", "nt", " #", decimal(dispS))
 
   instruction CmpJumpGtuRegP1NegNT : CmpJumpRegFormat =   {
-    let pred = !(R(s5)(15..0) as UWord > R(t5)) in
-      let pvalue = toPValue(!(R(s5)(15..0) as UWord > R(t5))) in
+    let pred = !((R(s5)(15..0) as UWord > R(t5))) in
+      let pvalue = toPValue(!((R(s5)(15..0) as UWord > R(t5)))) in
         {
           Pset(1, pvalue)          if pred then
             {
@@ -3263,8 +3263,8 @@ match reg with
   assembly CmpJumpGtuRegP1PosT = (AsmP(1), "=", ("cmp.gtu(", AsmR(s5), "", AsmR(t5), ")"), "; ", AsmPred(1, 0, true), " jump:", "t", " #", decimal(dispS))
 
   instruction CmpJumpGtuRegP0NegT : CmpJumpRegFormat =   {
-    let pred = !(R(s5)(15..0) as UWord > R(t5)) in
-      let pvalue = toPValue(!(R(s5)(15..0) as UWord > R(t5))) in
+    let pred = !((R(s5)(15..0) as UWord > R(t5))) in
+      let pvalue = toPValue(!((R(s5)(15..0) as UWord > R(t5)))) in
         {
           Pset(0, pvalue)          if pred then
             {
@@ -3286,8 +3286,8 @@ match reg with
   assembly CmpJumpGtuRegP0NegT = (AsmP(0), "=", ("cmp.gtu(", AsmR(s5), "", AsmR(t5), ")"), "; ", AsmPred(0, 1, true), " jump:", "t", " #", decimal(dispS))
 
   instruction CmpJumpGtuRegP1NegT : CmpJumpRegFormat =   {
-    let pred = !(R(s5)(15..0) as UWord > R(t5)) in
-      let pvalue = toPValue(!(R(s5)(15..0) as UWord > R(t5))) in
+    let pred = !((R(s5)(15..0) as UWord > R(t5))) in
+      let pvalue = toPValue(!((R(s5)(15..0) as UWord > R(t5)))) in
         {
           Pset(1, pvalue)          if pred then
             {
@@ -3395,7 +3395,7 @@ match reg with
   assembly LoadBytePredPosRegRel = (AsmPred(t2, false, false), AsmR(d5), "=", ("memb", AsmAddrRegRel(s5, immRegRel)))
 
   instruction LoadBytePredNegRegRel : LoadRegRelPredFormat =   {
-    if !testpred(t2) then
+    if !(testpred(t2)) then
       {
         R(d5) := MEM< 1 >((R(s5) + scaledImmS(immRegRel, 0))) as SByte
       }
@@ -3511,7 +3511,7 @@ match reg with
   assembly LoadHalfPredPosRegRel = (AsmPred(t2, false, false), AsmR(d5), "=", ("memh", AsmAddrRegRel(s5, immRegRel)))
 
   instruction LoadHalfPredNegRegRel : LoadRegRelPredFormat =   {
-    if !testpred(t2) then
+    if !(testpred(t2)) then
       {
         R(d5) := MEM< 2 >((R(s5) + scaledImmS(immRegRel, 1))) as SHalf
       }
@@ -3627,7 +3627,7 @@ match reg with
   assembly LoadWordPredPosRegRel = (AsmPred(t2, false, false), AsmR(d5), "=", ("memw", AsmAddrRegRel(s5, immRegRel)))
 
   instruction LoadWordPredNegRegRel : LoadRegRelPredFormat =   {
-    if !testpred(t2) then
+    if !(testpred(t2)) then
       {
         R(d5) := MEM< 4 >((R(s5) + scaledImmS(immRegRel, 2))) as SWord
       }
@@ -3717,7 +3717,7 @@ match reg with
   assembly LoadDoublePredPosRegRel = (AsmPred(t2, false, false), AsmRR(d5), "=", ("memd", AsmAddrRegRel(s5, immRegRel)))
 
   instruction LoadDoublePredNegRegRel : LoadRegRelPredFormat =   {
-    if !testpred(t2) then
+    if !(testpred(t2)) then
       {
         let result = MEM< 8 >((R(s5) + scaledImmS(immRegRel, 3))) as SDouble in
           {
@@ -3838,7 +3838,7 @@ match reg with
   assembly DecallocReturnPredPos = (AsmPred(pred, false, false), "dealloc_return", "")
 
   instruction DecallocReturnPredNeg : DeallocFrameFormat =   {
-    if !testpred(pred) then
+    if !(testpred(pred)) then
       {
         let restored = MEM< 8 >(FP) as Double in
           let LRnew = frameUnscramble(restored(63..32)) in
@@ -4519,7 +4519,7 @@ else
   , XTYPE_PRED_WRITING
   }
 
-  function implies(a : Bool, b : Bool) -> Bool = (!a | b)
+  function implies(a : Bool, b : Bool) -> Bool = (!(a) | b)
 
   group VLIW = (((XTYPE<0..1> | ALU32<0..1> | J<0..1> | CR<0..1>).(XTYPE<0..1> | ALU32<0..1> | J<0..1> | JR<0..1> | CR23<0..1>).(LD<0..1> | ST<0..1> | ALU32<0..1>).(LD<0..1> | ST<0..1> | ALU32<0..1>)) | SYSTEMSolo)
 }

--- a/vadl/test/resources/macros/macro-producing-macros.expanded.vadl
+++ b/vadl/test/resources/macros/macro-producing-macros.expanded.vadl
@@ -1,9 +1,9 @@
 instruction set architecture MacroProducingMacros = {
   constant a =
-    match (5 + 2) with
+    match 5 + 2 with
       { 7 => 1
       , 8 => 0
-      , _ => ((9 * 4) * 4)
+      , _ => (9 * 4) * 4
       }
 
 }

--- a/vadl/test/resources/macros/operators.expanded.vadl
+++ b/vadl/test/resources/macros/operators.expanded.vadl
@@ -1,2 +1,2 @@
-constant fiveTimesNine = (5 * 9)
-constant minusTwelve = -(12)
+constant fiveTimesNine = 5 * 9
+constant minusTwelve = -12

--- a/vadl/test/resources/macros/operators.expanded.vadl
+++ b/vadl/test/resources/macros/operators.expanded.vadl
@@ -1,2 +1,2 @@
 constant fiveTimesNine = (5 * 9)
-constant minusTwelve = -12
+constant minusTwelve = -(12)

--- a/vadl/test/resources/macros/rv3264im.expanded.vadl
+++ b/vadl/test/resources/macros/rv3264im.expanded.vadl
@@ -428,7 +428,7 @@ instruction set architecture RV3264I = {
 
   instruction JAL : Jtype =   let retaddr = PC.next in
     {
-      PC := ((PC + immS) & -2 as SIntR)
+      PC := ((PC + immS) & -(2 as SIntR))
       X(rd) := retaddr
     }
 
@@ -441,7 +441,7 @@ instruction set architecture RV3264I = {
 
   instruction JALR : Itype =   let retaddr = PC.next in
     {
-      PC := ((X(rs1) + immS) & -2 as SIntR)
+      PC := ((X(rs1) + immS) & -(2 as SIntR))
       X(rd) := retaddr
     }
 
@@ -532,7 +532,7 @@ instruction set architecture RV3264IM extending RV3264I = {
   constant MLen2 = (MLen * 2)
   constant MLen2_1 = (MLen2 - 1)
   constant TopBitSet = (1 as Regs << (MLen - 1)) as Regs
-  constant AllOnes = -1 as SIntR as Regs
+  constant AllOnes = -(1 as SIntR) as Regs
 
   function isOverflow(dividend : Regs, divisor : Regs) -> Bool = ((dividend = TopBitSet) & (divisor = AllOnes))
 

--- a/vadl/test/resources/macros/rv3264im.expanded.vadl
+++ b/vadl/test/resources/macros/rv3264im.expanded.vadl
@@ -2,7 +2,7 @@ instruction set architecture RV3264I = {
   constant Arch32 = 32
   constant Arch64 = 64
   constant MLen = Arch32
-  constant SftLen = ((MLen / 32) + 4)
+  constant SftLen = MLen / 32 + 4
   constant WLen = 32
 
   using Byte = Bits<8>
@@ -53,7 +53,7 @@ instruction set architecture RV3264I = {
   { imm : Bits<20>
   , rd : Index
   , opcode : Bits7
-  , immUp = (imm as SIntR << 12)
+  , immUp = imm as SIntR << 12
   }
   format Stype: Inst =
   { imm	 [31..25, 11..7]
@@ -69,13 +69,13 @@ instruction set architecture RV3264I = {
   , rs1	 [19..15]
   , funct3	 [14..12]
   , opcode	 [6..0]
-  , immS = (imm as SIntR << 1)
+  , immS = imm as SIntR << 1
   }
   format Jtype: Inst =
   { imm	 [31, 19..12, 20, 30..21]
   , rd	 [11..7]
   , opcode	 [6..0]
-  , immS = (imm as SIntR << 1)
+  , immS = imm as SIntR << 1
   }
 
   instruction ADD : Rtype =   X(rd) := (X(rs1) as Bits + X(rs2) as Bits) as Regs
@@ -248,7 +248,7 @@ instruction set architecture RV3264I = {
 
   assembly SLTIU = (mnemonic, " ", register(rd), ",", register(rs1), ",", decimal(imm))
 
-  instruction AUIPC : Utype =   X(rd) := (PC + immUp)
+  instruction AUIPC : Utype =   X(rd) := PC + immUp
 
 
   encoding AUIPC =
@@ -266,7 +266,7 @@ instruction set architecture RV3264I = {
 
   assembly LUI = (mnemonic, " ", register(rd), ",", hex(imm))
 
-  instruction LB : Itype =   let addr = (X(rs1) + immS) in
+  instruction LB : Itype =   let addr = X(rs1) + immS in
     X(rd) := MEM(addr) as SIntR
 
 
@@ -277,7 +277,7 @@ instruction set architecture RV3264I = {
 
   assembly LB = (mnemonic, " ", register(rd), ",", decimal(imm), "(", register(rs1), ")")
 
-  instruction LBU : Itype =   let addr = (X(rs1) + immS) in
+  instruction LBU : Itype =   let addr = X(rs1) + immS in
     X(rd) := MEM(addr) as UIntR
 
 
@@ -288,7 +288,7 @@ instruction set architecture RV3264I = {
 
   assembly LBU = (mnemonic, " ", register(rd), ",", decimal(imm), "(", register(rs1), ")")
 
-  instruction LH : Itype =   let addr = (X(rs1) + immS) in
+  instruction LH : Itype =   let addr = X(rs1) + immS in
     X(rd) := MEM< 2 >(addr) as SIntR
 
 
@@ -299,7 +299,7 @@ instruction set architecture RV3264I = {
 
   assembly LH = (mnemonic, " ", register(rd), ",", decimal(imm), "(", register(rs1), ")")
 
-  instruction LHU : Itype =   let addr = (X(rs1) + immS) in
+  instruction LHU : Itype =   let addr = X(rs1) + immS in
     X(rd) := MEM< 2 >(addr) as UIntR
 
 
@@ -310,7 +310,7 @@ instruction set architecture RV3264I = {
 
   assembly LHU = (mnemonic, " ", register(rd), ",", decimal(imm), "(", register(rs1), ")")
 
-  instruction LW : Itype =   let addr = (X(rs1) + immS) in
+  instruction LW : Itype =   let addr = X(rs1) + immS in
     X(rd) := MEM< 4 >(addr) as SIntR
 
 
@@ -321,7 +321,7 @@ instruction set architecture RV3264I = {
 
   assembly LW = (mnemonic, " ", register(rd), ",", decimal(imm), "(", register(rs1), ")")
 
-  instruction SB : Stype =   let addr = (X(rs1) + immS) in
+  instruction SB : Stype =   let addr = X(rs1) + immS in
     MEM(addr) := X(rs2) as Byte
 
 
@@ -332,7 +332,7 @@ instruction set architecture RV3264I = {
 
   assembly SB = (mnemonic, " ", register(rs2), ",", decimal(imm), "(", register(rs1), ")")
 
-  instruction SH : Stype =   let addr = (X(rs1) + immS) in
+  instruction SH : Stype =   let addr = X(rs1) + immS in
     MEM< 2 >(addr) := X(rs2) as Half
 
 
@@ -343,7 +343,7 @@ instruction set architecture RV3264I = {
 
   assembly SH = (mnemonic, " ", register(rs2), ",", decimal(imm), "(", register(rs1), ")")
 
-  instruction SW : Stype =   let addr = (X(rs1) + immS) in
+  instruction SW : Stype =   let addr = X(rs1) + immS in
     MEM< 4 >(addr) := X(rs2) as Word
 
 
@@ -354,8 +354,8 @@ instruction set architecture RV3264I = {
 
   assembly SW = (mnemonic, " ", register(rs2), ",", decimal(imm), "(", register(rs1), ")")
 
-  instruction BEQ : Btype =   if (X(rs1) as Bits = X(rs2)) then
-    PC := (PC + immS)
+  instruction BEQ : Btype =   if X(rs1) as Bits = X(rs2) then
+    PC := PC + immS
 
 
 
@@ -366,8 +366,8 @@ instruction set architecture RV3264I = {
 
   assembly BEQ = (mnemonic, " ", register(rs1), ",", register(rs2), ",", decimal(imm))
 
-  instruction BNE : Btype =   if (X(rs1) as Bits != X(rs2)) then
-    PC := (PC + immS)
+  instruction BNE : Btype =   if X(rs1) as Bits != X(rs2) then
+    PC := PC + immS
 
 
 
@@ -378,8 +378,8 @@ instruction set architecture RV3264I = {
 
   assembly BNE = (mnemonic, " ", register(rs1), ",", register(rs2), ",", decimal(imm))
 
-  instruction BGE : Btype =   if (X(rs1) as SInt >= X(rs2)) then
-    PC := (PC + immS)
+  instruction BGE : Btype =   if X(rs1) as SInt >= X(rs2) then
+    PC := PC + immS
 
 
 
@@ -390,8 +390,8 @@ instruction set architecture RV3264I = {
 
   assembly BGE = (mnemonic, " ", register(rs1), ",", register(rs2), ",", decimal(imm))
 
-  instruction BGEU : Btype =   if (X(rs1) as UInt >= X(rs2)) then
-    PC := (PC + immS)
+  instruction BGEU : Btype =   if X(rs1) as UInt >= X(rs2) then
+    PC := PC + immS
 
 
 
@@ -402,8 +402,8 @@ instruction set architecture RV3264I = {
 
   assembly BGEU = (mnemonic, " ", register(rs1), ",", register(rs2), ",", decimal(imm))
 
-  instruction BLT : Btype =   if (X(rs1) as SInt < X(rs2)) then
-    PC := (PC + immS)
+  instruction BLT : Btype =   if X(rs1) as SInt < X(rs2) then
+    PC := PC + immS
 
 
 
@@ -414,8 +414,8 @@ instruction set architecture RV3264I = {
 
   assembly BLT = (mnemonic, " ", register(rs1), ",", register(rs2), ",", decimal(imm))
 
-  instruction BLTU : Btype =   if (X(rs1) as UInt < X(rs2)) then
-    PC := (PC + immS)
+  instruction BLTU : Btype =   if X(rs1) as UInt < X(rs2) then
+    PC := PC + immS
 
 
 
@@ -428,7 +428,7 @@ instruction set architecture RV3264I = {
 
   instruction JAL : Jtype =   let retaddr = PC.next in
     {
-      PC := ((PC + immS) & -(2 as SIntR))
+      PC := PC + immS & -(2 as SIntR)
       X(rd) := retaddr
     }
 
@@ -441,7 +441,7 @@ instruction set architecture RV3264I = {
 
   instruction JALR : Itype =   let retaddr = PC.next in
     {
-      PC := ((X(rs1) + immS) & -(2 as SIntR))
+      PC := X(rs1) + immS & -(2 as SIntR)
       X(rd) := retaddr
     }
 
@@ -529,14 +529,14 @@ instruction set architecture RV3264I = {
   assembly SRAI = (mnemonic, " ", register(rd), ",", register(rs1), ",", decimal(sft))
 }
 instruction set architecture RV3264IM extending RV3264I = {
-  constant MLen2 = (MLen * 2)
-  constant MLen2_1 = (MLen2 - 1)
-  constant TopBitSet = (1 as Regs << (MLen - 1)) as Regs
+  constant MLen2 = MLen * 2
+  constant MLen2_1 = MLen2 - 1
+  constant TopBitSet = (1 as Regs << MLen - 1) as Regs
   constant AllOnes = -(1 as SIntR) as Regs
 
-  function isOverflow(dividend : Regs, divisor : Regs) -> Bool = ((dividend = TopBitSet) & (divisor = AllOnes))
+  function isOverflow(dividend : Regs, divisor : Regs) -> Bool = dividend = TopBitSet & divisor = AllOnes
 
-  instruction MUL : Rtype =   let result = (X(rs1) as SInt *# X(rs2) as SInt) in
+  instruction MUL : Rtype =   let result = X(rs1) as SInt *# X(rs2) as SInt in
     X(rd) := result as Regs
 
 
@@ -548,7 +548,7 @@ instruction set architecture RV3264IM extending RV3264I = {
 
   assembly MUL = (mnemonic, " ", register(rd), ",", register(rs1), ",", register(rs2))
 
-  instruction MULH : Rtype =   let result = (X(rs1) as SInt *# X(rs2) as SInt) in
+  instruction MULH : Rtype =   let result = X(rs1) as SInt *# X(rs2) as SInt in
     X(rd) := result(MLen2_1..MLen)
 
 
@@ -560,7 +560,7 @@ instruction set architecture RV3264IM extending RV3264I = {
 
   assembly MULH = (mnemonic, " ", register(rd), ",", register(rs1), ",", register(rs2))
 
-  instruction MULHSU : Rtype =   let result = (X(rs1) as SInt *# X(rs2) as UInt) in
+  instruction MULHSU : Rtype =   let result = X(rs1) as SInt *# X(rs2) as UInt in
     X(rd) := result(MLen2_1..MLen)
 
 
@@ -572,7 +572,7 @@ instruction set architecture RV3264IM extending RV3264I = {
 
   assembly MULHSU = (mnemonic, " ", register(rd), ",", register(rs1), ",", register(rs2))
 
-  instruction MULHU : Rtype =   let result = (X(rs1) as UInt *# X(rs2) as UInt) in
+  instruction MULHU : Rtype =   let result = X(rs1) as UInt *# X(rs2) as UInt in
     X(rd) := result(MLen2_1..MLen)
 
 
@@ -587,7 +587,7 @@ instruction set architecture RV3264IM extending RV3264I = {
   instruction DIV : Rtype =   let dividend = X(rs1) as SIntR in
     let divisor = X(rs2) as SIntR in
       X(rd) :=
-        if (divisor = 0 as SIntR) then
+        if divisor = 0 as SIntR then
           AllOnes
         else
           if isOverflow(dividend, divisor) then
@@ -607,7 +607,7 @@ instruction set architecture RV3264IM extending RV3264I = {
   instruction DIVU : Rtype =   let dividend = X(rs1) as UIntR in
     let divisor = X(rs2) as UIntR in
       X(rd) :=
-        if (divisor = 0 as UIntR) then
+        if divisor = 0 as UIntR then
           AllOnes
         else
           VADL::div(dividend, divisor) as SInt as SIntR as UIntR
@@ -624,7 +624,7 @@ instruction set architecture RV3264IM extending RV3264I = {
   instruction REM : Rtype =   let dividend = X(rs1) as SIntR in
     let divisor = X(rs2) as SIntR in
       X(rd) :=
-        if (divisor = 0 as SIntR) then
+        if divisor = 0 as SIntR then
           dividend
         else
           if isOverflow(dividend, divisor) then
@@ -644,7 +644,7 @@ instruction set architecture RV3264IM extending RV3264I = {
   instruction REMU : Rtype =   let dividend = X(rs1) as UIntR in
     let divisor = X(rs2) as UIntR in
       X(rd) :=
-        if (divisor = 0 as UIntR) then
+        if divisor = 0 as UIntR then
           dividend
         else
           VADL::mod(dividend, divisor) as SInt as SIntR as UIntR

--- a/vadl/test/vadl/ast/AstTestUtils.java
+++ b/vadl/test/vadl/ast/AstTestUtils.java
@@ -36,6 +36,7 @@ public class AstTestUtils {
     var progPretty = ast.prettyPrintToString();
     var astPretty = Assertions.assertDoesNotThrow(() -> VadlParser.parse(progPretty, ast.fileUri),
         "Cannot parse prettified input \n" + progPretty);
+    UNGROUPER.ungroup(astPretty);
     assertAstEquality(astPretty, ast);
   }
 
@@ -45,7 +46,7 @@ public class AstTestUtils {
     UNGROUPER.ungroup(actual);
     UNGROUPER.ungroup(expected);
     if (!actual.equals(expected)) {
-      Assertions.assertEquals(expected, actual, "Asts do not match");
+      Assertions.assertEquals(actual, expected, AstDiffPrinter.printDiff(actual, expected));
     }
   }
 

--- a/vadl/test/vadl/ast/AstTestUtils.java
+++ b/vadl/test/vadl/ast/AstTestUtils.java
@@ -32,6 +32,7 @@ public class AstTestUtils {
 
   static void verifyPrettifiedAst(Ast ast) {
     MODEL_REMOVER.removeModels(ast);
+    UNGROUPER.ungroup(ast);
     var progPretty = ast.prettyPrintToString();
     var astPretty = Assertions.assertDoesNotThrow(() -> VadlParser.parse(progPretty, ast.fileUri),
         "Cannot parse prettified input \n" + progPretty);
@@ -44,7 +45,7 @@ public class AstTestUtils {
     UNGROUPER.ungroup(actual);
     UNGROUPER.ungroup(expected);
     if (!actual.equals(expected)) {
-      Assertions.assertEquals(actual, expected, AstDiffPrinter.printDiff(actual, expected));
+      Assertions.assertEquals(expected, actual, "Asts do not match");
     }
   }
 

--- a/vadl/test/vadl/ast/BinaryPrecedenceTest.java
+++ b/vadl/test/vadl/ast/BinaryPrecedenceTest.java
@@ -19,6 +19,7 @@ package vadl.ast;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static vadl.ast.AstTestUtils.assertAstEquality;
+import static vadl.ast.AstTestUtils.verifyPrettifiedAst;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -217,16 +218,20 @@ public class BinaryPrecedenceTest {
   @Test
   void repeatedInvocationDoesNotChangeResult() {
     var prog = "constant n = 1 + 2 << 3 * 4 + 5 + 6 < 7";
+    var progAst = VadlParser.parse(prog);
     var binExpr =
-        (BinaryExpr) ((ConstantDefinition) VadlParser.parse(prog).definitions.get(0)).value;
+        (BinaryExpr) ((ConstantDefinition) progAst.definitions.get(0)).value;
     var reorderedOnce = prettyPrint(BinaryExpr.reorder(binExpr));
     var reorderedTwice = prettyPrint(BinaryExpr.reorder(binExpr));
     var reorderedThrice = prettyPrint(BinaryExpr.reorder(binExpr));
-    var expected = "(((1 + 2) << (((3 * 4) + 5) + 6)) < 7)";
 
-    assertThat(reorderedOnce, equalTo(expected));
-    assertThat(reorderedTwice, equalTo(expected));
-    assertThat(reorderedThrice, equalTo(expected));
+    var expected = "constant n = (((1 + 2) << (((3 * 4) + 5) + 6)) < 7)";
+    var expAst = VadlParser.parse(expected);
+
+    assertAstEquality(expAst, progAst);
+    verifyPrettifiedAst(expAst);
+    assertThat(reorderedOnce, equalTo(reorderedTwice));
+    assertThat(reorderedTwice, equalTo(reorderedThrice));
   }
 
   private void assertHasBeenReordered(Ast... asts) {

--- a/vadl/test/vadl/ast/FrontendIntegrationTest.java
+++ b/vadl/test/vadl/ast/FrontendIntegrationTest.java
@@ -16,20 +16,10 @@
 
 package vadl.ast;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-
-import java.io.File;
-import java.io.IOException;
-import java.nio.charset.Charset;
 import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.List;
-import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.testcontainers.shaded.org.checkerframework.checker.nullness.qual.Nullable;
 
 public class FrontendIntegrationTest {
 
@@ -53,54 +43,4 @@ public class FrontendIntegrationTest {
     Assertions.assertDoesNotThrow(() -> lowering.generate(ast), "Cannot generate VIAM");
   }
 
-  @Test
-  void testRv32im() throws IOException {
-    testPrettyPrintSpec(Path.of("../sys/risc-v"), "rv3264im.vadl", "rv32im.vadl");
-  }
-
-  private void testPrettyPrintSpec(Path rootDir, String... vadlSpecs) throws IOException {
-    var absRoot = rootDir.toAbsolutePath();
-    var sysName = rootDir.getFileName();
-    var prettyPath = Path.of("build/test/pretty-print/" + sysName);
-    if (prettyPath.toFile().exists()) {
-      FileUtils.forceDelete(prettyPath.toFile());
-    }
-
-    var specFiles = Arrays.stream(vadlSpecs).map(s -> absRoot.resolve(s).toFile())
-        .toList();
-    var prettyFiles =
-        Arrays.stream(vadlSpecs).map(s -> prettyPath.resolve(s).toFile())
-            .toList();
-
-    // first check all handwirtten specs
-    checkAll(specFiles, prettyPath);
-    // then check all pretty printed specs
-    checkAll(prettyFiles, null);
-  }
-
-  private void checkAll(List<File> specs, @Nullable Path prettyPrintPath) throws IOException {
-    for (var file : specs) {
-      check(file, prettyPrintPath);
-    }
-  }
-
-  private void check(File vadlFile, @Nullable Path prettyPrintPath) throws IOException {
-    System.out.println("Checking " + vadlFile);
-    assertThat(vadlFile).exists();
-
-    var ast = Assertions.assertDoesNotThrow(() -> VadlParser.parse(vadlFile.toPath()),
-        "Cannot parse input");
-    new Ungrouper().ungroup(ast);
-    new ModelRemover().removeModels(ast);
-    if (prettyPrintPath != null) {
-      var progPretty = ast.prettyPrintToString();
-      var resFile = prettyPrintPath.resolve(vadlFile.getName()).toFile();
-      FileUtils.createParentDirectories(resFile);
-      FileUtils.writeStringToFile(resFile, progPretty, Charset.defaultCharset());
-    }
-    var typechecker = new TypeChecker();
-    Assertions.assertDoesNotThrow(() -> typechecker.verify(ast), "Program isn't typesafe");
-    var lowering = new ViamLowering();
-    Assertions.assertDoesNotThrow(() -> lowering.generate(ast), "Cannot generate VIAM");
-  }
 }

--- a/vadl/test/vadl/ast/FrontendIntegrationTest.java
+++ b/vadl/test/vadl/ast/FrontendIntegrationTest.java
@@ -62,7 +62,9 @@ public class FrontendIntegrationTest {
     var absRoot = rootDir.toAbsolutePath();
     var sysName = rootDir.getFileName();
     var prettyPath = Path.of("build/test/pretty-print/" + sysName);
-    FileUtils.forceDelete(prettyPath.toFile());
+    if (prettyPath.toFile().exists()) {
+      FileUtils.forceDelete(prettyPath.toFile());
+    }
 
     var specFiles = Arrays.stream(vadlSpecs).map(s -> absRoot.resolve(s).toFile())
         .toList();

--- a/vadl/test/vadl/ast/ParserTest.java
+++ b/vadl/test/vadl/ast/ParserTest.java
@@ -19,8 +19,18 @@ package vadl.ast;
 import static org.assertj.core.api.Assertions.assertThat;
 import static vadl.ast.AstTestUtils.verifyPrettifiedAst;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.commons.io.FileUtils;
+import org.assertj.core.api.AssertionsForClassTypes;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.shaded.com.google.common.collect.Streams;
+import org.testcontainers.shaded.org.checkerframework.checker.nullness.qual.Nullable;
 import vadl.error.DiagnosticList;
 
 /**
@@ -261,5 +271,58 @@ public class ParserTest {
         """;
 
     Assertions.assertDoesNotThrow(() -> VadlParser.parse(prog));
+  }
+
+
+  @Test
+  void testRv32im() throws IOException {
+    testPrettyPrintSpec(Path.of("../sys/risc-v"), "rv3264im.vadl", "rv32im.vadl");
+  }
+
+  private void testPrettyPrintSpec(Path rootDir, String... vadlSpecs) throws IOException {
+    var absRoot = rootDir.toAbsolutePath();
+    var sysName = rootDir.getFileName();
+    var prettyPath = Path.of("build/test/pretty-print/" + sysName);
+    if (prettyPath.toFile().exists()) {
+      FileUtils.forceDelete(prettyPath.toFile());
+    }
+
+    var specFiles = Arrays.stream(vadlSpecs).map(s -> absRoot.resolve(s).toFile())
+        .toList();
+    var prettyFiles = Arrays.stream(vadlSpecs)
+        .map(s -> prettyPath.resolve(s).toFile())
+        .toList();
+
+    // first check all handwirtten specs
+    var originalAsts = checkAll(specFiles, prettyPath);
+    var prettyPrintAsts = checkAll(prettyFiles, null);
+
+    Streams.forEachPair(prettyPrintAsts.stream(), originalAsts.stream(), (actual, expected) ->
+        assertThat(actual.prettyPrintToString()).isEqualTo(expected.prettyPrintToString()));
+  }
+
+  private List<Ast> checkAll(List<File> specs, @Nullable Path prettyPrintPath) {
+    return specs.stream().map(s -> check(s, prettyPrintPath)).toList();
+  }
+
+  private Ast check(File vadlFile, @Nullable Path prettyPrintPath) {
+    System.out.println("Checking " + vadlFile);
+    AssertionsForClassTypes.assertThat(vadlFile).exists();
+
+    var ast = Assertions.assertDoesNotThrow(() -> VadlParser.parse(vadlFile.toPath()),
+        "Cannot parse input");
+    new Ungrouper().ungroup(ast);
+    new ModelRemover().removeModels(ast);
+    if (prettyPrintPath != null) {
+      var progPretty = ast.prettyPrintToString();
+      var resFile = prettyPrintPath.resolve(vadlFile.getName()).toFile();
+      try {
+        FileUtils.createParentDirectories(resFile);
+        FileUtils.writeStringToFile(resFile, progPretty, Charset.defaultCharset());
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+    return ast;
   }
 }

--- a/vadl/test/vadl/ast/ParserTest.java
+++ b/vadl/test/vadl/ast/ParserTest.java
@@ -200,6 +200,10 @@ public class ParserTest {
         constant a = -9
         constant b = !(a = 3)
         constant c = ~a
+        constant d = -4 as Bits<32>
+        constant e = -(4 as Bits<32>)
+        constant f = ~(3 as Bits<32>)
+        constant g = !(3 as Bool)
         """;
 
     var ast = Assertions.assertDoesNotThrow(() -> VadlParser.parse(prog), "Cannot parse input");


### PR DESCRIPTION
Fixes a couple of pretty print issues:
- Unary operators #239
- Assembly grammar default rules
- ABI definitions

Additionally it adds a pretty print test for the rv32im spec.