### PR TITLE
spec: Updated calling convention

### DIFF
--- a/vadl/test/resources/testSource/sys/risc-v/rv32i.vadl
+++ b/vadl/test/resources/testSource/sys/risc-v/rv32i.vadl
@@ -77,7 +77,7 @@ application binary interface ABI for RV32I = {
 
    // ra is callee saved because it is used as normal register and has to be restored.
    caller saved = [ a{0..7}, t{0..6} ]
-   callee saved = [ ra, gp, tp, fp, s{0..11} ]
+   callee saved = [ ra, s{0..11} ]
 
   constant sequence( rd : Bits<5>, val : SInt<32> ) =
   {

--- a/vadl/test/resources/testSource/sys/risc-v/rv32im.vadl
+++ b/vadl/test/resources/testSource/sys/risc-v/rv32im.vadl
@@ -77,7 +77,7 @@ application binary interface ABI for RV32IM = {
 
    // ra is callee saved because it is used as normal register and has to be restored.
    caller saved = [ a{0..7}, t{0..6} ]
-   callee saved = [ ra, gp, tp, fp, s{0..11} ]
+   callee saved = [ ra, s{0..11} ]
 
   constant sequence( rd : Bits<5>, val : SInt<32> ) =
   {

--- a/vadl/test/resources/testSource/sys/risc-v/rv64i.vadl
+++ b/vadl/test/resources/testSource/sys/risc-v/rv64i.vadl
@@ -81,7 +81,7 @@ application binary interface ABI for RV64I = {
 
    // ra is callee saved because it is used as normal register and has to be restored.
    caller saved = [ a{0..7}, t{0..6} ]
-   callee saved = [ ra, gp, tp, fp, s{0..11} ]
+   callee saved = [ ra, s{0..11} ]
 
    constant sequence( rd : Bits<5>, val : SInt<32> ) =
    {

--- a/vadl/test/resources/testSource/sys/risc-v/rv64im.vadl
+++ b/vadl/test/resources/testSource/sys/risc-v/rv64im.vadl
@@ -81,7 +81,7 @@ application binary interface ABI for RV64IM = {
 
    // ra is callee saved because it is used as normal register and has to be restored.
    caller saved = [ a{0..7}, t{0..6} ]
-   callee saved = [ X(1), gp, tp, fp, s{0..11} ]
+   callee saved = [ X(1), s{0..11} ]
 
    constant sequence( rd : Bits<5>, val : SInt<32> ) =
    {


### PR DESCRIPTION
Updated the calling convention because `fp` is already covered by `s0`. Additionally, `gp` and `tp` are not callee saved.