### PR TITLE
ci: Added aarch64 images

### DIFF
--- a/.github/workflows/build-aarch64-toolchain.yml
+++ b/.github/workflows/build-aarch64-toolchain.yml
@@ -1,0 +1,38 @@
+name: Build Aarch64 GNU Toolchain Image
+
+on:
+  workflow_dispatch: # Allows manual triggering
+
+permissions:
+  packages: write
+  contents: read
+
+jobs:
+  build:
+    uses: ./.github/workflows/reusable-image-build.yml
+    strategy:
+      matrix:
+        target:
+          - platform: linux/arm64
+            runner: self-hosted-arm64
+          - platform: linux/amd64
+            runner: self-hosted-x64
+    secrets:
+      X06_KEYCHAIN_PASSWORD: ${{ secrets.X06_KEYCHAIN_PASSWORD }}
+    with:
+      image: ghcr.io/openvadl/aarch64-toolchain
+      context: docker/iss/aarch64-toolchain
+      platform: ${{ matrix.target.platform }}
+      runner: ${{ matrix.target.runner }}
+      tags: |
+        latest
+
+  merge:
+    needs: build
+    uses: ./.github/workflows/reusable-image-merge.yml
+    secrets:
+      X06_KEYCHAIN_PASSWORD: ${{ secrets.X06_KEYCHAIN_PASSWORD }}
+    with:
+      image: ghcr.io/openvadl/aarch64-toolchain
+      tags: |
+        latest

--- a/.github/workflows/build-qemu-aarch64.yml
+++ b/.github/workflows/build-qemu-aarch64.yml
@@ -1,0 +1,34 @@
+name: Build QEMU aarch64 base image
+
+on:
+  workflow_dispatch: # Allows manual triggering
+
+permissions:
+  packages: write
+  contents: read
+
+jobs:
+  build:
+    uses: ./.github/workflows/reusable-image-build.yml
+    strategy:
+      matrix:
+        target:
+          - platform: linux/arm64
+            runner: self-hosted-arm64
+          - platform: linux/amd64
+            runner: self-hosted-x64
+    secrets:
+      X06_KEYCHAIN_PASSWORD: ${{ secrets.X06_KEYCHAIN_PASSWORD }}
+    with:
+      image: ghcr.io/openvadl/qemu-aarch64-base
+      context: docker/iss/qemu-aarch64
+      platform: ${{ matrix.target.platform }}
+      runner: ${{ matrix.target.runner }}
+
+  merge:
+    needs: build
+    uses: ./.github/workflows/reusable-image-merge.yml
+    secrets:
+      X06_KEYCHAIN_PASSWORD: ${{ secrets.X06_KEYCHAIN_PASSWORD }}
+    with:
+      image: ghcr.io/openvadl/qemu-aarch64-base

--- a/docker/iss/aarch64-toolchain/Dockerfile
+++ b/docker/iss/aarch64-toolchain/Dockerfile
@@ -1,0 +1,63 @@
+# Base build stage for all architectures
+FROM ubuntu:22.04 AS build
+
+WORKDIR /work
+
+RUN apt update
+RUN apt install -y wget tar xz-utils
+
+WORKDIR /work
+RUN mkdir /opt/aarch64
+
+RUN set -ex; \
+    ARCH=$(uname -m); \
+    case "$ARCH" in \
+        x86_64) SUFFIX="x86_64-aarch64-none-linux-gnu.tar.xz" ;; \
+        aarch64) SUFFIX="aarch64-aarch64-none-linux-gnu.tar.xz" ;; \
+        *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;; \
+    esac; \
+    wget -O /work/output.tar.xz "https://developer.arm.com/-/media/Files/downloads/gnu/14.2.rel1/binrel/arm-gnu-toolchain-14.2.rel1-$SUFFIX"; \
+    tar --strip-components=1 -xf /work/output.tar.xz -C /opt/aarch64
+
+FROM ubuntu:22.04 AS final
+COPY --from=build /opt/aarch64 /opt/aarch64
+
+ENV PATH=/opt/aarch64/bin:$PATH
+
+RUN apt update && \
+    apt install -y python3  \
+    python3-pip libmpc-dev libmpfr-dev libgmp-dev build-essential  \
+    gperf libtool patchutils bc zlib1g-dev libexpat-dev       \
+    libglib2.0-dev libslirp-dev
+
+# Testing toolchain commands
+
+RUN aarch64-none-linux-gnu-addr2line --help; \
+ aarch64-none-linux-gnu-ar --help; \
+ aarch64-none-linux-gnu-as --help; \
+ aarch64-none-linux-gnu-c++ --help; \
+ aarch64-none-linux-gnu-c++filt --help; \
+ aarch64-none-linux-gnu-cpp --help; \
+ aarch64-none-linux-gnu-elfedit --help; \
+ aarch64-none-linux-gnu-g++ --help; \
+ aarch64-none-linux-gnu-gcc --help; \
+ aarch64-none-linux-gnu-gcc-ar --help; \
+ aarch64-none-linux-gnu-gcc-nm --help; \
+ aarch64-none-linux-gnu-gcc-ranlib --help; \
+ aarch64-none-linux-gnu-gcov --help; \
+ aarch64-none-linux-gnu-gcov-dump --help; \
+ aarch64-none-linux-gnu-gcov-tool --help; \
+ aarch64-none-linux-gnu-gdb --help; \
+ aarch64-none-linux-gnu-gprof --help; \
+ aarch64-none-linux-gnu-ld --help; \
+ aarch64-none-linux-gnu-ld.bfd --help; \
+ aarch64-none-linux-gnu-lto-dump --help; \
+ aarch64-none-linux-gnu-nm --help; \
+ aarch64-none-linux-gnu-objcopy --help; \
+ aarch64-none-linux-gnu-objdump --help; \
+ aarch64-none-linux-gnu-ranlib --help; \
+ aarch64-none-linux-gnu-readelf --help; \
+ aarch64-none-linux-gnu-run --help; \
+ aarch64-none-linux-gnu-size --help; \
+ aarch64-none-linux-gnu-strings --help; \
+ aarch64-none-linux-gnu-strip --help

