### PR TITLE
parser: Fix crash with annotations on encodings

### DIFF
--- a/vadl/main/vadl/ast/MacroExpander.java
+++ b/vadl/main/vadl/ast/MacroExpander.java
@@ -648,7 +648,8 @@ class MacroExpander
   public Definition visit(AnnotationDefinition definition) {
     return new AnnotationDefinition(
         definition.keywords.stream().map(this::expandId).toList(),
-        definition.values.stream().map(this::expandExpr).toList(),
+        definition.values.stream().map(this::expandExpr)
+            .collect(Collectors.toCollection(ArrayList::new)),
         copyLoc(definition.loc));
   }
 

--- a/vadl/main/vadl/ast/SymbolTable.java
+++ b/vadl/main/vadl/ast/SymbolTable.java
@@ -1045,6 +1045,7 @@ class SymbolTable {
     public Void visit(EncodingDefinition definition) {
       // Link instruction and import all symbols from the instruction format.
       beforeTravel(definition);
+      definition.annotations.forEach(this::travel);
 
       var inst =
           definition.symbolTable().requireAs(definition.identifier(), InstructionDefinition.class);
@@ -1245,6 +1246,7 @@ class SymbolTable {
     @Override
     public Void visit(AsmDirectiveDefinition definition) {
       beforeTravel(definition);
+      definition.annotations.forEach(this::travel);
 
       // Only do rudimentary checks here, the rest is done in the typechecker.
       if (!AsmDirective.isAsmDirective(definition.builtinDirective.name)) {
@@ -1285,6 +1287,7 @@ class SymbolTable {
     @Override
     public Void visit(AsmGrammarLocalVarDefinition definition) {
       beforeTravel(definition);
+      definition.annotations.forEach(this::travel);
 
       // FIXME: @benjaminkasper99 should we maybe make "null" a symbol that is always in the
       // symboltable so we can avoid this special treatment here?
@@ -1330,6 +1333,7 @@ class SymbolTable {
     @Override
     public Void visit(AsmGrammarTypeDefinition definition) {
       beforeTravel(definition);
+      definition.annotations.forEach(this::travel);
 
       if (!AsmType.isInputAsmType(definition.id.name)) {
         var suggestions = Levenshtein.suggestions(definition.id.name,

--- a/vadl/main/vadl/ast/TypeChecker.java
+++ b/vadl/main/vadl/ast/TypeChecker.java
@@ -872,6 +872,9 @@ public class TypeChecker
   public Void visit(AnnotationDefinition definition) {
     // NOTE: I have the suspicion that we might have to delay the typechecking until the definition
     // on which the annotation is placed is completely typed checked.
+    if (definition.annotation == null) {
+      System.out.printf("");
+    }
     requireNonNull(definition.annotation).typeCheck(definition, this);
     return null;
   }


### PR DESCRIPTION
Unfortunately we skipped annotations on encoding definitions, which screwed up the state for the type checker and caused an crash.