### PR TITLE
frontend: Support slices on assignments

### DIFF
--- a/vadl/main/vadl/ast/AstUtils.java
+++ b/vadl/main/vadl/ast/AstUtils.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import vadl.types.BoolType;
 import vadl.types.BuiltInTable;
@@ -148,4 +149,10 @@ class AstUtils {
             new BinOp(operator, expr.location),
             expr.argsIndices.get(0).values.get(1));
   }
+
+
+  static List<Expr> flatArguments(List<CallIndexExpr.Arguments> args) {
+    return args.stream().flatMap(a -> a.values.stream()).collect(Collectors.toList());
+  }
+
 }

--- a/vadl/main/vadl/ast/BehaviorLowering.java
+++ b/vadl/main/vadl/ast/BehaviorLowering.java
@@ -729,7 +729,8 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
     if (expr.computedTarget() instanceof RegisterDefinition registerDefinition) {
       var args = firstArgs.stream().map(this::fetch).toList();
       var regFile = (RegisterTensor) viamLowering.fetch(registerDefinition).orElseThrow();
-      var type = (DataType) expr.argsIndices.get(0).type();
+      var type = expr.argsIndices.isEmpty() ? regFile.resultType(0) :
+          (DataType) expr.argsIndices.getFirst().type();
       var readRegFile = new ReadRegTensorNode(regFile, new NodeList<>(args.get(0)), type, null);
       var slicedNode = visitSliceIndexCall(expr, readRegFile,
           expr.argsIndices.subList(1, expr.argsIndices.size()));
@@ -758,7 +759,7 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
         words = constantEvaluator.eval(targetSymbol.size).value().intValueExact();
       }
       var memory = (Memory) viamLowering.fetch(memoryDefinition).orElseThrow();
-      var type = (DataType) expr.argsIndices.get(0).type();
+      var type = (DataType) expr.typeBeforeSlice();
       var readMem = new ReadMemNode(memory, words, args.get(0), type);
       var slicedNode = visitSliceIndexCall(expr, readMem,
           expr.argsIndices.subList(1, expr.argsIndices.size()));

