### PR TITLE
typechecker: Fix skipping imported specs

### DIFF
--- a/vadl/main/vadl/ast/TypeChecker.java
+++ b/vadl/main/vadl/ast/TypeChecker.java
@@ -992,8 +992,7 @@ public class TypeChecker
 
   @Override
   public Void visit(ImportDefinition importDefinition) {
-    // Do nothing on purpose.
-    // The symboltable should have already resolved everything.
+    importDefinition.moduleAst.definitions.forEach(this::check);
     return null;
   }
 


### PR DESCRIPTION
Previously the typechecker didn't check all files that where imported but only when a definition in the root spec pointed to a definition in the imported spec and required it to check it too.

This caused the bug where the ABI doesn't _need_ the result of the ISA for it's own typechecking and therefore didn't triggered the imported ISA to be typechecked. Which then crashed in the lowering when the ISA didn't have any types.

