### PR TITLE
frontend: Rename ExtendId and IdToStr to AsId and AsStr

### DIFF
--- a/docs/refman/aarch32.vadl
+++ b/docs/refman/aarch32.vadl
@@ -26,12 +26,12 @@ record Instr (id: Id, ass: Str, op: BinOp, opcode: Bin)
 record Cond  (str: Str, code: Id, ex: Ex)
 
 model ALImmCondInstr (cond: Cond, instr: Instr) : IsaDefs = {
-  instruction ExtendId ($instr.id, $cond.str) : ArLoImm =
+  instruction AsId ($instr.id, $cond.str) : ArLoImm =
     if ($cond.ex) then
       R(rd) := R(rn) $instr.op imm12 as Word
-  encoding ExtendId ($instr.id, $cond.str) =
+  encoding AsId ($instr.id, $cond.str) =
     {cc = cond::$cond.code, op = $instr.opcode, flags = 0}
-  assembly ExtendId ($instr.id, $cond.str) =
+  assembly AsId ($instr.id, $cond.str) =
     ($instr.ass, $cond.str, ' ', register(rd), ',', register(rn), ',', decimal(imm12))
   }
 

--- a/docs/refman/tutorial.md
+++ b/docs/refman/tutorial.md
@@ -588,7 +588,7 @@ $InstModel( ( ADD ; + ) )
 ~~~
 \endlisting
 
-### Lexical Macro Functions (ExtendId, IdToStr)
+### Lexical Macro Functions (AsId, AsStr)
 
 While most of the needs are covered by syntactical macros, string and identifier manipulation is best done using lexical
 macros.
@@ -596,9 +596,9 @@ A lexical macro acts on the abstraction level of token streams in contrast to an
 Two use-cases are supported using special syntax type converting functions.
 Firstly, templates generating instruction behavior and assembly often need the instruction name once in form of an
 identifier (`Id`) and again in form of a string (`Str`).
-This use case is covered by the `IdToStr` function (will be renamed to `AsStr`).
+This use case is covered by the `AsStr` function (will be renamed to `AsStr`).
 This function takes an `Id` typed syntax element and converts it to a `Str` typed syntax element.
-Secondly, the `ExtendId` function allows safe identifier manipulation (will be renamed to `AsId`).
+Secondly, the `AsId` function allows safe identifier manipulation (will be renamed to `AsId`).
 This function takes an arbitrary number of `Id` or `Str` typed syntax elements, converts `Id` typed elements to `Str`,
 concatenates them and returns a single `Id` typed syntax element.
 Listing \r{lexical_macros} shows a small example of both functions with their typed result as comment.
@@ -608,8 +608,8 @@ Therefore, it is not possible to define or refer to a model name or parameter us
 
 \listing{lexical_macros, Lexical Macro Examples}
 ~~~{.vadl}
-ExtendId( "", I, "Am", An, "Identifier" ) // --> IAmAnIdentifier : Id
-IdToStr( IAmAString )                     // --> "IAmAString"    : Str
+AsId( "", I, "Am", An, "Identifier" ) // --> IAmAnIdentifier : Id
+AsStr( IAmAString )                     // --> "IAmAString"    : Str
 ~~~
 \endlisting
 
@@ -733,12 +733,12 @@ record Instr (id: Id, ass: Str, op: BinOp, opcode: Bin)
 record Cond  (str: Str, code: Id, ex: Ex)
 
 model ALImmCondInstr (cond: Cond, instr: Instr) : IsaDefs = {
-  instruction ExtendId ($instr.id, $cond.str) : ArLoImm =
+  instruction AsId ($instr.id, $cond.str) : ArLoImm =
     if ($cond.ex) then
       R(rd) := R(rn) $instr.op imm12 as Word
-  encoding ExtendId ($instr.id, $cond.str) =
+  encoding AsId ($instr.id, $cond.str) =
     {cc = cond::$cond.code, op = $instr.opcode, flags = 0}
-  assembly ExtendId ($instr.id, $cond.str) =
+  assembly AsId ($instr.id, $cond.str) =
     ($instr.ass, $cond.str, ' ', register(rd), ',', register(rn), ',', decimal(imm12))
   }
 
@@ -769,7 +769,7 @@ The `Cond` record type definition consists of a string representing the extensio
 of the enumeration of the condition encoding and a boolean expression for condition evaluation.
 
 Now 15 different instructions with a unique identifier have to be created.
-This can be handled with the lexical macro function `ExtendId` by appending the extension string of the condition to the
+This can be handled with the lexical macro function `AsId` by appending the extension string of the condition to the
 identifier.
 
 The final problem is that there is a set of models which describe different kinds of conditional instructions and all

