### PR TITLE
chore: Fix checkstyle IDEA plugin scan scope

### DIFF
--- a/.idea/checkstyle-idea.xml
+++ b/.idea/checkstyle-idea.xml
@@ -2,9 +2,11 @@
 <project version="4">
   <component name="CheckStyle-IDEA" serialisationVersion="2">
     <checkstyleVersion>10.15.0</checkstyleVersion>
-    <scanScope>JavaOnly</scanScope>
+    <scanScope>JavaOnlyWithTests</scanScope>
     <option name="thirdPartyClasspath" />
-    <option name="activeLocationIds" />
+    <option name="activeLocationIds">
+      <option value="eb4f93b7-08cc-402a-83af-fe194f4bbf4c" />
+    </option>
     <option name="locations">
       <list>
         <ConfigurationLocation id="bundled-sun-checks" type="BUNDLED" scope="All" description="Sun Checks">(bundled)</ConfigurationLocation>


### PR DESCRIPTION
Make checkstyle IDEA plugin scan all java files _including tests_ in order to match the checks done in gradle task checkstyleAll (runs in CI)

This also adds `config/checkstyle/checkstyle.xml` to the active configuration used by default when running checks with the plugin. By this, the VADL configuration does not have to be selected manually. Not sure if this has any drawbacks.