### PR TITLE
lcb: Run the optimizer on derived graphs and enhance dumps

### DIFF
--- a/vadl/main/vadl/dump/BehaviorTimelineDisplay.java
+++ b/vadl/main/vadl/dump/BehaviorTimelineDisplay.java
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.dump;
+
+import vadl.viam.graph.Graph;
+
+/**
+ * Allows the display of the {@link Graph} in a timeline.
+ */
+public interface BehaviorTimelineDisplay {
+  String passId();
+  String passName();
+}

--- a/vadl/main/vadl/dump/BehaviorTimelineDisplay.java
+++ b/vadl/main/vadl/dump/BehaviorTimelineDisplay.java
@@ -31,4 +31,9 @@ public interface BehaviorTimelineDisplay {
    * Get the human-readable string from the timeline.
    */
   String passName();
+
+  /**
+   * Get the dot graph of the {@link Graph}.
+   */
+  String dotGraph();
 }

--- a/vadl/main/vadl/dump/BehaviorTimelineDisplay.java
+++ b/vadl/main/vadl/dump/BehaviorTimelineDisplay.java
@@ -22,6 +22,13 @@ import vadl.viam.graph.Graph;
  * Allows the display of the {@link Graph} in a timeline.
  */
 public interface BehaviorTimelineDisplay {
+  /**
+   * Get the pass key id.
+   */
   String passId();
+
+  /**
+   * Get the human-readable string from the timeline.
+   */
   String passName();
 }

--- a/vadl/main/vadl/dump/CollectBehaviorDotGraphPass.java
+++ b/vadl/main/vadl/dump/CollectBehaviorDotGraphPass.java
@@ -90,6 +90,9 @@ public class CollectBehaviorDotGraphPass extends Pass {
     return new Result(result, lastPass);
   }
 
