### PR TITLE
iss: Support EXTR instruction by adding LSR decomposer

### DIFF
--- a/vadl/main/vadl/iss/passes/opDecomposition/Decomposer.java
+++ b/vadl/main/vadl/iss/passes/opDecomposition/Decomposer.java
@@ -1,0 +1,306 @@
+// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.iss.passes.opDecomposition;
+
+import com.google.errorprone.annotations.concurrent.LazyInit;
+import javax.annotation.Nullable;
+import vadl.iss.passes.opDecomposition.decomposer.ShiftDecomposer;
+import vadl.javaannotations.DispatchFor;
+import vadl.javaannotations.Handler;
+import vadl.types.Type;
+import vadl.utils.GraphUtils;
+import vadl.utils.VadlBuiltInEmptyNoStatusDispatcher;
+import vadl.viam.Constant;
+import vadl.viam.graph.dependency.AsmBuiltInCall;
+import vadl.viam.graph.dependency.BuiltInCall;
+import vadl.viam.graph.dependency.ConstantNode;
+import vadl.viam.graph.dependency.ExpressionNode;
+import vadl.viam.graph.dependency.FieldAccessRefNode;
+import vadl.viam.graph.dependency.FieldRefNode;
+import vadl.viam.graph.dependency.FuncCallNode;
+import vadl.viam.graph.dependency.FuncParamNode;
+import vadl.viam.graph.dependency.LabelNode;
+import vadl.viam.graph.dependency.LetNode;
+import vadl.viam.graph.dependency.MiaBuiltInCall;
+import vadl.viam.graph.dependency.ReadArtificialResNode;
+import vadl.viam.graph.dependency.ReadMemNode;
+import vadl.viam.graph.dependency.ReadRegTensorNode;
+import vadl.viam.graph.dependency.ReadStageOutputNode;
+import vadl.viam.graph.dependency.SelectNode;
+import vadl.viam.graph.dependency.SignExtendNode;
+import vadl.viam.graph.dependency.SliceNode;
+import vadl.viam.graph.dependency.TruncateNode;
+import vadl.viam.graph.dependency.TupleGetFieldNode;
+import vadl.viam.graph.dependency.ZeroExtendNode;
+
+/**
+ * The decomposer is designed as a request system, where one node requests
+ * a slice from a dependency node.
+ * The slice's width must be smaller/equal than the target size.
+ * The request is dispatched to the correct implementation, which than takes care of
+ * returning an expression that represents the result of the requested slice.
+ * It must only use operations that are smaller equal the target size.
+ */
+@DispatchFor(
+    value = ExpressionNode.class,
+    include = "vadl.viam",
+    context = Decomposer.Request.class
+)
+@SuppressWarnings("OverloadMethodsDeclarationOrder")
+class Decomposer
+    implements VadlBuiltInEmptyNoStatusDispatcher<Decomposer.Request>, ShiftDecomposer {
+
+  record Slice(int hi, int lo) {
+    int width() {
+      return hi - lo + 1;
+    }
+
+    Slice shift(int n) {
+      return new Slice(hi + n, lo + n);
+    }
+  }
+
+  static class Request {
+    Slice slice;
+    @Nullable
+    ExpressionNode result;
+
+    public Request(Slice slice) {
+      this.slice = slice;
+    }
+  }
+
+  @LazyInit
+  BuiltInCall currCall;
+  int targetSize;
+
+  public Decomposer(int targetSize) {
+    this.targetSize = targetSize;
+  }
+
+  /**
+   * Decompose the expression by requesting its substitute and replace it by the substitute.
+   * The return type of the requested node must be <= the target size.
+   *
+   * @param expr the expression to decompose (will be replaced by the decomposed version)
+   */
+  void decompose(ExpressionNode expr) {
+    var exprW = expr.type().asDataType().bitWidth();
+    // we must start a decomposition with a node that has a valid return type size
+    expr.ensure(exprW <= targetSize, "Can only decompose expr that fits in target size.");
+    // start the request with the expressions' normal size
+    var repl = internalRequest(expr, new Slice(exprW - 1, 0));
+    expr.replaceAndDelete(repl);
+  }
+
+  @Override
+  public int targetSize() {
+    return targetSize;
+  }
+
+  @Override
+  public ExpressionNode request(ExpressionNode node, int msb, int lsb) {
+    return request(node, new Slice(msb, lsb));
+  }
+
+  private ExpressionNode request(ExpressionNode node, Slice slice) {
+    if (slice.lo() == 0 && node.type().asDataType().bitWidth() <= targetSize) {
+      // if the slice is just a truncate and the node does fit in the target size, we
+      // can just truncate and return it.
+      if (node.type().asDataType().bitWidth() - 1 == slice.hi()) {
+        return node;
+      } else {
+        return GraphUtils.truncate(node, Type.bits(slice.width()));
+      }
+    }
+
+    return internalRequest(node, slice);
+  }
+
+  private ExpressionNode internalRequest(ExpressionNode node, Slice slice) {
+    var req = new Request(slice);
+    DecomposerDispatcher.dispatch(this, req, node);
+    if (req.result == null) {
+      throw new IllegalStateException("Not yet implemented: " + node);
+    }
+    return req.result;
+  }
+
+  @Override
+  public void handleConcat(Request req) {
+    var lsb = req.slice.lo();
+    var msb = req.slice.hi();
+    var loVal = currCall.arg(1);
+    var hiVal = currCall.arg(0);
+    var loValWidth = loVal.type().asDataType().bitWidth();
+    if (lsb >= loValWidth) {               // slice lies completely in HI part
+      req.result = request(hiVal, req.slice.shift(-loValWidth));
+    } else if (msb < loValWidth) {         // slice lies completely in LO part
+      req.result = request(loVal, req.slice);
+    } else {                               // slice spans the boundary
+      var loSlice = new Slice(loValWidth - 1, lsb);           // 63…lsb
+      var hiSlice = new Slice(msb - loValWidth, 0);           // (msb-64)…0
+      var newLo = request(loVal, loSlice);
+      var newHi = request(hiVal, hiSlice);
+      req.result = GraphUtils.concat(newHi, newLo);
+    }
+  }
+
+
+  @Handler
+  void handle(Request rq, TruncateNode t) {
+    // width of the truncated value (= result width)
+    int outW = t.type().asDataType().bitWidth();
+
+    // slice must lie completely inside the truncated range
+    if (rq.slice.hi() >= outW) {
+      throw new IllegalArgumentException(
+          "requested bits " + rq.slice + " exceed " + outW + "-bit truncate");
+    }
+
+    /* forward the same slice to the input of the truncate */
+    rq.result = request(t.value(), rq.slice);
+  }
+
+  @Handler
+  void handle(Request rq, SignExtendNode se) {
+    int fromW = se.fromBitWidth();       // width before extension
+    int lsb = rq.slice.lo();
+    int msb = rq.slice.hi();
+    var src = se.value();                // original value
+
+    if (msb < fromW) {
+      // slice lies completely inside the original value
+      rq.result = request(src, rq.slice);
+
+    } else if (lsb >= fromW) {
+      // slice lies completely in the replicated sign-bit area
+      var signBit = request(src, new Slice(fromW - 1, fromW - 1));
+      rq.result = GraphUtils.signExtend(signBit, Type.bits(rq.slice.width()));
+    } else {
+      // slice crosses the boundary
+      var lowSlice = new Slice(fromW - 1, lsb);                // inside src
+      var highSize = msb - fromW + 1;                          // #sign bits
+      var lowPart = request(src, lowSlice);
+      var signBit = request(src, new Slice(fromW - 1, fromW - 1));
+      var highPart = GraphUtils.signExtend(signBit, Type.bits(highSize));
+      rq.result = GraphUtils.concat(highPart, lowPart);     // (hi, lo)
+    }
+  }
+
+  @Override
+  public void handleLSR(Request rq) {
+    rq.result = lsrDecompose(currCall, rq.slice.hi(), rq.slice.lo());
+  }
+
+
+  @Handler
+  void handle(Request rq, MiaBuiltInCall toHandle) {
+    throw new UnsupportedOperationException("Type MiaBuiltInCall not yet implemented");
+  }
+
+  @Handler
+  void handle(Request rq, ReadRegTensorNode toHandle) {
+    throw new UnsupportedOperationException("Type ReadRegTensorNode not yet implemented");
+  }
+
+  @Handler
+  void handle(Request rq, FieldRefNode toHandle) {
+    throw new UnsupportedOperationException("Type FieldRefNode not yet implemented");
+  }
+
+  @Handler
+  void handle(Request rq, FuncCallNode toHandle) {
+    throw new UnsupportedOperationException("Type FuncCallNode not yet implemented");
+  }
+
+  @Handler
+  void handle(Request rq, ReadStageOutputNode toHandle) {
+    throw new UnsupportedOperationException("Type ReadStageOutputNode not yet implemented");
+  }
+
+  @Handler
+  void handle(Request rq, LabelNode toHandle) {
+    throw new UnsupportedOperationException("Type LabelNode not yet implemented");
+  }
+
+  @Handler
+  void handle(Request rq, BuiltInCall toHandle) {
+    var previousCall = currCall;
+    currCall = toHandle;
+    dispatch(rq, toHandle.builtIn());
+    currCall = previousCall;
+  }
+
+  @Handler
+  void handle(Request rq, ConstantNode toHandle) {
+    var val = toHandle.constant().asVal();
+    var sliced = val.slice(Constant.BitSlice.of(rq.slice.hi(), rq.slice.lo()));
+    rq.result = sliced.toNode();
+  }
+
+  @Handler
+  void handle(Request rq, FieldAccessRefNode toHandle) {
+    throw new UnsupportedOperationException("Type FieldAccessRefNode not yet implemented");
+  }
+
+  @Handler
+  void handle(Request rq, ReadMemNode toHandle) {
+    throw new UnsupportedOperationException("Type ReadMemNode not yet implemented");
+  }
+
+  @Handler
+  void handle(Request rq, ReadArtificialResNode toHandle) {
+    throw new UnsupportedOperationException("Type ReadArtificialResNode not yet implemented");
+  }
+
+  @Handler
+  void handle(Request rq, TupleGetFieldNode toHandle) {
+    throw new UnsupportedOperationException("Type TupleGetFieldNode not yet implemented");
+  }
+
+  @Handler
+  void handle(Request rq, AsmBuiltInCall toHandle) {
+    throw new UnsupportedOperationException("Type AsmBuiltInCall not yet implemented");
+  }
+
+  @Handler
+  void handle(Request rq, FuncParamNode toHandle) {
+    throw new UnsupportedOperationException("Type FuncParamNode not yet implemented");
+  }
+
+  @Handler
+  void handle(Request rq, ZeroExtendNode toHandle) {
+    throw new UnsupportedOperationException("Type ZeroExtendNode not yet implemented");
+  }
+
+  @Handler
+  void handle(Request rq, LetNode toHandle) {
+    throw new UnsupportedOperationException("Type LetNode not yet implemented");
+  }
+
+  @Handler
+  void handle(Request rq, SliceNode toHandle) {
+    throw new UnsupportedOperationException("Type SliceNode not yet implemented");
+  }
+
+  @Handler
+  void handle(Request rq, SelectNode toHandle) {
+    throw new UnsupportedOperationException("Type SelectNode not yet implemented");
+  }
+
+}

