### PR TITLE
lcb: Fix #333

### DIFF
--- a/vadl/main/vadl/ast/BehaviorLowering.java
+++ b/vadl/main/vadl/ast/BehaviorLowering.java
@@ -1225,6 +1225,7 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
       argExprs.add(fetch(arg.value));
     }
     var call = new InstrCallNode(target, fieldsOrAccesses, argExprs);
+    call.setSourceLocation(statement.location());
     call = addToGraph(call);
     return SubgraphContext.of(statement, call);
   }

--- a/vadl/main/vadl/cppCodeGen/CppTypeMap.java
+++ b/vadl/main/vadl/cppCodeGen/CppTypeMap.java
@@ -123,7 +123,8 @@ public class CppTypeMap {
   }
 
   /**
-   * Upcast the given type to the next fitting bit size.
+   * Upcast the given type to the next fitting bit size. It will not upcast {@code type} when it
+   * is already a valid cpp type.
    */
   public static BitsType upcast(Type type) {
     if (type instanceof BitsType cast) {

--- a/vadl/main/vadl/gcb/passes/NormalizeFieldsToFieldAccessFunctionsPass.java
+++ b/vadl/main/vadl/gcb/passes/NormalizeFieldsToFieldAccessFunctionsPass.java
@@ -90,6 +90,7 @@ public class NormalizeFieldsToFieldAccessFunctionsPass extends Pass {
                     null, // can be automatically generated
                     createPredicateFunction(id, fieldRefNode)
                 );
+                instruction.format().fieldAccesses().add(fieldAccess);
                 var fieldAccessRefNode = new FieldAccessRefNode(
                     fieldAccess,
                     fieldRefNode.type()

--- a/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/LlvmPseudoInstructionLoweringUnconditionalJumpsStrategyImpl.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/LlvmPseudoInstructionLoweringUnconditionalJumpsStrategyImpl.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nonnull;
+import vadl.cppCodeGen.CppTypeMap;
 import vadl.error.Diagnostic;
 import vadl.gcb.passes.IsaMachineInstructionMatchingPass;
 import vadl.gcb.passes.PseudoInstructionLabel;
@@ -177,8 +178,9 @@ public class LlvmPseudoInstructionLoweringUnconditionalJumpsStrategyImpl extends
   }
 
   private static @Nonnull ValueType upcastFieldAccess(Format.FieldAccess fieldAccess) {
-    return ensurePresent(ValueType.from(fieldAccess.type()),
-        () -> Diagnostic.error("Cannot convert immediate type to LLVM type.",
+    return ensurePresent(ValueType.from(CppTypeMap.upcast(fieldAccess.type())),
+        () -> Diagnostic.error(
+                String.format("Cannot convert immediate type to LLVM type: %s", fieldAccess.type()),
                 fieldAccess.location())
             .help("Check whether this type exists in LLVM"));
   }
@@ -202,7 +204,7 @@ public class LlvmPseudoInstructionLoweringUnconditionalJumpsStrategyImpl extends
         .toList();
     if (usedFieldAccessFunctions.isEmpty()) {
       throw Diagnostic.error(
-              "Machine instruction must at one field access function to be able to "
+              "Machine instruction must have one field access function to be able to "
                   + "deduce the immediate layout for the machine instruction.",
               machineInstruction.location())
           .help("Use a field access function so the generator knows that this is the immediate.")


### PR DESCRIPTION
There were three bugs which are fixed in this PR. For the unconditional jump, we counted the number of field access functions. However, we counted the number of the format and not the actually used. So, we've got an error, despite the fact that it was correct. The second bug was that the an used field in the pseudo instruction was not upcasted and the third bug was that a jump instruction is not lowerable and crashed. Now, it doesn't crash anymore but remains unlowerable.

Closes #333