### PR TITLE
viam: Allow multiple field references in FieldAccess

### DIFF
--- a/vadl/main/vadl/cppCodeGen/common/GcbAccessOrExtractionFunctionCodeGenerator.java
+++ b/vadl/main/vadl/cppCodeGen/common/GcbAccessOrExtractionFunctionCodeGenerator.java
@@ -37,9 +37,8 @@ public class GcbAccessOrExtractionFunctionCodeGenerator extends AccessFunctionCo
    */
   public GcbAccessOrExtractionFunctionCodeGenerator(GcbCppFunctionForFieldAccess accessFunction,
                                                     Format.FieldAccess fieldAccess,
-                                                    String functionName,
-                                                    String fieldName) {
-    super(accessFunction, fieldAccess, functionName, fieldName);
+                                                    String functionName) {
+    super(accessFunction, fieldAccess, functionName);
   }
 
   /**
@@ -48,9 +47,8 @@ public class GcbAccessOrExtractionFunctionCodeGenerator extends AccessFunctionCo
   public GcbAccessOrExtractionFunctionCodeGenerator(
       GcbImmediateExtractionCppFunction extractionFunction,
       Format.FieldAccess fieldAccess,
-      String functionName,
-      String fieldName) {
-    super(extractionFunction, fieldAccess, functionName, fieldName);
+      String functionName) {
+    super(extractionFunction, fieldAccess, functionName);
   }
 
   @Override

--- a/vadl/main/vadl/lcb/template/superClass/AbstractEmitImmediateFilePass.java
+++ b/vadl/main/vadl/lcb/template/superClass/AbstractEmitImmediateFilePass.java
@@ -62,22 +62,19 @@ public abstract class AbstractEmitImmediateFilePass extends LcbTemplateRendering
         decodeFunctions.values().stream().map(x ->
                 new GcbAccessOrExtractionFunctionCodeGenerator(x,
                     x.fieldAccess(),
-                    x.identifier.lower(),
-                    x.fieldAccess().fieldRef().simpleName()).genFunctionDefinition())
+                    x.identifier.lower()).genFunctionDefinition())
             .sorted()
             .toList(),
         "decodeFunctionNames", decodeFunctionNames,
         "encodeFunctions",
         encodeFunctions.values().stream()
             .map(x -> new GcbAccessOrExtractionFunctionCodeGenerator(x, x.fieldAccess(),
-                x.identifier.lower(),
-                x.fieldAccess().fieldRef().simpleName()).genFunctionDefinition())
+                x.identifier.lower()).genFunctionDefinition())
             .sorted()
             .toList(),
         "predicateFunctions", predicateFunctions.values().stream()
             .map(x -> new GcbAccessOrExtractionFunctionCodeGenerator(x, x.fieldAccess(),
-                x.identifier.lower(),
-                x.fieldAccess().fieldRef().simpleName()).genFunctionDefinition())
+                x.identifier.lower()).genFunctionDefinition())
             .sorted()
             .toList());
   }

--- a/vadl/main/vadl/vdt/target/iss/IssDecisionTreeCodeGenerator.java
+++ b/vadl/main/vadl/vdt/target/iss/IssDecisionTreeCodeGenerator.java
@@ -25,6 +25,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import vadl.cppCodeGen.CppTypeMap;
 import vadl.cppCodeGen.common.AccessFunctionCodeGenerator;
 import vadl.types.BitsType;
@@ -343,10 +345,9 @@ public class IssDecisionTreeCodeGenerator implements Visitor<Void> {
    * @return The C++ expression for the field access
    */
   private String accessField(Format.FieldAccess access) {
-    var fieldRef = access.fieldRef();
-    var refName = "a->" + fieldRef.simpleName();
-
-    var generator = new AccessFunctionCodeGenerator(access, null, refName);
+    var fieldRefs = access.fieldRefs().stream()
+        .collect(Collectors.toMap(Function.identity(), f -> "a->" + f.simpleName()));
+    var generator = new AccessFunctionCodeGenerator(access, null, fieldRefs);
     return generator.genReturnExpression();
   }
 

