### PR TITLE
parser: Add record returns to models

### DIFF
--- a/vadl/main/vadl/ast/vadl.ATG
+++ b/vadl/main/vadl/ast/vadl.ATG
@@ -2068,7 +2068,7 @@ PRODUCTIONS
     ]
     SYM_PAREN_CLOSE                         (. macroContext.addFirst(params); .)
     SYM_COLON
-    basicSyntaxType<out SyntaxType returnType>
+    syntaxType<out SyntaxType returnType>
     SYM_EQ
 
     SYM_BRACE_OPEN

--- a/vadl/test/vadl/ast/MacroTests.java
+++ b/vadl/test/vadl/ast/MacroTests.java
@@ -424,6 +424,19 @@ public class MacroTests {
             assertThat(d).hasMessageContaining("Macro name already used: Test"));
   }
 
+  @Test
+  void macroWithRecordTypes() {
+    // There once was a time where record return types couldn't be parsed.
+    var prog1 = """
+        record InstrWithFunct (id: Id, mnemo: Str, opcode: Ex, funct: Id)
+        
+        model ExtendInstr (i: InstrWithFunct, ext: Str): InstrWithFunct = {
+          (ExtendId ($i.id,  $ext); $i.mnemo; $i.opcode; $i.funct)
+        }
+        """;
+    Assertions.assertDoesNotThrow(() -> VadlParser.parse(prog1));
+  }
+
 }
 
 


### PR DESCRIPTION
Models can now return record types. #247