### PR TITLE
iss-testing: Add support for more Embench benchmarks

### DIFF
--- a/sys/aarch64/aarch64.vadl
+++ b/sys/aarch64/aarch64.vadl
@@ -156,7 +156,7 @@ instruction set architecture AArch64Base = {
 
   // assembly X register names or zero
   function XSize (idx: Index) -> String =   // do not rename
-    if idx = 31 then "zr"  else "x" + decimal( idx )
+    if idx = 31 then "xzr"  else "x" + decimal( idx )
 
   // assembly W register names or sp
   function WSizeSP (idx: Index) -> String = // do not rename

--- a/vadl/test/resources/embench/__run_qemu.sh
+++ b/vadl/test/resources/embench/__run_qemu.sh
@@ -1,23 +1,6 @@
 #!/usr/bin/env bash
-
-# Capture the start time in nanoseconds
-start_time=$(date +%s%N)
-
-# Execute the command
-"$@"
+OUTPUT=$((time -p $@) 2>&1)
 RET=$?
-
-# Capture the end time in nanoseconds
-end_time=$(date +%s%N)
-
-# Calculate the elapsed time in seconds with millisecond precision
-elapsed_ns=$((end_time - start_time))
-elapsed_s=$(echo "scale=3; $elapsed_ns / 1000000000" | bc)
-
-# Format the elapsed time to ensure a leading zero before the decimal point
-formatted_time=$(printf "%0.3f" "$elapsed_s")
-
-# Output the formatted elapsed time
-echo "TIME=${formatted_time}s"
+echo $OUTPUT | sed -nE 's/.*real[[:space:]]*([0-9]+)\.([0-9]+).*/TIME=\1.\2/p'
 
 exit $RET

--- a/vadl/test/resources/embench/benchmark_speed.py
+++ b/vadl/test/resources/embench/benchmark_speed.py
@@ -191,8 +191,8 @@ def benchmark_speed(bench, target_args):
     appdir = os.path.join(gp['bd_benchdir'], bench)
     appexe = os.path.join(appdir, bench)
 
+    arglist = build_benchmark_cmd(bench, target_args)
     if os.path.isfile(appexe):
-        arglist = build_benchmark_cmd(bench, target_args)
         try:
             res = subprocess.run(
                 arglist,

--- a/vadl/test/resources/embench/build_virt-iss-a64.sh
+++ b/vadl/test/resources/embench/build_virt-iss-a64.sh
@@ -2,8 +2,9 @@
 
 cd $(realpath $(dirname "$0"))
 
-CFLAGS="-march=armv8-a+nofp+nosimd "
-EXCL="cubic,nbody,st,minver,statemate,wikisort,ud"
-TMPEXCL=",huffbench,md5sum,qrduino,sglib-combined,tarfind"
-FAILING=",edn,matmult-int,nettle-sha256,picojpeg,slre"
-./build_all.py --cc aarch64-none-elf-gcc --arch aarch64 --chip generic --board virt-iss --clean --cflags "$CFLAGS" --exclude "$EXCL$TMPEXCL$FAILING"  "$@"
+CFLAGS="-march=armv8-a -g"
+# benchmarks that use floating point types must be excluded
+FLOATEXCL="cubic,nbody,minver,st,statemate,ud,wikisort"
+UPFAILING=",qrduino" # probably some wrong implementation of a dummy
+FAILING=",picojpeg" # failing on generated ISS
+./build_all.py --cc aarch64-none-elf-gcc --arch aarch64 --chip generic --board virt-iss --clean --cflags "$CFLAGS" --exclude "$FLOATEXCL$UPFAILING$FAILING" "$@"

--- a/vadl/test/resources/embench/config/aarch64/boards/virt-iss/board.cfg
+++ b/vadl/test/resources/embench/config/aarch64/boards/virt-iss/board.cfg
@@ -17,10 +17,10 @@
 # IMPORTANT: This must be a rv64i compiled with -mcmodel=medany
 # cc = 'riscv64-unknown-elf-gcc'
 
-# - ld (same value as for cc)
-cflags = ['-c', '-O2', '-ffreestanding', '-ffunction-sections', '-specs=nosys.specs']
+# compiles without stdlib, no floating point, for armv8-a
+cflags = ['-c', '-O2', '-ffreestanding', '-ffunction-sections', '-specs=nosys.specs', '-mgeneral-regs-only', '-march=armv8-a']
 ldflags = [
-	'-static', '-O2', '-nostartfiles', '-Wl,-gc-sections', '-specs=nosys.specs',
+	'-static', '-O2', '-nostartfiles', '-nostdlib', '-Wl,-gc-sections', '-specs=nosys.specs',
 	'-T../../../config/aarch64/boards/virt-iss/link.ld',
 ]
 # - cc_define_pattern ('-D{0}')
@@ -34,7 +34,8 @@ user_libs = [
 	'-lm'
 	]
 # user_libs = ['-L/opt/riscv-medany/riscv64-unknown-elf/lib/', '-lc', '-lm']
-# dummy_libs = ['libc']
+# we must overwrite these as the toolchain stdlib versions use SIMD operations
+dummy_libs = ['memset', 'memcpy', 'memcmp', 'memmove', 'assert', 'str' ]
 # - cpu_mhz (1)
 # - warmup_heat (1)
 

--- a/vadl/test/resources/embench/pylib/embench_core.py
+++ b/vadl/test/resources/embench/pylib/embench_core.py
@@ -94,6 +94,10 @@ def setup_logging(logdir, prefix):
     logfile = os.path.join(
         logdir_abs, time.strftime('{pref}-%Y-%m-%d-%H%M%S.log'.format(pref=prefix))
     )
+    # -0000- so it is shown on top
+    latestlogfile = os.path.join(
+        logdir_abs, time.strftime('{pref}-0000-latest.log'.format(pref=prefix))
+    )
 
     # Set up logging
     log.setLevel(logging.DEBUG)
@@ -103,6 +107,9 @@ def setup_logging(logdir, prefix):
     file_h = logging.FileHandler(logfile)
     file_h.setLevel(logging.DEBUG)
     log.addHandler(file_h)
+    latestfile_h = logging.FileHandler(latestlogfile, mode='w')
+    latestfile_h.setLevel(logging.DEBUG)
+    log.addHandler(latestfile_h)
 
     # Log where the log file is
     log.debug('Log file: {log}\n'.format(log=logfile))

--- a/vadl/test/resources/embench/support/dummy-assert.c
+++ b/vadl/test/resources/embench/support/dummy-assert.c
@@ -1,6 +1,22 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-_Noreturn void __assert_fail(const char *expr, const char *file, int line, const char *func) {}
+_Noreturn void __assert_fail(const char *expr, const char *file, int line, const char *func) {
+    // infinite loop. when debuging it is easy to find the reason.
+    while (1) {}
+}
 
-_Noreturn void exit(int i) {}
+_Noreturn void __assert_func(const char *file, int line, const char *func, const char *expr) {
+    // infinite loop. when debuging it is easy to find the reason.
+    while (1) {}
+}
+
+_Noreturn void exit(int i) {
+    // infinite loop. when debuging it is easy to find the reason.
+    while (1) {}
+}
+
+_Noreturn void abort(void) {
+    // infinite loop. when debuging it is easy to find the reason.
+    while (1) {}
+}

--- a/vadl/test/resources/embench/support/dummy-libc.c
+++ b/vadl/test/resources/embench/support/dummy-libc.c
@@ -221,10 +221,10 @@ atoi (const char *nptr __attribute__ ((unused)))
   return 0;
 }
 
-double
+long
 atof (const char *nptr __attribute__ ((unused)))
 {
-  return 0.0;
+  return 0;
 }
 
 FILE *

--- a/vadl/test/resources/embench/support/dummy-memcpy.c
+++ b/vadl/test/resources/embench/support/dummy-memcpy.c
@@ -1,6 +1,6 @@
 #include <string.h>
 #include <stdint.h>
-#include <endian.h>
+// #include <endian.h>
 
 void *memcpy(void *restrict dest, const void *restrict src, size_t n)
 {

--- a/vadl/test/resources/embench/support/dummy-memmove.c
+++ b/vadl/test/resources/embench/support/dummy-memmove.c
@@ -1,0 +1,16 @@
+#include <stdint.h>
+#include <stddef.h>
+
+void *memmove(void *dest, const void *src, size_t n)
+{
+    unsigned char *d = dest;
+    const unsigned char *s = src;
+
+    if ((uintptr_t)d < (uintptr_t)s) {          /* safe comparison */
+        while (n--) *d++ = *s++;
+    } else if ((uintptr_t)d > (uintptr_t)s) {
+        d += n;  s += n;
+        while (n--) *--d = *--s;
+    }
+    return dest;
+}

--- a/vadl/test/resources/embench/support/dummy-str.c
+++ b/vadl/test/resources/embench/support/dummy-str.c
@@ -1,0 +1,18 @@
+#include <string.h>
+#include <stdint.h>
+
+size_t strlen(const char *s) {
+    size_t len = 0;
+    while (*s++) len++;
+    return len;
+}
+
+char *strchr(const char *s, int c) {
+    while (*s) {
+        if (*s == (char)c) return (char *)s;
+        s++;
+    }
+    return NULL;
+}
+
+const unsigned char _ctype_[256] = { /* initialize as needed */ };

--- a/vadl/test/resources/testSource/sys/aarch64/aarch64.vadl
+++ b/vadl/test/resources/testSource/sys/aarch64/aarch64.vadl
@@ -865,6 +865,15 @@ instruction set architecture AArch64Base = {
     $TwoRegOpEncAsm ($i; $size)
     }
 
+  model RevBytesHInstr (i: InstrWithFunct, size: Id): IsaDefs = {
+    instruction $i.id: TwoRegOpFormat = {
+      let xrn = (X(rn)) in
+        let result = (xrn(55..48),xrn(63..56),xrn(39..32),xrn(47..40),xrn(23..16),xrn(31..24),xrn(7..0),xrn(15..8)) in
+          X(rd) := result as Bits<Size::$size> as BitsX
+      }
+    $TwoRegOpEncAsm ($i; $size)
+    }
+
   model RevBytesWInstr (i: InstrWithFunct): IsaDefs = {
     instruction $i.id: TwoRegOpFormat =
       let xrn = (X(rn)) in
@@ -1360,8 +1369,9 @@ instruction set architecture AArch64Base = {
   $InstrWX             (CountBitsInstr        ; (CLS    ; "cls"   ; 0b1'0110'1011'0000'0000'0101; cls  ))
   $InstrWX             (CountBitsInstr        ; (CLZ    ; "clz"   ; 0b1'0110'1011'0000'0000'0100; clz  ))
   $InstrWX             (ReverseBitsInstr      ; (RBIT   ; "rbit"  ; 0b1'0110'1011'0000'0000'0000; rvb  ))
-  $RevBytesWInstr      (                        (REVW   ; "rev"   ; 0b1'0110'1011'0000'0000'0010; WSize))
+  $InstrWX             (RevBytesHInstr        ; (REV16  ; "rev16" ; 0b1'0110'1011'0000'0000'0001; half ))
   $RevBytesWInstr      (                        (REV32  ; "rev32" ; 0b1'0110'1011'0000'0000'0010; XSize))
+  $RevBytesWInstr      (                        (REVW   ; "rev"   ; 0b1'0110'1011'0000'0000'0010; WSize))
   $RevBytesXInstr      (                        (REVX   ; "rev"   ; 0b1'0110'1011'0000'0000'0011; XSize))
 
   $CondInstr           (CondCompareImmInstr   ; (CCMNI  ; "ccmn"  ; 0b0111'0100'1010'0    ; adds       ))
@@ -1550,6 +1560,12 @@ instruction set architecture AArch64Base = {
     , imm16    : Bits16                      // [15..0]  ignored
     }
 
+  format BTIFormat: Instr =                  // Branch target identification format
+    { op       [31..16]      : Bits16        // opcode part one
+    , opc      [15..8,5..0]  : Bits14        // opcode part two
+    , bti      [7..6]        : Bits2         // BTI target, PSTATE.BTYPE compatibility
+  }
+
   function SysRegName (sysreg: Bits16) -> String =
     match sysreg with
       { SysRegEncode::NZCV      => "nzcv"
@@ -1653,6 +1669,19 @@ instruction set architecture AArch64Base = {
     assembly $i.id = ($i.mnemo)
     }
 
+  function btiOp2(bti: Bits2) -> String = match bti with
+    { 0b01 => "c"
+    , 0b10 => "j"
+    , 0b11 => "jc"
+    , _    => ""
+    }
+
+  model BTIInstr (i: InstrNoFunct): IsaDefs = {
+    instruction $i.id: BTIFormat = {}
+    encoding $i.id = {op = 0b1101'0101'0000'0011, opc = $i.opcode}
+    assembly $i.id = ($i.mnemo, btiOp2(bti))
+    }
+
   model UndefinedInstr (i: InstrNoFunct): IsaDefs = {
     instruction $i.id: UndefinedInstrFormat =
       raise $UndefinedException ()
@@ -1668,7 +1697,7 @@ instruction set architecture AArch64Base = {
   $HaltInstr             ((HLT    ; "hlt"   ; 0b1101'0100'0100'0000                        ))
   $NopInstr              ((NOP    ; "nop"   ; 0b0010'0000'0001'1111                        ))
   $NopInstr              ((YIELD  ; "yield" ; 0b0010'0000'0011'1111                        ))
-  $NopInstr              ((BTI    ; "bti"   ; 0b0010'0100'0001'1111                        ))
+  $BTIInstr              ((BTI    ; "bti"   ; 0b0010'0100'''01'1111                        ))
   $UndefinedInstr        ((UDF    ; "udf"   ; 0b0000'0000'0000'0000                        ))
 
 }

--- a/vadl/test/resources/testSource/sys/aarch64/virt.vadl
+++ b/vadl/test/resources/testSource/sys/aarch64/virt.vadl
@@ -1,9 +1,7 @@
 
 import aarch64::AArch64Base
 
-instruction set architecture A64 extending AArch64Base = {
-
-}
+instruction set architecture A64 extending AArch64Base = { }
 
 [ htif ]
 processor Virt implements A64 = {


### PR DESCRIPTION
Adds support for more Embench benchmarks. 
For required stdlib functions we provide our own dummy implementations. This is required as the AArch64 toolchain uses SIMD instructions in the stdlib implementations.

Working benchmarks are `aha-mont64, crc32, edn, huffbench, matmult-int, md5sum, nettle-aes, nettle-sha256, nsichneu, primecount, sglib-combined, slre, tarfind`

Benchmarks that fail on the genreated ISS: `picojpeg`

Benchmarks that don't even run on upstream: `qrduino`

Benchmarks that can't be used because they use floating point types: `cubic,nbody,minver,st,statemate,ud,wikisort`

EDIT: Here are the first benchmark results (runtime relative, smaller is better)
![PaminaMasterThesis (2)](https://github.com/user-attachments/assets/b93fdf81-3815-47d9-8851-c80fb1d9e10c)

