### PR TITLE
lcb: Defined test macros __LP64__ and __LP64

### DIFF
--- a/vadl/main/vadl/lcb/template/clang/lib/Basic/Targets/EmitClangTargetCppFilePass.java
+++ b/vadl/main/vadl/lcb/template/clang/lib/Basic/Targets/EmitClangTargetCppFilePass.java
@@ -19,13 +19,10 @@ package vadl.lcb.template.clang.lib.Basic.Targets;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Predicate;
-import javax.annotation.Nonnull;
 import vadl.configuration.LcbConfiguration;
 import vadl.lcb.template.CommonVarNames;
 import vadl.lcb.template.LcbTemplateRenderingPass;
 import vadl.pass.PassResults;
-import vadl.viam.Abi;
 import vadl.viam.RegisterTensor;
 import vadl.viam.Specification;
 
@@ -52,7 +49,6 @@ public class EmitClangTargetCppFilePass extends LcbTemplateRenderingPass {
   @Override
   protected Map<String, Object> createVariables(final PassResults passResults,
                                                 Specification specification) {
-    var abi = specification.abi().orElseThrow();
     return Map.of(CommonVarNames.NAMESPACE,
         lcbConfiguration().targetName().value().toLowerCase(),
         CommonVarNames.REGISTERS, extractRegisters(specification)

--- a/vadl/main/vadl/lcb/template/clang/lib/Basic/Targets/EmitClangTargetCppFilePass.java
+++ b/vadl/main/vadl/lcb/template/clang/lib/Basic/Targets/EmitClangTargetCppFilePass.java
@@ -14,15 +14,18 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-package vadl.lcb.clang.lib.Basic.Targets;
+package vadl.lcb.template.clang.lib.Basic.Targets;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
+import javax.annotation.Nonnull;
 import vadl.configuration.LcbConfiguration;
 import vadl.lcb.template.CommonVarNames;
 import vadl.lcb.template.LcbTemplateRenderingPass;
 import vadl.pass.PassResults;
+import vadl.viam.Abi;
 import vadl.viam.RegisterTensor;
 import vadl.viam.Specification;
 
@@ -49,9 +52,11 @@ public class EmitClangTargetCppFilePass extends LcbTemplateRenderingPass {
   @Override
   protected Map<String, Object> createVariables(final PassResults passResults,
                                                 Specification specification) {
+    var abi = specification.abi().orElseThrow();
     return Map.of(CommonVarNames.NAMESPACE,
         lcbConfiguration().targetName().value().toLowerCase(),
-        CommonVarNames.REGISTERS, extractRegisters(specification));
+        CommonVarNames.REGISTERS, extractRegisters(specification)
+    );
   }
 
   private List<Map<String, String>> extractRegisters(Specification specification) {

--- a/vadl/main/vadl/lcb/template/clang/lib/Basic/Targets/EmitClangTargetsFilePass.java
+++ b/vadl/main/vadl/lcb/template/clang/lib/Basic/Targets/EmitClangTargetsFilePass.java
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-package vadl.lcb.clang.lib.Basic.Targets;
+package vadl.lcb.template.clang.lib.Basic.Targets;
 
 import java.io.IOException;
 import java.util.Map;

--- a/vadl/main/vadl/pass/PassOrders.java
+++ b/vadl/main/vadl/pass/PassOrders.java
@@ -256,8 +256,10 @@ public class PassOrders {
     order.add(new EmitVadlBuiltinHeaderFilePass(configuration));
     order.add(new vadl.lcb.clang.lib.Driver.ToolChains.EmitClangToolChainFilePass(configuration));
     order.add(new EmitClangTargetHeaderFilePass(configuration));
-    order.add(new vadl.lcb.template.clang.lib.Basic.Targets.EmitClangTargetsFilePass(configuration));
-    order.add(new vadl.lcb.template.clang.lib.Basic.Targets.EmitClangTargetCppFilePass(configuration));
+    order.add(
+        new vadl.lcb.template.clang.lib.Basic.Targets.EmitClangTargetsFilePass(configuration));
+    order.add(
+        new vadl.lcb.template.clang.lib.Basic.Targets.EmitClangTargetCppFilePass(configuration));
     order.add(new vadl.lcb.template.clang.lib.Basic.EmitClangBasicCMakeFilePass(configuration));
     order.add(
         new vadl.lcb.template.clang.lib.CodeGen.EmitCodeGenModuleCMakeFilePass(configuration));

--- a/vadl/main/vadl/pass/PassOrders.java
+++ b/vadl/main/vadl/pass/PassOrders.java
@@ -256,8 +256,8 @@ public class PassOrders {
     order.add(new EmitVadlBuiltinHeaderFilePass(configuration));
     order.add(new vadl.lcb.clang.lib.Driver.ToolChains.EmitClangToolChainFilePass(configuration));
     order.add(new EmitClangTargetHeaderFilePass(configuration));
-    order.add(new vadl.lcb.clang.lib.Basic.Targets.EmitClangTargetsFilePass(configuration));
-    order.add(new vadl.lcb.clang.lib.Basic.Targets.EmitClangTargetCppFilePass(configuration));
+    order.add(new vadl.lcb.template.clang.lib.Basic.Targets.EmitClangTargetsFilePass(configuration));
+    order.add(new vadl.lcb.template.clang.lib.Basic.Targets.EmitClangTargetCppFilePass(configuration));
     order.add(new vadl.lcb.template.clang.lib.Basic.EmitClangBasicCMakeFilePass(configuration));
     order.add(
         new vadl.lcb.template.clang.lib.CodeGen.EmitCodeGenModuleCMakeFilePass(configuration));

--- a/vadl/test/resources/llvm/riscv/spike/rv64im/has_LP64macro.c
+++ b/vadl/test/resources/llvm/riscv/spike/rv64im/has_LP64macro.c
@@ -1,0 +1,6 @@
+int main() {
+  #if _LP64
+  return 0;
+  #endif
+  return 1;
+}

--- a/vadl/test/resources/llvm/riscv/spike/rv64im/has__LP64__macro.c
+++ b/vadl/test/resources/llvm/riscv/spike/rv64im/has__LP64__macro.c
@@ -1,0 +1,6 @@
+int main() {
+  #if __LP64__
+  return 0;
+  #endif
+  return 1;
+}

--- a/vadl/test/vadl/lcb/riscv/QemuRiscvSimulationTest.java
+++ b/vadl/test/vadl/lcb/riscv/QemuRiscvSimulationTest.java
@@ -36,6 +36,9 @@ import vadl.pass.exception.DuplicatedPassKeyException;
 import vadl.utils.Pair;
 
 public abstract class QemuRiscvSimulationTest extends AbstractLcbTest {
+
+  protected static final String TEST_RESOURCES_LLVM_RISCV_SPIKE = "test/resources/llvm/riscv/spike";
+
   protected abstract String getTarget();
 
   protected abstract String getUpstreamBuildTarget();
@@ -48,9 +51,13 @@ public abstract class QemuRiscvSimulationTest extends AbstractLcbTest {
 
   protected abstract String getAbi();
 
-  private static Stream<String> inputFilesFromCFile() {
+  protected Stream<String> inputFilesFromCFile() {
+    return readFiles(TEST_RESOURCES_LLVM_RISCV_SPIKE);
+  }
+
+  protected Stream<String> readFiles(String pathName) {
     return Arrays.stream(
-            Objects.requireNonNull(new File("test/resources/llvm/riscv/spike")
+            Objects.requireNonNull(new File(pathName)
                 .listFiles()))
         .filter(File::isFile)
         .map(File::getName);

--- a/vadl/test/vadl/lcb/riscv/riscv64/QemuRiscv64SimulationTest.java
+++ b/vadl/test/vadl/lcb/riscv/riscv64/QemuRiscv64SimulationTest.java
@@ -16,6 +16,7 @@
 
 package vadl.lcb.riscv.riscv64;
 
+import java.util.stream.Stream;
 import vadl.lcb.riscv.QemuRiscvSimulationTest;
 
 public class QemuRiscv64SimulationTest extends QemuRiscvSimulationTest {
@@ -37,6 +38,17 @@ public class QemuRiscv64SimulationTest extends QemuRiscvSimulationTest {
   @Override
   protected String getAbi() {
     return "lp64";
+  }
+
+  @Override
+  protected Stream<String> inputFilesFromCFile() {
+    // Read the base tests + the tests under rv64im
+    // The tests copy all the tests into the container, but we do need to update
+    // the file name so it points to correct subdirectory, since every file is only executed
+    // per container, and it is controlled over the "INPUT" environment variable.
+    return Stream.concat(super.inputFilesFromCFile(),
+        readFiles(TEST_RESOURCES_LLVM_RISCV_SPIKE + "/" + getTarget())
+            .map(x -> getTarget() + "/" + x));
   }
 
   @Override


### PR DESCRIPTION
Added tests to verify that the macros are defined. `__LP64__` is also used in the floor function in wikisort.