### PR TITLE
language: Add CTZ and CTO built-ins

### DIFF
--- a/docs/refman/refmanual.md
+++ b/docs/refman/refmanual.md
@@ -103,10 +103,12 @@ type casting rules from `Bits<N>`:
 
 \lbl{refman_literals}
 
-For the type `Bool` there exist the two boolean literals `true` (value `1` as `Bits<1>`) and `false` (value `0` as `Bits<1>`).
+For the type `Bool` there exist the two boolean literals `true` (value `1` as `Bits<1>`) and `false` (value `0` as
+`Bits<1>`).
 
 Binary literals start with `0b` and hexadecimal literals start with `0x`.
-Binary, decimal and hexadecimal literals represent signed integers with an arbitrary length, they are implemented as a `BigInteger`.
+Binary, decimal and hexadecimal literals represent signed integers with an arbitrary length, they are implemented as a
+`BigInteger`.
 In the evaluation of constant expressions no truncation can happen.
 The apostrophe can be used to make the representation more comprehensible (see Listing \r{lst_literals}).
 
@@ -123,7 +125,6 @@ constant bitEx  = binLit + decEx // has the value 32
 ~~~
 
 \endlisting
-
 
 ### Tensors
 
@@ -421,20 +422,22 @@ function rrx ( a : Bits<N>, c : Bool ) -> Bits<N>
 ## Bit Counting Operations
 
 \listing{basic_math_bit_counting, VADL Bit Counting Operations}
+
 ~~~{.vadl}
 function cob( a : Bits<N> ) -> UInt<N> // counting one bits
 function czb( a : Bits<N> ) -> UInt<N> // counting zero bits
 function clz( a : Bits<N> ) -> UInt<N> // counting leading zeros
 function clo( a : Bits<N> ) -> UInt<N> // counting leading ones
 function cls( a : Bits<N> ) -> UInt<N> // counting leading sign bits (without sign bit)
+function ctz( a : Bits<N> ) -> UInt<N> // counting trailing zeros
+function cto( a : Bits<N> ) -> UInt<N> // counting trailing ones
 ~~~
-\endlisting
 
+\endlisting
 
 ## Assembly Directives
 
 \lbl{table_assembly_directives}
-
 
 | directive                 | explanation                                                                                                              |
 |:--------------------------|:-------------------------------------------------------------------------------------------------------------------------|
@@ -607,23 +610,21 @@ function cls( a : Bits<N> ) -> UInt<N> // counting leading sign bits (without si
 | WEAK_REFERENCE            |                                                                                                                          |
 | ZERO                      | .zero size; emit `size` amount of 0-valued bytes                                                                         |
 
-
 ## Assembly Grammar Rule Types
 
-| type          | explanation                                                                                                 |
-|:--------------|:------------------------------------------------------------------------------------------------------------|
-| @constant     | represents an integer value.                                                                                |
-| @expression   | represents a complex expression for an immediate operand. The `Expression` default rule is of this type.    |
-| @instruction  | represents an entire machine or pseudo instruction. It needs to consist of at least the `mnemonic` operand. |
-| @modifier     | represents a modifier defined in the `modifier` mappings of the assembly description.                       |
-| @operand      | represents a machine operand, which is used to build an instruction in the parser.                          |
-| @operands     | represents a sequence of `@operands`.                                                                       |
-| @register     | represents a register of the instruction set architecture corresponding to the assembly description.        |
-| @statements   | represents a sequence of `@instruction`, where each instruction is followed by an `EOL`.                    |
-| @string       | represents a sequence of characters. Most terminal rules are of this type.                                  |
-| @symbol       | represents a reference to a symbol, such as an assembly label.                                              |
-| @void         | represents the empty type. For rules like `EOL`.                                                            |
-
+| type         | explanation                                                                                                 |
+|:-------------|:------------------------------------------------------------------------------------------------------------|
+| @constant    | represents an integer value.                                                                                |
+| @expression  | represents a complex expression for an immediate operand. The `Expression` default rule is of this type.    |
+| @instruction | represents an entire machine or pseudo instruction. It needs to consist of at least the `mnemonic` operand. |
+| @modifier    | represents a modifier defined in the `modifier` mappings of the assembly description.                       |
+| @operand     | represents a machine operand, which is used to build an instruction in the parser.                          |
+| @operands    | represents a sequence of `@operands`.                                                                       |
+| @register    | represents a register of the instruction set architecture corresponding to the assembly description.        |
+| @statements  | represents a sequence of `@instruction`, where each instruction is followed by an `EOL`.                    |
+| @string      | represents a sequence of characters. Most terminal rules are of this type.                                  |
+| @symbol      | represents a reference to a symbol, such as an assembly label.                                              |
+| @void        | represents the empty type. For rules like `EOL`.                                                            |
 
 ## Assembly Grammar Rule Type Casts
 
