### PR TITLE
cli: Add default ISA lowering of root ISA

### DIFF
--- a/vadl-cli/main/vadl/cli/CheckCommand.java
+++ b/vadl-cli/main/vadl/cli/CheckCommand.java
@@ -16,13 +16,11 @@
 
 package vadl.cli;
 
-import java.io.IOException;
 import java.util.concurrent.Callable;
 import picocli.CommandLine.Command;
 import vadl.configuration.GeneralConfiguration;
 import vadl.pass.PassOrder;
 import vadl.pass.PassOrders;
-import vadl.viam.passes.verification.ViamVerificationPass;
 
 /**
  * The Command does provide the check subcommand.
@@ -35,7 +33,7 @@ import vadl.viam.passes.verification.ViamVerificationPass;
 public class CheckCommand extends BaseCommand implements Callable<Integer> {
 
   @Override
-  PassOrder passOrder(GeneralConfiguration configuration) throws IOException {
-    return PassOrders.viam(configuration).untilFirst(ViamVerificationPass.class);
+  PassOrder passOrder(GeneralConfiguration configuration) {
+    return PassOrders.check(configuration);
   }
 }

--- a/vadl/main/vadl/pass/PassOrders.java
+++ b/vadl/main/vadl/pass/PassOrders.java
@@ -123,6 +123,25 @@ import vadl.viam.passes.verification.ViamVerificationPass;
 public class PassOrders {
 
   /**
+   * Used by the {@code check} command.
+   * It doesn't apply transformation to the VIAM, however, it checks if the VDT can be constructed.
+   */
+  public static PassOrder check(GeneralConfiguration configuration) {
+    var order = new PassOrder();
+    order.add(new ViamCreationPass(configuration));
+
+    addHtmlDump(order, configuration, "VIAM Creation",
+        "Dump directly after frontend generated VIAM.");
+
+    order.add(new ViamVerificationPass(configuration));
+
+    // check if VDT can be constructed
+    addDecodePasses(order, configuration);
+
+    return order;
+  }
+
+  /**
    * Return the viam passes.
    */
   public static PassOrder viam(GeneralConfiguration configuration) throws IOException {
@@ -131,15 +150,6 @@ public class PassOrders {
     // this is just a pseudo pass to add the behavior to the HTML dump
     // at the stage directly after the VIAM creation.
     order.add(new ViamCreationPass(configuration));
-
-    if (configuration.getClass() == GeneralConfiguration.class) {
-      // only emit this dump if it is no specialized configuration (e.g. check)
-      // this avoids unnecessary (long) dumps when generating the ISS or LCB
-      // which have their own dumps at a later point.
-      addHtmlDump(order, configuration, "VIAM Creation",
-          "Dump directly after frontend generated VIAM.");
-    }
-
     order.add(new ViamVerificationPass(configuration));
 
     order.add(new StatusBuiltInInlinePass(configuration));
@@ -511,7 +521,7 @@ public class PassOrders {
    * @param order  into which the passes will be inserted.
    * @param config from which to decide if a dump is wanted.
    */
-  private static void addDecodePasses(PassOrder order, IssConfiguration config) {
+  private static void addDecodePasses(PassOrder order, GeneralConfiguration config) {
 
     // VDT Decode Passes
     order.add(new VdtLoweringPass(config));

--- a/vadl/main/vadl/types/BuiltInTable.java
+++ b/vadl/main/vadl/types/BuiltInTable.java
@@ -809,7 +809,7 @@ public class BuiltInTable {
    * {@code function rol ( a : Bits<N>, b : UInt<M> ) ->Bits<N> }
    */
   public static final BuiltIn ROL =
-      func("VADL::rol", Type.relation(BitsType.class, UIntType.class, BitsType.class))
+      func("VADL::rol", "<<>", Type.relation(BitsType.class, UIntType.class, BitsType.class))
           .takesDefault()
           .returnsFirstBitWidth(BitsType.class)
           .build();
@@ -841,7 +841,7 @@ public class BuiltInTable {
    * {@code function ror ( a : Bits<N>, b : UInt<M> ) -> Bits<N> }
    */
   public static final BuiltIn ROR =
-      func("VADL::ror", Type.relation(BitsType.class, UIntType.class, BitsType.class))
+      func("VADL::ror", "<>>", Type.relation(BitsType.class, UIntType.class, BitsType.class))
           .takesDefault()
           .returnsFirstBitWidth(BitsType.class)
           .build();

--- a/vadl/main/vadl/vdt/impl/theiling/TheilingDecodeTreeGenerator.java
+++ b/vadl/main/vadl/vdt/impl/theiling/TheilingDecodeTreeGenerator.java
@@ -193,9 +193,6 @@ public class TheilingDecodeTreeGenerator implements DecodeTreeGenerator<Instruct
    * @param instructions the instructions to validate
    */
   private void validate(Collection<Instruction> instructions) {
-    if (instructions == null) {
-      throw new IllegalArgumentException("Instructions cannot be null");
-    }
     if (instructions.isEmpty()) {
       throw new IllegalArgumentException("Instructions cannot be empty");
     }
@@ -203,11 +200,6 @@ public class TheilingDecodeTreeGenerator implements DecodeTreeGenerator<Instruct
     final int expectedWidth = instructions.iterator().next().width();
 
     for (Instruction instruction : instructions) {
-
-      if (instruction.pattern() == null) {
-        throw new IllegalArgumentException("Instruction fixed bit pattern cannot be null");
-      }
-
       if (instruction.width() <= 0) {
         throw new IllegalArgumentException("Instruction width must be greater than 0");
       }

--- a/vadl/main/vadl/vdt/passes/VdtLoweringPass.java
+++ b/vadl/main/vadl/vdt/passes/VdtLoweringPass.java
@@ -18,8 +18,8 @@ package vadl.vdt.passes;
 
 import java.io.IOException;
 import javax.annotation.Nullable;
-import vadl.configuration.IssConfiguration;
-import vadl.iss.passes.AbstractIssPass;
+import vadl.configuration.GeneralConfiguration;
+import vadl.pass.Pass;
 import vadl.pass.PassName;
 import vadl.pass.PassResults;
 import vadl.vdt.impl.theiling.TheilingDecodeTreeGenerator;
@@ -33,14 +33,14 @@ import vadl.viam.ViamError;
 /**
  * Lowering pass that creates the VDT (VADL Decode Tree) from the VIAM definition.
  */
-public class VdtLoweringPass extends AbstractIssPass {
+public class VdtLoweringPass extends Pass {
 
   /**
    * Constructor for the VDT Lowering Pass.
    *
    * @param configuration the configuration
    */
-  public VdtLoweringPass(IssConfiguration configuration) {
+  public VdtLoweringPass(GeneralConfiguration configuration) {
     super(configuration);
   }
 

--- a/vadl/main/vadl/vdt/passes/VdtLoweringPass.java
+++ b/vadl/main/vadl/vdt/passes/VdtLoweringPass.java
@@ -28,7 +28,6 @@ import vadl.vdt.utils.BitPattern;
 import vadl.vdt.utils.Instruction;
 import vadl.vdt.utils.PatternUtils;
 import vadl.viam.Specification;
-import vadl.viam.ViamError;
 
 /**
  * Lowering pass that creates the VDT (VADL Decode Tree) from the VIAM definition.
@@ -55,13 +54,19 @@ public class VdtLoweringPass extends Pass {
 
     var isa = viam.isa().orElse(null);
     if (isa == null) {
-      throw new ViamError("No ISA found in the specification");
+      return null;
     }
 
     var insns = isa.ownInstructions()
         .stream()
         .map(this::prepareInstruction)
         .toList();
+
+    if (insns.isEmpty()) {
+      // just skip if there are no instructions.
+      // this will only happen if we use the check command
+      return null;
+    }
 
     return new TheilingDecodeTreeGenerator().generate(insns);
   }


### PR DESCRIPTION
This PR lowers the root ISA, if there was no generator entry definition (such as `processor`) and a single root ISA could be determined.

Additionally the VDT generator is now executed on `check`, to validate that there are no overlapping instructions.

Currently, the VDT generator throws runtime exceptions if there are problems with the specification. @rascmatt will fix this by throwing detailed diagnostic user errors.