--- a/vadl/main/vadl/ast/BehaviorLowering.java
+++ b/vadl/main/vadl/ast/BehaviorLowering.java
@@ -974,8 +974,12 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
       // Register File Write
       if (callTarget.computedTarget() instanceof RegisterDefinition regFileTarget) {
         var reg = (RegisterTensor) viamLowering.fetch(regFileTarget).orElseThrow();
-        var indices = callTarget.argsIndices.getFirst().values.stream().map(this::fetch)
-            .collect(Collectors.toCollection(NodeList::new));
+        var indices = new NodeList<ExpressionNode>();
+        if (!callTarget.argsIndices.isEmpty()) {
+          indices = callTarget.argsIndices.getFirst().values.stream().map(this::fetch)
+              .collect(Collectors.toCollection(NodeList::new));
+        }
+
         var write = new WriteRegTensorNode(
             reg,
             indices,

--- a/vadl/main/vadl/ast/BehaviorLowering.java
+++ b/vadl/main/vadl/ast/BehaviorLowering.java
@@ -35,6 +35,7 @@ import vadl.types.SIntType;
 import vadl.types.Type;
 import vadl.types.UIntType;
 import vadl.utils.Either;
+import vadl.utils.GraphUtils;
 import vadl.utils.Pair;
 import vadl.utils.WithLocation;
 import vadl.viam.ArtificialResource;
@@ -48,7 +49,6 @@ import vadl.viam.Instruction;
 import vadl.viam.Memory;
 import vadl.viam.Procedure;
 import vadl.viam.RegisterTensor;
-import vadl.viam.Relocation;
 import vadl.viam.graph.Graph;
 import vadl.viam.graph.NodeList;
 import vadl.viam.graph.control.BeginNode;
@@ -75,6 +75,7 @@ import vadl.viam.graph.dependency.ProcCallNode;
 import vadl.viam.graph.dependency.ReadArtificialResNode;
 import vadl.viam.graph.dependency.ReadMemNode;
 import vadl.viam.graph.dependency.ReadRegTensorNode;
+import vadl.viam.graph.dependency.ReadResourceNode;
 import vadl.viam.graph.dependency.SelectNode;
 import vadl.viam.graph.dependency.SideEffectNode;
 import vadl.viam.graph.dependency.SignExtendNode;
@@ -84,6 +85,7 @@ import vadl.viam.graph.dependency.TupleGetFieldNode;
 import vadl.viam.graph.dependency.WriteArtificialResNode;
 import vadl.viam.graph.dependency.WriteMemNode;
 import vadl.viam.graph.dependency.WriteRegTensorNode;
+import vadl.viam.graph.dependency.WriteResourceNode;
 import vadl.viam.graph.dependency.ZeroExtendNode;
 
 
@@ -648,6 +650,34 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
       } else if (subCall.computedStatusIndex != null) {
         var indexing = new TupleGetFieldNode(subCall.computedStatusIndex, resultExpr, Type.bool());
         resultExpr = visitSliceIndexCall(expr, indexing, subCall.argsIndices);
+      } else if (exprBeforeSubcall instanceof ReadResourceNode resRead) {
+        var computedTarget = expr.target.path().target();
+        if (computedTarget instanceof CounterDefinition) {
+          // FIXME: @ffreitag this is currently hardcoded as was wrong before.
+          //  It must add the instruction width in bytes.
+          // This width is obtained by the format type of the current instruction
+          var instrWidth = 32;
+          // The byte is defined by the "word" that is returned by the main memory definition.
+          // So essentially the return type in the relation type of the memory definition.
+          var byteWidth = 8;
+          var instrWidthInByte = instrWidth / byteWidth;
+
+          // FIXME: Handle slicing and format subcall propperly
+          int offset = 0;
+          for (var subcall : expr.subCalls) {
+            var subcallName = subcall.id.name;
+            if (subcallName.equals("next")) {
+              offset += instrWidthInByte;
+            } else {
+              throw new IllegalStateException("unknown subcall: " + subcallName);
+            }
+          }
+
+          resultExpr = BuiltInCall.of(BuiltInTable.ADD,
+              resRead,
+              GraphUtils.intU(offset, resRead.type().bitWidth()).toNode()
+          );
+        }
       } else {
         throw new IllegalStateException();
       }
@@ -657,154 +687,76 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
   }
 
   private ExpressionNode visitSliceIndexCall(CallIndexExpr expr, ExpressionNode exprBeforeSlice,
-                                             List<CallIndexExpr.Arguments> argumentsList) {
-    if (argumentsList.isEmpty()) {
+                                             List<CallIndexExpr.Arguments> slices) {
+    if (slices.isEmpty()) {
       return exprBeforeSlice;
     }
 
-    var args = argumentsList.get(0);
-
-    // A range slice
-    if (!args.values.isEmpty() && args.values.get(0) instanceof RangeExpr rangeExpr) {
-      var from = constantEvaluator.eval(rangeExpr.from).value().intValueExact();
-      var to = constantEvaluator.eval(rangeExpr.to).value().intValueExact();
-      var bitSlice = new Constant.BitSlice(new Constant.BitSlice.Part(from, to));
-      var slice =
-          new SliceNode(exprBeforeSlice, bitSlice, Type.bits(from - to + 1));
-      slice.setSourceLocation(args.location);
-      return visitSliceIndexCall(expr, slice, argumentsList.subList(1, argumentsList.size()));
+    var result = exprBeforeSlice;
+    for (var slice : slices) {
+      var bitSlice = Objects.requireNonNull(slice.computedBitSlice);
+      var type = Type.bits(bitSlice.bitSize());
+      result = new SliceNode(exprBeforeSlice, slice.computedBitSlice, type);
     }
 
-    // A index (slice)
-    var fromTo = constantEvaluator.eval(args.values.get(0)).value().intValueExact();
-    var bitSlice = new Constant.BitSlice(new Constant.BitSlice.Part(fromTo, fromTo));
-    var slice =
-        new SliceNode(exprBeforeSlice, bitSlice, (DataType) expr.type());
-    slice.setSourceLocation(args.location);
-    return visitSliceIndexCall(expr, slice, argumentsList.subList(1, argumentsList.size()));
+    return result;
   }
 
   @Override
   public ExpressionNode visit(CallIndexExpr expr) {
 
-    List<Expr> firstArgs =
-        !expr.argsIndices.isEmpty() ? expr.argsIndices.get(0).values : new ArrayList<>();
+    List<Expr> argExprs = AstUtils.flatArguments(expr.args());
+    var args = argExprs.stream().map(this::fetch).toList();
+    var typeBeforeSlice = expr.typeBeforeSlice();
+
+    ExpressionNode exprBeforeSlice;
 
     // Builtin Call
     if (expr.computedBuiltIn != null) {
-      var args = firstArgs.stream().map(this::fetch).toList();
       if (BuiltInTable.ASM_PARSER_BUILT_INS.contains(expr.computedBuiltIn)) {
-        return new AsmBuiltInCall(expr.computedBuiltIn, new NodeList<>(args),
-            Objects.requireNonNull(expr.type));
+        exprBeforeSlice = new AsmBuiltInCall(expr.computedBuiltIn, new NodeList<>(args),
+            expr.typeBeforeSlice());
+      } else {
+        exprBeforeSlice = new BuiltInCall(expr.computedBuiltIn, new NodeList<>(args),
+            expr.typeBeforeSlice());
       }
-      return new BuiltInCall(expr.computedBuiltIn, new NodeList<>(args),
-          Objects.requireNonNull(expr.type));
-    }
+    } else {
+      exprBeforeSlice = switch (expr.computedTarget()) {
+        case FunctionDefinition funcDef -> new FuncCallNode(
+            (Function) viamLowering.fetch(funcDef).orElseThrow(),
+            new NodeList<>(args), typeBeforeSlice);
 
-    // Function Call
-    if (expr.computedTarget() instanceof FunctionDefinition functionDefinition) {
-      var args = firstArgs.stream().map(this::fetch).toList();
-      var function = (Function) viamLowering.fetch(functionDefinition).orElseThrow();
-      var type = expr.argsIndices.get(0).type();
-      var funcCall =
-          new FuncCallNode(function, new NodeList<>(args), type);
-      var slicedNode = visitSliceIndexCall(expr, funcCall,
-          expr.argsIndices.subList(1, expr.argsIndices.size()));
-      return visitSubCall(expr, slicedNode);
-    }
+        case RelocationDefinition funcDef -> new FuncCallNode(
+            (Function) viamLowering.fetch(funcDef).orElseThrow(),
+            new NodeList<>(args), typeBeforeSlice);
 
-    // Relocation Call (similar to function call)
-    if (expr.computedTarget() instanceof RelocationDefinition relocationDefinition) {
-      var args = firstArgs.stream().map(this::fetch).toList();
-      var relocation = (Relocation) viamLowering.fetch(relocationDefinition).orElseThrow();
-      var type = expr.argsIndices.get(0).type();
-      var funcCall =
-          new FuncCallNode(relocation, new NodeList<>(args), type);
-      var slicedNode = visitSliceIndexCall(expr, funcCall,
-          expr.argsIndices.subList(1, expr.argsIndices.size()));
-      return visitSubCall(expr, slicedNode);
-    }
+        case RegisterDefinition regDef -> new ReadRegTensorNode(
+            (RegisterTensor) viamLowering.fetch(regDef).orElseThrow(),
+            new NodeList<>(args), typeBeforeSlice.asDataType(), null);
 
-    // Register(file) read
-    if (expr.computedTarget() instanceof RegisterDefinition registerDefinition) {
-      var args = firstArgs.stream().map(this::fetch).toList();
-      var regFile = (RegisterTensor) viamLowering.fetch(registerDefinition).orElseThrow();
-      var type = expr.argsIndices.isEmpty() ? regFile.resultType(0) :
-          (DataType) expr.argsIndices.getFirst().type();
-      var readRegFile = new ReadRegTensorNode(regFile, new NodeList<>(args.get(0)), type, null);
-      var slicedNode = visitSliceIndexCall(expr, readRegFile,
-          expr.argsIndices.subList(1, expr.argsIndices.size()));
-      return visitSubCall(expr, slicedNode);
-    }
+        case AliasDefinition aliasDef -> new ReadArtificialResNode(
+            (ArtificialResource) viamLowering.fetch(aliasDef).orElseThrow(),
+            new NodeList<>(args), typeBeforeSlice.asDataType());
 
-    // Alias to registerfile read
-    if (expr.computedTarget() instanceof AliasDefinition aliasDefinition
-        && aliasDefinition.kind.equals(AliasDefinition.AliasKind.REGISTER)) {
-
-      var artificialResource =
-          (ArtificialResource) viamLowering.fetch(aliasDefinition).orElseThrow();
-      var address = firstArgs.stream().map(this::fetch).findFirst().orElseThrow();
-      var type = (DataType) expr.argsIndices.get(0).type();
-      var read = new ReadArtificialResNode(artificialResource, address, type);
-      var slicedNode = visitSliceIndexCall(expr, read,
-          expr.argsIndices.subList(1, expr.argsIndices.size()));
-      return visitSubCall(expr, slicedNode);
-    }
-
-    // Memory read
-    if (expr.computedTarget() instanceof MemoryDefinition memoryDefinition) {
-      var args = firstArgs.stream().map(this::fetch).toList();
-      var words = 1;
-      if (expr.target instanceof SymbolExpr targetSymbol) {
-        words = constantEvaluator.eval(targetSymbol.size).value().intValueExact();
-      }
-      var memory = (Memory) viamLowering.fetch(memoryDefinition).orElseThrow();
-      var type = (DataType) expr.typeBeforeSlice();
-      var readMem = new ReadMemNode(memory, words, args.get(0), type);
-      var slicedNode = visitSliceIndexCall(expr, readMem,
-          expr.argsIndices.subList(1, expr.argsIndices.size()));
-      return visitSubCall(expr, slicedNode);
-    }
-
-    // Program counter read
-    if (expr.computedTarget() instanceof CounterDefinition counterDefinition) {
-      // Calls like PC.next are translated to PC + 8 (if address is 8)
-      var counter = (Counter) viamLowering.fetch(counterDefinition).orElseThrow();
-      var counterType = (DataType) Objects.requireNonNull(counterDefinition.typeLiteral.type);
-
-      var regRead = new ReadRegTensorNode(counter.registerTensor(),
-          new NodeList<>(),
-          (DataType) Objects.requireNonNull(expr.type), null);
-
-      // FIXME: @ffreitag this is currently hardcoded as was wrong before.
-      //  It must add the instruction width in bytes.
-      // This width is obtained by the format type of the current instruction
-      var instrWidth = 32;
-      // The byte is defined by the "word" that is returned by the main memory definition.
-      // So essentially the return type in the relation type of the memory definition.
-      var byteWidth = 8;
-      var instrWidthInByte = instrWidth / byteWidth;
-
-      // FIXME: Handle slicing and format subcall propperly
-      int offset = 0;
-      for (var subcall : expr.subCalls) {
-        var subcallName = subcall.id.name;
-        if (subcallName.equals("next")) {
-          offset += instrWidthInByte;
-        } else {
-          throw new IllegalStateException("unknown subcall: " + subcallName);
+        case MemoryDefinition memDef -> {
+          var sizeExpr = expr.target.size();
+          var words = sizeExpr != null
+              ? constantEvaluator.eval(sizeExpr).value().intValueExact()
+              : 1;
+          yield new ReadMemNode((Memory) viamLowering.fetch(memDef).orElseThrow(),
+              words, args.getFirst(), typeBeforeSlice.asDataType());
         }
-      }
 
-      var constant = new ConstantNode(Constant.Value.of(offset, counterType));
-      return
-          new BuiltInCall(BuiltInTable.ADD, new NodeList<>(constant, regRead), counterType);
+        case CounterDefinition counterDef -> new ReadRegTensorNode(
+            ((Counter) viamLowering.fetch(counterDef).orElseThrow()).registerTensor(),
+            new NodeList<>(), expr.typeBeforeSlice().asDataType(), null);
+
+        default -> fetch((Expr) expr.target);
+      };
     }
 
-    // If nothing else, assume slicing and subcall
-    var exprBeforeSubCall = fetch((Expr) expr.target);
-    var result = visitSubCall(expr, exprBeforeSubCall);
-    result = visitSliceIndexCall(expr, result, expr.argsIndices);
+    var result = visitSliceIndexCall(expr, exprBeforeSlice, expr.slices());
+    result = visitSubCall(expr, result);
     return result;
   }
 
@@ -969,107 +921,82 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
   public SubgraphContext visit(AssignmentStatement statement) {
     var value = fetch(statement.valueExpression);
 
+    vadl.ast.Definition targetDef;
+    List<CallIndexExpr.Arguments> argGroups = List.of();
+    List<Constant.BitSlice> slices = List.of();
+
+    // the MEM<xyz>(...) value
+    @Nullable Integer callSize = null;
+
     if (statement.target instanceof CallIndexExpr callTarget) {
-      // FIXME: Ensure that no slicing is happending and handle format field masking access
+      targetDef = (vadl.ast.Definition) callTarget.computedTarget();
+      argGroups = callTarget.args();
+      slices = callTarget.slices().stream()
+          .map(s -> Objects.requireNonNull(s.computedBitSlice))
+          .toList();
 
-      // Register File Write
-      if (callTarget.computedTarget() instanceof RegisterDefinition regFileTarget) {
-        var reg = (RegisterTensor) viamLowering.fetch(regFileTarget).orElseThrow();
-        var indices = new NodeList<ExpressionNode>();
-        if (!callTarget.argsIndices.isEmpty()) {
-          indices = callTarget.argsIndices.getFirst().values.stream().map(this::fetch)
-              .collect(Collectors.toCollection(NodeList::new));
-        }
-
-        var write = new WriteRegTensorNode(
-            reg,
-            indices,
-            value,
-            null,
-            null);
-        write.setSourceLocation(statement.location());
-        write = Objects.requireNonNull(currentGraph).addWithInputs(write);
-        return SubgraphContext.of(statement, write);
-      }
-
-      // Alias Register File Write
-      if (callTarget.computedTarget() instanceof AliasDefinition aliasDefinition
-          && aliasDefinition.kind.equals(AliasDefinition.AliasKind.REGISTER)) {
-        var resource = (ArtificialResource) viamLowering.fetch(aliasDefinition).orElseThrow();
-        // FIXME: Support alias register writes
-        var address = callTarget.argsIndices.get(0).values.get(0).accept(this);
-        var write = new WriteArtificialResNode(resource, address, value);
-        return SubgraphContext.of(statement, write);
-      }
-
-      // Memory Write
-      if (callTarget.computedTarget() instanceof MemoryDefinition memoryTarget) {
-        var memory = (Memory) viamLowering.fetch(memoryTarget).orElseThrow();
-        var words = 1;
-        if (callTarget.target instanceof SymbolExpr targetSymbol) {
-          words = constantEvaluator.eval(targetSymbol.size).value().intValueExact();
-        }
-        var address = callTarget.argsIndices.get(0).values.get(0).accept(this);
-        var write = new WriteMemNode(memory, words, address, value);
-        write = Objects.requireNonNull(currentGraph).addWithInputs(write);
-        return SubgraphContext.of(statement, write);
-      }
-
-      throw new IllegalStateException(
-          "Call target \"%s\" not yet implemented, found in: %s".formatted(
-              callTarget.computedTarget(),
-              callTarget.location.toIDEString()));
-    } else if (statement.target instanceof Identifier identifierExpr) {
-      var computedTarget = Objects.requireNonNull(identifierExpr.target());
-
-      // Register Write
-      if (computedTarget instanceof RegisterDefinition registerDefinition) {
-        var register = (RegisterTensor) viamLowering.fetch(registerDefinition).orElseThrow();
-        var write = new WriteRegTensorNode(register, new NodeList<>(), value, null, null);
-        return SubgraphContext.of(statement, write);
-      }
-
-      // Alias Register Write
-      if (computedTarget instanceof AliasDefinition aliasDefinition
-          && aliasDefinition.kind.equals(AliasDefinition.AliasKind.REGISTER)) {
-        // FIXME: Register aliases cannot be artificial resources so we cannot create a
-        // write to an artificial resource here and just directly resolve it.
-        // https://github.com/OpenVADL/open-vadl/issues/104
-
-        // To make them work for now, they are at the moment always register file accesses so only
-        // implement them.
-
-        if (aliasDefinition.computedTarget instanceof RegisterDefinition) {
-          var register =
-              (RegisterTensor) viamLowering.fetch(
-                      Objects.requireNonNull(aliasDefinition.computedTarget))
-                  .orElseThrow();
-          var write = new WriteRegTensorNode(register, new NodeList<>(), value, null, null);
-          return SubgraphContext.of(statement, write);
-        }
-
-        // Here is the big hack where we create a pseudo AST node that just inlines the alias
-        // and generate the instance for that.
-        var fakeAssignment =
-            new AssignmentStatement(aliasDefinition.value, statement.valueExpression);
-        return visit(fakeAssignment);
-      }
-
-      // Counter (also register) Write
-      if (computedTarget instanceof CounterDefinition counterDefinition) {
-        var counter = (Counter) viamLowering.fetch(counterDefinition).orElseThrow();
-        var write =
-            new WriteRegTensorNode(counter.registerTensor(), new NodeList<>(),
-                value, null, null);
-        return SubgraphContext.of(statement, write);
-      }
-
-      throw new IllegalStateException("Identifier targeting %s not yet implemented".formatted(
-          computedTarget.getClass().getSimpleName()));
+      var sizeExpr = callTarget.target.size();
+      callSize = sizeExpr != null
+          ? constantEvaluator.eval(sizeExpr).value().intValueExact()
+          : null;
+    } else if (statement.target instanceof Identifier identTarget) {
+      targetDef = (vadl.ast.Definition) Objects.requireNonNull(identTarget.target());
+    } else {
+      throw new IllegalStateException("Unexpected target: " + statement);
     }
 
-    throw new IllegalStateException("unknown target expression: " + statement.target);
+    var argExprs = AstUtils.flatArguments(argGroups).stream().map(this::fetch)
+        .collect(Collectors.toCollection(NodeList::new));
+    var viamDef = viamLowering.fetch(targetDef).orElseThrow();
+
+    WriteResourceNode writeNode = switch (viamDef) {
+
+      case RegisterTensor regDef -> new WriteRegTensorNode(regDef, argExprs,
+          // slice the written value before writing it
+          slicecWriteValue(value,
+              new ReadRegTensorNode(regDef, argExprs, regDef.resultType(), null), slices),
+          null, null);
+
+      case ArtificialResource aliasDef -> new WriteArtificialResNode(aliasDef, argExprs,
+          // slice the written value before writing it
+          slicecWriteValue(value,
+              new ReadArtificialResNode(aliasDef, argExprs, aliasDef.resultType()), slices)
+      );
+
+      case Memory memDef -> {
+        var words = callSize != null ? callSize : 1;
+        // slice the written value before writing it
+        var slicedValue = slicecWriteValue(value,
+            new ReadMemNode(memDef, words, argExprs.getFirst(), memDef.resultType()), slices);
+        yield new WriteMemNode(
+            memDef, callSize != null ? callSize : 1,
+            argExprs.getFirst(), slicedValue
+        );
+      }
+
+      // FIXME: Adjust value based on counter position
+      case Counter counterDef -> new WriteRegTensorNode(counterDef.registerTensor(), argExprs,
+          // slice the written value before writing it
+          slicecWriteValue(value,
+              new ReadRegTensorNode(counterDef.registerTensor(), argExprs,
+                  counterDef.registerTensor().resultType(), null), slices),
+          null, null);
+
+      default -> throw new IllegalStateException("Unexpected target: " + viamDef);
+    };
+
+    return SubgraphContext.of(statement, writeNode);
   }
+
+  private ExpressionNode slicecWriteValue(ExpressionNode expression, ReadResourceNode entireRead,
+                                          List<Constant.BitSlice> slices) {
+    if (slices.isEmpty()) {
+      return expression;
+    }
+
+    throw new IllegalStateException("Bit slices on writes are not yet supported");
+  }
+
 
   @Override
   public SubgraphContext visit(BlockStatement statement) {

--- a/vadl/main/vadl/ast/Definition.java
+++ b/vadl/main/vadl/ast/Definition.java
@@ -393,6 +393,8 @@ class RangeFormatField extends FormatField {
 
   // While the ranges are expressions in diffrent forms, once computed they are stored here to
   // make them easier to process.
+  // FIXME: @flofriday we should use a Constant.BitSlice instead of this list of BitRange.
+  //   BitSlice is much more complete and also easier to handle
   @Nullable
   List<FormatDefinition.BitRange> computedRanges;
 

--- a/vadl/main/vadl/ast/Definition.java
+++ b/vadl/main/vadl/ast/Definition.java
@@ -2321,7 +2321,7 @@ final class EnumerationDefinition extends Definition implements IdentifiableNode
   }
 }
 
-final class ExceptionDefinition extends Definition implements IdentifiableNode {
+final class ExceptionDefinition extends Definition implements IdentifiableNode, TypedNode {
   IdentifierOrPlaceholder id;
   @Child
   Statement statement;
@@ -2329,6 +2329,8 @@ final class ExceptionDefinition extends Definition implements IdentifiableNode {
   List<Parameter> params;
   SourceLocation loc;
 
+  @Nullable
+  ConcreteRelationType type;
 
   ExceptionDefinition(IdentifierOrPlaceholder id, List<Parameter> params,
                       Statement statement,
@@ -2392,6 +2394,11 @@ final class ExceptionDefinition extends Definition implements IdentifiableNode {
     result = 31 * result + Objects.hashCode(statement);
     result = 31 * result + Objects.hashCode(params);
     return result;
+  }
+
+  @Override
+  public ConcreteRelationType type() {
+    return Objects.requireNonNull(type);
   }
 }
 

--- a/vadl/main/vadl/ast/Expr.java
+++ b/vadl/main/vadl/ast/Expr.java
@@ -1696,8 +1696,8 @@ final class CallIndexExpr extends Expr implements IsCallExpr {
   public List<Arguments> args() {
     if (computedBuiltIn != null) {
       // if we reference a built-in, we must check if the built-in takes arguments
-      if (computedBuiltIn.argTypeClasses().isEmpty() ||
-          argsIndices.isEmpty()) {
+      if (computedBuiltIn.argTypeClasses().isEmpty()
+          || argsIndices.isEmpty()) {
         return List.of();
       }
       return List.of(argsIndices.getFirst());
@@ -1713,7 +1713,11 @@ final class CallIndexExpr extends Expr implements IsCallExpr {
 
     if (computedTarget() instanceof TypedNode typedNode) {
       var type = typedNode.type();
-      if (type instanceof ConcreteRelationType) {
+      if (type instanceof ConcreteRelationType relType) {
+        if (relType.argTypes().isEmpty()) {
+          // relation types that don't expect an argument don't have any argument groups
+          return List.of();
+        }
         return argsIndices.isEmpty() ? List.of() : List.of(argsIndices.getFirst());
       }
       // in the case of a register:
@@ -1723,6 +1727,10 @@ final class CallIndexExpr extends Expr implements IsCallExpr {
     return List.of();
   }
 
+  /**
+   * Returns a list of all argument groups that represent slices on the result
+   * of the call.
+   */
   public List<Arguments> slices() {
     return argsIndices.subList(args().size(), argsIndices.size());
   }

--- a/vadl/main/vadl/ast/Expr.java
+++ b/vadl/main/vadl/ast/Expr.java
@@ -1882,7 +1882,7 @@ final class CallIndexExpr extends Expr implements IsCallExpr {
      * This does ignore further manipulation by the argsIndicies.
      */
     @Nullable
-    FormatDefinition.BitRange computedFormatFieldBitRange;
+    Constant.BitSlice computedBitSlice;
 
     /**
      * If the subcall is status access, this field tells which index in the status type the

--- a/vadl/main/vadl/ast/Expr.java
+++ b/vadl/main/vadl/ast/Expr.java
@@ -27,12 +27,14 @@ import vadl.javaannotations.ast.Child;
 import vadl.types.BitsType;
 import vadl.types.BoolType;
 import vadl.types.BuiltInTable;
+import vadl.types.ConcreteRelationType;
 import vadl.types.SIntType;
 import vadl.types.TupleType;
 import vadl.types.Type;
 import vadl.types.UIntType;
 import vadl.utils.SourceLocation;
 import vadl.utils.WithLocation;
+import vadl.viam.Constant;
 
 /**
  * The Expression node of the AST.
@@ -1656,6 +1658,9 @@ final class CallIndexExpr extends Expr implements IsCallExpr {
   @Nullable
   BuiltInTable.BuiltIn computedBuiltIn;
 
+  @Nullable
+  Type typeBeforeSlice;
+
   public CallIndexExpr(IsSymExpr target, List<Arguments> argsIndices, List<SubCall> subCalls,
                        SourceLocation location) {
     this.target = target;
@@ -1666,6 +1671,60 @@ final class CallIndexExpr extends Expr implements IsCallExpr {
 
   public Node computedTarget() {
     return Objects.requireNonNull(target.path().target());
+  }
+
+  public Type typeBeforeSlice() {
+    return Objects.requireNonNull(typeBeforeSlice);
+  }
+
+  /**
+   * Returns the {@link Arguments} for a call to some definition.
+   * As arguments must (e.g. function call arguments or register indices) must not be mixed
+   * with slices in the same group, the returned list provides ONLY arguments (no slices).
+   *
+   * <p>If the target has a {@link ConcreteRelationType}, there will only be a single argument
+   * returned.
+   * If the target is a register and has a tensor type, multiple arguments might be returned,
+   * as access to multidimensional registers may be written in separate groups.</p>
+   *
+   * <p><b>NOTE:</b>This method may only be called if the type checker has already
+   * resolved either the {@link #computedBuiltIn} or {@link #computedTarget()}, otherwise
+   * calling this function will result in a crash.
+   * (so it is generally safe after the type check)</p>
+   */
+  // FIXME: Implement access to multidimensional registers
+  public List<Arguments> args() {
+    if (computedBuiltIn != null) {
+      // if we reference a built-in, we must check if the built-in takes arguments
+      if (computedBuiltIn.argTypeClasses().isEmpty() ||
+          argsIndices.isEmpty()) {
+        return List.of();
+      }
+      return List.of(argsIndices.getFirst());
+    }
+
+    if (computedTarget() instanceof LetExpr) {
+      // let expressions don't have any arguments.
+      // they are typed nodes, but arguments referring to let exprs are not
+      // using the let expr's type, but just the value defined in it.
+      // so the type would be null when calling .type()
+      return List.of();
+    }
+
+    if (computedTarget() instanceof TypedNode typedNode) {
+      var type = typedNode.type();
+      if (type instanceof ConcreteRelationType) {
+        return argsIndices.isEmpty() ? List.of() : List.of(argsIndices.getFirst());
+      }
+      // in the case of a register:
+      // arguments are all argument groups that don't start with a range expression and
+      // don't exceed the number of tensor indices.
+    }
+    return List.of();
+  }
+
+  public List<Arguments> slices() {
+    return argsIndices.subList(args().size(), argsIndices.size());
   }
 
   @Override
@@ -1770,14 +1829,12 @@ final class CallIndexExpr extends Expr implements IsCallExpr {
     List<Expr> values;
     SourceLocation location;
 
+    // FIXME: I think this type does not make sense here.
     @Nullable
     Type type;
 
-    /**
-     * If the argument is a slice or a field access the typechecker will cache the result here.
-     */
     @Nullable
-    FormatDefinition.BitRange computedBitRange;
+    Constant.BitSlice computedBitSlice;
 
     Arguments(List<Expr> values, SourceLocation location) {
       this.values = values;

--- a/vadl/main/vadl/ast/Statement.java
+++ b/vadl/main/vadl/ast/Statement.java
@@ -242,8 +242,7 @@ final class LetStatement extends Statement {
   public int hashCode() {
     return Objects.hash(identifiers, valueExpr, body);
   }
-
-
+  
 }
 
 final class IfStatement extends Statement {

--- a/vadl/main/vadl/ast/TypeChecker.java
+++ b/vadl/main/vadl/ast/TypeChecker.java
@@ -17,6 +17,7 @@
 package vadl.ast;
 
 import static java.util.Objects.requireNonNull;
+import static vadl.error.Diagnostic.ensure;
 import static vadl.error.Diagnostic.error;
 import static vadl.error.Diagnostic.warning;
 
@@ -33,7 +34,6 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
@@ -59,6 +59,7 @@ import vadl.types.asmTypes.StringAsmType;
 import vadl.utils.Pair;
 import vadl.utils.SourceLocation;
 import vadl.utils.WithLocation;
+import vadl.viam.Constant;
 
 /**
  * A experimental, temporary type-checker to verify expressions and attach types to the AST.
@@ -479,7 +480,7 @@ public class TypeChecker
       constantEvaluator.eval(definition.value);
     } catch (EvaluationError e) {
       throw error("Invalid constant value", definition.value)
-          .locationDescription(e.location, "%s", Objects.requireNonNull(e.getMessage()))
+          .locationDescription(e.location, "%s", requireNonNull(e.getMessage()))
           .description("All constants must be able to be evaluated")
           .build();
     }
@@ -918,8 +919,9 @@ public class TypeChecker
 
   @Override
   public Void visit(ExceptionDefinition definition) {
-    definition.params.forEach(param -> check(param.typeLiteral));
+    var types = definition.params.stream().map(param -> check(param.typeLiteral)).toList();
     check(definition.statement);
+    definition.type = Type.concreteRelation(types, Type.void_());
     return null;
   }
 
@@ -2450,6 +2452,48 @@ public class TypeChecker
     return null;
   }
 
+  private Constant.BitSlice.Part checkSliceRange(RangeExpr range, BitsType valueType) {
+    int from = constantEvaluator.eval(range.from).value().intValueExact();
+    int to = constantEvaluator.eval(range.to).value().intValueExact();
+
+    // NOTE: From is always larger than to
+    var rangeSize = (from - to) + 1;
+    if (rangeSize < 1) {
+      throw error("Invalid Range", range)
+          .description("Range must be >= 1 but was %s", rangeSize)
+          .build();
+    }
+
+    if (from >= valueType.bitWidth()) {
+      throw error("Invalid Range", range)
+          .description("Range start %d out of bounds for `%s`", from, valueType)
+          .build();
+    }
+    if (to < 0) {
+      throw error("Invalid Range", range)
+          .description("Range end must be at least zero but was %s", to)
+          .build();
+    }
+
+    return new Constant.BitSlice.Part(from, to);
+  }
+
+  private Constant.BitSlice.Part checkIndexSlice(Expr indexExpr, BitsType valueType) {
+    check(indexExpr);
+    int sliceIndex = constantEvaluator.eval(indexExpr).value().intValueExact();
+    if (sliceIndex >= valueType.bitWidth()) {
+      throw error("Invalid Index", indexExpr)
+          .description("Index %d out of bounds for `%s`", sliceIndex, valueType)
+          .build();
+    }
+    if (sliceIndex < 0) {
+      throw error("Invalid Index", indexExpr)
+          .description("Index must be at least zero but was %s", sliceIndex)
+          .build();
+    }
+    return new Constant.BitSlice.Part(sliceIndex, sliceIndex);
+  }
+
   /**
    * Visits one or multiple index and slice calls.
    *
@@ -2460,107 +2504,51 @@ public class TypeChecker
    *
    * @param expr            to visit
    * @param typeBeforeSlice is the type just before.
-   * @param argumentsList   the list or arguments which hold slices or indexes
+   * @param sliceGroups     the list or arguments which hold slices or indexes
    */
   private void visitSliceIndexCall(CallIndexExpr expr, Type typeBeforeSlice,
-                                   List<CallIndexExpr.Arguments> argumentsList) {
-    if (argumentsList.isEmpty()) {
+                                   List<CallIndexExpr.Arguments> sliceGroups) {
+    if (sliceGroups.isEmpty()) {
       expr.type = typeBeforeSlice;
       return;
     }
-    var args = argumentsList.get(0);
+
+    var lastSlice = sliceGroups.getLast();
 
     // FIXME: Adjust for vectors in the future
     if (!(typeBeforeSlice instanceof BitsType targetBitsType)) {
-      var loc = expr.target.location().join(args.location);
+      var loc = expr.target.location().join(lastSlice.location);
       throw error("Type Mismatch", loc)
           .description("Only bit types can be sliced but the target was a `%s`", typeBeforeSlice)
           .build();
     }
 
-    // A range slice
-    if (!args.values.isEmpty() && args.values.get(0) instanceof RangeExpr rangeExpr) {
-      int from = constantEvaluator.eval(rangeExpr.from).value().intValueExact();
-      int to = constantEvaluator.eval(rangeExpr.to).value().intValueExact();
+    BitsType currType = targetBitsType;
+    for (var slice : sliceGroups) {
+      // construct BitSlice for each slice group
+      var parts = new ArrayList<Constant.BitSlice.Part>();
+      for (var partExpr : slice.values) {
+        // for each part construct a BitSlice.Part
+        var part = partExpr instanceof RangeExpr rangeSlice
+            ? checkSliceRange(rangeSlice, currType)
+            : checkIndexSlice(partExpr, currType);
+        parts.add(part);
+      }
 
-
-      // NOTE: From is always larger than to
-      var rangeSize = (from - to) + 1;
-      if (rangeSize < 1) {
-        throw error("Invalid Range", rangeExpr)
-            .description("Range must be >= 1 but was %s", rangeSize)
+      var bitSlice = new Constant.BitSlice(parts.toArray(new Constant.BitSlice.Part[0]));
+      if (bitSlice.hasOverlappingParts()) {
+        throw error("Overlapping slice parts", slice.location)
+            .locationDescription(slice.location, "Some parts of the slice are overlapping.")
+            .note("Slices must have distinct, non-overlapping parts.")
             .build();
       }
 
-      if (from >= targetBitsType.bitWidth()) {
-        throw error("Invalid Range", rangeExpr)
-            .description("Range start %d out of bounds for `%s`", from, targetBitsType)
-            .build();
-      }
-      if (to < 0) {
-        throw error("Invalid Range", rangeExpr)
-            .description("Range end must be at least zero but was %s", to)
-            .build();
-      }
-      var type = targetBitsType.withBitWidth(rangeSize);
-      args.type = type;
-      args.computedBitRange = new FormatDefinition.BitRange(from, to);
-      visitSliceIndexCall(expr, type, argumentsList.subList(1, argumentsList.size()));
-      return;
+      currType = Type.bits(bitSlice.bitSize());
+      slice.computedBitSlice = bitSlice;
+      slice.type = currType;
     }
 
-    // A index (slice)
-    if (args.values.size() != 1) {
-      var loc = expr.target.location().join(args.location);
-      // FIXME: This is wrong, you can also do it with multiple and they get concatinated
-      throw error("Invalid call", loc)
-          .description("You can only call `%s` with one argument", typeBeforeSlice)
-          .build();
-    }
-
-    check(args.values.get(0));
-    int sliceIndex = constantEvaluator.eval(args.values.get(0)).value().intValueExact();
-    if (sliceIndex >= targetBitsType.bitWidth()) {
-      throw error("Invalid Index", args.values.get(0))
-          .description("Index %d out of bounds for `%s`", sliceIndex, targetBitsType)
-          .build();
-    }
-    if (sliceIndex < 0) {
-      throw error("Invalid Index", args.values.get(0))
-          .description("Index must be at least zero but was %s", sliceIndex)
-          .build();
-    }
-
-    var type = targetBitsType.withBitWidth(1);
-    args.type = type;
-    args.computedBitRange = new FormatDefinition.BitRange(sliceIndex, sliceIndex);
-    visitSliceIndexCall(expr, type, argumentsList.subList(1, argumentsList.size()));
-  }
-
-  /**
-   * Throws if a subcall exists.
-   *
-   * @param expr       with possibly subcalls.
-   * @param callTarget to which is called.
-   */
-  private void verifyNoSubcall(CallIndexExpr expr, Definition callTarget) {
-    verifyNoSubcall(expr, callTarget.getClass().getSimpleName());
-  }
-
-  /**
-   * Throws if a subcall exists.
-   *
-   * @param expr       with possibly subcalls.
-   * @param targetName to which is called.
-   */
-  private void verifyNoSubcall(CallIndexExpr expr, String targetName) {
-    if (expr.subCalls.isEmpty()) {
-      return;
-    }
-
-    throw error("Invalid subcall", expr)
-        .description("Calls to %s cannot have subcalls", targetName)
-        .build();
+    expr.type = currType;
   }
 
   /**
@@ -2571,10 +2559,31 @@ public class TypeChecker
    *
    * @param expr of the call.
    */
+  @SuppressWarnings("NullAway") // required as there is a false positive in the switch
   private void visitSubCall(CallIndexExpr expr, Type typeBeforeSubCall) {
     if (expr.subCalls.isEmpty()) {
       expr.type = typeBeforeSubCall;
       return;
+    }
+
+
+    // FIXME: Make this more generic
+    switch (expr.target.path().target()) {
+      case CounterDefinition counter -> {
+        ensure(expr.slices().isEmpty(), () -> error("Invalid counter sub-call", expr)
+            .locationDescription(expr, "Cannot do sub call and slice on counter."));
+        var validSubCalls = List.of("next");
+        ensure(expr.subCalls.size() == 1, () -> error("Invalid counter sub-call", expr)
+            .locationDescription(expr, "Only a single sub-call expected."));
+        var subCall = expr.subCalls.getFirst();
+        ensure(validSubCalls.contains(subCall.id.name),
+            () -> error("Invalid counter sub-call", subCall.id)
+                .locationDescription(subCall.id, "Counter has no sub-call named `%s`",
+                    subCall.id.name));
+        return;
+      }
+      case null, default -> {
+      }
     }
 
 
@@ -2619,283 +2628,170 @@ public class TypeChecker
 
   @Override
   public Void visit(CallIndexExpr expr) {
+    // try to find target symbol in symbol table
+    var targetSymbol = expr.symbolTable().requireSymbol(expr.target.path(), () ->
+        error("Unknown call target", expr.target)
+            .locationNote(expr.target, "Nothing found that can be called with this name."));
 
-    // The first call of the multicalls depends on the thing that is being called.
-    // However since the definitions aren't part of the typesystem we need to resolve them
-    // manually.
-    // If no target matches, we can assume a slice and index call (depending on the type).
-
-    var callTarget = expr.symbolTable().findAs(expr.target.path(), Definition.class);
-
-    // Handle register File
-    if (callTarget instanceof RegisterDefinition
-        || (callTarget instanceof AliasDefinition aliasDef
-        && aliasDef.kind.equals(AliasDefinition.AliasKind.REGISTER))) {
-      
-      check(callTarget);
-
-      // the start of the index calls (might be 1 if the destination is a reg file)
-      var indexSubListStart = 0;
-      var callTargetType = ((TypedNode) callTarget).type();
-      var typeBeforeIndex = callTargetType;
-      if (callTargetType instanceof ConcreteRelationType relType) {
-        // If the call type is a relation type, it is a register file, so the first
-        // argument list must be treated as a list of arguments to the register file.
-        // FIXME: This must be more generic if the relation has multiple arguments
-        var argList = expr.argsIndices.get(0);
-        var arg = argList.values.get(0);
-        check(arg);
-        var requiredArgType = relType.argTypes().get(0);
-        argList.values.set(0, tryWrapImplicitCast(arg, requiredArgType));
-        typeBeforeIndex = relType.resultType();
-        argList.type = typeBeforeIndex;
-        indexSubListStart = 1;
-      }
-
-      // all further argument indices are slice calls
-      visitSliceIndexCall(expr, typeBeforeIndex,
-          expr.argsIndices.subList(indexSubListStart, expr.argsIndices.size()));
-      // the after the index slice we might have a type that can be called like .next
-      visitSubCall(expr, expr.type());
-      return null;
+    switch (targetSymbol) {
+      case SymbolTable.AstSymbol astSymbol -> processCallOfTarget(expr, astSymbol.origin());
+      case SymbolTable.BuiltInSymbol ignored -> processCallOfBuiltIn(expr);
     }
 
-    // Handle memory
-    if (callTarget instanceof MemoryDefinition memDef) {
-      if (expr.argsIndices.size() != 1 || expr.argsIndices.get(0).values.size() != 1) {
-        throw error("Invalid Memory Usage", expr)
-            .description("Memory access must have exactly one argument.")
-            .build();
-      }
-      verifyNoSubcall(expr, memDef);
-
-      var argList = expr.argsIndices.get(0);
-      var arg = argList.values.get(0);
-      check(arg);
-
-      check(memDef);
-      var requiredArgType =
-          requireNonNull(requireNonNull(memDef.type).argTypes().get(0));
-
-      argList.values.set(0, wrapImplicitCast(arg, requiredArgType));
-      arg = argList.values.get(0);
-      var actualArgType = arg.type();
-
-      if (!actualArgType.equals(requiredArgType)) {
-        throw typeMissmatchError(expr, requiredArgType, actualArgType);
-      }
-
-      var callType = memDef.type().resultType();
-      if (expr.target instanceof SymbolExpr targetSymbol) {
-        int multiplier = constantEvaluator.eval(targetSymbol.size).value().intValueExact();
-        if (!(callType instanceof BitsType callBitsType)) {
-          throw new IllegalStateException();
-        }
-
-        callType = callBitsType.scaleBy(multiplier);
-      }
-
-      argList.type = callType;
-      expr.type = callType;
-      visitSliceIndexCall(expr, expr.type(), expr.argsIndices.subList(1, expr.argsIndices.size()));
-      visitSubCall(expr, expr.type());
-      return null;
-    }
-
-    // Handle Counter
-    if (callTarget instanceof CounterDefinition counterDef) {
-      check(counterDef);
-      var counterType = counterDef.typeLiteral.type;
-      expr.type = counterType;
-
-      if (!expr.argsIndices.isEmpty()) {
-        throw error("Invalid Counter Usage", expr)
-            .description("A counter isn't a callable thing.")
-            .build();
-      }
-
-      // FIXME: Handle slicing and format subcall propperly
-      if (counterDef.kind == CounterDefinition.CounterKind.PROGRAM) {
-        var allowedSubcalls = List.of("next");
-        // FIXME: better error message
-        if (expr.subCalls.stream().anyMatch(s -> !allowedSubcalls.contains(s.id.name))) {
-          throw error("Unknown counter access", expr)
-              .description("Unknown counter access, only the following are allowed %s",
-                  allowedSubcalls)
-              .build();
-        }
-        if (expr.subCalls.stream().anyMatch(s -> !s.argsIndices.isEmpty())) {
-          throw error("Invalid next of counter", expr)
-              .description("`.next` doesn't take any arguments")
-              .build();
-        }
-      } else {
-        throw new RuntimeException("Don't know how to handle group counters yet");
-      }
-
-      //visitSliceIndexCall(expr, expr.type(), expr.argsIndices);
-      //visitSubCall(expr, expr.type());
-      return null;
-    }
-
-    // FIXME: @flofriday, implementation of function definition and relocation definition
-    //    are identical. Exception definition is also very similar.
-    //    This should be refactored.
-    // User defined functions
-    if (callTarget instanceof FunctionDefinition functionDef) {
-      check(functionDef);
-      var funcType = functionDef.type();
-      var expectedArgCount = funcType.argTypes().size();
-      var actualArgCount = expr.argsIndices.get(0).values.size();
-      if (expectedArgCount != actualArgCount) {
-        throw error("Invalid Function Call", expr)
-            .description("Expected `%s` arguments but got `%s`", expectedArgCount, actualArgCount)
-            .build();
-      }
-
-      var args = expr.argsIndices.get(0);
-      args.values.forEach(this::check);
-      for (int i = 0; i < expectedArgCount; i++) {
-        var arg = args.values.get(i);
-        args.values.set(i, wrapImplicitCast(arg, funcType.argTypes().get(i)));
-        arg = args.values.get(i);
-        if (!arg.type().equals(funcType.argTypes().get(i))) {
-          throw typeMissmatchError(expr, funcType.argTypes().get(i), arg.type());
-        }
-      }
-
-      expr.type = funcType.resultType();
-      expr.argsIndices.get(0).type = funcType.resultType();
-      visitSliceIndexCall(expr, expr.type(), expr.argsIndices.subList(1, expr.argsIndices.size()));
-      visitSubCall(expr, expr.type());
-      return null;
-    }
-
-    // Relocation call (similar to function)
-    if (callTarget instanceof RelocationDefinition relocationDef) {
-      check(relocationDef);
-      var relocationType = relocationDef.type();
-      var expectedArgCount = relocationType.argTypes().size();
-      var actualArgCount = expr.argsIndices.get(0).values.size();
-      if (expectedArgCount != actualArgCount) {
-        throw error("Invalid Function Call", expr)
-            .description("Expected %s arguments but got `%s`", expectedArgCount, actualArgCount)
-            .build();
-      }
-
-      var args = expr.argsIndices.get(0);
-      args.values.forEach(this::check);
-      for (int i = 0; i < expectedArgCount; i++) {
-        var arg = args.values.get(i);
-        args.values.set(i, wrapImplicitCast(arg, relocationType.argTypes().get(i)));
-        arg = args.values.get(i);
-        if (!arg.type().equals(relocationType.argTypes().get(i))) {
-          throw typeMissmatchError(expr, relocationType.argTypes().get(i), arg.type());
-        }
-      }
-
-      expr.type = relocationType.resultType();
-      expr.argsIndices.get(0).type = relocationType.resultType();
-      visitSliceIndexCall(expr, expr.type(), expr.argsIndices.subList(1, expr.argsIndices.size()));
-      visitSubCall(expr, expr.type());
-      return null;
-    }
-
-    if (callTarget instanceof ExceptionDefinition exceptionDef) {
-      // TODO: Check if exception was called with a raise
-      check(exceptionDef);
-      var expectedArgCount = exceptionDef.params.size();
-      var paramTypes = exceptionDef.params.stream().map(Parameter::type).toList();
-      var actualArgCount = expr.argsIndices.get(0).values.size();
-      if (expectedArgCount != actualArgCount) {
-        throw error("Invalid Exception Raise", expr)
-            .description("Expected %s arguments but got `%s`", expectedArgCount, actualArgCount)
-            .build();
-      }
-      var args = expr.argsIndices.get(0);
-      args.values.forEach(this::check);
-      for (int i = 0; i < expectedArgCount; i++) {
-        var arg = args.values.get(i);
-        args.values.set(i, wrapImplicitCast(arg, paramTypes.get(i)));
-        arg = args.values.get(i);
-        if (!arg.type().equals(paramTypes.get(i))) {
-          throw typeMissmatchError(expr, paramTypes.get(i), arg.type());
-        }
-      }
-
-      expr.type = Type.void_();
-      return null;
-    }
-
-
-    // Builtin function
-    List<Expr> args =
-        !expr.argsIndices.isEmpty() ? expr.argsIndices.get(0).values : new ArrayList<>();
-    var argTypes = args.stream().map(this::check).toList();
-    var builtin = AstUtils.getBuiltIn(expr.target.path().pathToString(), argTypes);
-    if (builtin != null) {
-      // FIXME: Find a better solution that is universal enough for binary operations and builtin
-      // functions.
-
-      // If the function is also a unary operation, we instead type check it as if it were a unary
-      // operation which has some special type rules.
-      if (builtin.operator() != null && builtin.signature().argTypeClasses().size() == 1) {
-
-        var fakeUnExpr = AstUtils.getBuiltinUnOp(expr, builtin);
-        check(fakeUnExpr);
-
-        // Set type and arguments since they might have been wrapped in type casts
-        expr.argsIndices.get(0).values.set(0, fakeUnExpr.operand);
-        expr.type = fakeUnExpr.type;
-        expr.argsIndices.get(0).type = fakeUnExpr.type;
-      }
-
-      // If the function is also a binary operation, we instead type check it as if it were a binary
-      // operation which has some special type rules.
-      if (builtin.operator() != null && builtin.signature().argTypeClasses().size() == 2) {
-        var fakeBinExpr = AstUtils.getBuiltinBinOp(expr, builtin);
-        check(fakeBinExpr);
-
-        // Set type and arguments since they might have been wraped in type casts
-        expr.replaceArgsFor(0, List.of(fakeBinExpr.left, fakeBinExpr.right));
-        expr.type = fakeBinExpr.type;
-        expr.argsIndices.get(0).type = fakeBinExpr.type;
-      }
-
-      // FIXME: Better casting for const types.
-      // Should we also constanteval here if all arguments are constant?
-      argTypes = requireNonNull(expr.argsIndices.get(0).values.stream().map(v -> v.type)).toList();
-      if (expr.type == null && !builtin.takes(argTypes)) {
-        // FIXME: Better format that error
-        throw error("Type Mismatch", expr)
-            .description("Expected %s but got `%s`", builtin.signature().argTypeClasses(), argTypes)
-            .build();
-      }
-
-      // Note: cannot set the computed type because builtins aren't a definition.
-      expr.computedBuiltIn = builtin;
-      if (expr.type == null) {
-        expr.type = builtin.returns(argTypes);
-        expr.argsIndices.get(0).type = builtin.returns(argTypes);
-      }
-      visitSliceIndexCall(expr, expr.type(), expr.argsIndices.subList(1, expr.argsIndices.size()));
-      visitSubCall(expr, expr.type());
-      return null;
-    }
-
-
-    // If nothing else, assume slicing and subcall
-    if (expr.target instanceof Identifier targetIdentifier) {
-      expr.type = check(targetIdentifier);
-    } else if (expr.target instanceof IdentifierPath targetIdentifierPath) {
-      expr.type = check(targetIdentifierPath);
-    } else {
-      throw new IllegalStateException();
-    }
-    visitSliceIndexCall(expr, expr.type(), expr.argsIndices);
+    var slices = expr.slices();
+    // all further argument indices are slice calls
+    visitSliceIndexCall(expr, expr.typeBeforeSlice(), slices);
+    // the after the index slice we might have a type that can be called like .next
     visitSubCall(expr, expr.type());
+
     return null;
   }
+
+  private void processCallOfBuiltIn(CallIndexExpr expr) {
+    // Builtin function
+    List<Expr> args =
+        !expr.argsIndices.isEmpty() ? expr.argsIndices.getFirst().values : new ArrayList<>();
+    var argTypes = args.stream().map(this::check).toList();
+    var builtin = AstUtils.getBuiltIn(expr.target.path().pathToString(), argTypes);
+
+    if (builtin == null) {
+      throw error("Invalid call target", expr.target)
+          .locationNote(expr.target, "Couldn't find builtin function `%s`",
+              expr.target.path())
+          .build();
+    }
+
+    expr.computedBuiltIn = builtin;
+
+    // FIXME: Find a better solution that is universal enough for binary operations and builtin
+    // functions.
+
+    // If the function is also a unary operation, we instead type check it as if it were a unary
+    // operation which has some special type rules.
+    if (builtin.operator() != null && builtin.signature().argTypeClasses().size() == 1) {
+
+      var fakeUnExpr = AstUtils.getBuiltinUnOp(expr, builtin);
+      check(fakeUnExpr);
+
+      // Set type and arguments since they might have been wrapped in type casts
+      expr.argsIndices.get(0).values.set(0, fakeUnExpr.operand);
+      expr.typeBeforeSlice = fakeUnExpr.type;
+      expr.argsIndices.get(0).type = fakeUnExpr.type;
+    }
+
+    // If the function is also a binary operation, we instead type check it as if it were a binary
+    // operation which has some special type rules.
+    if (builtin.operator() != null && builtin.signature().argTypeClasses().size() == 2) {
+      var fakeBinExpr = AstUtils.getBuiltinBinOp(expr, builtin);
+      check(fakeBinExpr);
+
+      // Set type and arguments since they might have been wraped in type casts
+      expr.replaceArgsFor(0, List.of(fakeBinExpr.left, fakeBinExpr.right));
+      expr.typeBeforeSlice = fakeBinExpr.type;
+      expr.argsIndices.get(0).type = fakeBinExpr.type;
+    }
+
+    // FIXME: Better casting for const types.
+    // Should we also constanteval here if all arguments are constant?
+    argTypes = requireNonNull(expr.argsIndices.get(0).values.stream().map(v -> v.type)).toList();
+    if (expr.typeBeforeSlice == null && !builtin.takes(argTypes)) {
+      // FIXME: Better format that error
+      throw error("Type Mismatch", expr)
+          .description("Expected %s but got `%s`", builtin.signature().argTypeClasses(), argTypes)
+          .build();
+    }
+
+    // Note: cannot set the computed type because builtins aren't a definition.
+    expr.computedBuiltIn = builtin;
+    if (expr.typeBeforeSlice == null) {
+      expr.typeBeforeSlice = builtin.returns(argTypes);
+      expr.argsIndices.getFirst().type = builtin.returns(argTypes);
+    }
+  }
+
+  private void processCallOfTarget(CallIndexExpr expr, Node callTarget) {
+    if (!(callTarget instanceof TypedNode typedNode) || callTarget instanceof LetExpr) {
+      // if the target is not a typed node, we just assume that it is some expression
+      // that can be sliced.
+      // if it is a let expr, we must also only check the target
+      expr.typeBeforeSlice = check((Expr) expr.target);
+      return;
+    }
+
+    switch (typedNode) {
+      case Expr e -> check(e);
+      case Definition e -> check(e);
+      default -> throw new IllegalStateException("Unexpected value: " + typedNode);
+    }
+
+    var argGroups = expr.args();
+    var argExprs = AstUtils.flatArguments(argGroups);
+
+    for (var argExpr : argExprs) {
+      ensure(!(argExpr instanceof RangeExpr), () -> error("Invalid argument", argExpr)
+          .locationNote(argExpr, "Expected argument value but got a range expression."));
+    }
+
+    var type = typedNode.type();
+    if (type instanceof ConcreteRelationType relType) {
+      ensure(relType.argTypes().size() == argExprs.size(),
+          () -> error("Invalid number of arguments", expr)
+              .locationNote(expr, "Expected %s arguments but got %s.", relType.argTypes().size(),
+                  argExprs.size()));
+
+      if (argGroups.size() != 1) {
+        // concrete relations have exactly one group
+        throw new IllegalStateException(
+            "At this point, we should know that there is exactly one argument group.");
+      }
+
+      // concrete relation types have only a single arg group (e.g. functions)
+      var argGroup = argGroups.getFirst();
+      for (int i = 0; i < argGroup.values.size(); i++) {
+        var arg = argGroup.values.get(i);
+        check(arg);
+        argGroup.values.set(i, tryWrapImplicitCast(arg, relType.argTypes().get(i)));
+      }
+
+      // set the type, this is overridden if there are slice or subcalls that get processed next
+      expr.typeBeforeSlice = relType.resultType();
+      // set the arg group type (representing the call result)
+      argGroups.getFirst().type = relType.resultType();
+
+    } else {
+      if (!argGroups.isEmpty()) {
+        // if there are argument groups, there was some logic failure.
+        // NOTE: This will change onces we have tensor registers.
+        throw new IllegalStateException(
+            "Non concrete relation types must not have any arguments.");
+      }
+      expr.typeBeforeSlice = typedNode.type();
+    }
+
+    var targetSizeExpr = expr.target.size();
+    if (targetSizeExpr != null) {
+      if (!(expr.typeBeforeSlice() instanceof BitsType exprType)) {
+        throw error("Invalid scaling type", targetSizeExpr)
+            .locationDescription(targetSizeExpr, "Result type `%s` cannot be scaled.",
+                expr.typeBeforeSlice())
+            .build();
+      }
+      // handle the targetSize expression if defined
+      int multiplier = constantEvaluator.eval(targetSizeExpr).value().intValueExact();
+
+      if (callTarget instanceof MemoryDefinition) {
+        // in case of a memory definition, scale the result type
+        expr.typeBeforeSlice = exprType.scaleBy(multiplier);
+      } else {
+        throw error("Invalid call size", expr)
+            .locationDescription(expr.target, "The call target doesn't support a size expression.")
+            .build();
+      }
+    }
+
+
+  }
+
 
   @SuppressWarnings("UnusedVariable")
   @Override

--- a/vadl/main/vadl/ast/TypeChecker.java
+++ b/vadl/main/vadl/ast/TypeChecker.java
@@ -2602,7 +2602,10 @@ public class TypeChecker
               .build();
         }
 
-        subCall.computedFormatFieldBitRange = formatType.format.getFieldRange(fieldName);
+        // FIXME: @flofriday replace once computed field ranges are Constant.BitSlice
+        var fieldRange = requireNonNull(formatType.format.getFieldRange(fieldName));
+        var slicePart = new Constant.BitSlice.Part(fieldRange.from(), fieldRange.to());
+        subCall.computedBitSlice = new Constant.BitSlice(slicePart);
         subCall.formatFieldType = fieldType;
         visitSliceIndexCall(expr, subCall.formatFieldType, subCall.argsIndices);
         type = expr.type;

--- a/vadl/main/vadl/utils/GraphUtils.java
+++ b/vadl/main/vadl/utils/GraphUtils.java
@@ -179,7 +179,7 @@ public class GraphUtils {
     return (T) users.get(0);
   }
 
-  //// GRAPH CREATION UTILS ////
+  /// / GRAPH CREATION UTILS ////
 
   /**
    * Creates a unary operation built-in call with the specified operation and a constant value.

--- a/vadl/main/vadl/viam/Constant.java
+++ b/vadl/main/vadl/viam/Constant.java
@@ -914,9 +914,6 @@ public abstract class Constant {
           "slice cannot be empty: %s", this);
       this.parts = normalized(parts);
       this.statistics = stream().summaryStatistics();
-      ViamError.ensure(
-          !hasOverlappingParts(),
-          "parts of slice must not overlap: %s", this);
     }
 
     @Override
@@ -1006,7 +1003,7 @@ public abstract class Constant {
           .iterator();
     }
 
-    private boolean hasOverlappingParts() {
+    public boolean hasOverlappingParts() {
       return parts.stream()
           .anyMatch(part -> parts.stream()
               .anyMatch(

--- a/vadl/main/vadl/viam/Constant.java
+++ b/vadl/main/vadl/viam/Constant.java
@@ -1011,6 +1011,10 @@ public abstract class Constant {
           .iterator();
     }
 
+    /**
+     * Determines if there are any overlapping parts in the slice.
+     * This returns true if two or more parts are indexing the same position.
+     */
     public boolean hasOverlappingParts() {
       return parts.stream()
           .anyMatch(part -> parts.stream()

--- a/vadl/main/vadl/viam/Constant.java
+++ b/vadl/main/vadl/viam/Constant.java
@@ -916,6 +916,10 @@ public abstract class Constant {
       this.statistics = stream().summaryStatistics();
     }
 
+    public static BitSlice of(int msb, int lsb) {
+      return new BitSlice(new Part(msb, lsb));
+    }
+
     @Override
     public Type type() {
       return Type.bitSlice();
@@ -967,11 +971,15 @@ public abstract class Constant {
       return statistics.getMin();
     }
 
+    public Constant.Value mask() {
+      var mask = stream().boxed().reduce(BigInteger.ZERO, BigInteger::setBit, BigInteger::or);
+      return Value.fromTwosComplement(mask, Type.bits(msb() + 1));
+    }
+
     @Override
     public java.lang.String toString() {
       return "[" + parts.stream().map(Part::toString).collect(Collectors.joining(", ")) + "]";
     }
-
 
     @Override
     public boolean equals(Object o) {

--- a/vadl/main/vadl/viam/graph/dependency/ReadArtificialResNode.java
+++ b/vadl/main/vadl/viam/graph/dependency/ReadArtificialResNode.java
@@ -17,12 +17,12 @@
 package vadl.viam.graph.dependency;
 
 import java.util.List;
-import javax.annotation.Nullable;
 import vadl.javaannotations.viam.DataValue;
 import vadl.types.DataType;
 import vadl.viam.ArtificialResource;
 import vadl.viam.graph.GraphNodeVisitor;
 import vadl.viam.graph.Node;
+import vadl.viam.graph.NodeList;
 
 /**
  * A read of an {@link ArtificialResource}.
@@ -33,9 +33,9 @@ public class ReadArtificialResNode extends ReadResourceNode {
   private final ArtificialResource resource;
 
   public ReadArtificialResNode(ArtificialResource artificialResource,
-                               @Nullable ExpressionNode address,
+                               NodeList<ExpressionNode> indices,
                                DataType type) {
-    super(address, type);
+    super(indices, type);
     this.resource = artificialResource;
   }
 
@@ -46,12 +46,12 @@ public class ReadArtificialResNode extends ReadResourceNode {
 
   @Override
   public ExpressionNode copy() {
-    return new ReadArtificialResNode(resource, hasAddress() ? address().copy() : null, type());
+    return new ReadArtificialResNode(resource, indices, type());
   }
 
   @Override
   public Node shallowCopy() {
-    return new ReadArtificialResNode(resource, hasAddress() ? address() : null, type());
+    return new ReadArtificialResNode(resource, indices, type());
   }
 
   @Override

--- a/vadl/main/vadl/viam/graph/dependency/ReadMemNode.java
+++ b/vadl/main/vadl/viam/graph/dependency/ReadMemNode.java
@@ -57,8 +57,8 @@ public class ReadMemNode extends ReadResourceNode {
   public void verifyState() {
     super.verifyState();
     ensure(memory.wordSize() * words == type().bitWidth(),
-        "Type missmatch of expected node type and read bit width. %s vs %s",
-        type().bitWidth(), memory.wordSize() * words);
+        "Type mismatch of expected node type and read bit width. %s vs %s",
+        memory.wordSize() * words, type().bitWidth());
   }
 
   public int words() {

--- a/vadl/main/vadl/viam/graph/dependency/WriteArtificialResNode.java
+++ b/vadl/main/vadl/viam/graph/dependency/WriteArtificialResNode.java
@@ -22,6 +22,7 @@ import vadl.javaannotations.viam.DataValue;
 import vadl.viam.ArtificialResource;
 import vadl.viam.graph.GraphNodeVisitor;
 import vadl.viam.graph.Node;
+import vadl.viam.graph.NodeList;
 
 /**
  * A write to an {@link ArtificialResource}.
@@ -35,21 +36,20 @@ public class WriteArtificialResNode extends WriteResourceNode {
    * Writes a value to a {@link ArtificialResource}.
    */
   public WriteArtificialResNode(ArtificialResource resource,
-                                @Nullable ExpressionNode address,
+                                NodeList<ExpressionNode> indices,
                                 ExpressionNode value) {
-    super(address, value);
+    super(indices, value, null);
     this.resource = resource;
   }
 
   /**
    * Writes a value to a {@link ArtificialResource}.
    */
-  public WriteArtificialResNode(ArtificialResource resource, ExpressionNode address,
+  public WriteArtificialResNode(ArtificialResource resource, NodeList<ExpressionNode> indices,
                                 ExpressionNode value,
                                 @Nullable ExpressionNode condition) {
-    super(address, value);
+    super(indices, value, condition);
     this.resource = resource;
-    this.condition = condition;
   }
 
   @Override
@@ -66,7 +66,7 @@ public class WriteArtificialResNode extends WriteResourceNode {
   @Override
   public Node copy() {
     return new WriteArtificialResNode(resource,
-        address().copy(),
+        indices().copy(),
         value.copy(),
         (condition != null ? condition.copy() : null));
   }
@@ -74,7 +74,7 @@ public class WriteArtificialResNode extends WriteResourceNode {
   @Override
   public Node shallowCopy() {
     return new WriteArtificialResNode(resource,
-        address(),
+        indices().copy(),
         value,
         condition);
   }

--- a/vadl/test/resources/testSource/sys/risc-v/rv3264im.vadl
+++ b/vadl/test/resources/testSource/sys/risc-v/rv3264im.vadl
@@ -52,7 +52,7 @@ instruction set architecture RV3264Base = {
   using UShft    = UInt<SftLen>           // 5 or 6 bit unsigned shift ammount
 
   [ zero: X(0) ]                          // register with index 0 always is 0
-  register    X : Index   -> Regs    // integer register with 32 registers of 32 bits
+  register         X : Index   -> Regs    // integer register with 32 registers of 32 bits
   program counter PC : Address            // PC points to the start of the current instruction
   memory         MEM : Address -> Byte    // byte addressed memory
 

--- a/vadl/test/vadl/ast/CallIndexExprTest.java
+++ b/vadl/test/vadl/ast/CallIndexExprTest.java
@@ -1,0 +1,169 @@
+// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.ast;
+
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import vadl.error.Diagnostic;
+import vadl.utils.ViamUtils;
+import vadl.viam.Function;
+import vadl.viam.passes.verification.ViamVerifier;
+
+public class CallIndexExprTest {
+
+  private static String wrapProg(String defs) {
+    return """
+        instruction set architecture TEST = {
+          register A: Bits<32>
+          register X: Bits<5> -> Bits<32>
+        
+          alias register B: Format = A
+          alias register Z: Format = X(1)
+        
+          memory MEM: Bits<64> -> Bits<8>
+        
+          function D -> Bits<32> = 32
+          function E(a: Bits<32>, b: Bits<32>) -> Bits<32> = a + b
+        
+          format Format: Bits<32> =
+          { one   [30..16]
+          , two   [31, 6..2, 15..10]
+          , three [9]
+          , four  [8..7, 1..0]
+          }
+        
+          %s
+        }
+        processor CPU implements TEST = {}
+        """.formatted(defs);
+  }
+
+  static Stream<String> validReadInputs() {
+    return Stream.of(
+        "function T -> Bits<32> = D",
+        "function T -> Bits<1> = D(2)",
+        "function T -> Bits<10> = D(10..1)",
+        "function T -> Bits<2> = D(4, 2)",
+        "function T -> Bits<2> = D(10..1)(4, 2)",
+        "function T -> Bits<2> = E(2, 3)(4, 2)",
+        "function T -> Bits<1> = E(2, 3)(4, 2)(1)",
+        "function T -> Bits<1> = A(1)",
+        "function T -> Bits<10> = A(11..2)",
+        "function T  -> Bits<32> = X(2)",
+        "function T  -> Bits<1> = X(2)(1)",
+        "function T  -> Bits<10> = X(2)(11..2)",
+
+        "function T  -> Bits<15> = B.one",
+        "function T  -> Bits<6> = B.one(10..5)",
+        "function T  -> Bits<6> = B(10..5)",
+        "function T  -> Bits<6> = Z(10..5)",
+        "function T  -> Bits<1> = Z.three",
+
+        "function T  -> Bits<24> = MEM<3>(2)",
+        "function T  -> Bits<6> = MEM<3>(2)(10..5)",
+        "function T  -> Bits<4> = MEM(2)(5..2)",
+        "function T  -> Bits<4> = MEM(2)(4, 2, 3, 4)",
+
+        "function T  -> Bits<10> = X(2)(11..2)"
+    );
+  }
+
+  @MethodSource("validReadInputs")
+  @ParameterizedTest
+  void validReads(String input) {
+    var ast = Assertions.assertDoesNotThrow(
+        () -> VadlParser.parse(wrapProg(input)), "Cannot parse input");
+    var typechecker = new TypeChecker();
+    Assertions.assertDoesNotThrow(() -> typechecker.verify(ast), "Program isn't typesafe");
+    var lowering = new ViamLowering();
+    var spec = Assertions.assertDoesNotThrow(() -> lowering.generate(ast), "Cannot generate VIAM");
+    ViamVerifier.verifyAllIn(spec);
+    var testFuncs = ViamUtils.findDefinitionsByFilter(spec,
+            d -> d instanceof Function && d.simpleName().startsWith("T"))
+        .stream().toList();
+    assertThat(testFuncs).size().isEqualTo(1);
+  }
+
+
+  static Stream<String> validWriteInputs() {
+    return Stream.of(
+        "A(10) := 1",
+        "A(10, 12) := 3",
+        "A(10..5) := 63",
+        "B.one := 63",
+        "Z.one := 63",
+        "MEM(2) := 63",
+        "MEM(2)(7..5) := 3",
+        "MEM<2>(2) := 4",
+        "MEM<2>(2)(11..6) := 4",
+        ""
+    );
+  }
+
+  @MethodSource("validWriteInputs")
+  @ParameterizedTest
+  void validWrites(String input) {
+    var prog = """
+        instruction T: Format = {
+        %s
+        }
+        encoding T = {two = 3}
+        assembly T = ""
+        """.formatted(input);
+
+    var ast = Assertions.assertDoesNotThrow(
+        () -> VadlParser.parse(wrapProg(prog)), "Cannot parse input");
+    var typechecker = new TypeChecker();
+    Assertions.assertDoesNotThrow(() -> typechecker.verify(ast), "Program isn't typesafe");
+    var lowering = new ViamLowering();
+    var spec = Assertions.assertDoesNotThrow(() -> lowering.generate(ast), "Cannot generate VIAM");
+    ViamVerifier.verifyAllIn(spec);
+    var testFuncs = ViamUtils.findDefinitionsByFilter(spec,
+            d -> d instanceof Function && d.simpleName().startsWith("T"))
+        .stream().toList();
+    assertThat(testFuncs).size().isEqualTo(1);
+  }
+
+  static Stream<Arguments> invalidReadInputs() {
+    return Stream.of(
+        Arguments.of("function T -> Bits<32> = D(1)", "Expected `Bits<32>` but got `Bits<1>`"),
+        Arguments.of("function T -> Bits<32> = E(1)(2)", "Expected 2 arguments but got 1."),
+        Arguments.of("function T -> Bits<32> = E(1,2,3)", "Expected 2 arguments but got 3."),
+        Arguments.of("function T -> Bits<32> = E(1,2)(32..1)",
+            "Range start 32 out of bounds for `Bits<32>`"),
+        Arguments.of("function T -> Bits<32> = B.one", "Expected `Bits<32>` but got `Bits<15>`"),
+        Arguments.of("function T -> Bits<1> = MEM<2>(2, 1)",
+            "Expected 1 arguments but got 2.")
+    );
+  }
+
+  @MethodSource("invalidReadInputs")
+  @ParameterizedTest
+  void invalidReads(String input, String error) {
+    var ast = Assertions.assertDoesNotThrow(
+        () -> VadlParser.parse(wrapProg(input)), "Cannot parse input");
+    var typechecker = new TypeChecker();
+    var diag = Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
+    assertThat(diag).hasMessageContaining(error);
+  }
+}

--- a/vadl/test/vadl/ast/ExceptionTest.java
+++ b/vadl/test/vadl/ast/ExceptionTest.java
@@ -96,7 +96,7 @@ public class ExceptionTest {
     var typechecker = new TypeChecker();
     var throwable = assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
     org.assertj.core.api.Assertions.assertThat(throwable.getMessage())
-        .contains("Expected 0 arguments but got `2`");
+        .contains("Expected 0 arguments but got 2");
   }
 
   @Test
@@ -109,7 +109,7 @@ public class ExceptionTest {
     var typechecker = new TypeChecker();
     var throwable = assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
     org.assertj.core.api.Assertions.assertThat(throwable.getMessage())
-        .contains("Expected `Bits<5>` but got `Bits<8>`.");
+        .contains("Expected `Bits<5>` but got `Const<200>`.");
   }
 
   // TODO: Currently this check is implicit given the return type.

--- a/vadl/test/vadl/ast/ExceptionTest.java
+++ b/vadl/test/vadl/ast/ExceptionTest.java
@@ -96,7 +96,7 @@ public class ExceptionTest {
     var typechecker = new TypeChecker();
     var throwable = assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
     org.assertj.core.api.Assertions.assertThat(throwable.getMessage())
-        .contains("Expected 0 arguments but got 2");
+        .contains("Only bit types can be sliced but the target was a `void`");
   }
 
   @Test

--- a/vadl/test/vadl/ast/FrontendIntegrationTest.java
+++ b/vadl/test/vadl/ast/FrontendIntegrationTest.java
@@ -20,6 +20,7 @@ import java.nio.file.Path;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import vadl.viam.passes.verification.ViamVerifier;
 
 public class FrontendIntegrationTest {
 
@@ -40,7 +41,8 @@ public class FrontendIntegrationTest {
     var typechecker = new TypeChecker();
     Assertions.assertDoesNotThrow(() -> typechecker.verify(ast), "Program isn't typesafe");
     var lowering = new ViamLowering();
-    Assertions.assertDoesNotThrow(() -> lowering.generate(ast), "Cannot generate VIAM");
+    var spec = Assertions.assertDoesNotThrow(() -> lowering.generate(ast), "Cannot generate VIAM");
+    ViamVerifier.verifyAllIn(spec);
   }
 
 }


### PR DESCRIPTION
This PR supports slices on assignments. 
For instance: 
```
A(1, 10..2) := someExpr()
A.myField := someExpr()
```

Additionally it completely refactors the typechecking and lowering of `CallIndexExpr`, which had a lot of code duplication, had limitations and was not generalized.