@@ -648,6 +649,7 @@ function cls( a : Bits<N> ) -> UInt<N> // counting leading sign bits (without si
 ## Assembly Terminal Rules
 
 \listing{assembly_terminals, Assembly Terminal Rules}
+
 ~~~{.vadl}
 @string   | AMP            | "&"
 @string   | AMPAMP         | "&&"
@@ -690,14 +692,16 @@ function cls( a : Bits<N> ) -> UInt<N> // counting leading sign bits (without si
 @string   | STRING         | "\\\".*\\\""
 @string   | TILDE          | "~"
 ~~~
+
 \endlisting
 
-
 ## Assembly Nonterminal Rules
+
 The following grammar rules are default rules that can be used in other rule definitions.
 Default grammar rules can be overwritten by defining a new rule with the exact same name.
 
-- Expression: An expression can be a signed integer, a complex expression (e.g., `2 + 3`) or a symbol reference (e.g., `.foo`).
+- Expression: An expression can be a signed integer, a complex expression (e.g., `2 + 3`) or a symbol reference (e.g.,
+  `.foo`).
 - Identifier: Identifier is used to allow any string.
 - ImmediateOperand: ImmediateOperand is an expression with a cast to @operand.
 - Instruction: The instruction default rule is an alternative over all grammar rules with the type @instruction.
@@ -708,6 +712,7 @@ Default grammar rules can be overwritten by defining a new rule with the exact s
 - Statement: Statement is the Instruction default rule followed by an End-Of-Line token.
 
 \listing{assembly_nonterminals, Assembly Nonterminal Rules}
+
 ~~~{.vadl}
  Expression        | @expression
  Identifier        | @string
@@ -719,4 +724,5 @@ Default grammar rules can be overwritten by defining a new rule with the exact s
  Register          | @register
  Statement         | @instruction
 ~~~
+
 \endlisting