--- a/vadl/main/vadl/iss/passes/opDecomposition/IssOpDecompositionPass.java
+++ b/vadl/main/vadl/iss/passes/opDecomposition/IssOpDecompositionPass.java
@@ -24,9 +24,12 @@ import static vadl.types.BuiltInTable.SUMULL;
 import static vadl.types.BuiltInTable.UMULL;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Optional;
 import javax.annotation.Nullable;
 import vadl.configuration.IssConfiguration;
 import vadl.error.Diagnostic;
+import vadl.error.DiagnosticList;
 import vadl.iss.passes.AbstractIssPass;
 import vadl.iss.passes.opDecomposition.nodes.IssMul2Node;
 import vadl.iss.passes.opDecomposition.nodes.IssMulKind;
@@ -34,8 +37,11 @@ import vadl.iss.passes.opDecomposition.nodes.IssMulhNode;
 import vadl.iss.passes.tcgLowering.Tcg_32_64;
 import vadl.pass.PassName;
 import vadl.pass.PassResults;
+import vadl.types.DataType;
 import vadl.types.Type;
+import vadl.utils.ViamUtils;
 import vadl.viam.Constant;
+import vadl.viam.DefProp;
 import vadl.viam.Specification;
 import vadl.viam.graph.Graph;
 import vadl.viam.graph.Node;