--- a/docker/iss/aarch64-toolchain/README.md
+++ b/docker/iss/aarch64-toolchain/README.md
@@ -1,7 +1,7 @@
 # RISC-V Toolchain Image
 
-This dockerfile provides the instructions to build an ubuntu docker image with the [RISC-V
-GNU toolchain]() installed.
+This dockerfile provides the instructions to build an ubuntu docker image with the [Aarch64
+gnu toolchain]() installed.
 
 The RISC-V GNU toolchain is pretty large and takes some time to build.
 Thus is it very time-consuming to build a multi-platform image on one machine
@@ -40,15 +40,15 @@ Copy both hashes and place paste them as argument to this command
 
 ```bash
 docker buildx imagetools create \
-    -t <username>/riscv-toolchain:<version-tag> \
-    <username>/riscv-toolchain@<sha256-hash-machine-1> \
-    <username>/riscv-toolchain@<sha256-hash-machine-2>
+    -t <username>/aarch64-toolchain:<version-tag> \
+    <username>/aarch64-toolchain@<sha256-hash-machine-1> \
+    <username>/aarch64-toolchain@<sha256-hash-machine-2>
 ```
 
 Now you can inspect the image build using
 
 ```bash
-docker buildx imagetools inspect <username>/riscv-toolchain:<version-tag>
+docker buildx imagetools inspect <username>/aarch64-toolchain:<version-tag>
 ```
 
 It is also available on the container repository now.

--- a/docker/iss/qemu-aarch64/Dockerfile
+++ b/docker/iss/qemu-aarch64/Dockerfile
@@ -1,0 +1,10 @@
+FROM ghcr.io/openvadl/qemu-base@sha256:f4cb8676c5a3cdb4f886b8bbcde6bae07c3b03e9f8a78bc216a7358bdff2054b AS build
+
+WORKDIR /qemu/build
+RUN ../configure --target-list=aarch64-softmmu
+RUN make -j $(nproc)
+RUN make install
+
+FROM ubuntu:22.04 as final
+COPY --from=build /usr/local/bin/ /usr/local/bin
+COPY --from=build /opt/riscv /opt/riscv

--- a/docker/iss/qemu-aarch64/README.md
+++ b/docker/iss/qemu-aarch64/README.md
@@ -1,0 +1,12 @@
+# OpenVADL QEMU Image
+
+This image contains the sources and prebuild of QEMU with Aarch64.
+
+To build a push the image run
+
+```bash
+docker buildx build --platform linux/amd64,linux/arm64 -t open-vadl/qemu-aarch64:latest -f Dockerfile --push .
+```
+
+This will quite some time. You want to ensure a stable
+internet connection.

--- a/docker/iss/qemu-riscv64/README.md
+++ b/docker/iss/qemu-riscv64/README.md
@@ -2,7 +2,7 @@
 
 This image contains the sources and prebuild of QEMU with RISCV.
 
-To build an push the image run
+To build a push the image run
 
 ```bash
 docker buildx build --platform linux/amd64,linux/arm64 -t open-vadl/qemu-riscv64:latest -f Dockerfile --push .


### PR DESCRIPTION
This PR adds an image for aarch64 qemu and an image with an aarch64 toolchain (bare metal and linux gnu).