### PR TITLE
lcb: Fixed wikisort benchmark

### DIFF
--- a/vadl/test/resources/embench/benchmark-extras/rv32-run-benchmarks-spike-clang-lcb-O0.sh
+++ b/vadl/test/resources/embench/benchmark-extras/rv32-run-benchmarks-spike-clang-lcb-O0.sh
@@ -12,18 +12,6 @@ rm -r ../src/cubic
 # long jump problem
 rm -r ../src/statemate
 
-# In file included from /src/embench/src/wikisort/libwikisort.c:30:
-# In file included from /opt/riscv-cross/riscv64-unknown-elf/include/limits.h:132:
-# In file included from /src/llvm-final/build/lib/clang/17/include/limits.h:21:
-# /usr/include/limits.h:145:5: error: function-like macro '__GLIBC_USE' is not defined
-#  145 | #if __GLIBC_USE (IEC_60559_BFP_EXT_C2X)
-rm -r ../src/wikisort
-
-# aha-mont64
-# edn
-# sglib-combined
-# crc32
-
 #rm -r ../src/aha-mont64
 #rm -r ../src/crc32
 #rm -r ../src/edn

--- a/vadl/test/resources/embench/benchmark-extras/rv32-run-benchmarks-spike-clang-lcb-O3.sh
+++ b/vadl/test/resources/embench/benchmark-extras/rv32-run-benchmarks-spike-clang-lcb-O3.sh
@@ -10,18 +10,6 @@ cd $(realpath $(dirname "$0"))
 # miscompile
 rm -r ../src/cubic
 
-# In file included from /src/embench/src/wikisort/libwikisort.c:30:
-# In file included from /opt/riscv-cross/riscv64-unknown-elf/include/limits.h:132:
-# In file included from /src/llvm-final/build/lib/clang/17/include/limits.h:21:
-# /usr/include/limits.h:145:5: error: function-like macro '__GLIBC_USE' is not defined
-#  145 | #if __GLIBC_USE (IEC_60559_BFP_EXT_C2X)
-rm -r ../src/wikisort
-
-# aha-mont64
-# edn
-# sglib-combined
-# crc32
-
 #rm -r ../src/aha-mont64
 #rm -r ../src/crc32
 #rm -r ../src/edn

--- a/vadl/test/resources/embench/benchmark-extras/rv64-run-benchmarks-spike-clang-lcb-O0.sh
+++ b/vadl/test/resources/embench/benchmark-extras/rv64-run-benchmarks-spike-clang-lcb-O0.sh
@@ -5,37 +5,14 @@ cd $(realpath $(dirname "$0"))
 
 # Spike
 rm -r ../src/cubic
-#rm -r ../src/minver
-#rm -r ../src/nbody
-#rm -r ../src/st
-#rm -r ../src/ud
-#rm -r ../src/wikisort
 
 rm -r ../src/minver
 rm -r ../src/slre
 rm -r ../src/edn
-rm -r ../src/wikisort
 rm -r ../src/statemate
 
 ../build_spike-clang-O0_rv64.sh
 ./run-benchmark.sh "rv64-spike" ./benchmark_spike_rv64gc.sh
-
-# miscompile
-#rm -r ../src/picojpeg
-#rm -r ../src/sglib-combined
-#rm -r ../src/minver
-#rm -r ../src/slre
-#rm -r ../src/qrduino
-#rm -r ../src/nettle-sha256
-#rm -r ../src/edn
-#rm -r ../src/wikisort
-# long jump problem
-#rm -r ../src/statemate
-
-# aha-mont64
-# edn
-# sglib-combined
-# crc32
 
 #rm -r ../src/aha-mont64
 #rm -r ../src/crc32
@@ -60,4 +37,3 @@ rm -r ../src/statemate
 
 ../build_spike-lcb-O0_rv64.sh
 ./run-benchmark.sh "rv64-spike" ./benchmark_spike_rv64gc.sh
-#cat /src/embench/benchmark-extras/results/rv32-spike/1.json

--- a/vadl/test/resources/embench/benchmark-extras/rv64-run-benchmarks-spike-clang-lcb-O3.sh
+++ b/vadl/test/resources/embench/benchmark-extras/rv64-run-benchmarks-spike-clang-lcb-O3.sh
@@ -9,7 +9,6 @@ rm -r ../src/minver
 rm -r ../src/nbody
 rm -r ../src/st
 rm -r ../src/ud
-rm -r ../src/wikisort
 
 ../build_spike-clang-O3_rv64.sh
 ./run-benchmark.sh "rv64-spike" ./benchmark_spike_rv64gc.sh

--- a/vadl/test/resources/embench/src/wikisort/libwikisort.c
+++ b/vadl/test/resources/embench/src/wikisort/libwikisort.c
@@ -27,7 +27,6 @@
 #include <stdarg.h>
 #include <string.h>
 #include <math.h>
-#include <limits.h>
 
 /* various #defines for the C code */
 #ifndef true


### PR DESCRIPTION
The benchmark uses an include for <limits.h>.
The libc, which we are using, includes the limits.h from the host system which requires a glibc macro which is undefined. It's not clear to me why it is undefind but we actually don't need the <limits.h> include in the benchmark. The easiest fix is to remove it.