@@ -81,16 +87,42 @@ public class IssOpDecompositionPass extends AbstractIssPass {
   @Nullable
   @Override
   public Object execute(PassResults passResults, Specification viam) throws IOException {
-    viam.processor().ifPresent(m -> m.isa().ownInstructions()
-        .forEach(i -> new OpDecomposer(i.behavior(), configuration().targetSize())
-            .decompose())
-    );
+    var largeOperationErrors = new ArrayList<Diagnostic>();
+    ViamUtils.findDefinitionsByFilter(viam, d -> d instanceof DefProp.WithBehavior)
+        .stream().flatMap(d -> ((DefProp.WithBehavior) d).behaviors().stream())
+        .forEach(behavior -> {
+          new OpDecomposer(behavior, configuration().targetSize())
+              .decompose();
+          // check if there are still large operations left
+          checkNoLargeOperations(behavior).ifPresent(largeOperationErrors::add);
+        });
+
+    if (!largeOperationErrors.isEmpty()) {
+      throw new DiagnosticList(largeOperationErrors);
+    }
 
     return null;
   }
+
+  private Optional<Diagnostic> checkNoLargeOperations(Graph behavior) {
+    return behavior.getNodes(ExpressionNode.class)
+        .filter(n -> (n.type() instanceof DataType)
+            && n.type().asDataType().bitWidth() > configuration().targetSize().width)
+        .map(n -> Diagnostic.error("Too large operation type", n)
+            .locationDescription(n, "The ISS was not able to decompose this to smaller types.")
+            .note("Operation decomposition is still in early stages and "
+                + "only implemented for special cases.")
+            .build())
+        .findFirst();
+  }
 }
 
