### PR TITLE
sys/aarch64.vadl: Fix MRS nzcv shift

### DIFF
--- a/sys/aarch64/aarch64.vadl
+++ b/sys/aarch64/aarch64.vadl
@@ -1552,7 +1552,7 @@ instruction set architecture AArch64Base = {
   model MrsRegInstr (i: InstrNoFunct): IsaDefs = {
     instruction $i.id: MoveSystemRegFormat =
       if sysreg = SysRegEncode::NZCV
-        then X(rt) := NZCV as BitsX << 26
+        then X(rt) := NZCV as BitsX << 28
         else if CurrentEL = 0
         then raise $UndefinedException ()
         else match sysreg with


### PR DESCRIPTION
I think the NZCV register should be shifted by 28 bits, instead of 26 bits, as it is the 4 most significant bits.