+  /**
+   * Return the dot representation for {@link Graph}.
+   */
   public static String createDotGraphFor(Graph graph) {
     return new DotGraphVisualizer()
         .load(graph)

--- a/vadl/main/vadl/dump/CollectBehaviorDotGraphPass.java
+++ b/vadl/main/vadl/dump/CollectBehaviorDotGraphPass.java
@@ -90,7 +90,7 @@ public class CollectBehaviorDotGraphPass extends Pass {
     return new Result(result, lastPass);
   }
 
-  private static String createDotGraphFor(Graph graph) {
+  public static String createDotGraphFor(Graph graph) {
     return new DotGraphVisualizer()
         .load(graph)
         .visualize();

--- a/vadl/main/vadl/dump/CollectBehaviorDotGraphPass.java
+++ b/vadl/main/vadl/dump/CollectBehaviorDotGraphPass.java
@@ -59,6 +59,25 @@ public class CollectBehaviorDotGraphPass extends Pass {
       Map<Definition, List<String>> behaviors,
       PassResults.SingleResult prevPass
   ) {
+    /**
+     * The {@link CollectBehaviorDotGraphPass} creates a {@link Result} based on the previously
+     * executed pass. However, rendering the {@link Result} might be weird and requires mapping
+     * logic. This method is a helper method which duplicates pass information which simplifies
+     * the rendering. It returns a list where each entry is separate pass result which contains
+     * the dot graph.
+     */
+    public List<PassResults.DotGraphResult> map() {
+      return behaviors.entrySet().stream()
+          .flatMap(x -> x.getValue().stream()
+              .map(behaviorDotGraph -> new PassResults.DotGraphResult(
+                  prevPass.passKey(),
+                  prevPass().pass(),
+                  prevPass().durationMs(),
+                  behaviorDotGraph,
+                  prevPass().skipped(),
+                  x.getKey())))
+          .toList();
+    }
   }
 
   public CollectBehaviorDotGraphPass(GeneralConfiguration configuration) {

--- a/vadl/main/vadl/dump/InfoUtils.java
+++ b/vadl/main/vadl/dump/InfoUtils.java
@@ -89,7 +89,7 @@ public class InfoUtils {
   @SuppressWarnings("LineLength")
   public static Info.Modal createGraphModalWithTimeline(String title,
                                                         String modalTitle,
-                                                        List<Pair<BehaviorTimelineDisplay, String>> passGraphs) {
+                                                        List<BehaviorTimelineDisplay> passGraphs) {
     // create new empty modal info and get its id
     var info = new Info.Modal(title, "");
     var id = info.id();
@@ -121,7 +121,7 @@ public class InfoUtils {
         .mapToObj(i -> {
           var graphUnSelectedClass =
               i == 0 ? "graph-" + id + "-selected" : "graph-" + id + "-unselected";
-          var pass = passGraphs.get(i).left();
+          var pass = passGraphs.get(i);
           var passId = pass.passId();
           return """
               <button
@@ -138,7 +138,7 @@ public class InfoUtils {
             <script id="dot-graph-%s-%s" type="application/dot">
               %s
             </script>
-            """.formatted(id, p.left().passId(), p.right()))
+            """.formatted(id, p.passId(), p.dotGraph()))
         .collect(Collectors.joining("\n"));
 
     var style = """
@@ -201,7 +201,7 @@ public class InfoUtils {
         %s
         """.formatted(id, passBtns, dotGraphScripts, style, setGraphFunc);
 
-    var firstPass = passGraphs.get(0).left();
+    var firstPass = passGraphs.get(0);
     // add JavaScript to render the dot graph when the modal is first opened
     info.jsOnFirstOpen = """
         var initBtn = document.querySelector(

--- a/vadl/main/vadl/dump/InfoUtils.java
+++ b/vadl/main/vadl/dump/InfoUtils.java
@@ -19,7 +19,6 @@ package vadl.dump;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import vadl.pass.PassResults;
 import vadl.utils.Pair;
 
 /**
@@ -90,7 +89,7 @@ public class InfoUtils {
   @SuppressWarnings("LineLength")
   public static Info.Modal createGraphModalWithTimeline(String title,
                                                         String modalTitle,
-                                                        List<Pair<PassResults.SingleResult, String>> passGraphs) {
+                                                        List<Pair<BehaviorTimelineDisplay, String>> passGraphs) {
     // create new empty modal info and get its id
     var info = new Info.Modal(title, "");
     var id = info.id();
@@ -123,7 +122,7 @@ public class InfoUtils {
           var graphUnSelectedClass =
               i == 0 ? "graph-" + id + "-selected" : "graph-" + id + "-unselected";
           var pass = passGraphs.get(i).left();
-          var passId = pass.passKey();
+          var passId = pass.passId();
           return """
               <button
                   id="btn-pass-%s"
@@ -132,14 +131,14 @@ public class InfoUtils {
                   %s
               </button>
               """.formatted(passId, graphUnSelectedClass, id, id, passId,
-              pass.pass().getClass().getSimpleName());
+              pass.passName());
         }).collect(Collectors.joining("\n"));
 
     var dotGraphScripts = passGraphs.stream().map(p -> """
             <script id="dot-graph-%s-%s" type="application/dot">
               %s
             </script>
-            """.formatted(id, p.left().passKey(), p.right()))
+            """.formatted(id, p.left().passId(), p.right()))
         .collect(Collectors.joining("\n"));
 
     var style = """
@@ -209,7 +208,7 @@ public class InfoUtils {
             ".graph-%s-selected"
         );
         setGraph%s("dot-graph-%s-%s", initBtn);
-        """.formatted(id, id, id, firstPass.passKey());
+        """.formatted(id, id, id, firstPass.passId());
 
     return info;
   }

--- a/vadl/main/vadl/dump/infoEnrichers/LcbEnricherCollection.java
+++ b/vadl/main/vadl/dump/infoEnrichers/LcbEnricherCollection.java
@@ -21,6 +21,8 @@ import static vadl.dump.InfoEnricher.forType;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import vadl.dump.BehaviorTimelineDisplay;
+import vadl.dump.CollectBehaviorDotGraphPass;
 import vadl.dump.Info;
 import vadl.dump.InfoEnricher;
 import vadl.dump.InfoUtils;
@@ -28,8 +30,8 @@ import vadl.dump.entities.DefinitionEntity;
 import vadl.gcb.passes.IsaMachineInstructionMatchingPass;
 import vadl.gcb.passes.MachineInstructionCtx;
 import vadl.lcb.passes.llvmLowering.LlvmLoweringPass;
-import vadl.lcb.passes.llvmLowering.domain.LlvmLoweringRecord;
 import vadl.lcb.passes.llvmLowering.tablegen.model.tableGenOperand.TableGenInstructionOperand;
+import vadl.utils.Pair;
 import vadl.viam.Instruction;
 
 /**
@@ -81,7 +83,7 @@ public class LcbEnricherCollection {
                 passResults.lastResultOf(LlvmLoweringPass.class);
 
         if (results != null && definitionEntity.origin() instanceof Instruction instruction) {
-          var result = (LlvmLoweringRecord) results.machineInstructionRecords().get(instruction);
+          var result = results.machineInstructionRecords().get(instruction);
 
           if (result != null) {
             var renderedInputOperands =
@@ -98,6 +100,78 @@ public class LcbEnricherCollection {
                 "TableGen Output Operands",
                 renderedOutputOperands
             ));
+
+            for (var derivedGraph : result.optResults()) {
+              record Unoptimised() implements BehaviorTimelineDisplay {
+                @Override
+                public String passId() {
+                  return "UnoptimisedPassId";
+                }
+
+                @Override
+                public String passName() {
+                  return "Unoptimised";
+                }
+              }
+
+              record Canonicalizer() implements BehaviorTimelineDisplay {
+                @Override
+                public String passId() {
+                  return "CanonicalizerPassId";
+                }
+
+                @Override
+                public String passName() {
+                  return "Canonicalizer";
+                }
+              }
+
+              record AlgebraicOptimisation() implements BehaviorTimelineDisplay {
+                @Override
+                public String passId() {
+                  return "AlgebraicOptimisationPassId";
+                }
+
+                @Override
+                public String passName() {
+                  return "AlgebraicOptimisation";
+                }
+              }
+
+              record BehaviorRewritten() implements BehaviorTimelineDisplay {
+                @Override
+                public String passId() {
+                  return "BehaviorRewrittenPassId";
+                }
+
+                @Override
+                public String passName() {
+                  return "BehaviorRewritten";
+                }
+              }
+
+              List<Pair<BehaviorTimelineDisplay, String>> timeline =
+                  List.of(
+                      Pair.of(new Unoptimised(),
+                          CollectBehaviorDotGraphPass.createDotGraphFor(derivedGraph.before())),
+                      Pair.of(new Canonicalizer(),
+                          CollectBehaviorDotGraphPass.createDotGraphFor(
+                              derivedGraph.canonicalized())),
+                      Pair.of(new AlgebraicOptimisation(),
+                          CollectBehaviorDotGraphPass.createDotGraphFor(
+                              derivedGraph.algebraicSimplified())),
+                      Pair.of(new BehaviorRewritten(),
+                          CollectBehaviorDotGraphPass.createDotGraphFor(
+                              derivedGraph.optimised()))
+                  );
+
+              var info = InfoUtils.createGraphModalWithTimeline(
+                  "Lowered derived llvm graph",
+                  definitionEntity.origin().simpleName() + "Behavior",
+                  timeline
+              );
+              definitionEntity.addInfo(info);
+            }
           }
         }
       });

--- a/vadl/main/vadl/dump/infoEnrichers/LcbEnricherCollection.java
+++ b/vadl/main/vadl/dump/infoEnrichers/LcbEnricherCollection.java
@@ -31,7 +31,6 @@ import vadl.gcb.passes.IsaMachineInstructionMatchingPass;
 import vadl.gcb.passes.MachineInstructionCtx;
 import vadl.lcb.passes.llvmLowering.LlvmLoweringPass;
 import vadl.lcb.passes.llvmLowering.tablegen.model.tableGenOperand.TableGenInstructionOperand;
-import vadl.utils.Pair;
 import vadl.viam.Instruction;
 
 /**
@@ -102,7 +101,7 @@ public class LcbEnricherCollection {
             ));
 
             for (var derivedGraph : result.optResults()) {
-              record Unoptimised() implements BehaviorTimelineDisplay {
+              record Unoptimised(String dot) implements BehaviorTimelineDisplay {
                 @Override
                 public String passId() {
                   return "UnoptimisedPassId";
@@ -112,9 +111,14 @@ public class LcbEnricherCollection {
                 public String passName() {
                   return "Unoptimised";
                 }
+
+                @Override
+                public String dotGraph() {
+                  return dot;
+                }
               }
 
-              record Canonicalizer() implements BehaviorTimelineDisplay {
+              record Canonicalizer(String dot) implements BehaviorTimelineDisplay {
                 @Override
                 public String passId() {
                   return "CanonicalizerPassId";
@@ -124,9 +128,14 @@ public class LcbEnricherCollection {
                 public String passName() {
                   return "Canonicalizer";
                 }
+
+                @Override
+                public String dotGraph() {
+                  return dot;
+                }
               }
 
-              record AlgebraicOptimisation() implements BehaviorTimelineDisplay {
+              record AlgebraicOptimisation(String dot) implements BehaviorTimelineDisplay {
                 @Override
                 public String passId() {
                   return "AlgebraicOptimisationPassId";
@@ -136,9 +145,14 @@ public class LcbEnricherCollection {
                 public String passName() {
                   return "AlgebraicOptimisation";
                 }
+
+                @Override
+                public String dotGraph() {
+                  return dot;
+                }
               }
 
-              record BehaviorRewritten() implements BehaviorTimelineDisplay {
+              record BehaviorRewritten(String dot) implements BehaviorTimelineDisplay {
                 @Override
                 public String passId() {
                   return "BehaviorRewrittenPassId";
@@ -148,22 +162,27 @@ public class LcbEnricherCollection {
                 public String passName() {
                   return "BehaviorRewritten";
                 }
+
+                @Override
+                public String dotGraph() {
+                  return dot;
+                }
               }
 
-              List<Pair<BehaviorTimelineDisplay, String>> timeline =
+              List<BehaviorTimelineDisplay> timeline =
                   List.of(
-                      Pair.of(new Unoptimised(),
+                      new Unoptimised(
                           CollectBehaviorDotGraphPass.createDotGraphFor(derivedGraph.before())),
-                      Pair.of(new Canonicalizer(),
-                          CollectBehaviorDotGraphPass.createDotGraphFor(
-                              derivedGraph.canonicalized())),
-                      Pair.of(new AlgebraicOptimisation(),
-                          CollectBehaviorDotGraphPass.createDotGraphFor(
-                              derivedGraph.algebraicSimplified())),
-                      Pair.of(new BehaviorRewritten(),
-                          CollectBehaviorDotGraphPass.createDotGraphFor(
-                              derivedGraph.optimised()))
+                      new Canonicalizer(CollectBehaviorDotGraphPass.createDotGraphFor(
+                          derivedGraph.canonicalized())),
+                      new AlgebraicOptimisation(CollectBehaviorDotGraphPass.createDotGraphFor(
+                          derivedGraph.algebraicSimplified())),
+                      new BehaviorRewritten(CollectBehaviorDotGraphPass.createDotGraphFor(
+                          derivedGraph.optimised()))
                   );
+
+              // Reverse, so the list is starts at latest.
+              timeline.reversed();
 
               var info = InfoUtils.createGraphModalWithTimeline(
                   "Lowered derived llvm graph",

--- a/vadl/main/vadl/dump/infoEnrichers/ViamEnricherCollection.java
+++ b/vadl/main/vadl/dump/infoEnrichers/ViamEnricherCollection.java
@@ -24,12 +24,12 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import vadl.dump.BehaviorTimelineDisplay;
 import vadl.dump.CollectBehaviorDotGraphPass;
 import vadl.dump.Info;
 import vadl.dump.InfoEnricher;
 import vadl.dump.InfoUtils;
 import vadl.dump.entities.DefinitionEntity;
-import vadl.pass.PassResults;
 import vadl.utils.Pair;
 import vadl.utils.SourceLocation;
 import vadl.viam.DefProp;
@@ -163,12 +163,12 @@ public class ViamEnricherCollection {
 
       // filter only passes that altered graph
       var filteredBehaviorGraphs =
-          new ArrayList<Pair<PassResults.SingleResult, String>>();
+          new ArrayList<Pair<BehaviorTimelineDisplay, String>>();
       behaviorGraphs.forEach(entry -> {
         if (filteredBehaviorGraphs.isEmpty()
             || !filteredBehaviorGraphs.get(filteredBehaviorGraphs.size() - 1).right()
             .equals(entry.right())) {
-          filteredBehaviorGraphs.add(entry);
+          filteredBehaviorGraphs.add(Pair.of(entry.left(), entry.right()));
         }
       });
 

--- a/vadl/main/vadl/lcb/passes/llvmLowering/domain/LlvmLoweringRecord.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/domain/LlvmLoweringRecord.java
@@ -20,6 +20,7 @@ package vadl.lcb.passes.llvmLowering.domain;
 import java.util.Collections;
 import java.util.List;
 import vadl.lcb.passes.llvmLowering.LlvmLoweringPass;
+import vadl.lcb.passes.llvmLowering.strategies.LlvmInstructionLoweringStrategy;
 import vadl.lcb.passes.llvmLowering.tablegen.model.TableGenInstAlias;
 import vadl.lcb.passes.llvmLowering.tablegen.model.TableGenPattern;
 import vadl.viam.CompilerInstruction;
@@ -62,15 +63,20 @@ public abstract class LlvmLoweringRecord {
    */
   public static class Machine extends LlvmLoweringRecord {
     private final Instruction instructionRef;
+    private final List<LlvmInstructionLoweringStrategy.DerivedGraphOptimisationResult>
+        optimisationResult;
 
     /**
      * Constructor.
      */
     public Machine(Instruction instructionRef,
                    LlvmLoweringPass.BaseInstructionInfo info,
-                   List<TableGenPattern> patterns) {
+                   List<TableGenPattern> patterns,
+                   List<LlvmInstructionLoweringStrategy.DerivedGraphOptimisationResult>
+                       optimisationResults) {
       super(info, patterns);
       this.instructionRef = instructionRef;
+      this.optimisationResult = optimisationResults;
     }
 
 
@@ -80,7 +86,11 @@ public abstract class LlvmLoweringRecord {
 
     @Override
     public LlvmLoweringRecord withInfo(LlvmLoweringPass.BaseInstructionInfo baseInstructionInfo) {
-      return new Machine(instructionRef, baseInstructionInfo, patterns());
+      return new Machine(instructionRef, baseInstructionInfo, patterns(), optimisationResult);
+    }
+
+    public List<LlvmInstructionLoweringStrategy.DerivedGraphOptimisationResult> optResults() {
+      return optimisationResult;
     }
   }
 

--- a/vadl/main/vadl/lcb/passes/llvmLowering/strategies/LlvmInstructionLoweringStrategy.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/strategies/LlvmInstructionLoweringStrategy.java
@@ -381,7 +381,7 @@ public abstract class LlvmInstructionLoweringStrategy {
    * @param behavior is the graph which should be optimised.
    */
   private DerivedGraphOptimisationResult optimise(Graph behavior) {
-    var before = behavior.copy();
+    final var before = behavior.copy();
     Canonicalizer.canonicalize(behavior);
     var canonicalized = behavior.copy();
     new AlgebraicSimplifier(AlgebraicSimplificationPass.rules).run(behavior);

--- a/vadl/main/vadl/lcb/passes/llvmLowering/strategies/LlvmInstructionLoweringStrategy.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/strategies/LlvmInstructionLoweringStrategy.java
@@ -114,6 +114,11 @@ import vadl.viam.graph.dependency.SignExtendNode;
 import vadl.viam.graph.dependency.WriteMemNode;
 import vadl.viam.graph.dependency.WriteRegTensorNode;
 import vadl.viam.graph.dependency.WriteResourceNode;
+import vadl.viam.passes.algebraic_simplication.AlgebraicSimplificationPass;
+import vadl.viam.passes.algebraic_simplication.AlgebraicSimplifier;
+import vadl.viam.passes.behaviorRewrite.BehaviorRewritePass;
+import vadl.viam.passes.behaviorRewrite.BehaviorRewriteSimplifier;
+import vadl.viam.passes.canonicalization.Canonicalizer;
 
 /**
  * Defines how a {@link Instruction} will be lowered to {@link TableGenInstruction}.
@@ -308,6 +313,9 @@ public abstract class LlvmInstructionLoweringStrategy {
 
     if (isLowerable) {
       var additionalBehaviors = new ArrayList<Pair<Graph, List<TableGenInstructionOperand>>>();
+      // This list stores the optimisations result which can be then displayed in the dump.
+      var additionalBehaviorsBookkeeping = new ArrayList<DerivedGraphOptimisationResult>();
+
       var patterns = new ArrayList<TableGenPattern>();
       var alternatives = new ArrayList<TableGenPattern>();
 
@@ -318,7 +326,8 @@ public abstract class LlvmInstructionLoweringStrategy {
 
       // Iterate over all the constructed behaviors.
       for (var pair : additionalBehaviors) {
-        var behavior = pair.left();
+        var optimisationResult = optimise(pair.left());
+        var behavior = optimisationResult.optimised;
         var inputOperands = pair.right();
 
         var localPatterns = generatePatterns(instruction,
@@ -336,20 +345,52 @@ public abstract class LlvmInstructionLoweringStrategy {
 
         patterns.addAll(localPatterns);
         alternatives.addAll(localAlternatives);
+        additionalBehaviorsBookkeeping.add(optimisationResult);
       }
 
       return Optional.of(new LlvmLoweringRecord.Machine(
           instruction,
           info,
-          Stream.concat(patterns.stream(), alternatives.stream()).toList()
+          Stream.concat(patterns.stream(), alternatives.stream()).toList(),
+          additionalBehaviorsBookkeeping
       ));
     } else {
       return Optional.of(new LlvmLoweringRecord.Machine(
           instruction,
           info,
-          Collections.emptyList()
-      ));
+          Collections.emptyList(),
+          Collections.emptyList()));
     }
+  }
+
+  /**
+   * Helper class to capture the intermediate results between the optimisations.
+   */
+  public record DerivedGraphOptimisationResult(
+      Graph optimised,
+      Graph before,
+      Graph canonicalized,
+      Graph algebraicSimplified
+  ) {
+  }
+
+  /**
+   * Optimises the given graph by running {@link Canonicalizer}, {@link AlgebraicSimplifier} and
+   * {@link BehaviorRewriteSimplifier}. This method modifies the given parameter and returns it.
+   *
+   * @param behavior is the graph which should be optimised.
+   */
+  private DerivedGraphOptimisationResult optimise(Graph behavior) {
+    var before = behavior.copy();
+    Canonicalizer.canonicalize(behavior);
+    var canonicalized = behavior.copy();
+    new AlgebraicSimplifier(AlgebraicSimplificationPass.rules).run(behavior);
+    var algebraicSimplified = behavior.copy();
+    new BehaviorRewriteSimplifier(BehaviorRewritePass.rules).run(behavior);
+
+    return new DerivedGraphOptimisationResult(
+        behavior, before, canonicalized, algebraicSimplified
+    );
   }
 
   /**

--- a/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/LlvmInstructionLoweringConditionalBranchesStrategyImpl.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/LlvmInstructionLoweringConditionalBranchesStrategyImpl.java
@@ -30,6 +30,7 @@ import static vadl.viam.ViamError.ensurePresent;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -126,8 +127,8 @@ public class LlvmInstructionLoweringConditionalBranchesStrategyImpl
     return new LlvmLoweringRecord.Machine(
         instruction,
         info,
-        allPatterns
-    );
+        allPatterns,
+        Collections.emptyList());
   }
 
   @Override

--- a/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/LlvmInstructionLoweringIndirectJumpStrategyImpl.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/LlvmInstructionLoweringIndirectJumpStrategyImpl.java
@@ -126,8 +126,8 @@ public class LlvmInstructionLoweringIndirectJumpStrategyImpl
     return Optional.of(new LlvmLoweringRecord.Machine(
         instruction,
         info,
-        patterns
-    ));
+        patterns,
+        Collections.emptyList()));
   }
 
   @Override

--- a/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/LlvmInstructionLoweringUnconditionalJumpsStrategyImpl.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/LlvmInstructionLoweringUnconditionalJumpsStrategyImpl.java
@@ -96,8 +96,8 @@ public class LlvmInstructionLoweringUnconditionalJumpsStrategyImpl
     return new LlvmLoweringRecord.Machine(
         instruction,
         info.withFlags(flags),
-        Collections.emptyList()
-    );
+        Collections.emptyList(),
+        Collections.emptyList());
   }
 
 

--- a/vadl/main/vadl/pass/PassResults.java
+++ b/vadl/main/vadl/pass/PassResults.java
@@ -20,6 +20,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
+import vadl.dump.BehaviorTimelineDisplay;
 import vadl.pass.exception.PassError;
 
 /**
@@ -198,7 +199,16 @@ public final class PassResults {
       long durationMs,
       @Nullable Object result,
       boolean skipped
-  ) {
+  ) implements BehaviorTimelineDisplay {
+    @Override
+    public String passId() {
+      return passKey.value();
+    }
+
+    @Override
+    public String passName() {
+      return pass.getClass().getSimpleName();
+    }
   }
 
 }

--- a/vadl/main/vadl/pass/PassResults.java
+++ b/vadl/main/vadl/pass/PassResults.java
@@ -18,10 +18,12 @@ package vadl.pass;
 
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import vadl.dump.BehaviorTimelineDisplay;
 import vadl.pass.exception.PassError;
+import vadl.viam.Definition;
 
 /**
  * Holds and maintains the pass results of all executed passes.
@@ -193,13 +195,69 @@ public final class PassResults {
    * Holds all components of a finished pass execution, namely the unique {@link PassKey},
    * the actual {@link Pass} instance and the result object from the pass execution.
    */
-  public record SingleResult(
-      PassKey passKey,
-      Pass pass,
-      long durationMs,
-      @Nullable Object result,
-      boolean skipped
-  ) implements BehaviorTimelineDisplay {
+  public static class SingleResult {
+    protected final PassKey passKey;
+    protected final Pass pass;
+    private final long durationMs;
+    @Nullable
+    protected final Object result;
+    private final boolean skipped;
+
+    /**
+     * Constructor.
+     */
+    public SingleResult(PassKey passKey, Pass pass, long durationMs, @Nullable Object result,
+                        boolean skipped) {
+      this.passKey = passKey;
+      this.pass = pass;
+      this.durationMs = durationMs;
+      this.result = result;
+      this.skipped = skipped;
+    }
+
+    public long durationMs() {
+      return durationMs;
+    }
+
+    public Pass pass() {
+      return pass;
+    }
+
+    public PassKey passKey() {
+      return passKey;
+    }
+
+    @Nullable
+    public Object result() {
+      return result;
+    }
+
+    public boolean skipped() {
+      return skipped;
+    }
+  }
+
+  /**
+   * This class is a {@link SingleResult} but indicates that the {@code result} is a dot graph
+   * which renderable for the behavior timeline in the dump.
+   */
+  public static class DotGraphResult extends SingleResult implements BehaviorTimelineDisplay {
+    // VIAM definition of the graph.
+    private final Definition definition;
+
+    /**
+     * Constructor.
+     */
+    public DotGraphResult(PassKey passKey,
+                          Pass pass,
+                          long durationMs,
+                          String result,
+                          boolean skipped,
+                          Definition definition) {
+      super(passKey, pass, durationMs, result, skipped);
+      this.definition = definition;
+    }
+
     @Override
     public String passId() {
       return passKey.value();
@@ -209,6 +267,15 @@ public final class PassResults {
     public String passName() {
       return pass.getClass().getSimpleName();
     }
-  }
 
+    @Override
+    public String dotGraph() {
+      // We know that the cast is ok because the constructor also expects a string.
+      return (String) Objects.requireNonNull(result);
+    }
+
+    public Definition definition() {
+      return definition;
+    }
+  }
 }


### PR DESCRIPTION
It is sometimes necessary to create multiple graphs based on the original viam graph. This PR adds the functionality s.t these graphs get also optimised. Additionally, they will be dumped so that a developer can see why a LLVM graph was not lowered properly.

For example, the ADDI has a VIAM behavior, a lowered LCB graph and an additional graph where the immediate is replaced by a frame index.
<img width="1167" alt="Screenshot 2025-05-15 at 12 52 32" src="https://github.com/user-attachments/assets/1acb465a-1822-4c47-a599-7dd22d52d17c" />