--- a/vadl/main/vadl/viam/Format.java
+++ b/vadl/main/vadl/viam/Format.java
@@ -280,7 +280,7 @@ public class Format extends Definition implements DefProp.WithType {
     @Nullable
     private Function encoding;
     private final Function predicate;
-    private final Field fieldRef;
+    private final List<Field> fieldRefs;
 
 
     /**
@@ -298,12 +298,13 @@ public class Format extends Definition implements DefProp.WithType {
 
       this.accessFunction = accessFunction;
 
-      var decodeFormatRefs = accessFunction.behavior().getNodes(FieldRefNode.class).toList();
-      ensure(!decodeFormatRefs.isEmpty(),
+      var decodeFormatFields = accessFunction.behavior().getNodes(FieldRefNode.class)
+          .map(FieldRefNode::formatField).toList();
+      ensure(!decodeFormatFields.isEmpty(),
           "Immediate decode function must reference at least one format field. Got: %s",
-          decodeFormatRefs);
+          decodeFormatFields);
 
-      this.fieldRef = decodeFormatRefs.get(0).formatField();
+      this.fieldRefs = decodeFormatFields;
       this.encoding = encoding;
       this.predicate = predicate;
     }
@@ -337,8 +338,19 @@ public class Format extends Definition implements DefProp.WithType {
       return predicate;
     }
 
+    /**
+     * Returns the first format field the field access refers to.
+     *
+     * @deprecated As there can be multiple format fields.
+     */
+    @Deprecated
     public Field fieldRef() {
-      return fieldRef;
+      ensure(fieldRefs.size() == 1, "Only one field reference expected, but found: %s", fieldRefs);
+      return fieldRefs().getFirst();
+    }
+
+    public List<Field> fieldRefs() {
+      return fieldRefs;
     }
 
     @Override
@@ -349,12 +361,13 @@ public class Format extends Definition implements DefProp.WithType {
     @Override
     public void verify() {
       super.verify();
-      if (encoding != null) {
-        ensure(encoding.returnType() instanceof DataType
-                && encoding.returnType().isTrivialCastTo(fieldRef.type()),
-            "Encoding type mismatch. Couldn't match encoding type %s with field reference type %s",
-            encoding.returnType(), fieldRef().type());
-      }
+      // TODO: We must specify how we treat encoding of multiple fields from one access function
+      // if (encoding != null) {
+      // ensure(encoding.returnType() instanceof DataType
+      //         && encoding.returnType().isTrivialCastTo(fieldRef.type()),
+      //     "Encoding type mismatch. Couldn't match encoding type %s with field reference type %s",
+      //     encoding.returnType(), fieldRef().type());
+      // }
     }
 
     @Override
@@ -379,12 +392,12 @@ public class Format extends Definition implements DefProp.WithType {
       FieldAccess that = (FieldAccess) o;
       return Objects.equals(accessFunction, that.accessFunction)
           && Objects.equals(encoding, that.encoding) && Objects.equals(predicate, that.predicate)
-          && Objects.equals(fieldRef, that.fieldRef);
+          && Objects.equals(fieldRefs, that.fieldRefs);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(accessFunction, encoding, predicate, fieldRef);
+      return Objects.hash(accessFunction, encoding, predicate, fieldRefs);
     }
   }
 }

--- a/vadl/test/vadl/cppCodeGen/EncodingCodeGeneratorCppVerificationTest.java
+++ b/vadl/test/vadl/cppCodeGen/EncodingCodeGeneratorCppVerificationTest.java
@@ -141,13 +141,11 @@ public class EncodingCodeGeneratorCppVerificationTest extends AbstractCppCodeGen
                   GcbCppFunctionForFieldAccess encodingFunction) {
     var decodeFunctionGenerator =
         new GcbAccessOrExtractionFunctionCodeGenerator(accessFunction, accessFunction.fieldAccess(),
-            accessFunction.identifier.lower(),
-            accessFunction.fieldAccess().fieldRef().simpleName());
+            accessFunction.identifier.lower());
     var encodeFunctionGenerator =
         new GcbAccessOrExtractionFunctionCodeGenerator(encodingFunction,
             encodingFunction.fieldAccess(),
-            encodingFunction.identifier.lower(),
-            encodingFunction.fieldAccess().fieldRef().simpleName());
+            encodingFunction.identifier.lower());
 
     var decodeFunction = decodeFunctionGenerator.genFunctionDefinition();
     var encodeFunction = encodeFunctionGenerator.genFunctionDefinition();

--- a/vadl/test/vadl/lcb/riscv/riscv64/verification/ImmediateExtractionCodeGeneratorCppVerificationRiscv64Test.java
+++ b/vadl/test/vadl/lcb/riscv/riscv64/verification/ImmediateExtractionCodeGeneratorCppVerificationRiscv64Test.java
@@ -137,7 +137,7 @@ public class ImmediateExtractionCodeGeneratorCppVerificationRiscv64Test extends 
         new GcbImmediateExtractionCppFunction(fieldAccess.fieldRef().extractFunction());
     var extractionFunctionCodeGenerator =
         new GcbAccessOrExtractionFunctionCodeGenerator(extractFunction,
-            fieldAccess, extractFunction.identifier.lower(), fieldAccess.fieldRef().simpleName());
+            fieldAccess, extractFunction.identifier.lower());
     var extractionFunctionCode = extractionFunctionCodeGenerator.genFunctionDefinition();
     var extractionFunctionName = extractionFunctionCodeGenerator.genFunctionName();
 


### PR DESCRIPTION
Until now, we assumed that there is exactly one field a field access is referring to. 
However, there might be multiple fields referenced in a single field access. E.g. the AArch64 spec defines
```
  format BitFieldMoveFormat: Instr =  // bit field move format
    { ...
    , immr       : Bits6              // rotate right count (bit field low position)
    , imms       : Bits6              // bit field length -1 or high position
    , ...
    , rightWSize = BitfieldRightWSize (imms(4..0), immr(4..0))
    , rightXSize = BitfieldRightXSize (imms, immr)
    }
```

The `Format.FieldAccess` VIAM definition now holds a list of field references (instead of a single one). The `fieldRef()` method is still available as we currently don't have a good way to handle multiple field references in the LCB.

Additionally, the decoder now correctly handle multiple field references. (@rascmatt)