-
+/**
+ * This is the old decomposer, which is highly specialized on long mul.
+ * We should move the implementation to the {@link Decomposer} which can handle
+ * things more generalized. However, it might be necessary to find certain patterns for
+ * performance reasons.
+ */
 class OpDecomposer {
 
   Tcg_32_64 targetSize;
@@ -105,6 +137,23 @@ class OpDecomposer {
     behavior.getNodes(BuiltInCall.class).forEach(this::handle);
     // delete all dependency nodes that are not used anymore
     behavior.deleteUnusedDependencies();
+
+    // find all nodes that result has an ok width but has a too large input.
+    var foundOne = true;
+    while (foundOne) {
+      foundOne = false;
+      var hit = behavior.getNodes(ExpressionNode.class)
+          .filter(node -> node.type() instanceof DataType)
+          .filter(node -> node.type().asDataType().bitWidth() <= targetSize.width)
+          .filter(node -> node.inputs().map(ExpressionNode.class::cast)
+              .anyMatch(i -> i.type().asDataType().bitWidth() > targetSize.width))
+          .findFirst();
+      if (hit.isPresent()) {
+        foundOne = true;
+        // replace the current hit with the decomposed version.
+        new Decomposer(targetSize.width).decompose(hit.get());
+      }
+    }
   }
 
   private void handle(BuiltInCall call) {

--- a/vadl/main/vadl/iss/passes/opDecomposition/IssOpDecompositionPass.java
+++ b/vadl/main/vadl/iss/passes/opDecomposition/IssOpDecompositionPass.java
@@ -39,9 +39,8 @@ import vadl.pass.PassName;
 import vadl.pass.PassResults;
 import vadl.types.DataType;
 import vadl.types.Type;
-import vadl.utils.ViamUtils;
 import vadl.viam.Constant;
-import vadl.viam.DefProp;
+import vadl.viam.Instruction;
 import vadl.viam.Specification;
 import vadl.viam.graph.Graph;
 import vadl.viam.graph.Node;
@@ -88,8 +87,7 @@ public class IssOpDecompositionPass extends AbstractIssPass {
   @Override
   public Object execute(PassResults passResults, Specification viam) throws IOException {
     var largeOperationErrors = new ArrayList<Diagnostic>();
-    ViamUtils.findDefinitionsByFilter(viam, d -> d instanceof DefProp.WithBehavior)
-        .stream().flatMap(d -> ((DefProp.WithBehavior) d).behaviors().stream())
+    viam.isa().get().ownInstructions().stream().map(Instruction::behavior)
         .forEach(behavior -> {
           new OpDecomposer(behavior, configuration().targetSize())
               .decompose();

--- a/vadl/main/vadl/iss/passes/opDecomposition/decomposer/IDecomposer.java
+++ b/vadl/main/vadl/iss/passes/opDecomposition/decomposer/IDecomposer.java
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.iss.passes.opDecomposition.decomposer;
+
+import vadl.viam.graph.dependency.ExpressionNode;
+
+/**
+ * The super interface of all decomposer mix-ins like the {@link ShiftDecomposer}.
+ * It provides required functions that the actual decomposer implements.
+ */
+public interface IDecomposer {
+
+  int targetSize();
+
+  ExpressionNode request(ExpressionNode node, int hi, int lo);
+
+}

--- a/vadl/main/vadl/iss/passes/opDecomposition/decomposer/ShiftDecomposer.java
+++ b/vadl/main/vadl/iss/passes/opDecomposition/decomposer/ShiftDecomposer.java
@@ -1,0 +1,243 @@
+// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.iss.passes.opDecomposition.decomposer;
+
+import static vadl.error.Diagnostic.ensure;
+import static vadl.error.Diagnostic.error;
+import static vadl.utils.GraphUtils.bits;
+import static vadl.utils.GraphUtils.equ;
+import static vadl.utils.GraphUtils.intU;
+import static vadl.utils.GraphUtils.neq;
+import static vadl.utils.GraphUtils.select;
+import static vadl.viam.Constant.Value.zero;
+
+import java.util.ArrayList;
+import java.util.List;
+import vadl.types.BitsType;
+import vadl.types.BuiltInTable;
+import vadl.types.Type;
+import vadl.utils.GraphUtils;
+import vadl.viam.Constant;
+import vadl.viam.graph.dependency.BuiltInCall;
+import vadl.viam.graph.dependency.ExpressionNode;
+
+/**
+ * The shift decomposer is responsible for splitting a shift operations into multiple smaller
+ * operations that extract a certain data slice of the result,
+ * without using > target size operations.
+ */
+@SuppressWarnings({"LocalVariableName", "ParamterName"})
+public interface ShiftDecomposer extends IDecomposer {
+  /**
+   * De-composes a logical-shift-right call so that **only** the bit-range
+   * {@code [hi‥lo]} of the result is materialised.
+   *
+   * <p>Instead of building the full {@code a >> (b % N)} value (word-width =N),
+   * the method:
+   * <ol>
+   *   <li>retrieves {@code a} and {@code b} from {@code src};</li>
+   *   <li>computes the effective distance
+   *       {@code eff = b % N}</li>
+   *   <li>splits it into whole-chunk and in-chunk parts<br>
+   *       {@code sb   = eff / K}   // K = piece size, e.g. 8<br>
+   *       {@code sbit = eff % K};</li>
+   *   <li>selects just the source pieces that can contribute to bits
+   *       {@code hi‥lo} (at most two);</li>
+   *   <li>builds those two pieces with 8-bit helpers:<br>
+   *       {@code lo = lsr8(src[i+sb], sbit);} <br>
+   *       {@code hi = sbit? lsl8(src[i+sb+1], K-sbit) : 0;}<br>
+   *       however, this is unrolled and represented as a chain of selects in the dependency graph
+   *       </li>
+   *   <li>ORs, masks and concatenates so the final node is exactly
+   *       {@code hi-lo+1} bits wide.</li>
+   * </ol>
+   *
+   * @param src built-in LSR call {@code LSR(a,b)} (both unsigned)
+   * @param hi  most-significant bit of the slice (inclusive, 0 = LSB)
+   * @param lo  least-significant bit of the slice
+   * @return graph expression that equals {@code (a >> (b % N))[hi:lo]}
+   * @throws IllegalArgumentException if {@code hi < lo} or indices exceed word width
+   */
+  default ExpressionNode lsrDecompose(BuiltInCall src, int hi, int lo) {
+    src.ensure(src.builtIn() == BuiltInTable.LSR, "Not a lsr built-in call");
+
+    var a = src.arg(0);
+    var aT = a.type().asDataType();
+
+    // bit width of source type
+    final var N = aT.bitWidth();
+
+    // shift amount in VADL is b % N
+    var b = effectiveShiftAmount(src.arg(1), N);
+    var bT = b.type().asDataType();
+
+    // bit width per piece
+    final var K = targetSize();
+    final var K_NODE = intU(K, bT.bitWidth()).toNode();
+
+    // number of parts that are shifted as a whole (b / K)
+    var sp = BuiltInTable.UDIV.call(b, K_NODE);
+    var CHUNKS = N / K;
+    // maximum possible part that can be shifted as a whole
+    var SP_MAX = CHUNKS - 1;
+    // number of bits that are shifted within a piece (b % K)
+    var sbit = BuiltInTable.UMOD.call(b, K_NODE);
+
+    // a boolean expression if there are any shifts within one piece
+    var carry = neq(sbit, zero(sbit.type().asDataType()).toNode());
+
+    // pieces of shift value
+    var pieces = getPieces(a, K);
+
+    int firstIdx = lo / K;   // LSB slice
+    int lastIdx = hi / K;    // MSB slice
+    int offLo = lo % K;      // start bit inside first slice
+    int offHi = hi % K;      // end   bit inside last  slice
+
+    // order little endian ... LSB -> MSB
+    List<ExpressionNode> outs = new ArrayList<>();
+    for (var i = firstIdx; i <= lastIdx; i++) {
+      var piece = calculatePiece(i, pieces, sp, sbit, carry, SP_MAX);
+      outs.add(piece);
+    }
+
+    if (offHi != K - 1) {
+      // slice HI piece to correct offHi
+      var li = outs.size() - 1;
+      var lpiece = outs.get(li);
+      outs.set(li, GraphUtils.slice(lpiece, offHi, 0));
+    }
+
+    if (offLo != 0) {
+      // slice LO piece to correct offLo
+      var lpiece = outs.getFirst();
+      var pW = lpiece.type().asDataType().bitWidth();
+      outs.set(0, GraphUtils.slice(lpiece, pW - 1, offLo));
+    }
+
+    // make it big endian (LSB -> MSB to MSB -> LSB)
+    outs = outs.reversed();
+
+    return GraphUtils.concat(outs.toArray(ExpressionNode[]::new));
+  }
+
+  private ExpressionNode calculatePiece(int i, List<ExpressionNode> pieces, ExpressionNode sp,
+                                        ExpressionNode sbit, ExpressionNode carry, int spMax) {
+    var lo = lsrCalcLow(i, pieces, sp, spMax);
+    var hi = lsrCalcHigh(i, pieces, sp, spMax);
+    return lsrBuildOut(lo, hi, carry, sbit);
+  }
+
+  private ExpressionNode lsrBuildOut(ExpressionNode lo, ExpressionNode hi, ExpressionNode carry,
+                                     ExpressionNode sbit) {
+    // constants
+    var pieceSize = lo.type().asDataType().bitWidth();
+    var pieceSizeNode = GraphUtils.bits(pieceSize, sbit.type().asDataType().bitWidth()).toNode();
+
+    // calulate the << shift amount to place the hi bits in place of the result
+    var adj = BuiltInTable.SUB.call(pieceSizeNode, sbit);
+    // if carry is false, there are no bit shifts (only whole piece shifts (sp), and therefore
+    // we don't have to place the higher bits into position
+    var select = GraphUtils.select(carry,
+        BuiltInTable.LSL.call(hi, adj),
+        Constant.Value.zero(hi.type().asDataType()).toNode()
+    );
+
+    // we shift lo part of the piece by the shift bits
+    var lsr = BuiltInTable.LSR.call(lo, sbit);
+    // we merge upper and lower part to one
+    return BuiltInTable.OR.call(lsr, select);
+  }
+
+  private ExpressionNode lsrCalcLow(int i,
+                                    List<ExpressionNode> pieces,
+                                    ExpressionNode sp,
+                                    int spMax) {
+    int pieceW = pieces.getFirst().type().asDataType().bitWidth();
+    var zeroExpr = Constant.Value.zero(Type.bits(pieceW)).toNode();
+    int last = pieces.size() - 1;          // index of the MSB slice
+
+    ExpressionNode lo = zeroExpr;              // default = 0
+
+    /* build a chain of  selects:  (sp==j ? pieces[i+j] : prev) ------ */
+    for (int j = spMax; j >= 0; --j) {        // j = 0 … SP_MAX
+      int srcIdx = i + j;                    // slice that would land here
+      if (srcIdx > last) {
+        continue;           // shifts beyond word ⇒ 0
+      }
+
+      var target = pieces.get(srcIdx);       // valid source slice
+
+      // constant `j`
+      var cmpVal = bits(j, sp.type().asDataType().bitWidth()).toNode();
+      var cmp = equ(sp, cmpVal);
+      lo = select(cmp, target, lo);
+    }
+    return lo;                                 // 8-bit data-flow only
+  }
+
+  private ExpressionNode lsrCalcHigh(int i, List<ExpressionNode> pieces, ExpressionNode sp,
+                                     int spMax) {
+    int pieceW = pieces.getFirst().type().asDataType().bitWidth();
+    var zeroExpr = Constant.Value.zero(Type.bits(pieceW)).toNode();
+    int last = pieces.size() - 1;          // index of the MSB slice
+
+    ExpressionNode hi = zeroExpr;
+
+    if (i == spMax) {
+      // not possible, SP_MAX + 1 is always 0
+      return hi;
+    }
+
+    for (var j = spMax; j >= i; --j) {
+      int srcIdx = i + j + 1;
+      if (srcIdx > last) {
+        continue;
+      }
+      var target = pieces.get(srcIdx);
+      var cmpVal = bits(j, sp.type().asDataType().bitWidth()).toNode();
+      var cmp = equ(sp, cmpVal);
+      hi = select(cmp, target, hi);
+    }
+    return hi;
+  }
+
+  private ExpressionNode effectiveShiftAmount(ExpressionNode expr, int srcW) {
+    var exprW = expr.type().asDataType().bitWidth();
+    var srcMinW = BitsType.minimalRequiredWidthFor(srcW);
+    var t = Type.bits(Math.max(srcMinW, exprW));
+    expr = GraphUtils.zeroExtend(expr, t);
+    return BuiltInTable.UMOD.call(expr, Constant.Value.of(srcW, t).toNode());
+  }
+
+  private List<ExpressionNode> getPieces(ExpressionNode src, int pieceWidth) {
+    var srcW = src.type().asDataType().bitWidth();
+    // TODO: Support any width
+    ensure(srcW % pieceWidth == 0, () -> error("Invalid shift value size", src)
+        .note("We currently only support shift values that are a multiple of %s", pieceWidth));
+
+    var pieces = srcW / pieceWidth;
+    var piecesList = new ArrayList<ExpressionNode>();
+    for (var i = 0; i < pieces; i++) {
+      var lo = i * pieceWidth;
+      var hi = (i + 1) * pieceWidth - 1;
+      piecesList.add(request(src, hi, lo));
+    }
+    return piecesList;
+  }
+
+}

--- a/vadl/main/vadl/viam/Constant.java
+++ b/vadl/main/vadl/viam/Constant.java
@@ -635,11 +635,9 @@ public abstract class Constant {
      * The resulting type is the same as this type, the result is truncated on overflow.
      */
     public Constant.Value lsr(Constant.Value other) {
-      ensure(other.type().getClass() == UIntType.class,
-          "LSR shift argument must be an unsigned integer.");
-
+      var shift = other.modulo(of(type().bitWidth(), other.type()), false);
       var newValue = value
-          .shiftRight(other.intValue());
+          .shiftRight(shift.intValue());
       return fromTwosComplement(newValue, type());
     }
 
@@ -721,8 +719,8 @@ public abstract class Constant {
       var result = BigInteger.ZERO;
       // reversed index positions, e.g. (4, 1..3) -> 3,2,1,4
       var idxPos = slice.stream().boxed().toList().reversed();
-      var i = 0;
-      for (var pos : idxPos) {
+      for (var i = 0; i < idxPos.size(); i++) {
+        var pos = idxPos.get(i);
         // build the result from 0 to slice.size - 1
         if (value.testBit(pos)) {
           // if the value has 1 at pos, then we set the bit in the result

--- a/vadl/main/vadl/viam/Constant.java
+++ b/vadl/main/vadl/viam/Constant.java
@@ -635,7 +635,12 @@ public abstract class Constant {
      * The resulting type is the same as this type, the result is truncated on overflow.
      */
     public Constant.Value lsr(Constant.Value other) {
-      var shift = other.modulo(of(type().bitWidth(), other.type()), false);
+      var shift = other;
+      var valWidth = BigInteger.valueOf(type().bitWidth());
+      if (shift.value.compareTo(valWidth) >= 0) {
+        // if shift value is greather equal the value width, we must take the modulo
+        shift = other.modulo(of(type().bitWidth(), other.type()), false);
+      }
       var newValue = value
           .shiftRight(shift.intValue());
       return fromTwosComplement(newValue, type());

--- a/vadl/main/vadl/viam/graph/dependency/BuiltInCall.java
+++ b/vadl/main/vadl/viam/graph/dependency/BuiltInCall.java
@@ -78,6 +78,9 @@ public class BuiltInCall extends AbstractFunctionCallNode implements Canonicaliz
     return this.builtIn;
   }
 
+  public ExpressionNode arg(int index) {
+    return args.get(index);
+  }
 
   @Override
   public void accept(GraphNodeVisitor visitor) {

--- a/vadl/main/vadl/viam/graph/dependency/SignExtendNode.java
+++ b/vadl/main/vadl/viam/graph/dependency/SignExtendNode.java
@@ -24,10 +24,6 @@ import vadl.viam.graph.Node;
 
 /**
  * Represents a sign extension of the node's value to the assigned type.
- * This node is constructed during the
- * {@link vadl.viam.passes.typeCastElimination.TypeCastEliminationPass}.
- *
- * @see vadl.viam.passes.typeCastElimination.TypeCastEliminator
  */
 public class SignExtendNode extends UnaryNode implements Canonicalizable {
 

--- a/vadl/main/vadl/viam/graph/visualize/DotGraphVisualizer.java
+++ b/vadl/main/vadl/viam/graph/visualize/DotGraphVisualizer.java
@@ -82,13 +82,16 @@ public class DotGraphVisualizer implements GraphVisualizer<String, Graph> {
           .append(" [label=%s %s]".formatted(wrapStr(label(node)), nodeStyle(node)))
           .append(";\n");
 
-      node.inputs().filter(this::nodeFilter).forEach((input) -> {
+      var inputs = node.inputs().filter(this::nodeFilter).toList();
+      for (var i = 0; i < inputs.size(); i++) {
+        var input = inputs.get(i);
         dotBuilder.append("     ")
             .append(wrapStr(input.id))
             .append(" -> ")
             .append(wrapStr(node.id))
-            .append("[dir=back arrowtail=empty];\n");
-      });
+            .append("[dir=back arrowtail=empty label=\"i: " + i + "\"];\n");
+      }
+
 
       node.successors().filter(this::nodeFilter).forEach(successor -> {
 

--- a/vadl/main/vadl/viam/passes/functionInliner/ArtificialResInlinerPass.java
+++ b/vadl/main/vadl/viam/passes/functionInliner/ArtificialResInlinerPass.java
@@ -74,7 +74,7 @@ public class ArtificialResInlinerPass extends Pass {
         .toList()
         .forEach(node -> {
           node.replaceAndDelete(
-              FunctionInlinerPass.inline(node.resourceDefinition().readFunction(), node.indices()));
+              Inliner.inline(node.resourceDefinition().readFunction(), node.indices()));
         });
   }
 

--- a/vadl/main/vadl/viam/passes/functionInliner/FieldAccessInlinerPass.java
+++ b/vadl/main/vadl/viam/passes/functionInliner/FieldAccessInlinerPass.java
@@ -16,7 +16,6 @@
 
 package vadl.viam.passes.functionInliner;
 
-import static vadl.utils.GraphUtils.getSingleNode;
 import static vadl.utils.ViamUtils.findDefinitionsByFilter;
 
 import java.io.IOException;
@@ -27,8 +26,6 @@ import vadl.pass.PassName;
 import vadl.pass.PassResults;
 import vadl.viam.Instruction;
 import vadl.viam.Specification;
-import vadl.viam.graph.control.ReturnNode;
-import vadl.viam.graph.dependency.FieldAccessRefNode;
 
 /**
  * FieldAccessInlinerPass is a transformation pass that inlines field access operations
@@ -51,16 +48,7 @@ public class FieldAccessInlinerPass extends Pass {
 
     findDefinitionsByFilter(viam, d -> d instanceof Instruction)
         .stream().map(Instruction.class::cast)
-        .forEach(instruction -> {
-          var fieldAccesses = instruction.behavior().getNodes(FieldAccessRefNode.class)
-              .toList();
-
-          fieldAccesses.forEach(fieldAccessRefNode -> {
-            var behavior = fieldAccessRefNode.fieldAccess().accessFunction().behavior();
-            var returnNode = getSingleNode(behavior, ReturnNode.class);
-            fieldAccessRefNode.replaceAndDelete(returnNode.value().copy());
-          });
-        });
+        .forEach(instruction -> Inliner.inlineFieldAccess(instruction.behavior()));
     return null;
   }
 }

--- a/vadl/main/vadl/viam/passes/functionInliner/Inliner.java
+++ b/vadl/main/vadl/viam/passes/functionInliner/Inliner.java
@@ -60,11 +60,18 @@ public class Inliner {
         .filter(funcCallNode -> !(funcCallNode.function() instanceof Relocation))
         .toList();
 
+    if (functionCalls.isEmpty()) {
+      return;
+    }
+
     functionCalls.forEach(functionCall -> {
       // replace the function call by a copy of the return value of the function
       functionCall.replaceAndDelete(
           inline(functionCall.function(), functionCall.arguments()));
     });
+
+    // do it again until there are no more function calls
+    inlineFuncs(behavior);
   }
 
 

--- a/vadl/test/resources/testSource/sys/aarch64/virt.vadl
+++ b/vadl/test/resources/testSource/sys/aarch64/virt.vadl
@@ -19,6 +19,12 @@ instruction set architecture A64 extending AArch64Base = {
     encoding MRSNZCV = { op = 0b110101010011, o0 = 0b1, op1 = 0b011, crn = 0b0100, crm = 0b0010, op2 = 0b000 }
     assembly MRSNZCV = ( "mrs X", decimal(rt), ", nzcv" )
 
+    // TODO: Remove this once andi implemented the HINT instruction
+    format HINTNopFormat: Instr =
+    { op      [31..0] }
+    instruction HINTNop: HINTNopFormat = { }
+    encoding HINTNop = { op = 0b11010101000000110010000000011111 }
+    assembly HINTNop = ( "hint #0" )
 }
 
 [ htif ]

--- a/vadl/test/vadl/iss/aarch64/IssA64InstrTest.java
+++ b/vadl/test/vadl/iss/aarch64/IssA64InstrTest.java
@@ -137,6 +137,15 @@ public class IssA64InstrTest extends AbstractIssAarch64InstrTest {
   }
 
   @TestFactory
+  Stream<DynamicTest> testEXTR() throws IOException {
+    // EXTR: Extract register.
+    // TODO: EXTR W (sf == 0) variants ("EXTRW").
+    //    This is currently not possible as the check
+    //    `if sf == '0' && imms<5> == '1' then EndOfDecode(Decode_UNDEF);` is not implemented yet.
+    return runTestsWith(makeTestCases("EXTRX"));
+  }
+
+  @TestFactory
   Stream<DynamicTest> testMOVK() throws IOException {
     return runTestsWith(makeTestCasesFromPrefixes("MOVK"));
   }

--- a/vadl/test/vadl/iss/passes/opDecomposition/IssOpDecompositionPassTest.java
+++ b/vadl/test/vadl/iss/passes/opDecomposition/IssOpDecompositionPassTest.java
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.iss.passes.opDecomposition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static vadl.utils.GraphUtils.bits;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+import vadl.types.BuiltInTable;
+import vadl.viam.graph.Graph;
+import vadl.viam.graph.dependency.ConstantNode;
+import vadl.viam.graph.dependency.ExpressionNode;
+import vadl.viam.passes.canonicalization.Canonicalizer;
+
+public class IssOpDecompositionPassTest {
+
+  @TestFactory
+  Stream<DynamicTest> lsrTests() {
+    return Stream.of(
+        lsrSimple(0b01110000, 1, 8, 4),
+        lsrSimple(0b110100, 6, 8, 4),
+        lsrSimple(0b00000001, 1, 8, 4),  // Shift LSB
+        lsrSimple(0b10000000, 7, 8, 4),  // Shift MSB
+        lsrSimple(0b11111111, 8, 8, 4),  // Full shift
+        lsrSimple(0b00000000, 3, 8, 4),  // All zeros
+        lsrSimple(0b10101010, 2, 8, 4),  // Alternating bits
+        lsrSimple(0b11110000, 4, 8, 4),  // High nibble
+        lsrSimple(0b00001111, 4, 8, 4),  // Low nibble
+        lsrSimple(0b11111111, 0, 8, 4),  // No shift
+
+        lsrCplx(0b01110000, 1, 8, 0b111, 6, 3, 4),
+        lsrCplx(0b10110100, 3, 8, 0b0001, 7, 4, 4),
+        lsrCplx(0b00000001, 1, 8, 0b0, 5, 0, 4),  // Shift LSB
+        lsrCplx(0b10000000, 7, 8, 0b1, 6, 0, 4),  // Shift MSB
+        lsrCplx(0b11111111, 8, 8, 0b1, 4, 4, 4),  // Full shift
+        lsrCplx(0b00000000, 3, 8, 0b0, 3, 2, 4),  // All zeros
+        lsrCplx(0b10101010, 2, 8, 0b1010, 6, 2, 4),  // Alternating bits
+        lsrCplx(0b11110000, 4, 8, 0b1111, 3, 0, 4),  // High nibble
+        lsrCplx(0b00001111, 4, 8, 0b0, 5, 0, 4),  // Low nibble
+        lsrCplx(0b11111111, 0, 8, 0b1111, 6, 3, 4),   // No shift
+
+        lsrSimple(0b110100, 6, 8, 2),
+        lsrSimple(0b10000000, 7, 8, 2),  // Shift MSB
+        lsrSimple(0b11111111, 8, 8, 2),  // Full shift
+        lsrSimple(0b00000000, 3, 8, 2),  // All zeros
+        lsrSimple(0b10101010, 2, 8, 2),  // Alternating bits
+        lsrSimple(0b11110000, 4, 8, 2),  // High nibble
+        lsrSimple(0b00001111, 4, 8, 2),  // Low nibble
+        lsrSimple(0b11111111, 0, 8, 2),  // No shift
+
+        lsrCplx(0b10110100, 3, 8, 0b0001, 7, 4, 2),
+        lsrCplx(0b10000000, 7, 8, 0b1, 6, 0, 2),  // Shift MSB
+        lsrCplx(0b11111111, 8, 8, 0b1, 4, 4, 2),  // Full shift
+        lsrCplx(0b00000000, 3, 8, 0b0, 3, 2, 2),  // All zeros
+        lsrCplx(0b10101010, 2, 8, 0b1010, 6, 2, 2),  // Alternating bits
+        lsrCplx(0b11110000, 4, 8, 0b1111, 3, 0, 2),  // High nibble
+        lsrCplx(0b00001111, 4, 8, 0b0, 5, 0, 2),  // Low nibble
+        lsrCplx(0b11111111, 0, 8, 0b1111, 6, 3, 2)   // No shift
+    );
+  }
+
+  private DynamicTest lsrSimple(long a, int b, int width, int targetSize) {
+    return DynamicTest.dynamicTest("LSR_" + a + "_" + b, () -> {
+      var aN = bits(a, width).toNode();
+      var bN = bits(b, width).toNode();
+      var shift = BuiltInTable.LSR.call(aN, bN);
+      testRequest(shift, targetSize);
+    });
+  }
+
+  private DynamicTest lsrCplx(long a, int b, int width, int expected, int hi, int lo,
+                              int targetSize) {
+    return DynamicTest.dynamicTest("CPLX_LSR_" + a + "_" + b, () -> {
+      var aN = bits(a, width).toNode();
+      var bN = bits(b, width).toNode();
+      var shift = BuiltInTable.LSR.call(aN, bN);
+      testRequest(shift, hi, lo, expected, targetSize);
+    });
+  }
+
+
+  private void testRequest(ExpressionNode expr, int hi, int lo, long expected, int targetSize) {
+    var decomposed = new Decomposer(targetSize).request(expr.copy(), hi, lo);
+    var testGraph = new Graph("test");
+    testGraph.addWithInputs(decomposed);
+
+    var decomposeResult = Canonicalizer.canonicalizeSubGraph(decomposed);
+
+    assertThat(decomposeResult).isInstanceOf(ConstantNode.class);
+
+    var decompVal = ((ConstantNode) decomposeResult).constant().asVal();
+    assertThat(decompVal.longValue()).isEqualTo(expected);
+  }
+
+  private void testRequest(ExpressionNode expr, int targetSize) {
+    var refGraph = new Graph("ref");
+    var ref = refGraph.addWithInputs(expr.copy());
+    var expectedResult = Canonicalizer.canonicalizeSubGraph(ref);
+
+    assertThat(expectedResult).isInstanceOf(ConstantNode.class);
+
+    var expectedVal = ((ConstantNode) expectedResult).constant().asVal().longValue();
+    System.out.println(((ConstantNode) expectedResult).constant().asVal().binary());
+    var hi = ref.type().asDataType().bitWidth() - 1;
+    testRequest(ref, hi, 0, expectedVal, targetSize);
+  }
+
+}


### PR DESCRIPTION
This PR adds support for the `EXTR` instruction which contains a 128 bit LSR call. 
Thus, it is required to be decomposed, which is done by the new Decomposer.