### PR TITLE
iss: Fix Risc-V test runner

### DIFF
--- a/vadl/test/resources/scripts/iss_qemu/compilers/riscv_compiler.py
+++ b/vadl/test/resources/scripts/iss_qemu/compilers/riscv_compiler.py
@@ -57,6 +57,8 @@ async def build_assembly(id: str, core: str) -> Path:
   la x2, tohost
   sd x1, 0(x2)
   
+  1: j 1b # Loop to avoid running off into invalid memory
+  
   .section .tohost, "aw", @progbits
   .align 6; 
   .global tohost; 


### PR DESCRIPTION
The qemu simulation attempts to decode multiple invalid instructions, as it runs off into invalid memory:

Test to reproduce:

```yaml
tests:
- id: BEQ
  debug: true
  asm_core: |-  
    li t0, 123
    add x3, x0, t0
```

The test results report illegal instructions:

```yaml
simLogs:
  stdout: []
  stderr:
  - '[EState] use tohost addr: 0x0'
  - 'qemu-system-rv64im: RV64IM translate, illegal instr, pc: 0x80000018 , insn: 0x0000'
  - ''
  - 'qemu-system-rv64im: RV64IM translate, illegal instr, pc: 0x80000018 , insn: 0x0000'
  - ''
  - '[REG] x0: 0x0000000000000000'
  - '[REG] x1: 0x0000000000000001'
  - '[REG] x2: 0x0000000080001000'
 [...]
```

@Jozott00 Pls check if that makes sense or if there's another reason for this.