--- a/sys/aarch64/aarch64.vadl
+++ b/sys/aarch64/aarch64.vadl
@@ -270,14 +270,14 @@ instruction set architecture AArch64Base = {
     }
 
   model AddSubExtInstrBase (i: InstrWithFunct, extId: Id, size: Id, f: Flags, extEx: Ex, optId: Id, enc: Encs, asm: Ex): IsaDefs = {
-    instruction ExtendId ($i.id, $extId): AddSubExtFormat =
+    instruction AsId ($i.id, $extId): AddSubExtFormat =
       let result, flags = VADL::$i.funct (S(rn) as Bits<Size::$size>, ($extEx) as Bits<Size::$size>) in {
         $f.resModel (match: Id ($f.ff = OffFlags => S ; _ => X)(rd) ; result )
         }
     //[raise Undefined : imm3(2) = 1 && imm3(1..0) != 0]
-    encoding ExtendId ($i.id, $extId) = { op = $i.opcode, sf = SF::$size, ff = FF::$f.ff, option = ExtendType::$optId, $enc }
-    assembly ExtendId ($i.id, $extId) = ( $i.mnemo, $f.mext, ' ', ExtendId($size, match: Str ($f.ff = OffFlags => "SP" ; _ => ""))(rd), 
-                       ', ', ExtendId($size, "SP")(rn), ', ', $asm )
+    encoding AsId ($i.id, $extId) = { op = $i.opcode, sf = SF::$size, ff = FF::$f.ff, option = ExtendType::$optId, $enc }
+    assembly AsId ($i.id, $extId) = ( $i.mnemo, $f.mext, ' ', AsId($size, match: Str ($f.ff = OffFlags => "SP" ; _ => ""))(rd),
+                       ', ', AsId($size, "SP")(rn), ', ', $asm )
     }
 
   model AddSubExtInstr (i: InstrWithFunct, size: Id, f: Flags): IsaDefs = {
@@ -321,12 +321,12 @@ instruction set architecture AArch64Base = {
         $f.resModel (match: Id ($f.ff = OffFlags => S ; _ => X)(rd) ; result )
         }
     encoding $i.id = { op = $i.opcode, sf = SF::$size, ff = FF::$f.ff, sh = $sh }
-    assembly $i.id = ( $i.mnemo, $f.mext, ' ', ExtendId($size, match: Str ($f.ff = OffFlags => "SP" ; _ => ""))(rd), 
-                       ', ', ExtendId($size, "SP")(rn), ', ', "#", decimal($immEx), $asm )
+    assembly $i.id = ( $i.mnemo, $f.mext, ' ', AsId($size, match: Str ($f.ff = OffFlags => "SP" ; _ => ""))(rd),
+                       ', ', AsId($size, "SP")(rn), ', ', "#", decimal($immEx), $asm )
     }
 
   model ExtInstrStr (i: InstrWithFunct, ext: Str): InstrWithFunct = {
-    (ExtendId ($i.id,  $ext); $i.mnemo; $i.opcode; $i.funct)
+    (AsId ($i.id,  $ext); $i.mnemo; $i.opcode; $i.funct)
     }
 
   model AddSubImmInstr (i: InstrWithFunct, size: Id, f: Flags): IsaDefs = {
@@ -595,7 +595,7 @@ instruction set architecture AArch64Base = {
   model LogicImmEncAsm (i: InstrWithFunct, size: Id, ext: Str): IsaDefs = {
     //[raise Undefined : sf = 0 && imm13(12) = 1]
     encoding $i.id = { op = $i.opcode, sf = SF::$size }
-    assembly $i.id = ($i.mnemo, ' ', ExtendId($size, $ext)(rd), ', ', $size(rn), ', #', decimal(immX))
+    assembly $i.id = ($i.mnemo, ' ', AsId($size, $ext)(rd), ', ', $size(rn), ', #', decimal(immX))
     }
 
   model LogicImmFlagInstr (i: InstrWithFunct, size: Id): IsaDefs = {
@@ -655,7 +655,7 @@ instruction set architecture AArch64Base = {
     }
 
   model LogicRegShiftExtInstr (modelid: InstrWithFunctSizeRegShift, i: InstrWithFunct, ext: Str, size: Id, s: RegShift): IsaDefs = {
-    $modelid ((ExtendId ($i.id, $ext); $i.mnemo; $i.opcode; $i.funct); $size; $s)
+    $modelid ((AsId ($i.id, $ext); $i.mnemo; $i.opcode; $i.funct); $size; $s)
     }
 
   model LogicRegShiftInstr (modelid: InstrWithFunctSizeRegShift, i: InstrWithFunct, size: Id): IsaDefs = {
@@ -706,10 +706,10 @@ instruction set architecture AArch64Base = {
   model notOrIdent (not: Id, ex: Ex) : Ex = { match: Ex ($not = not => ~($ex) ;_=> $ex) }
   
   model MovInstr (i: InstrWithFunct, size: Id, pos: Id, posex: Ex): IsaDefs = {
-    instruction ExtendId ($i.id, $pos): MovFormat = 
+    instruction AsId ($i.id, $pos): MovFormat =
       X(rd) := $posex
-    encoding ExtendId ($i.id, $pos) = { sf = SF::$size, op = $i.opcode, pos = Position::$pos }
-    assembly ExtendId ($i.id, $pos) = ($i.mnemo, ' ', $size(rd), ', #', decimal(imm16),
+    encoding AsId ($i.id, $pos) = { sf = SF::$size, op = $i.opcode, pos = Position::$pos }
+    assembly AsId ($i.id, $pos) = ($i.mnemo, ' ', $size(rd), ', #', decimal(imm16),
       match: Str ($pos = Pos00 => ""; $pos = Pos16 => ", LSL #16"; $pos = Pos32 => ", LSL #32"; _ => ", LSL #48"))
     }
 
@@ -753,7 +753,7 @@ instruction set architecture AArch64Base = {
   model ExtractRegPairInstr (i: InstrWithFunct, size: Id): IsaDefs = {
     instruction $i.id: ExtractRegFormat =
       let pair = (X(rn) as Bits<Size::$size>, X(rm) as Bits<Size::$size>) in
-        X(rd) :=  (pair >> ExtendId (shift, $size)) as Bits<Size::$size> as BitsX
+        X(rd) :=  (pair >> AsId (shift, $size)) as Bits<Size::$size> as BitsX
     encoding $i.id = { op = $i.opcode, sf = SF::$size, N = SF::$size }
     assembly $i.id = ($i.mnemo, ' ', $size(rd), ', ', $size(rn), ', ', $size(rm), ', #', decimal(imms))
     }
@@ -810,8 +810,8 @@ instruction set architecture AArch64Base = {
     // (sf != N) cannot happen as N is set in encoding
     // [raise Undefined : sf = 0 && (imms(5) = 1 || immr(5) = 1)]
     instruction $i.id: BitFieldMoveFormat =
-      let left = ExtendId (left, $size) in
-        let right = ExtendId (right, $size) in
+      let left = AsId (left, $size) in
+        let right = AsId (right, $size) in
           let xrn = X(rn) as $i.funct<Size::$size> << left >> right in
             let result = match: Ex ($i.mnemo = "bfm" =>
               let mask = ~(~(0 as Bits<Size::$size>) << left >> right) in
@@ -860,7 +860,7 @@ instruction set architecture AArch64Base = {
 
   model ReverseBitsInstr (i: InstrWithFunct, size: Id): IsaDefs = {
     instruction $i.id: TwoRegOpFormat =
-      let result = ExtendId (revBits, $size) (X(rn) as Bits<Size::$size>) in
+      let result = AsId (revBits, $size) (X(rn) as Bits<Size::$size>) in
         X(rd) := result as Bits<Size::$size> as BitsX
     $TwoRegOpEncAsm ($i; $size)
     }
@@ -1026,7 +1026,7 @@ instruction set architecture AArch64Base = {
     }
 
   model ExtendCondInstr (modelid: InstrWithCond, i: InstrWithFunct, c: Cond): IsaDefs = {
-    $modelid ((ExtendId($i.id, $c.cc); $i.mnemo; $i.opcode; $i.funct); $c)
+    $modelid ((AsId($i.id, $c.cc); $i.mnemo; $i.opcode; $i.funct); $c)
     }
 
   model CondInstr (modelid: InstrWithCond, i: InstrWithFunct): IsaDefs = {
@@ -1173,7 +1173,7 @@ instruction set architecture AArch64Base = {
     }
 
   model MemoryRegisterXtd (i: InstrNoFunct, m: Memory, option: Id, scaled: Id, asm: Ex, addr: Ex): IsaDefs = {
-  	$MemoryRegisterBase ((ExtendId ($i.id, $option, $scaled); $i.mnemo; $i.opcode); $m; $option; $scaled; $asm; $addr)
+  	$MemoryRegisterBase ((AsId ($i.id, $option, $scaled); $i.mnemo; $i.opcode); $m; $option; $scaled; $asm; $addr)
     }
 
   model MemoryRegisterInstr (i: InstrNoFunct, m: Memory): IsaDefs = {
@@ -1207,7 +1207,7 @@ instruction set architecture AArch64Base = {
 // memory enriching models *****************************************************
 
   model MemoryInstr (memmodel: MemoryModel, i: InstrNoFunct, xtdId: Str, m: Memory): IsaDefs = {
-  	$memmodel ((ExtendId ($i.id, $xtdId); $i.mnemo; $i.opcode); $m)
+  	$memmodel ((AsId ($i.id, $xtdId); $i.mnemo; $i.opcode); $m)
     }
 
   model StoreInstr (memmodel: MemoryModel, i: InstrNoFunct): IsaDefs = {
@@ -1251,25 +1251,25 @@ instruction set architecture AArch64Base = {
 
   model MemoryRegPairEncAsm (i: InstrWithFunct, extId: Str, size: Id, isLoad: Bool, op: Bin, asm: Ex): IsaDefs = {
     //[raise Undefined() : match: Ex ( $isLoad = true => Ex1 ; _=> Ex2)]
-    encoding ExtendId ($i.id, $extId) = { opc = $i.opcode, op = $op }
-    assembly ExtendId ($i.id, $extId) = ($i.mnemo, ' ', $size(rt), ', ', $size(rt2), $asm)
+    encoding AsId ($i.id, $extId) = { opc = $i.opcode, op = $op }
+    assembly AsId ($i.id, $extId) = ($i.mnemo, ' ', $size(rt), ', ', $size(rt2), $asm)
     }
 
   model MemoryRegPairInstr (i: InstrWithFunct, size: Id, isLoad: Bool, memstmts: Stats): IsaDefs = {
     // TODO check SP alignment
     instruction $i.id: MemoryPairFormat = 
-      let addr = S(rn) + ExtendId (off, $size) in { $memstmts }
+      let addr = S(rn) + AsId (off, $size) in { $memstmts }
     $MemoryRegPairEncAsm ($i; ""; $size; $isLoad; 0b101'010; ("[", XSizeSP(rn), Imm7decimal(imm7), "]"))
-    instruction ExtendId ($i.id, "Pre"): MemoryPairFormat =
-      let addr = S(rn) + ExtendId (off, $size) in {
+    instruction AsId ($i.id, "Pre"): MemoryPairFormat =
+      let addr = S(rn) + AsId (off, $size) in {
           $memstmts
           S(rn) := addr
         }
     $MemoryRegPairEncAsm ($i; "Pre"; $size; $isLoad; 0b101'011; ("[", XSizeSP(rn), Imm7decimal(imm7), "]!"))
-    instruction ExtendId ( $i.id, "Pst"): MemoryPairFormat =
+    instruction AsId ( $i.id, "Pst"): MemoryPairFormat =
       let addr = S(rn) in {
           $memstmts
-          S(rn) := addr + ExtendId (off, $size)
+          S(rn) := addr + AsId (off, $size)
         }
     $MemoryRegPairEncAsm ($i; "Pst"; $size; $isLoad; 0b101'001; ("[", XSizeSP(rn), "]", Imm7decimal(imm7)))
     }

--- a/sys/v-risc/VarRisc.vadl
+++ b/sys/v-risc/VarRisc.vadl
@@ -144,18 +144,18 @@ instruction set architecture VarRISC32 = {
   }
 
   model ComputeInstruction ( name : Id, op : BinOp, ltype: Id, rtype: Id, code : Val ) : IsaDefs = {
-    $ShortRegInstr (ExtendId ( $name, '_S' ) ; $op ; $ltype ; $rtype ; $code )
-    $ShortImmInstr (ExtendId ( $name, 'I_S') ; $op ; $ltype ; $rtype ; $code )
+    $ShortRegInstr (AsId ( $name, '_S' ) ; $op ; $ltype ; $rtype ; $code )
+    $ShortImmInstr (AsId ( $name, 'I_S') ; $op ; $ltype ; $rtype ; $code )
     $RegInstr      (           $name         ; $op ; $ltype ; $rtype ; $code )
-    $ImmInstr      (ExtendId ( $name, 'I'  ) ; $op ; $ltype ; $rtype ; $code )
+    $ImmInstr      (AsId ( $name, 'I'  ) ; $op ; $ltype ; $rtype ; $code )
   }
 
   model LongImmInstruction (name : Id, op : BinOp, ltype: Id, rtype: Id, code : Val) : IsaDefs = {
-    instruction ExtendId ( $name, 'I_L') : TYPE_L =
+    instruction AsId ( $name, 'I_L') : TYPE_L =
         let res = R(rs1) as $ltype $op imm in
             R(rd) := res as Regs
-    encoding ExtendId ( $name, 'I_L') = { opcode = ImmLOff + $code }
-    assembly ExtendId ( $name, 'I_L') = ( mnemonic, ' ', register(rd), ',', register(rs1), ',', decimal(imm) )
+    encoding AsId ( $name, 'I_L') = { opcode = ImmLOff + $code }
+    assembly AsId ( $name, 'I_L') = ( mnemonic, ' ', register(rd), ',', register(rs1), ',', decimal(imm) )
     $ComputeInstruction ( $name; $op; $ltype; $rtype; $code )
   }
 
@@ -167,10 +167,10 @@ instruction set architecture VarRISC32 = {
   }
 
   model BranchSInstruction ( name : Id, code : Val ) : IsaDefs = {
-    instruction ExtendId ( $name, '_S' ) : TYPE_B =
+    instruction AsId ( $name, '_S' ) : TYPE_B =
       PC := PC + offsetS
-    encoding ExtendId ( $name, '_S' ) = { opcode = $code }
-    assembly ExtendId ( $name, '_S' ) = ( mnemonic, ' ', decimal (offset) )
+    encoding AsId ( $name, '_S' ) = { opcode = $code }
+    assembly AsId ( $name, '_S' ) = ( mnemonic, ' ', decimal (offset) )
   }
 
   model JumpLinkInstruction ( name : Id, code : Val ) : IsaDefs = {
@@ -189,17 +189,17 @@ instruction set architecture VarRISC32 = {
     encoding $name = { opcode = MemCode, func5 = $code }
     assembly $name = ( mnemonic, ' ', register(rd), ',', decimal(imm), '(', register(rs1), ')' )
 
-    instruction ExtendId ( $name, '_L') : TYPE_L =
+    instruction AsId ( $name, '_L') : TYPE_L =
       let a = R(rs1) + immU in $memstmt
-    encoding ExtendId ( $name, '_L') = { opcode = MemLOff + $code }
-    assembly ExtendId ( $name, '_L') = ( mnemonic, ' ', register(rd), ',', decimal(imm), '(', register(rs1), ')' )
+    encoding AsId ( $name, '_L') = { opcode = MemLOff + $code }
+    assembly AsId ( $name, '_L') = ( mnemonic, ' ', register(rd), ',', decimal(imm), '(', register(rs1), ')' )
   }
 
   model ShortMemInstruction ( name : Id, memstmt : Stat, code : Val ) : IsaDefs = {
-    instruction ExtendId ( $name, '_S') : TYPE_S =
+    instruction AsId ( $name, '_S') : TYPE_S =
       let a = R(rs1) in $memstmt
-    encoding ExtendId ( $name, '_S') = { opcode = MemSOff + $code }
-    assembly ExtendId ( $name, '_S') = ( mnemonic, ' ', register(rd), ',(', register(rs1), ')' )
+    encoding AsId ( $name, '_S') = { opcode = MemSOff + $code }
+    assembly AsId ( $name, '_S') = ( mnemonic, ' ', register(rd), ',(', register(rs1), ')' )
     $MemoryInstruction ( $name; $memstmt; $code )
   }
 
@@ -210,24 +210,24 @@ instruction set architecture VarRISC32 = {
     encoding $name = { opcode = MemCode, func5 = $code }
     assembly $name = ( mnemonic, ' ', register(rd), ',', register(rs1), ',', decimal(imm) )
 
-    instruction ExtendId ( $name, '_L') : TYPE_L = {
+    instruction AsId ( $name, '_L') : TYPE_L = {
       if R(rd) as $reltype $op R(rs1) then
         PC := PC + offsetS
     }
-    encoding ExtendId ( $name, '_L') = { opcode = BraLOff + $code }
-    assembly ExtendId ( $name, '_L') = ( mnemonic, ' ', register(rd), ',', register(rs1), ',', decimal(imm) )
+    encoding AsId ( $name, '_L') = { opcode = BraLOff + $code }
+    assembly AsId ( $name, '_L') = ( mnemonic, ' ', register(rd), ',', register(rs1), ',', decimal(imm) )
   }
 
   model CondImmInstruction ( name : Id, op : BinOp, reltype: Id, imm: Id, code : Val ) : IsaDefs = {
-    instruction ExtendId ( $name, 'I') : TYPE_I =
+    instruction AsId ( $name, 'I') : TYPE_I =
       R(rd) :=  ( R(rs1) as $reltype $op $imm ) as Regs
-    encoding ExtendId ( $name, 'I') = { opcode = ImmCode, func5 = $code }
-    assembly ExtendId ( $name, 'I') = ( mnemonic, ' ', register(rd), ',', register(rs1), ',', decimal(imm) )
+    encoding AsId ( $name, 'I') = { opcode = ImmCode, func5 = $code }
+    assembly AsId ( $name, 'I') = ( mnemonic, ' ', register(rd), ',', register(rs1), ',', decimal(imm) )
 
-    instruction ExtendId ( $name, 'I_L') : TYPE_L =
+    instruction AsId ( $name, 'I_L') : TYPE_L =
       R(rd) :=  ( R(rd) as $reltype $op $imm ) as Regs
-    encoding ExtendId ( $name, 'I_L') = { opcode = CodeI_L, func5 = $code }
-    assembly ExtendId ( $name, 'I_L') = ( mnemonic, ' ', register(rd), ',', decimal(imm))
+    encoding AsId ( $name, 'I_L') = { opcode = CodeI_L, func5 = $code }
+    assembly AsId ( $name, 'I_L') = ( mnemonic, ' ', register(rd), ',', decimal(imm))
   }
 
   model CondInstruction ( name : Id, op : BinOp, reltype: Id, imm: Id, code : Val ) : IsaDefs = {
@@ -247,12 +247,12 @@ instruction set architecture VarRISC32 = {
     encoding $name = { opcode = ImmCode, func5 = $code }
     assembly $name = ( mnemonic, ' ', register(rd), ',', decimal(imm))
 
-    instruction ExtendId ( $name, '_L' ) : TYPE_L = {
+    instruction AsId ( $name, '_L' ) : TYPE_L = {
         R(rd) := PC.next
         PC := PC + offsetS
         }
-    encoding ExtendId ( $name, '_L') = { opcode = CodeI_L, func5 = $code }
-    assembly ExtendId ( $name, '_L') = ( mnemonic, ' ', register(rd), ',', decimal(imm))
+    encoding AsId ( $name, '_L') = { opcode = CodeI_L, func5 = $code }
+    assembly AsId ( $name, '_L') = ( mnemonic, ' ', register(rd), ',', decimal(imm))
   }
 
 /* instruction encoding and opcode space of opcode and func5/func9

--- a/vadl/main/vadl/ast/AstVisitor.java
+++ b/vadl/main/vadl/ast/AstVisitor.java
@@ -715,7 +715,7 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   }
 
   @Override
-  public Void visit(ExtendIdExpr expr) {
+  public Void visit(AsIdExpr expr) {
     beforeTravel(expr);
     expr.children().forEach(this::travel);
     afterTravel(expr);
@@ -723,7 +723,7 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   }
 
   @Override
-  public Void visit(IdToStrExpr expr) {
+  public Void visit(AsStrExpr expr) {
     beforeTravel(expr);
     expr.children().forEach(this::travel);
     afterTravel(expr);

--- a/vadl/main/vadl/ast/BehaviorLowering.java
+++ b/vadl/main/vadl/ast/BehaviorLowering.java
@@ -948,13 +948,13 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
   }
 
   @Override
-  public ExpressionNode visit(ExtendIdExpr expr) {
+  public ExpressionNode visit(AsIdExpr expr) {
     throw new RuntimeException(
         "The behavior generator doesn't implement yet: " + expr.getClass().getSimpleName());
   }
 
   @Override
-  public ExpressionNode visit(IdToStrExpr expr) {
+  public ExpressionNode visit(AsStrExpr expr) {
     throw new RuntimeException(
         "The behavior generator doesn't implement yet: " + expr.getClass().getSimpleName());
   }

--- a/vadl/main/vadl/ast/ConstantEvaluator.java
+++ b/vadl/main/vadl/ast/ConstantEvaluator.java
@@ -363,13 +363,13 @@ class ConstantEvaluator implements ExprVisitor<ConstantValue> {
   }
 
   @Override
-  public ConstantValue visit(ExtendIdExpr expr) {
+  public ConstantValue visit(AsIdExpr expr) {
     throw new IllegalStateException(
         "The constant evaluator should never see a %s".formatted(expr.getClass().getSimpleName()));
   }
 
   @Override
-  public ConstantValue visit(IdToStrExpr expr) {
+  public ConstantValue visit(AsStrExpr expr) {
     throw new IllegalStateException(
         "The constant evaluator should never see a %s".formatted(expr.getClass().getSimpleName()));
   }

--- a/vadl/main/vadl/ast/Expr.java
+++ b/vadl/main/vadl/ast/Expr.java
@@ -130,9 +130,9 @@ interface ExprVisitor<R> {
 
   R visit(MatchExpr expr);
 
-  R visit(ExtendIdExpr expr);
+  R visit(AsIdExpr expr);
 
-  R visit(IdToStrExpr expr);
+  R visit(AsStrExpr expr);
 
   R visit(ExistsInExpr expr);
 
@@ -758,7 +758,7 @@ class StringLiteral extends Expr {
   }
 
   public StringLiteral(Identifier fromId, SourceLocation loc) {
-    // TODO More robust string escaping - only used for prettifying expanded IdToStr code
+    // TODO More robust string escaping - only used for prettifying expanded AsStr code
     this.token = '"' + fromId.name.replaceAll("\"", "\\\"") + '"';
     this.value = fromId.name;
     this.loc = loc;
@@ -827,7 +827,7 @@ class StringLiteral extends Expr {
  * }</pre></p>
  */
 sealed interface IdentifierOrPlaceholder extends IsId
-    permits Identifier, MacroInstanceExpr, MacroMatchExpr, PlaceholderExpr, ExtendIdExpr {
+    permits Identifier, MacroInstanceExpr, MacroMatchExpr, PlaceholderExpr, AsIdExpr {
 }
 
 /**
@@ -1052,14 +1052,14 @@ final class MacroMatchExpr extends Expr implements IsMacroMatch, IdentifierOrPla
 }
 
 /**
- * An internal temporary node representing the ExtendId built-in.
+ * An internal temporary node representing the AsId built-in.
  * This node should never leave the parser.
  */
-final class ExtendIdExpr extends Expr implements IdentifierOrPlaceholder, IsId {
+final class AsIdExpr extends Expr implements IdentifierOrPlaceholder, IsId {
   GroupedExpr expr;
   SourceLocation loc;
 
-  ExtendIdExpr(GroupedExpr expr, SourceLocation loc) {
+  AsIdExpr(GroupedExpr expr, SourceLocation loc) {
     this.expr = expr;
     this.loc = loc;
   }
@@ -1081,7 +1081,7 @@ final class ExtendIdExpr extends Expr implements IdentifierOrPlaceholder, IsId {
 
   @Override
   public void prettyPrintExpr(int indent, StringBuilder builder, Precedence parentPrec) {
-    builder.append("ExtendId ");
+    builder.append("AsId ");
     expr.prettyPrint(0, builder);
   }
 
@@ -1094,7 +1094,7 @@ final class ExtendIdExpr extends Expr implements IdentifierOrPlaceholder, IsId {
       return false;
     }
 
-    ExtendIdExpr that = (ExtendIdExpr) o;
+    AsIdExpr that = (AsIdExpr) o;
     return expr.equals(that.expr);
   }
 
@@ -1118,14 +1118,14 @@ final class ExtendIdExpr extends Expr implements IdentifierOrPlaceholder, IsId {
 }
 
 /**
- * An internal temporary node representing the IdToStr built-in.
+ * An internal temporary node representing the AsStr built-in.
  * This node should never leave the parser.
  */
-final class IdToStrExpr extends Expr {
+final class AsStrExpr extends Expr {
   IdentifierOrPlaceholder id;
   SourceLocation loc;
 
-  IdToStrExpr(IdentifierOrPlaceholder id, SourceLocation loc) {
+  AsStrExpr(IdentifierOrPlaceholder id, SourceLocation loc) {
     this.id = id;
     this.loc = loc;
   }
@@ -1147,7 +1147,7 @@ final class IdToStrExpr extends Expr {
 
   @Override
   public void prettyPrintExpr(int indent, StringBuilder builder, Precedence parentPrec) {
-    builder.append("IdToStr (");
+    builder.append("AsStr (");
     id.prettyPrint(0, builder);
     builder.append(")");
   }
@@ -1161,7 +1161,7 @@ final class IdToStrExpr extends Expr {
       return false;
     }
 
-    IdToStrExpr that = (IdToStrExpr) o;
+    AsStrExpr that = (AsStrExpr) o;
     return id.equals(that.id);
   }
 
@@ -1444,7 +1444,7 @@ sealed interface IsSymExpr extends IsCallExpr permits SymbolExpr, IsId {
 }
 
 sealed interface IsId extends IsSymExpr
-    permits ExtendIdExpr, Identifier, IdentifierOrPlaceholder, IdentifierPath, MacroInstanceExpr,
+    permits AsIdExpr, Identifier, IdentifierOrPlaceholder, IdentifierPath, MacroInstanceExpr,
     MacroMatchExpr, PlaceholderExpr {
   @Override
   default IsId path() {

--- a/vadl/main/vadl/ast/MacroExpander.java
+++ b/vadl/main/vadl/ast/MacroExpander.java
@@ -402,7 +402,15 @@ class MacroExpander
           .locationDescription(expr, "This expands to an empty identifier name.")
           .note("Empty identifiers are forbidden as they needlessly obfuscate the code.")
           .build());
+    } else if (!ParserUtils.isValidIdentifier(name)) {
+      this.errors.add(error("Invalid Identifier: `%s`".formatted(name), expr)
+          .locationDescription(expr, "This expands to an invalid identifier name.")
+          .note(
+              "Identifiers must match the regex /[a-zA-Z][a-zA-Z0-9_]*/ and cannot clash "
+                  + "with a keyword.")
+          .build());
     }
+
     return new Identifier(nameBuilder.toString(), copyLoc(expr.location()));
   }
 

--- a/vadl/main/vadl/ast/MacroExpander.java
+++ b/vadl/main/vadl/ast/MacroExpander.java
@@ -378,7 +378,7 @@ class MacroExpander
   }
 
   @Override
-  public Expr visit(ExtendIdExpr expr) {
+  public Expr visit(AsIdExpr expr) {
     var nameBuilder = new StringBuilder();
     var expressions = (GroupedExpr) expr.expr.accept(this);
     for (var inner : expressions.expressions) {
@@ -387,11 +387,11 @@ class MacroExpander
       } else if (inner instanceof StringLiteral string) {
         nameBuilder.append(string.value);
       } else if (inner instanceof PlaceholderExpr
-          || inner instanceof ExtendIdExpr || inner instanceof IdToStrExpr) {
+          || inner instanceof AsIdExpr || inner instanceof AsStrExpr) {
         // Will be expanded as soon as the used placeholders are bound
-        return new ExtendIdExpr(expressions, copyLoc(expr.location()));
+        return new AsIdExpr(expressions, copyLoc(expr.location()));
       } else {
-        reportError("Unsupported 'ExtendId' parameter " + inner, inner.location());
+        reportError("Unsupported 'AsId' parameter " + inner, inner.location());
         nameBuilder.append(inner);
       }
     }
@@ -407,12 +407,12 @@ class MacroExpander
   }
 
   @Override
-  public Expr visit(IdToStrExpr expr) {
+  public Expr visit(AsStrExpr expr) {
     var idOrPlaceholder = expandId(expr.id);
     if (idOrPlaceholder instanceof Identifier id) {
       return new StringLiteral(id, copyLoc(expr.location()));
     } else {
-      return new IdToStrExpr(idOrPlaceholder, copyLoc(expr.location()));
+      return new AsStrExpr(idOrPlaceholder, copyLoc(expr.location()));
     }
   }
 
@@ -1285,7 +1285,7 @@ class MacroExpander
         || node instanceof MacroMatchExpr || node instanceof MacroMatchStatement
         || node instanceof MacroInstanceNode || node instanceof MacroInstanceDefinition
         || node instanceof MacroInstanceExpr || node instanceof MacroInstanceStatement
-        || node instanceof ExtendIdExpr || node instanceof IdToStrExpr;
+        || node instanceof AsIdExpr || node instanceof AsStrExpr;
 
   }
 

--- a/vadl/main/vadl/ast/ParserUtils.java
+++ b/vadl/main/vadl/ast/ParserUtils.java
@@ -411,10 +411,10 @@ class ParserUtils {
    * After: parser is in the same state as before.
    */
   static boolean isMacroReplacementOfType(Parser parser, BasicSyntaxType syntaxType) {
-    if (parser.la.kind == Parser._EXTEND_ID) {
+    if (parser.la.kind == Parser._AS_ID) {
       return BasicSyntaxType.ID.isSubTypeOf(syntaxType);
     }
-    if (parser.la.kind == Parser._ID_TO_STR) {
+    if (parser.la.kind == Parser._AS_STR) {
       return BasicSyntaxType.STR.isSubTypeOf(syntaxType);
     }
     SyntaxType macroMatchType = macroMatchType(parser);

--- a/vadl/main/vadl/ast/ParserUtils.java
+++ b/vadl/main/vadl/ast/ParserUtils.java
@@ -32,6 +32,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import vadl.error.Diagnostic;
@@ -403,6 +404,29 @@ class ParserUtils {
    */
   static boolean isIdentifierToken(Token token) {
     return ID_TOKENS[token.kind];
+  }
+
+  private static final Pattern identifierPattern = Pattern.compile("[a-zA-Z][a-zA-Z0-9_]*");
+
+  /**
+   * Checks whether a string can be used as an indentifier.
+   *
+   * @param text to be checked.
+   * @return whether it would be a valid identifier.
+   */
+  static boolean isValidIdentifier(String text) {
+
+    if (!identifierPattern.matcher(text).matches()) {
+      return false;
+    }
+
+    // Only some keywords are allowed as tokens.
+    var tokenId = Scanner.literals.get(text);
+    if (tokenId != null && !ID_TOKENS[tokenId]) {
+      return false;
+    }
+
+    return true;
   }
 
   /**

--- a/vadl/main/vadl/ast/TypeChecker.java
+++ b/vadl/main/vadl/ast/TypeChecker.java
@@ -3013,13 +3013,13 @@ public class TypeChecker
   }
 
   @Override
-  public Void visit(ExtendIdExpr expr) {
+  public Void visit(AsIdExpr expr) {
     throw new IllegalStateException(
         "No %s should ever reach the Typechecker".formatted(expr.getClass().getSimpleName()));
   }
 
   @Override
-  public Void visit(IdToStrExpr expr) {
+  public Void visit(AsStrExpr expr) {
     throw new IllegalStateException(
         "No %s should ever reach the Typechecker".formatted(expr.getClass().getSimpleName()));
   }

--- a/vadl/main/vadl/ast/Ungrouper.java
+++ b/vadl/main/vadl/ast/Ungrouper.java
@@ -177,12 +177,12 @@ public class Ungrouper
   }
 
   @Override
-  public Expr visit(ExtendIdExpr expr) {
+  public Expr visit(AsIdExpr expr) {
     return expr;
   }
 
   @Override
-  public Expr visit(IdToStrExpr expr) {
+  public Expr visit(AsStrExpr expr) {
     return expr;
   }
 

--- a/vadl/main/vadl/ast/vadl.ATG
+++ b/vadl/main/vadl/ast/vadl.ATG
@@ -1964,9 +1964,7 @@ PRODUCTIONS
 
   AsStr<out Node body> (. var start = nextTokenLoc(); .)
   = AS_STR
-    SYM_PAREN_OPEN
-    identifierOrPlaceholder<out IdentifierOrPlaceholder id>
-    SYM_PAREN_CLOSE (. body = new AsStrExpr(id, start.join(lastTokenLoc())); .)
+    groupedExpression<out GroupedExpr expr> (. body = new AsStrExpr(expr, start.join(lastTokenLoc())); .)
   .
 
   macroMatch<out Node node>                           (. var start = nextTokenLoc(); .)

--- a/vadl/main/vadl/ast/vadl.ATG
+++ b/vadl/main/vadl/ast/vadl.ATG
@@ -123,7 +123,7 @@ TOKENS
   ENUMERATION  = "enumeration".
   EXCEPTION    = "exception".
   EXISTS       = "exists".
-  EXTEND_ID    = "ExtendId".
+  AS_ID    = "AsId".
   EXTENDING    = "extending".
   FALSE        = "false".
   FETCH        = "fetch".
@@ -138,7 +138,7 @@ TOKENS
   GRAMMAR      = "grammar".
   GROUP        = "group".
   HIT          = "hit".
-  ID_TO_STR    = "IdToStr".
+  AS_STR    = "AsStr".
   IF_KW        = "if".
   INT          = "int".
   IMPLEMENTS   = "implements".
@@ -1952,21 +1952,21 @@ PRODUCTIONS
   macroReplacement<out Node body> (. body = DUMMY_ID; .)
   = ( macroMatch<out body>
     | maximumMacroExpr<out body>
-    | extendId<out body>
-    | idToStr<out body>
+    | AsId<out body>
+    | AsStr<out body>
     )                             (. body = expandNode(this, body); .)
   .
 
-  extendId<out Node body>                   (. var start = nextTokenLoc(); .)
-  = EXTEND_ID
-    groupedExpression<out GroupedExpr expr> (. body = new ExtendIdExpr(expr, start.join(lastTokenLoc())); .)
+  AsId<out Node body>                   (. var start = nextTokenLoc(); .)
+  = AS_ID
+    groupedExpression<out GroupedExpr expr> (. body = new AsIdExpr(expr, start.join(lastTokenLoc())); .)
   .
 
-  idToStr<out Node body> (. var start = nextTokenLoc(); .)
-  = ID_TO_STR
+  AsStr<out Node body> (. var start = nextTokenLoc(); .)
+  = AS_STR
     SYM_PAREN_OPEN
     identifierOrPlaceholder<out IdentifierOrPlaceholder id>
-    SYM_PAREN_CLOSE (. body = new IdToStrExpr(id, start.join(lastTokenLoc())); .)
+    SYM_PAREN_CLOSE (. body = new AsStrExpr(id, start.join(lastTokenLoc())); .)
   .
 
   macroMatch<out Node node>                           (. var start = nextTokenLoc(); .)

--- a/vadl/test/resources/macros/hexagon.vadl
+++ b/vadl/test/resources/macros/hexagon.vadl
@@ -255,7 +255,7 @@ instruction set architecture QDSP6 =
       R(d5) := VADL::$op($lhs, $rhs)
     }
     encoding $name = { $encs }
-    assembly $name = (AsmR(d5), " = ", IdToStr(op), "(", $asm, ")")
+    assembly $name = (AsmR(d5), " = ", AsStr(op), "(", $asm, ")")
   }
 
   $ALUBase ( AddImm    ; AddImmFormat ; iclass=0b1011                               ; add   ; R(s5); extendS(imm) ; (AsmR(s5),",#",decimal(imm)) )
@@ -453,7 +453,7 @@ instruction set architecture QDSP6 =
       R(d5) := VADL::$op($lhs, $rhs)
     }
     encoding $name = { $encs }
-    assembly $name = ($asmprefix, AsmR(d5), " = ", IdToStr($op), "(", $asm, ")")
+    assembly $name = ($asmprefix, AsmR(d5), " = ", AsStr($op), "(", $asm, ")")
   }
 
   $ALUPredBase( AddImmPredPos; AddPredImmFormat; iclass=0b0111, rs=0, majop=0b100, ps=0, dn=0; add; R(s5); extendS(immS); AsmPred(u2, false, false); (AsmR(s5),",#",decimal(immS));  testpred(u2))
@@ -760,14 +760,14 @@ instruction set architecture QDSP6 =
     assembly $name = (AsmP($p), "=", $asmPred, "; ", AsmPred($p, $neg, true), " jump:", $asmHint, " #", decimal(dispS))
   }
   model CmpJump ( name: Id, iformat: Id, encs: Encs, predEx: Ex, asmPred: Ex ) : IsaDefs = {
-    $CmpJumpBase( ExtendId($name, "P0", "Pos", "NT"); $iformat; hint=0, $encs; 0; 0;  ($predEx); $asmPred; "nt" )
-    $CmpJumpBase( ExtendId($name, "P1", "Pos", "NT"); $iformat; hint=0, $encs; 0; 1;  ($predEx); $asmPred; "nt" )
-    $CmpJumpBase( ExtendId($name, "P0", "Neg", "NT"); $iformat; hint=0, $encs; 1; 0; !($predEx); $asmPred; "nt" )
-    $CmpJumpBase( ExtendId($name, "P1", "Neg", "NT"); $iformat; hint=0, $encs; 1; 1; !($predEx); $asmPred; "nt" )
-    $CmpJumpBase( ExtendId($name, "P0", "Pos", "T" ); $iformat; hint=1, $encs; 0; 0;  ($predEx); $asmPred; "t" )
-    $CmpJumpBase( ExtendId($name, "P1", "Pos", "T" ); $iformat; hint=1, $encs; 0; 1;  ($predEx); $asmPred; "t" )
-    $CmpJumpBase( ExtendId($name, "P0", "Neg", "T" ); $iformat; hint=1, $encs; 1; 0; !($predEx); $asmPred; "t" )
-    $CmpJumpBase( ExtendId($name, "P1", "Neg", "T" ); $iformat; hint=1, $encs; 1; 1; !($predEx); $asmPred; "t" )
+    $CmpJumpBase( AsId($name, "P0", "Pos", "NT"); $iformat; hint=0, $encs; 0; 0;  ($predEx); $asmPred; "nt" )
+    $CmpJumpBase( AsId($name, "P1", "Pos", "NT"); $iformat; hint=0, $encs; 0; 1;  ($predEx); $asmPred; "nt" )
+    $CmpJumpBase( AsId($name, "P0", "Neg", "NT"); $iformat; hint=0, $encs; 1; 0; !($predEx); $asmPred; "nt" )
+    $CmpJumpBase( AsId($name, "P1", "Neg", "NT"); $iformat; hint=0, $encs; 1; 1; !($predEx); $asmPred; "nt" )
+    $CmpJumpBase( AsId($name, "P0", "Pos", "T" ); $iformat; hint=1, $encs; 0; 0;  ($predEx); $asmPred; "t" )
+    $CmpJumpBase( AsId($name, "P1", "Pos", "T" ); $iformat; hint=1, $encs; 0; 1;  ($predEx); $asmPred; "t" )
+    $CmpJumpBase( AsId($name, "P0", "Neg", "T" ); $iformat; hint=1, $encs; 1; 0; !($predEx); $asmPred; "t" )
+    $CmpJumpBase( AsId($name, "P1", "Neg", "T" ); $iformat; hint=1, $encs; 1; 1; !($predEx); $asmPred; "t" )
   }
 
   $CmpJump( CmpJumpEqMinus1; CmpJumpFormat   ; op=0b001100;  R(s5)          =  -1            ; ("cmp.eq(",AsmR(s5),"#-1)") )
@@ -839,14 +839,14 @@ instruction set architecture QDSP6 =
   }
 
   model LoadBase ( base: LoadBaseT, name: Id, type: Id, size: Lit, scale: Lit, asmfunc: Ex) : IsaDefs = {
-    $base( ExtendId( $name, IdToStr($type), "GPRel" )        ; LoadFormat          ; iclass=0b0100, gp=1, type1=0b1,      type=MemoryAccessType::$type, unsigned=0; $size; GP + scaledImmU(immGPRel, $scale)    ; ExtendId(S, IdToStr($type)); ""; ($asmfunc, AsmAddrGPRel(immGPRel))       ; true )
-    $base( ExtendId( $name, IdToStr($type), "RegRel" )       ; LoadFormat          ; iclass=0b1001, gp=0, type1=0b1,      type=MemoryAccessType::$type, unsigned=0; $size; R(s5) + scaledImmS(immRegRel, $scale); ExtendId(S, IdToStr($type)); ""; ($asmfunc, AsmAddrRegRel(s5, immRegRel)) ; true )
-    $base( ExtendId( $name, IdToStr($type), "PredPosRegRel" ); LoadRegRelPredFormat; iclass=0b0100, op=0b010, dn=0, ps=0, type=MemoryAccessType::$type, unsigned=0; $size; R(s5) + scaledImmS(immRegRel, $scale); ExtendId(S, IdToStr($type)); AsmPred(t2, false, false); ($asmfunc, AsmAddrRegRel(s5, immRegRel)) ;  testpred(t2) )
-    $base( ExtendId( $name, IdToStr($type), "PredNegRegRel" ); LoadRegRelPredFormat; iclass=0b0100, op=0b010, dn=0, ps=1, type=MemoryAccessType::$type, unsigned=0; $size; R(s5) + scaledImmS(immRegRel, $scale); ExtendId(S, IdToStr($type)); AsmPred(t2, true , false); ($asmfunc, AsmAddrRegRel(s5, immRegRel)) ; !testpred(t2) )
+    $base( AsId( $name, AsStr($type), "GPRel" )        ; LoadFormat          ; iclass=0b0100, gp=1, type1=0b1,      type=MemoryAccessType::$type, unsigned=0; $size; GP + scaledImmU(immGPRel, $scale)    ; AsId(S, AsStr($type)); ""; ($asmfunc, AsmAddrGPRel(immGPRel))       ; true )
+    $base( AsId( $name, AsStr($type), "RegRel" )       ; LoadFormat          ; iclass=0b1001, gp=0, type1=0b1,      type=MemoryAccessType::$type, unsigned=0; $size; R(s5) + scaledImmS(immRegRel, $scale); AsId(S, AsStr($type)); ""; ($asmfunc, AsmAddrRegRel(s5, immRegRel)) ; true )
+    $base( AsId( $name, AsStr($type), "PredPosRegRel" ); LoadRegRelPredFormat; iclass=0b0100, op=0b010, dn=0, ps=0, type=MemoryAccessType::$type, unsigned=0; $size; R(s5) + scaledImmS(immRegRel, $scale); AsId(S, AsStr($type)); AsmPred(t2, false, false); ($asmfunc, AsmAddrRegRel(s5, immRegRel)) ;  testpred(t2) )
+    $base( AsId( $name, AsStr($type), "PredNegRegRel" ); LoadRegRelPredFormat; iclass=0b0100, op=0b010, dn=0, ps=1, type=MemoryAccessType::$type, unsigned=0; $size; R(s5) + scaledImmS(immRegRel, $scale); AsId(S, AsStr($type)); AsmPred(t2, true , false); ($asmfunc, AsmAddrRegRel(s5, immRegRel)) ; !testpred(t2) )
   }
   model LoadBaseU (base: LoadBaseT, name: Id, type: Id, size: Lit, scale: Lit, asmfunc: Ex) : IsaDefs = {
-    $base( ExtendId( $name, "U", IdToStr($type), "GPRel" ) ; LoadFormat; iclass=0b0100, gp=1, type1=0b1, type=MemoryAccessType::$type, unsigned=1; $size; GP + scaledImmU(immGPRel, $scale)    ; ExtendId(U, IdToStr($type)); ""; ($asmfunc, AsmAddrGPRel(immGPRel))       ; true )
-    $base( ExtendId( $name, "U", IdToStr($type), "RegRel" ); LoadFormat; iclass=0b1001, gp=0, type1=0b1, type=MemoryAccessType::$type, unsigned=1; $size; R(s5) + scaledImmS(immRegRel, $scale); ExtendId(U, IdToStr($type)); ""; ($asmfunc, AsmAddrRegRel(s5, immRegRel)) ; true )
+    $base( AsId( $name, "U", AsStr($type), "GPRel" ) ; LoadFormat; iclass=0b0100, gp=1, type1=0b1, type=MemoryAccessType::$type, unsigned=1; $size; GP + scaledImmU(immGPRel, $scale)    ; AsId(U, AsStr($type)); ""; ($asmfunc, AsmAddrGPRel(immGPRel))       ; true )
+    $base( AsId( $name, "U", AsStr($type), "RegRel" ); LoadFormat; iclass=0b1001, gp=0, type1=0b1, type=MemoryAccessType::$type, unsigned=1; $size; R(s5) + scaledImmS(immRegRel, $scale); AsId(U, AsStr($type)); ""; ($asmfunc, AsmAddrRegRel(s5, immRegRel)) ; true )
   }
 
   $LoadBase ( LoadSizeBase;   Load ; Byte   ; 1 ; 0; "memb"  )
@@ -949,12 +949,12 @@ instruction set architecture QDSP6 =
   }
 
   model StoreBase   ( base: StoreBaseT, name: Id, type: Id, size: Lit, scale: Lit, asmfunc: Ex) : IsaDefs = {
-    $base( ExtendId( $name, IdToStr($type), "GPRel" )      ; iclass=0b0100, gp=1, type1=0, type=MemoryAccessType::$type, unsigned = 0; $size; GP + scaledImmU(immGPRel, $scale)    ; $type; 0        ; ($asmfunc, AsmAddrGPRel(immGPRel))       ; "")
-    $base( ExtendId( $name, IdToStr($type), "RegRel" )     ; iclass=0b1010, gp=0, type1=1, type=MemoryAccessType::$type, unsigned = 0; $size; R(s5) + scaledImmS(immRegRel, $scale); $type; 0        ; ($asmfunc, AsmAddrRegRel(s5, immRegRel)) ; "")
+    $base( AsId( $name, AsStr($type), "GPRel" )      ; iclass=0b0100, gp=1, type1=0, type=MemoryAccessType::$type, unsigned = 0; $size; GP + scaledImmU(immGPRel, $scale)    ; $type; 0        ; ($asmfunc, AsmAddrGPRel(immGPRel))       ; "")
+    $base( AsId( $name, AsStr($type), "RegRel" )     ; iclass=0b1010, gp=0, type1=1, type=MemoryAccessType::$type, unsigned = 0; $size; R(s5) + scaledImmS(immRegRel, $scale); $type; 0        ; ($asmfunc, AsmAddrRegRel(s5, immRegRel)) ; "")
   }
   model StoreBaseHigh( base: StoreBaseT, name: Id, type: Id, size: Lit, scale: Lit, asmfunc: Ex) : IsaDefs = {
-    $base( ExtendId( $name, "H", IdToStr($type), "GPRel" ) ; iclass=0b0100, gp=1, type1=0, type=MemoryAccessType::$type, unsigned = 1; $size; GP + scaledImmU(immGPRel, $scale)    ; $type; $size * 8; ($asmfunc, AsmAddrGPRel(immGPRel))       ; ".H")
-    $base( ExtendId( $name, "H", IdToStr($type), "RegRel" ); iclass=0b1010, gp=0, type1=1, type=MemoryAccessType::$type, unsigned = 1; $size; R(s5) + scaledImmS(immRegRel, $scale); $type; $size * 8; ($asmfunc, AsmAddrRegRel(s5, immRegRel)) ; ".H")
+    $base( AsId( $name, "H", AsStr($type), "GPRel" ) ; iclass=0b0100, gp=1, type1=0, type=MemoryAccessType::$type, unsigned = 1; $size; GP + scaledImmU(immGPRel, $scale)    ; $type; $size * 8; ($asmfunc, AsmAddrGPRel(immGPRel))       ; ".H")
+    $base( AsId( $name, "H", AsStr($type), "RegRel" ); iclass=0b1010, gp=0, type1=1, type=MemoryAccessType::$type, unsigned = 1; $size; R(s5) + scaledImmS(immRegRel, $scale); $type; $size * 8; ($asmfunc, AsmAddrRegRel(s5, immRegRel)) ; ".H")
   }
 
   $StoreBase    ( StoreSizeBase ;  Store ; Byte ;   1 ; 0; "memb"  )
@@ -1075,7 +1075,7 @@ instruction set architecture QDSP6 =
       R(x5) := VADL::$op(immU, VADL::$shiftop(R(x5), shiftU) as UInt)
     }
     encoding $name = { iclass=0b1101, regtype=0b1110, $encs }
-    assembly $name = (AsmR(x5), " = ", IdToStr($op), "(#", decimal(immU), IdToStr($shiftop), "(", AsmR(x5), "#", decimal(shiftU), "))")
+    assembly $name = (AsmR(x5), " = ", AsStr($op), "(#", decimal(immU), AsStr($shiftop), "(", AsmR(x5), "#", decimal(shiftU), "))")
   }
 
   $ALUImmShifted ( AddImmAsl ; majop=0b010 ; add ; lsl )

--- a/vadl/test/resources/testSource/sys/aarch64/aarch64.vadl
+++ b/vadl/test/resources/testSource/sys/aarch64/aarch64.vadl
@@ -321,8 +321,8 @@ instruction set architecture AArch64Base = {
         $f.resModel (match: Id ($f.ff = OffFlags => S ; _ => X)(rd) ; result )
         }
     encoding $i.id = { op = $i.opcode, sf = SF::$size, ff = FF::$f.ff, sh = $sh }
-    assembly $i.id = ( $i.mnemo, $f.mext, ' ', ExtendId($size, match: Str ($f.ff = OffFlags => "SP" ; _ => ""))(rd),
-                       ', ', ExtendId($size, "SP")(rn), ', ', "#", decimal($immEx), $asm )
+    assembly $i.id = ( $i.mnemo, $f.mext, ' ', AsId($size, match: Str ($f.ff = OffFlags => "SP" ; _ => ""))(rd),
+                       ', ', AsId($size, "SP")(rn), ', ', "#", decimal($immEx), $asm )
     }
 
   model ExtInstrStr (i: InstrWithFunct, ext: Str): InstrWithFunct = {

--- a/vadl/test/resources/testSource/sys/aarch64/aarch64.vadl
+++ b/vadl/test/resources/testSource/sys/aarch64/aarch64.vadl
@@ -270,14 +270,14 @@ instruction set architecture AArch64Base = {
     }
 
   model AddSubExtInstrBase (i: InstrWithFunct, extId: Id, size: Id, f: Flags, extEx: Ex, optId: Id, enc: Encs, asm: Ex): IsaDefs = {
-    instruction ExtendId ($i.id, $extId): AddSubExtFormat =
+    instruction AsId ($i.id, $extId): AddSubExtFormat =
       let result, flags = VADL::$i.funct (S(rn) as Bits<Size::$size>, ($extEx) as Bits<Size::$size>) in {
         $f.resModel (match: Id ($f.ff = OffFlags => S ; _ => X)(rd) ; result )
         }
     //[raise Undefined : imm3(2) = 1 && imm3(1..0) != 0]
-    encoding ExtendId ($i.id, $extId) = { op = $i.opcode, sf = SF::$size, ff = FF::$f.ff, option = ExtendType::$optId, $enc }
-    assembly ExtendId ($i.id, $extId) = ( $i.mnemo, $f.mext, ' ', ExtendId($size, match: Str ($f.ff = OffFlags => "SP" ; _ => ""))(rd),
-                       ', ', ExtendId($size, "SP")(rn), ', ', $asm )
+    encoding AsId ($i.id, $extId) = { op = $i.opcode, sf = SF::$size, ff = FF::$f.ff, option = ExtendType::$optId, $enc }
+    assembly AsId ($i.id, $extId) = ( $i.mnemo, $f.mext, ' ', AsId($size, match: Str ($f.ff = OffFlags => "SP" ; _ => ""))(rd),
+                       ', ', AsId($size, "SP")(rn), ', ', $asm )
     }
 
   model AddSubExtInstr (i: InstrWithFunct, size: Id, f: Flags): IsaDefs = {
@@ -326,7 +326,7 @@ instruction set architecture AArch64Base = {
     }
 
   model ExtInstrStr (i: InstrWithFunct, ext: Str): InstrWithFunct = {
-    (ExtendId ($i.id,  $ext); $i.mnemo; $i.opcode; $i.funct)
+    (AsId ($i.id,  $ext); $i.mnemo; $i.opcode; $i.funct)
     }
 
   model AddSubImmInstr (i: InstrWithFunct, size: Id, f: Flags): IsaDefs = {
@@ -595,7 +595,7 @@ instruction set architecture AArch64Base = {
   model LogicImmEncAsm (i: InstrWithFunct, size: Id, ext: Str): IsaDefs = {
     //[raise Undefined : sf = 0 && imm13(12) = 1]
     encoding $i.id = { op = $i.opcode, sf = SF::$size }
-    assembly $i.id = ($i.mnemo, ' ', ExtendId($size, $ext)(rd), ', ', $size(rn), ', #', decimal(immX))
+    assembly $i.id = ($i.mnemo, ' ', AsId($size, $ext)(rd), ', ', $size(rn), ', #', decimal(immX))
     }
 
   model LogicImmFlagInstr (i: InstrWithFunct, size: Id): IsaDefs = {
@@ -655,7 +655,7 @@ instruction set architecture AArch64Base = {
     }
 
   model LogicRegShiftExtInstr (modelid: InstrWithFunctSizeRegShift, i: InstrWithFunct, ext: Str, size: Id, s: RegShift): IsaDefs = {
-    $modelid ((ExtendId ($i.id, $ext); $i.mnemo; $i.opcode; $i.funct); $size; $s)
+    $modelid ((AsId ($i.id, $ext); $i.mnemo; $i.opcode; $i.funct); $size; $s)
     }
 
   model LogicRegShiftInstr (modelid: InstrWithFunctSizeRegShift, i: InstrWithFunct, size: Id): IsaDefs = {
@@ -706,10 +706,10 @@ instruction set architecture AArch64Base = {
   model notOrIdent (not: Id, ex: Ex) : Ex = { match: Ex ($not = not => ~($ex) ;_=> $ex) }
 
   model MovInstr (i: InstrWithFunct, size: Id, pos: Id, posex: Ex): IsaDefs = {
-    instruction ExtendId ($i.id, $pos): MovFormat =
+    instruction AsId ($i.id, $pos): MovFormat =
       X(rd) := $posex
-    encoding ExtendId ($i.id, $pos) = { sf = SF::$size, op = $i.opcode, pos = Position::$pos }
-    assembly ExtendId ($i.id, $pos) = ($i.mnemo, ' ', $size(rd), ', #', decimal(imm16),
+    encoding AsId ($i.id, $pos) = { sf = SF::$size, op = $i.opcode, pos = Position::$pos }
+    assembly AsId ($i.id, $pos) = ($i.mnemo, ' ', $size(rd), ', #', decimal(imm16),
       match: Str ($pos = Pos00 => ""; $pos = Pos16 => ", LSL #16"; $pos = Pos32 => ", LSL #32"; _ => ", LSL #48"))
     }
 
@@ -753,7 +753,7 @@ instruction set architecture AArch64Base = {
   model ExtractRegPairInstr (i: InstrWithFunct, size: Id): IsaDefs = {
     instruction $i.id: ExtractRegFormat =
       let pair = (X(rn) as Bits<Size::$size>, X(rm) as Bits<Size::$size>) in
-        X(rd) :=  (pair >> ExtendId (shift, $size)) as Bits<Size::$size> as BitsX
+        X(rd) :=  (pair >> AsId (shift, $size)) as Bits<Size::$size> as BitsX
     encoding $i.id = { op = $i.opcode, sf = SF::$size, N = SF::$size }
     assembly $i.id = ($i.mnemo, ' ', $size(rd), ', ', $size(rn), ', ', $size(rm), ', #', decimal(imms))
     }
@@ -810,8 +810,8 @@ instruction set architecture AArch64Base = {
     // (sf != N) cannot happen as N is set in encoding
     // [raise Undefined : sf = 0 && (imms(5) = 1 || immr(5) = 1)]
     instruction $i.id: BitFieldMoveFormat =
-      let left = ExtendId (left, $size) in
-        let right = ExtendId (right, $size) in
+      let left = AsId (left, $size) in
+        let right = AsId (right, $size) in
           let xrn = X(rn) as $i.funct<Size::$size> << left >> right in
             let result = match: Ex ($i.mnemo = "bfm" =>
               let mask = ~(~(0 as Bits<Size::$size>) << left >> right) in
@@ -860,7 +860,7 @@ instruction set architecture AArch64Base = {
 
   model ReverseBitsInstr (i: InstrWithFunct, size: Id): IsaDefs = {
     instruction $i.id: TwoRegOpFormat =
-      let result = ExtendId (revBits, $size) (X(rn) as Bits<Size::$size>) in
+      let result = AsId (revBits, $size) (X(rn) as Bits<Size::$size>) in
         X(rd) := result as Bits<Size::$size> as BitsX
     $TwoRegOpEncAsm ($i; $size)
     }
@@ -1026,7 +1026,7 @@ instruction set architecture AArch64Base = {
     }
 
   model ExtendCondInstr (modelid: InstrWithCond, i: InstrWithFunct, c: Cond): IsaDefs = {
-    $modelid ((ExtendId($i.id, $c.cc); $i.mnemo; $i.opcode; $i.funct); $c)
+    $modelid ((AsId($i.id, $c.cc); $i.mnemo; $i.opcode; $i.funct); $c)
     }
 
   model CondInstr (modelid: InstrWithCond, i: InstrWithFunct): IsaDefs = {
@@ -1173,7 +1173,7 @@ instruction set architecture AArch64Base = {
     }
 
   model MemoryRegisterXtd (i: InstrNoFunct, m: Memory, option: Id, scaled: Id, asm: Ex, addr: Ex): IsaDefs = {
-  	$MemoryRegisterBase ((ExtendId ($i.id, $option, $scaled); $i.mnemo; $i.opcode); $m; $option; $scaled; $asm; $addr)
+  	$MemoryRegisterBase ((AsId ($i.id, $option, $scaled); $i.mnemo; $i.opcode); $m; $option; $scaled; $asm; $addr)
     }
 
   model MemoryRegisterInstr (i: InstrNoFunct, m: Memory): IsaDefs = {
@@ -1207,7 +1207,7 @@ instruction set architecture AArch64Base = {
 // memory enriching models *****************************************************
 
   model MemoryInstr (memmodel: MemoryModel, i: InstrNoFunct, xtdId: Str, m: Memory): IsaDefs = {
-  	$memmodel ((ExtendId ($i.id, $xtdId); $i.mnemo; $i.opcode); $m)
+  	$memmodel ((AsId ($i.id, $xtdId); $i.mnemo; $i.opcode); $m)
     }
 
   model StoreInstr (memmodel: MemoryModel, i: InstrNoFunct): IsaDefs = {
@@ -1251,25 +1251,25 @@ instruction set architecture AArch64Base = {
 
   model MemoryRegPairEncAsm (i: InstrWithFunct, extId: Str, size: Id, isLoad: Bool, op: Bin, asm: Ex): IsaDefs = {
     //[raise Undefined() : match: Ex ( $isLoad = true => Ex1 ; _=> Ex2)]
-    encoding ExtendId ($i.id, $extId) = { opc = $i.opcode, op = $op }
-    assembly ExtendId ($i.id, $extId) = ($i.mnemo, ' ', $size(rt), ', ', $size(rt2), $asm)
+    encoding AsId ($i.id, $extId) = { opc = $i.opcode, op = $op }
+    assembly AsId ($i.id, $extId) = ($i.mnemo, ' ', $size(rt), ', ', $size(rt2), $asm)
     }
 
   model MemoryRegPairInstr (i: InstrWithFunct, size: Id, isLoad: Bool, memstmts: Stats): IsaDefs = {
     // TODO check SP alignment
     instruction $i.id: MemoryPairFormat =
-      let addr = S(rn) + ExtendId (off, $size) in { $memstmts }
+      let addr = S(rn) + AsId (off, $size) in { $memstmts }
     $MemoryRegPairEncAsm ($i; ""; $size; $isLoad; 0b101'010; ("[", XSizeSP(rn), Imm7decimal(imm7), "]"))
-    instruction ExtendId ($i.id, "Pre"): MemoryPairFormat =
-      let addr = S(rn) + ExtendId (off, $size) in {
+    instruction AsId ($i.id, "Pre"): MemoryPairFormat =
+      let addr = S(rn) + AsId (off, $size) in {
           $memstmts
           S(rn) := addr
         }
     $MemoryRegPairEncAsm ($i; "Pre"; $size; $isLoad; 0b101'011; ("[", XSizeSP(rn), Imm7decimal(imm7), "]!"))
-    instruction ExtendId ( $i.id, "Pst"): MemoryPairFormat =
+    instruction AsId ( $i.id, "Pst"): MemoryPairFormat =
       let addr = S(rn) in {
           $memstmts
-          S(rn) := addr + ExtendId (off, $size)
+          S(rn) := addr + AsId (off, $size)
         }
     $MemoryRegPairEncAsm ($i; "Pst"; $size; $isLoad; 0b101'001; ("[", XSizeSP(rn), "]", Imm7decimal(imm7)))
     }

--- a/vadl/test/resources/testSource/sys/risc-v/rvcsr.vadl
+++ b/vadl/test/resources/testSource/sys/risc-v/rvcsr.vadl
@@ -183,21 +183,21 @@ instruction set architecture RV32IZicsr extending RV3264Base = {
 
   // extend = "" or "I", offset = 0 or 4, rs1imm = X(rs1) or rs1 as Regs
   model CsrInstr (extend : Str, offset : Int, rs1imm : Ex) : IsaDefs = {
-    $CsrBaseInstr (ExtendId(CSRRW, $extend) ; 0b001 ; $offset ; // atomic CSR Read / Write
+    $CsrBaseInstr (AsId(CSRRW, $extend) ; 0b001 ; $offset ; // atomic CSR Read / Write
             let rs1imm = $rs1imm in {
               if rd != 0 then
                 X(rd)     := CSR(csridx)
               CSR(csridx) := rs1imm
             }
       )
-    $CsrBaseInstr (ExtendId(CSRRS, $extend) ; 0b010 ; $offset ; // atomic CSR Read and Set bits
+    $CsrBaseInstr (AsId(CSRRS, $extend) ; 0b010 ; $offset ; // atomic CSR Read and Set bits
             let csr_csridx = CSR(csridx) in {
               if rs1 != 0 then
                 CSR(csridx) := csr_csridx | $rs1imm
               X(rd)         := csr_csridx
             }
       )
-    $CsrBaseInstr (ExtendId(CSRRC, $extend) ; 0b011 ; $offset ; // atomic CSR Read and Clear bits
+    $CsrBaseInstr (AsId(CSRRC, $extend) ; 0b011 ; $offset ; // atomic CSR Read and Clear bits
             let csr_csridx = CSR(csridx) in {
               if rs1 != 0 then
                 CSR(csridx) := csr_csridx & ~($rs1imm)

--- a/vadl/test/resources/testSource/sys/v-risc/VarRisc.vadl
+++ b/vadl/test/resources/testSource/sys/v-risc/VarRisc.vadl
@@ -144,18 +144,18 @@ instruction set architecture VarRISC32 = {
   }
 
   model ComputeInstruction ( name : Id, op : BinOp, ltype: Id, rtype: Id, code : Val ) : IsaDefs = {
-    $ShortRegInstr (ExtendId ( $name, '_S' ) ; $op ; $ltype ; $rtype ; $code )
-    $ShortImmInstr (ExtendId ( $name, 'I_S') ; $op ; $ltype ; $rtype ; $code )
+    $ShortRegInstr (AsId ( $name, '_S' ) ; $op ; $ltype ; $rtype ; $code )
+    $ShortImmInstr (AsId ( $name, 'I_S') ; $op ; $ltype ; $rtype ; $code )
     $RegInstr      (           $name         ; $op ; $ltype ; $rtype ; $code )
-    $ImmInstr      (ExtendId ( $name, 'I'  ) ; $op ; $ltype ; $rtype ; $code )
+    $ImmInstr      (AsId ( $name, 'I'  ) ; $op ; $ltype ; $rtype ; $code )
   }
 
   model LongImmInstruction (name : Id, op : BinOp, ltype: Id, rtype: Id, code : Val) : IsaDefs = {
-    instruction ExtendId ( $name, 'I_L') : TYPE_L =
+    instruction AsId ( $name, 'I_L') : TYPE_L =
         let res = R(rs1) as $ltype $op imm in
             R(rd) := res as Regs
-    encoding ExtendId ( $name, 'I_L') = { opcode = ImmLOff + $code }
-    assembly ExtendId ( $name, 'I_L') = ( mnemonic, ' ', register(rd), ',', register(rs1), ',', decimal(imm) )
+    encoding AsId ( $name, 'I_L') = { opcode = ImmLOff + $code }
+    assembly AsId ( $name, 'I_L') = ( mnemonic, ' ', register(rd), ',', register(rs1), ',', decimal(imm) )
     $ComputeInstruction ( $name; $op; $ltype; $rtype; $code )
   }
 
@@ -167,10 +167,10 @@ instruction set architecture VarRISC32 = {
   }
 
   model BranchSInstruction ( name : Id, code : Val ) : IsaDefs = {
-    instruction ExtendId ( $name, '_S' ) : TYPE_B =
+    instruction AsId ( $name, '_S' ) : TYPE_B =
       PC := PC + offsetS
-    encoding ExtendId ( $name, '_S' ) = { opcode = $code }
-    assembly ExtendId ( $name, '_S' ) = ( mnemonic, ' ', decimal (offset) )
+    encoding AsId ( $name, '_S' ) = { opcode = $code }
+    assembly AsId ( $name, '_S' ) = ( mnemonic, ' ', decimal (offset) )
   }
 
   model JumpLinkInstruction ( name : Id, code : Val ) : IsaDefs = {
@@ -189,17 +189,17 @@ instruction set architecture VarRISC32 = {
     encoding $name = { opcode = MemCode, func5 = $code }
     assembly $name = ( mnemonic, ' ', register(rd), ',', decimal(imm), '(', register(rs1), ')' )
 
-    instruction ExtendId ( $name, '_L') : TYPE_L =
+    instruction AsId ( $name, '_L') : TYPE_L =
       let a = R(rs1) + immU in $memstmt
-    encoding ExtendId ( $name, '_L') = { opcode = MemLOff + $code }
-    assembly ExtendId ( $name, '_L') = ( mnemonic, ' ', register(rd), ',', decimal(imm), '(', register(rs1), ')' )
+    encoding AsId ( $name, '_L') = { opcode = MemLOff + $code }
+    assembly AsId ( $name, '_L') = ( mnemonic, ' ', register(rd), ',', decimal(imm), '(', register(rs1), ')' )
   }
 
   model ShortMemInstruction ( name : Id, memstmt : Stat, code : Val ) : IsaDefs = {
-    instruction ExtendId ( $name, '_S') : TYPE_S =
+    instruction AsId ( $name, '_S') : TYPE_S =
       let a = R(rs1) in $memstmt
-    encoding ExtendId ( $name, '_S') = { opcode = MemSOff + $code }
-    assembly ExtendId ( $name, '_S') = ( mnemonic, ' ', register(rd), ',(', register(rs1), ')' )
+    encoding AsId ( $name, '_S') = { opcode = MemSOff + $code }
+    assembly AsId ( $name, '_S') = ( mnemonic, ' ', register(rd), ',(', register(rs1), ')' )
     $MemoryInstruction ( $name; $memstmt; $code )
   }
 
@@ -210,24 +210,24 @@ instruction set architecture VarRISC32 = {
     encoding $name = { opcode = MemCode, func5 = $code }
     assembly $name = ( mnemonic, ' ', register(rd), ',', register(rs1), ',', decimal(imm) )
 
-    instruction ExtendId ( $name, '_L') : TYPE_L = {
+    instruction AsId ( $name, '_L') : TYPE_L = {
       if R(rd) as $reltype $op R(rs1) then
         PC := PC + offsetS
     }
-    encoding ExtendId ( $name, '_L') = { opcode = BraLOff + $code }
-    assembly ExtendId ( $name, '_L') = ( mnemonic, ' ', register(rd), ',', register(rs1), ',', decimal(imm) )
+    encoding AsId ( $name, '_L') = { opcode = BraLOff + $code }
+    assembly AsId ( $name, '_L') = ( mnemonic, ' ', register(rd), ',', register(rs1), ',', decimal(imm) )
   }
 
   model CondImmInstruction ( name : Id, op : BinOp, reltype: Id, imm: Id, code : Val ) : IsaDefs = {
-    instruction ExtendId ( $name, 'I') : TYPE_I =
+    instruction AsId ( $name, 'I') : TYPE_I =
       R(rd) :=  ( R(rs1) as $reltype $op $imm ) as Regs
-    encoding ExtendId ( $name, 'I') = { opcode = ImmCode, func5 = $code }
-    assembly ExtendId ( $name, 'I') = ( mnemonic, ' ', register(rd), ',', register(rs1), ',', decimal(imm) )
+    encoding AsId ( $name, 'I') = { opcode = ImmCode, func5 = $code }
+    assembly AsId ( $name, 'I') = ( mnemonic, ' ', register(rd), ',', register(rs1), ',', decimal(imm) )
 
-    instruction ExtendId ( $name, 'I_L') : TYPE_L =
+    instruction AsId ( $name, 'I_L') : TYPE_L =
       R(rd) :=  ( R(rd) as $reltype $op $imm ) as Regs
-    encoding ExtendId ( $name, 'I_L') = { opcode = CodeI_L, func5 = $code }
-    assembly ExtendId ( $name, 'I_L') = ( mnemonic, ' ', register(rd), ',', decimal(imm))
+    encoding AsId ( $name, 'I_L') = { opcode = CodeI_L, func5 = $code }
+    assembly AsId ( $name, 'I_L') = ( mnemonic, ' ', register(rd), ',', decimal(imm))
   }
 
   model CondInstruction ( name : Id, op : BinOp, reltype: Id, imm: Id, code : Val ) : IsaDefs = {
@@ -247,12 +247,12 @@ instruction set architecture VarRISC32 = {
     encoding $name = { opcode = ImmCode, func5 = $code }
     assembly $name = ( mnemonic, ' ', register(rd), ',', decimal(imm))
 
-    instruction ExtendId ( $name, '_L' ) : TYPE_L = {
+    instruction AsId ( $name, '_L' ) : TYPE_L = {
         R(rd) := PC.next
         PC := PC + offsetS
         }
-    encoding ExtendId ( $name, '_L') = { opcode = CodeI_L, func5 = $code }
-    assembly ExtendId ( $name, '_L') = ( mnemonic, ' ', register(rd), ',', decimal(imm))
+    encoding AsId ( $name, '_L') = { opcode = CodeI_L, func5 = $code }
+    assembly AsId ( $name, '_L') = ( mnemonic, ' ', register(rd), ',', decimal(imm))
   }
 
 /* instruction encoding and opcode space of opcode and func5/func9

--- a/vadl/test/vadl/ast/MacroTests.java
+++ b/vadl/test/vadl/ast/MacroTests.java
@@ -449,7 +449,7 @@ public class MacroTests {
         record InstrWithFunct (id: Id, mnemo: Str, opcode: Ex, funct: Id)
         
         model ExtendInstr (i: InstrWithFunct, ext: Str): InstrWithFunct = {
-          (ExtendId ($i.id,  $ext); $i.mnemo; $i.opcode; $i.funct)
+          (AsId ($i.id,  $ext); $i.mnemo; $i.opcode; $i.funct)
         }
         """;
     Assertions.assertDoesNotThrow(() -> VadlParser.parse(prog1));

--- a/vadl/test/vadl/ast/MacroTests.java
+++ b/vadl/test/vadl/ast/MacroTests.java
@@ -455,6 +455,42 @@ public class MacroTests {
     Assertions.assertDoesNotThrow(() -> VadlParser.parse(prog1));
   }
 
+  @Test
+  void asIdTest() {
+    // There once was a time where record return types couldn't be parsed.
+    var prog1 = """
+        constant AsId("one") = 1
+        constant AsId("th", "ree") = 3
+        constant AsId(max, count) = 42
+        constant AsId(open, "vadl") = 2024
+        """;
+    var prog2 = """
+        constant one = 1
+        constant three = 3
+        constant maxcount = 42
+        constant openvadl = 2024
+        """;
+    assertAstEquality(VadlParser.parse(prog1), VadlParser.parse(prog2));
+  }
+
+  @Test
+  void asStrTest() {
+    // There once was a time where record return types couldn't be parsed.
+    var prog1 = """
+        function one -> String = AsStr(one)
+        function three -> String = AsStr(th, ree)
+        function maxcount -> String = AsStr("max", "count")
+        function openvadl -> String = AsStr("open", vadl)
+        """;
+    var prog2 = """
+        function one -> String = "one"
+        function three -> String = "three"
+        function maxcount -> String = "maxcount"
+        function openvadl -> String = "openvadl"
+        """;
+    assertAstEquality(VadlParser.parse(prog1), VadlParser.parse(prog2));
+  }
+
 }
 
 

--- a/vadl/test/vadl/ast/MacroTests.java
+++ b/vadl/test/vadl/ast/MacroTests.java
@@ -22,6 +22,8 @@ import static vadl.ast.AstTestUtils.assertAstEquality;
 import java.net.URI;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import vadl.error.Diagnostic;
 import vadl.error.DiagnosticList;
 
@@ -491,6 +493,18 @@ public class MacroTests {
     assertAstEquality(VadlParser.parse(prog1), VadlParser.parse(prog2));
   }
 
+  @ParameterizedTest
+  @ValueSource(strings = {"", "7", "_x", "encoding"})
+  void invalidIdentifierAsId(String string) {
+    var prog = """
+        constant AsId("%s") = 6
+        """.formatted(string);
+    var diagnostics = Assertions.assertThrows(DiagnosticList.class, () -> VadlParser.parse(prog));
+    var diagnostic = diagnostics.items.getFirst();
+    Assertions.assertTrue(
+        diagnostic.reason.contains("Invalid") && diagnostic.reason.contains("Identifier"),
+        "Reason was: `%s`".formatted(diagnostic.reason));
+  }
 }
 
 


### PR DESCRIPTION
As discussed in #103 `AsStr` now also takes multiple arguments like `AsId`.

The PR also addresses an issue with `AsId` and now only allows valid identifiers. #82 