--- a/vadl/main/resources/templates/common/vadl-builtins.h
+++ b/vadl/main/resources/templates/common/vadl-builtins.h
@@ -626,8 +626,6 @@ static inline Bits VADL_clz(Bits a, Width w) {
      * We'll shift the value down until the top bit is set or the value is 0.
      */
     Bits topBitPos = w;
-    Bits maskW     = VADL_mask(w); /* e.g., (1ULL << w) - 1. */
-    x &= maskW;
 
     Bits leading = 0ULL;
     while (leading < w) {
@@ -651,8 +649,6 @@ static inline Bits VADL_clo(Bits a, Width w) {
         return 0ULL;
     }
     Bits x     = VADL_uextract(a, w);
-    Bits maskW = VADL_mask(w);
-    x &= maskW;
 
     Bits leading = 0ULL;
     while (leading < w) {
@@ -697,6 +693,50 @@ static inline Bits VADL_cls(Bits a, Width w) {
         leading++;
     }
     return leading;
+}
+
+/*-----------------------------------------------------------------------
+ *    ctz(a : Bits<N>) => count trailing zeros in a
+ *---------------------------------------------------------------------*/
+static inline Bits VADL_ctz(Bits a, Width w) {
+    /* We look at only w bits. If w == 0, there's nothing to count. */
+    if (w == 0) {
+        return 0ULL;
+    }
+    Bits x = VADL_uextract(a, w);
+
+    Bits trailing = 0ULL;
+    while (trailing < w) {
+        /* Check least‑significant bit among w bits */
+        if ((x & 1ULL) != 0ULL) {
+            break; /* found a 1 => stop */
+        }
+        trailing++;
+        x >>= 1ULL; /* shift right so next bit becomes LSB */
+    }
+    return trailing;
+}
+
+/*-----------------------------------------------------------------------
+ *    cto(a : Bits<N>) => count trailing ones in a
+ *---------------------------------------------------------------------*/
+static inline Bits VADL_cto(Bits a, Width w) {
+    /* We look at only w bits. If w == 0, there's nothing to count. */
+    if (w == 0) {
+        return 0ULL;
+    }
+    Bits x = VADL_uextract(a, w);
+
+    Bits trailing = 0ULL;
+    while (trailing < w) {
+        /* Check least‑significant bit among w bits */
+        if ((x & 1ULL) == 0ULL) {
+            break; /* found a 0 => stop */
+        }
+        trailing++;
+        x >>= 1ULL;
+    }
+    return trailing;
 }
 
 

--- a/vadl/main/vadl/iss/passes/IssNormalizationPass.java
+++ b/vadl/main/vadl/iss/passes/IssNormalizationPass.java
@@ -677,6 +677,17 @@ class IssNormalizer implements VadlBuiltInNoStatusDispatcher<BuiltInCall> {
   }
 
   @Override
+  public void handleCTZ(BuiltInCall input) {
+    throw graphError(input, "Normalization not yet implemented for this built-in");
+
+  }
+
+  @Override
+  public void handleCTO(BuiltInCall input) {
+    throw graphError(input, "Normalization not yet implemented for this built-in");
+  }
+
+  @Override
   public void handleConcat(BuiltInCall input) {
     // do nothing (result is already fine)
   }

--- a/vadl/main/vadl/types/BuiltInTable.java
+++ b/vadl/main/vadl/types/BuiltInTable.java
@@ -943,6 +943,29 @@ public class BuiltInTable {
           .returnsFirstBitWidth(UIntType.class)
           .build();
 
+  /**
+   * Counting trailing zeros.
+   *
+   * <p>{@code function ctz( a : Bits<N> ) -> UInt<N>  }
+   */
+  public static final BuiltIn CTZ =
+      func("VADL::ctz", Type.relation(BitsType.class, UIntType.class))
+          .takesDefault()
+          .returnsFirstBitWidth(UIntType.class)
+          .build();
+
+
+  /**
+   * Counting trailing ones.
+   *
+   * <p>{@code function cto( a : Bits<N> ) -> UInt<N> }
+   */
+  public static final BuiltIn CTO =
+      func("VADL::cto", Type.relation(BitsType.class, UIntType.class))
+          .takesDefault()
+          .returnsFirstBitWidth(UIntType.class)
+          .build();
+
 
   ///// FUNCTIONS //////
 
@@ -1259,6 +1282,8 @@ public class BuiltInTable {
       CLZ,
       CLO,
       CLS,
+      CTZ,
+      CTO,
 
       // FUNCTIONS
 

--- a/vadl/main/vadl/utils/VadlBuiltInEmptyNoStatusDispatcher.java
+++ b/vadl/main/vadl/utils/VadlBuiltInEmptyNoStatusDispatcher.java
@@ -183,6 +183,14 @@ public interface VadlBuiltInEmptyNoStatusDispatcher<T> extends VadlBuiltInNoStat
   }
 
   @Override
+  default void handleCTZ(T input) {
+  }
+
+  @Override
+  default void handleCTO(T input) {
+  }
+
+  @Override
   default void handleConcat(T input) {
   }
 }

--- a/vadl/main/vadl/utils/VadlBuiltInNoStatusDispatcher.java
+++ b/vadl/main/vadl/utils/VadlBuiltInNoStatusDispatcher.java
@@ -109,6 +109,10 @@ public interface VadlBuiltInNoStatusDispatcher<T> {
       handleCLO(input);
     } else if (builtIn == BuiltInTable.CLS) {
       handleCLS(input);
+    } else if (builtIn == BuiltInTable.CTZ) {
+      handleCLZ(input);
+    } else if (builtIn == BuiltInTable.CTO) {
+      handleCLO(input);
     } else if (builtIn == BuiltInTable.CONCATENATE_BITS) {
       handleConcat(input);
     } else {
@@ -181,7 +185,6 @@ public interface VadlBuiltInNoStatusDispatcher<T> {
 
   void handleLSR(T input);
 
-
   void handleROL(T input);
 
   void handleROR(T input);
@@ -197,6 +200,10 @@ public interface VadlBuiltInNoStatusDispatcher<T> {
   void handleCLO(T input);
 
   void handleCLS(T input);
+
+  void handleCTZ(T input);
+
+  void handleCTO(T input);
 
   void handleConcat(T input);
 

--- a/vadl/main/vadl/viam/Constant.java
+++ b/vadl/main/vadl/viam/Constant.java
@@ -804,7 +804,7 @@ public abstract class Constant {
     }
 
     private String asString(String prefix, int radix) {
-      return asString(prefix, radix, true);
+      return asString(prefix, radix, false);
     }
 
     /**

--- a/vadl/test/vadl/cppCodeGen/BuiltinCTest.java
+++ b/vadl/test/vadl/cppCodeGen/BuiltinCTest.java
@@ -1677,6 +1677,75 @@ public class BuiltinCTest extends DockerExecutionTest {
     return unaryTest(BuiltInTable.CLS, a, size, expected);
   }
 
+  /* ───── Count Trailing Zeros ────────────────────────────── */
+  @TestFactory
+  Stream<DynamicTest> ctzTests() {
+    return runTests(
+        // 1-bit
+        ctz(0x0, 1, 0x1),           // 0 → 1 trailing zero
+        ctz(0x1, 1, 0x0),           // 1 → 0
+        // 2-bit
+        ctz(0x0, 2, 0x2),
+        ctz(0x1, 2, 0x0),
+        ctz(0x2, 2, 0x1),           // 10b → 1
+        // 8-bit
+        ctz(0xFF, 8, 0x0),
+        ctz(0x80, 8, 0x7),
+        ctz(0x01, 8, 0x0),
+        ctz(0x00, 8, 0x8),
+        // 16-bit
+        ctz(0x8000, 16, 0xF),
+        ctz(0x0001, 16, 0x0),
+        ctz(0x0000, 16, 0x10),
+        // 32-bit
+        ctz(0x80000000L, 32, 0x1F),
+        ctz(0x00000001, 32, 0x0),
+        ctz(0x00000000, 32, 0x20),
+        // 64-bit
+        ctz(0x8000000000000000L, 64, 0x3F),
+        ctz(0x0000000000000001L, 64, 0x0),
+        ctz(0x0000000000000000L, 64, 0x40)
+    );
+  }
+
+  private Function ctz(long a, int size, long expected) {
+    return unaryTest(BuiltInTable.CTZ, a, size, expected);
+  }
+
+  /* ───── Count Trailing Ones ─────────────────────────────── */
+  @TestFactory
+  Stream<DynamicTest> ctoTests() {
+    return runTests(
+        // 1-bit
+        cto(0x0, 1, 0x0),
+        cto(0x1, 1, 0x1),
+        // 2-bit
+        cto(0x0, 2, 0x0),
+        cto(0x1, 2, 0x1),
+        cto(0x3, 2, 0x2),           // 11b → 2
+        // 8-bit
+        cto(0xFF, 8, 0x8),
+        cto(0x01, 8, 0x1),
+        cto(0xFE, 8, 0x0),
+        // 16-bit
+        cto(0xFFFF, 16, 0x10),
+        cto(0x0001, 16, 0x1),
+        cto(0xFFFE, 16, 0x0),
+        // 32-bit
+        cto(0xFFFFFFFFL, 32, 0x20),
+        cto(0x00000001, 32, 0x1),
+        cto(0xFFFFFFFE, 32, 0x0),
+        // 64-bit
+        cto(0xFFFFFFFFFFFFFFFFL, 64, 0x40),
+        cto(0x0000000000000001L, 64, 0x1),
+        cto(0xFFFFFFFFFFFFFFFEL, 64, 0x0)
+    );
+  }
+
+  private Function cto(long a, int size, long expected) {
+    return unaryTest(BuiltInTable.CTO, a, size, expected);
+  }
+
   /// TEST HELPER FUNCTIONS ///
 
   private Function unaryTest(BuiltInTable.BuiltIn builtIn, long val, int size, long expected) {


### PR DESCRIPTION
Adds the `CTZ` and `CTO` built-ins.
```
function ctz( a : Bits<N> ) -> UInt<N> // counting trailing zeros
function cto( a : Bits<N> ) -> UInt<N> // counting trailing ones
```

This closes #278.