### PR TITLE
typechecker: Fix wrong long multiply type

### DIFF
--- a/vadl/main/vadl/ast/TypeChecker.java
+++ b/vadl/main/vadl/ast/TypeChecker.java
@@ -2155,9 +2155,9 @@ public class TypeChecker
       } else if (leftTyp instanceof UIntType || rightTyp instanceof UIntType) {
         expr.type = Type.unsignedInt(leftBitWidth * 2);
         return null;
-      } else {
-        expr.type = Type.bits(leftBitWidth * 2);
       }
+      expr.type = Type.bits(leftBitWidth * 2);
+      return null;
     }
 
     var bitWidth = ((BitsType) leftTyp).bitWidth();


### PR DESCRIPTION
Because the typechecker didn't return after handling one specific special case it sometimes continued with the generic case, resulting in the wrong type.

