### PR TITLE
iss: Add TB-Layer to cosimulation

### DIFF
--- a/vadl-cosim/config.toml
+++ b/vadl-cosim/config.toml
@@ -27,16 +27,7 @@ ignore_unset_registers = true
 
 # Ignore specific registers
 # Filters in conjunction with `ignore_unset_registers`
-ignore_registers = [
-	"mcycle",
-	"minstret",
-	"cycle",
-	"instret",
-	"a1",
-	"a2",
-	"pc",
-	"t0", 
-]
+ignore_registers = []
 
 # Defines a list of clients to test against
 # A single client is also possible, e.g. to check if a crash or similar occurs
@@ -45,10 +36,10 @@ ignore_registers = [
 
 # Optional: A custom name for a client
 # Will default to the index of the client in this list
-name = "Client 1"
+name = "VADL"
 
 # The executable of the ISS
-exec = "qemu-system-rv64im"
+exec = "qemu-system-a64"
 
 # "bios" | "kernel": Defines where the test-executable is passed to when starting the QEMU-client
 pass_test_exec_to = "bios"
@@ -68,52 +59,55 @@ additional_args = [
 skip_n_instructions = 0
 
 [[qemu.clients]]
-name = "Client 2"
+name = "UPSTREAM"
 
-exec = "qemu-system-riscv64"
+exec = "qemu-system-aarch64"
 
-pass_test_exec_to = "bios"
+pass_test_exec_to = "kernel"
 
 additional_args = [
-	"-nographic",
+	"-nographic",	
+	"-M", "virt",
+	"-cpu", "cortex-a57",
+	"-semihosting",
 ]
 
 skip_n_instructions = 0
 
 # Defines a custom map where the key (e.g. x0) is mapped to another value (e.g. zero)
 [qemu.gdb_reg_map]
-x0 = "zero"
-x1 = "ra"
-x2 = "sp"
-x3 = "gp"
-x4 = "tp"
-x5 = "t0"
-x6 = "t1"
-x7 = "t2"
-x8 = "fp"
-x9 = "s1"
-x10 = "a0"
-x11 = "a1"
-x12 = "a2"
-x13 = "a3"
-x14 = "a4"
-x15 = "a5"
-x16 = "a6"
-x17 = "a7"
-x18 = "s2"
-x19 = "s3"
-x20 = "s4"
-x21 = "s5"
-x22 = "s6"
-x23 = "s7"
-x24 = "s8"
-x25 = "s9"
-x26 = "s10"
-x27 = "s11"
-x28 = "t3"
-x29 = "t4"
-x30 = "t5"
-x31 = "t6"
+s0 = "x0"
+s1 = "x1"
+s2 = "x2"
+s3 = "x3"
+s4 = "x4"
+s5 = "x5"
+s6 = "x6"
+s7 = "x7"
+s8 = "x8"
+s9 = "x9"
+s10 = "x10"
+s11 = "x11"
+s12 = "x12"
+s13 = "x13"
+s14 = "x14"
+s15 = "x15"
+s16 = "x16"
+s17 = "x17"
+s18 = "x18"
+s19 = "x19"
+s20 = "x20"
+s21 = "x21"
+s22 = "x22"
+s23 = "x23"
+s24 = "x24"
+s25 = "x25"
+s26 = "x26"
+s27 = "x27"
+s28 = "x28"
+s29 = "x29"
+s30 = "x30"
+s31 = "sp"
 pc = "pc"
 
 
@@ -122,7 +116,7 @@ pc = "pc"
 
 # The path to the compiled file to use for testing
 # This file will be passed to all clients
-test_exec="./qemu-setup/build/addw_jump.elf"
+test_exec="./qemu-setup/build/elf-demo"
 
 # The maximum trace length during a test-run
 # The trace acts as a sized dequeue, meaning newer trace-entries push out the oldest trace-entries if the length has been reached
@@ -146,7 +140,7 @@ max_trace_length = -1
 # "tb-strict": The execution-step is the *execution of a single translation-blocks*.
 #			   The same as "tb" but without the synchronization logic. Meaning that equal translation-blocks are assumed.
 #			   This option is useful if the instructions of the ISS are already correct and the TB-Block generator needs to be tested.
-layer = "tb"
+layer = "insn"
 
 # "lockstep": All clients are run and compared one *execution-step* at a time.
 # 			  This means that the test will exit on the first divergence (or at the end if no diffs where found) 
@@ -173,7 +167,7 @@ level = "DEBUG"
 
 # The directory will also contain files for the stdout and stderr of each client
 dir = "./cosim-run/log"
-file = "cosim.json"
+file = "cosim.log"
 
 # Clears the logfile every time the program is run
 clear_on_rerun = true

--- a/vadl-cosim/config.toml
+++ b/vadl-cosim/config.toml
@@ -23,7 +23,7 @@ plugin="./qemu-setup/build/contrib/plugins/libcosimulation.so"
 # Whether to ignore registers that are not defined by a [qemu.gdb_reg_map] mapping
 # This option is useful to test the current implementation of a simulator which might not yet have all registers implemented against another (complete) implementation
 # Filters in conjunction with `ignore_registers`
-ignore_unset_registers = false 
+ignore_unset_registers = true
 
 # Ignore specific registers
 # Filters in conjunction with `ignore_unset_registers`
@@ -56,7 +56,7 @@ pass_test_exec_to = "bios"
 # Applies additional arguments to the ISS-executable, e.g. `qemu-system-riscv64 -nographic -d plugin`
 additional_args = [
 	"-nographic",
-	"-d", "plugin"
+	"-d", "plugin",
 	# "-s",
 	# "-S",
 ]
@@ -146,7 +146,7 @@ max_trace_length = -1
 # "tb-strict": The execution-step is the *execution of a single translation-blocks*.
 #			   The same as "tb" but without the synchronization logic. Meaning that equal translation-blocks are assumed.
 #			   This option is useful if the instructions of the ISS are already correct and the TB-Block generator needs to be tested.
-layer = "insn"
+layer = "tb-strict"
 
 # "lockstep": All clients are run and compared one *execution-step* at a time.
 # 			  This means that the test will exit on the first divergence (or at the end if no diffs where found) 

--- a/vadl-cosim/config.toml
+++ b/vadl-cosim/config.toml
@@ -140,7 +140,7 @@ max_trace_length = -1
 # "tb-strict": The execution-step is the *execution of a single translation-blocks*.
 #			   The same as "tb" but without the synchronization logic. Meaning that equal translation-blocks are assumed.
 #			   This option is useful if the instructions of the ISS are already correct and the TB-Block generator needs to be tested.
-layer = "insn"
+layer = "tb"
 
 # "lockstep": All clients are run and compared one *execution-step* at a time.
 # 			  This means that the test will exit on the first divergence (or at the end if no diffs where found) 

--- a/vadl-cosim/config.toml
+++ b/vadl-cosim/config.toml
@@ -27,16 +27,7 @@ ignore_unset_registers = true
 
 # Ignore specific registers
 # Filters in conjunction with `ignore_unset_registers`
-ignore_registers = [
-	"mcycle",
-	"minstret",
-	"cycle",
-	"instret",
-	"a1",
-	"a2",
-	"pc",
-	"t0", 
-]
+ignore_registers = []
 
 # Defines a list of clients to test against
 # A single client is also possible, e.g. to check if a crash or similar occurs
@@ -45,10 +36,10 @@ ignore_registers = [
 
 # Optional: A custom name for a client
 # Will default to the index of the client in this list
-name = "Client 1"
+name = "VADL"
 
 # The executable of the ISS
-exec = "qemu-system-rv64im"
+exec = "qemu-system-a64"
 
 # "bios" | "kernel": Defines where the test-executable is passed to when starting the QEMU-client
 pass_test_exec_to = "bios"
@@ -56,9 +47,6 @@ pass_test_exec_to = "bios"
 # Applies additional arguments to the ISS-executable, e.g. `qemu-system-riscv64 -nographic -d plugin`
 additional_args = [
 	"-nographic",
-	"-d", "plugin",
-	# "-s",
-	# "-S",
 ]
 
 # The following three options configure which instructions from the `test_exec` executable should actually be tested.
@@ -68,52 +56,55 @@ additional_args = [
 skip_n_instructions = 0
 
 [[qemu.clients]]
-name = "Client 2"
+name = "UPSTREAM"
 
-exec = "qemu-system-riscv64"
+exec = "qemu-system-aarch64"
 
-pass_test_exec_to = "bios"
+pass_test_exec_to = "kernel"
 
 additional_args = [
 	"-nographic",
+	"-M", "virt",
+	"-cpu", "cortex-a57",
+	"-semihosting",
 ]
 
 skip_n_instructions = 0
 
 # Defines a custom map where the key (e.g. x0) is mapped to another value (e.g. zero)
 [qemu.gdb_reg_map]
-x0 = "zero"
-x1 = "ra"
-x2 = "sp"
-x3 = "gp"
-x4 = "tp"
-x5 = "t0"
-x6 = "t1"
-x7 = "t2"
-x8 = "fp"
-x9 = "s1"
-x10 = "a0"
-x11 = "a1"
-x12 = "a2"
-x13 = "a3"
-x14 = "a4"
-x15 = "a5"
-x16 = "a6"
-x17 = "a7"
-x18 = "s2"
-x19 = "s3"
-x20 = "s4"
-x21 = "s5"
-x22 = "s6"
-x23 = "s7"
-x24 = "s8"
-x25 = "s9"
-x26 = "s10"
-x27 = "s11"
-x28 = "t3"
-x29 = "t4"
-x30 = "t5"
-x31 = "t6"
+s0 = "x0"
+s1 = "x1"
+s2 = "x2"
+s3 = "x3"
+s4 = "x4"
+s5 = "x5"
+s6 = "x6"
+s7 = "x7"
+s8 = "x8"
+s9 = "x9"
+s10 = "x10"
+s11 = "x11"
+s12 = "x12"
+s13 = "x13"
+s14 = "x14"
+s15 = "x15"
+s16 = "x16"
+s17 = "x17"
+s18 = "x18"
+s19 = "x19"
+s20 = "x20"
+s21 = "x21"
+s22 = "x22"
+s23 = "x23"
+s24 = "x24"
+s25 = "x25"
+s26 = "x26"
+s27 = "x27"
+s28 = "x28"
+s29 = "x29"
+s30 = "x30"
+s31 = "sp"
 pc = "pc"
 
 
@@ -122,7 +113,7 @@ pc = "pc"
 
 # The path to the compiled file to use for testing
 # This file will be passed to all clients
-test_exec="./qemu-setup/build/addw.elf"
+test_exec="./qemu-setup/build/elf-demo"
 
 # The maximum trace length during a test-run
 # The trace acts as a sized dequeue, meaning newer trace-entries push out the oldest trace-entries if the length has been reached
@@ -146,7 +137,7 @@ max_trace_length = -1
 # "tb-strict": The execution-step is the *execution of a single translation-blocks*.
 #			   The same as "tb" but without the synchronization logic. Meaning that equal translation-blocks are assumed.
 #			   This option is useful if the instructions of the ISS are already correct and the TB-Block generator needs to be tested.
-layer = "tb"
+layer = "insn"
 
 # "lockstep": All clients are run and compared one *execution-step* at a time.
 # 			  This means that the test will exit on the first divergence (or at the end if no diffs where found) 

--- a/vadl-cosim/config.toml
+++ b/vadl-cosim/config.toml
@@ -27,7 +27,16 @@ ignore_unset_registers = true
 
 # Ignore specific registers
 # Filters in conjunction with `ignore_unset_registers`
-ignore_registers = []
+ignore_registers = [
+	"mcycle",
+	"minstret",
+	"cycle",
+	"instret",
+	"a1",
+	"a2",
+	"pc",
+	"t0", 
+]
 
 # Defines a list of clients to test against
 # A single client is also possible, e.g. to check if a crash or similar occurs
@@ -36,10 +45,10 @@ ignore_registers = []
 
 # Optional: A custom name for a client
 # Will default to the index of the client in this list
-name = "VADL"
+name = "Client 1"
 
 # The executable of the ISS
-exec = "qemu-system-a64"
+exec = "qemu-system-rv64im"
 
 # "bios" | "kernel": Defines where the test-executable is passed to when starting the QEMU-client
 pass_test_exec_to = "bios"
@@ -47,6 +56,9 @@ pass_test_exec_to = "bios"
 # Applies additional arguments to the ISS-executable, e.g. `qemu-system-riscv64 -nographic -d plugin`
 additional_args = [
 	"-nographic",
+	"-d", "plugin"
+	# "-s",
+	# "-S",
 ]
 
 # The following three options configure which instructions from the `test_exec` executable should actually be tested.
@@ -56,55 +68,52 @@ additional_args = [
 skip_n_instructions = 0
 
 [[qemu.clients]]
-name = "UPSTREAM"
+name = "Client 2"
 
-exec = "qemu-system-aarch64"
+exec = "qemu-system-riscv64"
 
-pass_test_exec_to = "kernel"
+pass_test_exec_to = "bios"
 
 additional_args = [
 	"-nographic",
-	"-M", "virt",
-	"-cpu", "cortex-a57",
-	"-semihosting",
 ]
 
 skip_n_instructions = 0
 
 # Defines a custom map where the key (e.g. x0) is mapped to another value (e.g. zero)
 [qemu.gdb_reg_map]
-s0 = "x0"
-s1 = "x1"
-s2 = "x2"
-s3 = "x3"
-s4 = "x4"
-s5 = "x5"
-s6 = "x6"
-s7 = "x7"
-s8 = "x8"
-s9 = "x9"
-s10 = "x10"
-s11 = "x11"
-s12 = "x12"
-s13 = "x13"
-s14 = "x14"
-s15 = "x15"
-s16 = "x16"
-s17 = "x17"
-s18 = "x18"
-s19 = "x19"
-s20 = "x20"
-s21 = "x21"
-s22 = "x22"
-s23 = "x23"
-s24 = "x24"
-s25 = "x25"
-s26 = "x26"
-s27 = "x27"
-s28 = "x28"
-s29 = "x29"
-s30 = "x30"
-s31 = "sp"
+x0 = "zero"
+x1 = "ra"
+x2 = "sp"
+x3 = "gp"
+x4 = "tp"
+x5 = "t0"
+x6 = "t1"
+x7 = "t2"
+x8 = "fp"
+x9 = "s1"
+x10 = "a0"
+x11 = "a1"
+x12 = "a2"
+x13 = "a3"
+x14 = "a4"
+x15 = "a5"
+x16 = "a6"
+x17 = "a7"
+x18 = "s2"
+x19 = "s3"
+x20 = "s4"
+x21 = "s5"
+x22 = "s6"
+x23 = "s7"
+x24 = "s8"
+x25 = "s9"
+x26 = "s10"
+x27 = "s11"
+x28 = "t3"
+x29 = "t4"
+x30 = "t5"
+x31 = "t6"
 pc = "pc"
 
 
@@ -113,7 +122,7 @@ pc = "pc"
 
 # The path to the compiled file to use for testing
 # This file will be passed to all clients
-test_exec="./qemu-setup/build/elf-demo"
+test_exec="./qemu-setup/build/addw_jump.elf"
 
 # The maximum trace length during a test-run
 # The trace acts as a sized dequeue, meaning newer trace-entries push out the oldest trace-entries if the length has been reached
@@ -137,7 +146,7 @@ max_trace_length = -1
 # "tb-strict": The execution-step is the *execution of a single translation-blocks*.
 #			   The same as "tb" but without the synchronization logic. Meaning that equal translation-blocks are assumed.
 #			   This option is useful if the instructions of the ISS are already correct and the TB-Block generator needs to be tested.
-layer = "insn"
+layer = "tb"
 
 # "lockstep": All clients are run and compared one *execution-step* at a time.
 # 			  This means that the test will exit on the first divergence (or at the end if no diffs where found) 

--- a/vadl-cosim/config.toml
+++ b/vadl-cosim/config.toml
@@ -48,7 +48,7 @@ ignore_registers = [
 name = "Client 1"
 
 # The executable of the ISS
-exec = "qemu-system-riscv64"
+exec = "qemu-system-rv64im"
 
 # "bios" | "kernel": Defines where the test-executable is passed to when starting the QEMU-client
 pass_test_exec_to = "bios"
@@ -146,7 +146,7 @@ max_trace_length = -1
 # "tb-strict": The execution-step is the *execution of a single translation-blocks*.
 #			   The same as "tb" but without the synchronization logic. Meaning that equal translation-blocks are assumed.
 #			   This option is useful if the instructions of the ISS are already correct and the TB-Block generator needs to be tested.
-layer = "tb-strict"
+layer = "tb"
 
 # "lockstep": All clients are run and compared one *execution-step* at a time.
 # 			  This means that the test will exit on the first divergence (or at the end if no diffs where found) 

--- a/vadl-cosim/config.toml
+++ b/vadl-cosim/config.toml
@@ -27,7 +27,8 @@ ignore_unset_registers = true
 
 # Ignore specific registers
 # Filters in conjunction with `ignore_unset_registers`
-ignore_registers = []
+ignore_registers = [ "s0", "x0" ]
+
 
 # Defines a list of clients to test against
 # A single client is also possible, e.g. to check if a crash or similar occurs
@@ -52,11 +53,11 @@ additional_args = [
 	# "-S",
 ]
 
-# The following three options configure which instructions from the `test_exec` executable should actually be tested.
-# NOTE: Only applies to `layer = "insn" | "tb-strict"`
-# NOTE: This option is must be set per client to be able to account for different setup-codes per ISS
-# Skips the first n instructions 
-skip_n_instructions = 0
+# # The following three options configure which instructions from the `test_exec` executable should actually be tested.
+# # NOTE: Only applies to `layer = "insn" | "tb-strict"`
+# # NOTE: This option is must be set per client to be able to account for different setup-codes per ISS
+# # Skips the first n instructions 
+skip_n_instructions = 2
 
 [[qemu.clients]]
 name = "UPSTREAM"
@@ -70,9 +71,10 @@ additional_args = [
 	"-M", "virt",
 	"-cpu", "cortex-a57",
 	"-semihosting",
+	"-d", "plugin",
 ]
 
-skip_n_instructions = 0
+skip_n_instructions = 1
 
 # Defines a custom map where the key (e.g. x0) is mapped to another value (e.g. zero)
 [qemu.gdb_reg_map]
@@ -116,7 +118,7 @@ pc = "pc"
 
 # The path to the compiled file to use for testing
 # This file will be passed to all clients
-test_exec="./qemu-setup/build/elf-demo"
+test_exec="./qemu-setup/build/sglib-combined"
 
 # The maximum trace length during a test-run
 # The trace acts as a sized dequeue, meaning newer trace-entries push out the oldest trace-entries if the length has been reached
@@ -148,10 +150,10 @@ layer = "tb"
 mode = "lockstep" 
 
 # Execute all remaining instructions (overrides `stop_after_n_instructions` if set to true)
-execute_all_remaining_instructions = true
+execute_all_remaining_instructions = false
 
 # Execute the next (after skipped) n instructions
-stop_after_n_instructions = 0
+stop_after_n_instructions = 100
 
 # Where the test result should be saved and in which format
 [testing.protocol.out]

--- a/vadl-cosim/src/annotate-fields.py
+++ b/vadl-cosim/src/annotate-fields.py
@@ -23,9 +23,77 @@ The generated __init__ method is printed to stdout, simply add it to the class-s
 
 import re
 from typing import Optional
+from dataclasses import dataclass
+from pprint import pprint
 
 fields = '[("size", c_size_t), ("buffer", c_uint8 * MAX_INSN_DATA_SIZE)]'
 
+@dataclass
+class CField:
+    ctype: str
+    name: str
+    array_mod: Optional[str]
+
+@dataclass
+class CStruct:
+    name: str
+    cfields: list[CField]
+
+def parse_cfield(input: str) -> CField:
+    expr = re.compile(r"\s*(.*?)\s+(.*?)\s*(\[(.*?)\])?\s*;")
+    found = expr.findall(input)[0]
+    ctype = found[0]
+    name = found[1]
+    array_mod = found[3]
+    if array_mod.strip() == "":
+        array_mod = None
+    cfield = CField(ctype, name, array_mod)
+    return cfield
+
+def parse_cstructs(input: str) -> list[CStruct]:
+    expr = re.compile(r"\s*typedef\s*struct\s*{((.|\s)*?)}\s*(.*?)\s*;", re.MULTILINE)
+    found = expr.findall(input)
+    cstructs = []
+
+    for f in found:
+        cfields = filter(lambda s: len(s) > 0, f[0].split("\n"))
+        cfields = list(map(parse_cfield, cfields))
+        name = f[2]
+        cstructs.append(CStruct(name, cfields))
+
+    return cstructs
+
+def into_python_str(cstruct: CStruct) -> str:
+    out = ""
+
+    for field in cstruct.cfields:
+        if field.array_mod is not None:
+            out += f"{field.array_mod} = <TODO>\n"
+
+    out += "_fields_ = "
+
+    def format_field(field: CField) -> str:
+        if field.array_mod is not None:
+            return f"(\"{field.name}\", {c_typ(field.ctype)} * {field.array_mod})" 
+        else:
+            return f"(\"{field.name}\", {c_typ(field.ctype)})"
+
+    fs = ", ".join([format_field(f) for f in cstruct.cfields])
+    out += f"[{fs}]\n\n"
+
+    out += "def __init__(self, *args: Any, **kw: Any) -> None:\n"
+    out += "\tsuper().__init__(*args, **kw)\n"
+
+    def format_init_field(field: CField) -> str:
+        if field.array_mod is not None:
+            return f"\tself.{field.name}: Annotated[{python_array_typ(field.ctype)}, {c_typ(field.ctype)} * {field.array_mod}]"
+        else:
+            return f"\tself.{field.name}: Annotated[{python_typ(field.ctype)}, {c_typ(field.ctype)}]"
+
+    fs = "\n".join([format_init_field(f) for f in cstruct.cfields])
+    out += fs
+    return out
+        
 
 def array_typ(typ: str) -> Optional[tuple[str, str]]:
     expr = re.compile(r"^(.*?)\*(.*?)$")
@@ -37,44 +105,68 @@ def array_typ(typ: str) -> Optional[tuple[str, str]]:
         return None
 
 
+def c_typ(typ: str) -> str:
+    if typ[0].isupper():
+        return typ
+    else:
+        return f"c_{typ}"
+
 def python_typ(typ: str) -> str:
     typ_map = {
-        "c_uint64": "int",
-        "c_int": "int",
-        "c_uint": "int",
-        "c_uint8": "int",
-        "c_size_t": "int",
-        "c_char": "str",
+        "uint64": "int",
+        "int": "int",
+        "uint": "int",
+        "uint8": "int",
+        "size_t": "int",
+        "char": "bytes",
     }
-    if typ.startswith("c_"):
+    if typ in typ_map:
         return typ_map[typ]
     else:
         return typ
 
-
-expr = re.compile(r'(\("(.*?)",(.*?)\))')
-found = expr.findall(fields)
-
-output = ""
-output += "def __init__(self, *args: Any, **kw: Any) -> None:\n"
-output += "\tsuper().__init__(*args, **kw)\n"
-
-for match in found:
-    name = match[1].strip()
-    typ = match[2].strip()
-    arr_typ = array_typ(typ)
-    if arr_typ:
-        inner_typ = arr_typ[0]
-        inner_size = arr_typ[1]
-        if inner_typ == "c_char":
-            output += (
-                f"\tself.{name}: Annotated[bytes, {inner_typ} * self.{inner_size}]\n"
-            )
-        else:
-            ptyp = python_typ(inner_typ)
-            output += f"\tself.{name}: Annotated[list[{ptyp}], {inner_typ} * self.{inner_size}]\n"
+def python_array_typ(typ: str) -> str:
+    ptyp = python_typ(typ)
+    if ptyp == "bytes":
+        return ptyp
     else:
-        ptyp = python_typ(typ)
-        output += f"\tself.{name}: Annotated[{ptyp}, {typ}]\n"
+        return f"list[{ptyp}]"
 
-print(output)
+s = """
+typedef struct {
+  int init_mask;
+  SHMCPU cpus[MAX_CPU_COUNT];
+  TBInfo tb_info;
+} BrokerSHM_TB;
+"""
+
+cstructs = parse_cstructs(s)
+into_python = [into_python_str(cstruct) for cstruct in cstructs]
+print("\n\n".join(into_python))
+
+# expr = re.compile(r'(\("(.*?)",(.*?)\))')
+# found = expr.findall(fields)
+#
+# output = ""
+# output += "def __init__(self, *args: Any, **kw: Any) -> None:\n"
+# output += "\tsuper().__init__(*args, **kw)\n"
+#
+# for match in found:
+#     name = match[1].strip()
+#     typ = match[2].strip()
+#     arr_typ = array_typ(typ)
+#     if arr_typ:
+#         inner_typ = arr_typ[0]
+#         inner_size = arr_typ[1]
+#         if inner_typ == "c_char":
+#             output += (
+#                 f"\tself.{name}: Annotated[bytes, {inner_typ} * self.{inner_size}]\n"
+#             )
+#         else:
+#             ptyp = python_typ(inner_typ)
+#             output += f"\tself.{name}: Annotated[list[{ptyp}], {inner_typ} * self.{inner_size}]\n"
+#     else:
+#         ptyp = python_typ(typ)
+#         output += f"\tself.{name}: Annotated[{ptyp}, {typ}]\n"
+#
+# print(output)

--- a/vadl-cosim/src/annotate-fields.py
+++ b/vadl-cosim/src/annotate-fields.py
@@ -26,6 +26,7 @@ from typing import Optional
 
 fields = '[("size", c_size_t), ("buffer", c_uint8 * MAX_INSN_DATA_SIZE)]'
 
+
 def array_typ(typ: str) -> Optional[tuple[str, str]]:
     expr = re.compile(r"^(.*?)\*(.*?)$")
     found = expr.findall(typ)
@@ -34,6 +35,7 @@ def array_typ(typ: str) -> Optional[tuple[str, str]]:
         return f[0].strip(), f[1].strip()
     else:
         return None
+
 
 def python_typ(typ: str) -> str:
     typ_map = {
@@ -49,12 +51,13 @@ def python_typ(typ: str) -> str:
     else:
         return typ
 
+
 expr = re.compile(r'(\("(.*?)",(.*?)\))')
 found = expr.findall(fields)
 
-output = ''
-output += 'def __init__(self, *args: Any, **kw: Any) -> None:\n'
-output += '\tsuper().__init__(*args, **kw)\n'
+output = ""
+output += "def __init__(self, *args: Any, **kw: Any) -> None:\n"
+output += "\tsuper().__init__(*args, **kw)\n"
 
 for match in found:
     name = match[1].strip()
@@ -63,13 +66,15 @@ for match in found:
     if arr_typ:
         inner_typ = arr_typ[0]
         inner_size = arr_typ[1]
-        if inner_typ == 'c_char':
-            output += f'\tself.{name}: Annotated[bytes, {inner_typ} * self.{inner_size}]\n'
+        if inner_typ == "c_char":
+            output += (
+                f"\tself.{name}: Annotated[bytes, {inner_typ} * self.{inner_size}]\n"
+            )
         else:
             ptyp = python_typ(inner_typ)
-            output += f'\tself.{name}: Annotated[list[{ptyp}], {inner_typ} * self.{inner_size}]\n'
+            output += f"\tself.{name}: Annotated[list[{ptyp}], {inner_typ} * self.{inner_size}]\n"
     else:
         ptyp = python_typ(typ)
-        output += f'\tself.{name}: Annotated[{ptyp}, {typ}]\n'
+        output += f"\tself.{name}: Annotated[{ptyp}, {typ}]\n"
 
 print(output)

--- a/vadl-cosim/src/config.py
+++ b/vadl-cosim/src/config.py
@@ -17,8 +17,9 @@
 
 from dataclasses import dataclass, field
 import tomllib
-from typing import Literal, Optional 
+from typing import Literal, Optional
 import dacite
+
 
 @dataclass
 class Logging:
@@ -28,10 +29,12 @@ class Logging:
     enable: bool = True
     clear_on_rerun: bool = False
 
+
 @dataclass
 class Out:
     dir: str = "./result"
     format: Literal["json"] = "json"
+
 
 @dataclass
 class Protocol:
@@ -41,19 +44,22 @@ class Protocol:
     stop_after_n_instructions: int
     out: Out = field(default_factory=Out)
 
+
 @dataclass
 class Testing:
     test_exec: str
     protocol: Protocol
     max_trace_length: int
 
+
 @dataclass
 class Client:
     exec: str
-    pass_test_exec_to: Literal['bios', 'kernel']
+    pass_test_exec_to: Literal["bios", "kernel"]
     additional_args: list[str]
     skip_n_instructions: int = 0
     name: Optional[str] = None
+
 
 @dataclass
 class Qemu:
@@ -63,9 +69,11 @@ class Qemu:
     ignore_registers: list[str]
     ignore_unset_registers: bool = True
 
+
 @dataclass
 class Dev:
     dry_run: bool
+
 
 @dataclass
 class Config:
@@ -73,6 +81,7 @@ class Config:
     testing: Testing
     logging: Logging
     dev: Dev
+
 
 def load_config(path: str) -> Config | None:
     with open(path, mode="rb") as config_file:
@@ -83,4 +92,3 @@ def load_config(path: str) -> Config | None:
             print(f"Missing required field: {e}")
         except Exception as e:
             print(f"Error while loading config: {e}")
-

--- a/vadl-cosim/src/config.py
+++ b/vadl-cosim/src/config.py
@@ -39,7 +39,7 @@ class Out:
 @dataclass
 class Protocol:
     mode: Literal["lockstep"]
-    layer: Literal["tb", "insn"]
+    layer: Literal["tb", "insn", "tb-strict"]
     execute_all_remaining_instructions: bool
     stop_after_n_instructions: int
     out: Out = field(default_factory=Out)

--- a/vadl-cosim/src/cosimulation_broker.py
+++ b/vadl-cosim/src/cosimulation_broker.py
@@ -31,7 +31,7 @@ from typing import Any, Optional, TypeAlias
 
 from src import qemu_ipc
 from src.config import Config
-from src.cstructs import SHMCPU, BrokerSHM_Exec, SHMRegister
+from src.cstructs import MAX_CPU_COUNT, SHMCPU, SHMRegister
 from src.qemu_ipc import QEMUClient
 
 logger = logging.getLogger(__name__)
@@ -89,12 +89,12 @@ def diff_cpus(
             ClientDiff(
                 "cpu.init_mask",
                 f"{init_mask1:08b}",
-                f"{init_mask1:08b}",
+                f"{init_mask2:08b}",
             )
         )
         return diffs
 
-    for idx in range(BrokerSHM_Exec.MAX_CPU_COUNT):
+    for idx in range(MAX_CPU_COUNT):
         if init_mask1 & (1 << idx):
             cpu1 = cpus1[idx]
             cpu2 = cpus2[idx]
@@ -137,35 +137,38 @@ def diff_cpu(
             )
         )
 
-    if cpu1.registers_size < cpu2.registers_size:
-        for reg_index in range(cpu1.registers_size):
-            c1reg = cpu1.registers[reg_index]
-            r1name = c1reg.fname(config.qemu.gdb_reg_map)
+    # Registers per CPU are tested using the following logic:
+    # 1. The cpu with less registers is selected. (sub_cpu)
+    #    Assumption: The register set of one CPU must be a subset (or equal) of the other.
+    # 2. Take each register of the selected cpu by index.
+    # 3. Find the corresponding register of the other CPU by its name.
+    # 3.1 Both the "built-in" and gdb-register-mapped names are compared and the register is selected if any match.
+    # 3.2 However, if the register name is in the ignore_registers list
+    #     or is not present in the gdb_reg_map while ignore_unset_registers is set,
+    #     then the register comparison is skipped.
+    # 3.3 Example:
+    #   Assume c1reg = "t0" and config.qemu.ignore_registers = [ "t0", ... ] -> comparison skipped
+    #   Assume c1reg = "t0" and config.qemu.gdb_reg_map = [ "some-value": "not-t0" ]
+    #       If config.qemu.ignore_unset_registers is True:
+    #           -> comparsion skipped
+    #       Else:
+    #           -> continue comparing
+    sub_cpu = min(cpu1, cpu2, key=lambda x: x.registers_size)
+    super_cpu = max(cpu1, cpu2, key=lambda x: x.registers_size)
 
-            if r1name in config.qemu.ignore_registers or (
-                config.qemu.ignore_unset_registers
-                and r1name not in config.qemu.gdb_reg_map.values()
-            ):
-                break
+    for reg_index in range(sub_cpu.registers_size):
+        csub_reg = sub_cpu.registers[reg_index]
+        rsub_name = csub_reg.fname(config.qemu.gdb_reg_map)
 
-            c2reg = reg_by_name(cpu2.registers, c1reg.name.fstr(), config)
+        if rsub_name in config.qemu.ignore_registers or (
+            config.qemu.ignore_unset_registers
+            and rsub_name not in config.qemu.gdb_reg_map.values()
+        ):
+            continue
 
-            diffs.extend(diff_register(c1reg, c2reg, cpu_index, reg_index, config))
-    else:
-        for reg_index in range(cpu2.registers_size):
-            c2reg = cpu2.registers[reg_index]
+        csuper_reg = reg_by_name(super_cpu.registers, csub_reg.name.fstr(), config)
 
-            r2name = c2reg.fname(config.qemu.gdb_reg_map)
-
-            if r2name in config.qemu.ignore_registers or (
-                config.qemu.ignore_unset_registers
-                and r2name not in config.qemu.gdb_reg_map.values()
-            ):
-                break
-
-            c1reg = reg_by_name(cpu1.registers, c2reg.name.fstr(), config)
-
-            diffs.extend(diff_register(c1reg, c2reg, cpu_index, reg_index, config))
+        diffs.extend(diff_register(csub_reg, csuper_reg, cpu_index, reg_index, config))
 
     return diffs
 
@@ -315,7 +318,6 @@ def run_lockstep(config: Config, traces: deque[Trace]) -> Report:
     # Release each client once and then compare their states
     # NOTE: Maybe parallelize this for exec-level and tb-strict-level testing,
     #       for tb-level testing this might not be possible due to the differently generated TBs
-
     if (
         config.testing.protocol.layer == "insn"
         or config.testing.protocol.layer == "tb-strict"
@@ -339,29 +341,43 @@ def run_lockstep(config: Config, traces: deque[Trace]) -> Report:
     else:
         while any_client_open(clients):
             client_sync_infos: list[ClientSyncInfo] = []
+            insns_executed_per_client: list[int] = [0] * len(clients)
             for i, client in enumerate(clients):
                 # Execute the client until it hit a jump instruction which will serve as a synchronization point
                 while client.is_open:
-                    start_pc = client.shm_struct.shm_tb.tb_info.pc
-                    tb_size = client.shm_struct.shm_tb.tb_info.insns_info_size
+                    shm = client.shm_struct.shm_tb
+                    start_pc = shm.tb_info.pc
+                    insn_sizes = [
+                        insn_info.data.size
+                        for insn_info in shm.tb_info.insns_info_list()
+                    ]
+                    insns_executed_per_client[i] = len(insn_sizes)
+
                     if client.run():
-                        end_pc = client.shm_struct.shm_tb.tb_info.pc
+                        end_pc = shm.tb_info.pc
                         sync_info = ClientSyncInfo(
                             start_pc=start_pc,
                             end_pc=end_pc,
-                            tb_size=tb_size,
+                            insn_sizes=insn_sizes,
                             client_idx=i,
                         )
                         if sync_info.is_jump():
+                            logger.debug(f"found jump: {sync_info}")
                             client_sync_infos.append(sync_info)
                             break
 
             # Every client reached a jump-instruction - therefore all should be at the same PC
-            ref_pc = client_sync_infos[0].end_pc
-            for client_sync_info in client_sync_infos[1:]:
-                if client_sync_info.end_pc != ref_pc:
-                    logger.debug("client diverged during tb synchronization")
-                    return report_from_diffs(diffs)
+            # and have executed the same amount of instructions
+            end_pc_diverged = any(
+                info.end_pc != client_sync_infos[0].end_pc for info in client_sync_infos
+            )
+            insns_executed_diverged = any(
+                insns_executed != insns_executed_per_client[0]
+                for insns_executed in insns_executed_per_client
+            )
+            if end_pc_diverged or insns_executed_diverged:
+                logger.debug("client diverged during tb synchronization")
+                return report_from_diffs(diffs)
 
             if not execute_remaining:
                 if stop_after > 0:
@@ -429,16 +445,16 @@ def any_client_open(clients: list[QEMUClient]) -> bool:
 class ClientSyncInfo:
     start_pc: int
     end_pc: int
-    tb_size: int
+    insn_sizes: list[int]
     client_idx: int
 
     def is_jump(self) -> bool:
-        return self.start_pc + self.tb_size * 4 != self.end_pc
+        return self.start_pc + sum(self.insn_sizes) != self.end_pc
 
     def __str__(self):
         return (
             f"ClientSyncInfo(start_pc={hex(self.start_pc)}, end_pc={hex(self.end_pc)}, "
-            f"tb_size={self.tb_size}, client_idx={self.client_idx})"
+            f"insn_sizes={self.insn_sizes}, client_idx={self.client_idx})"
         )
 
     def __repr__(self):

--- a/vadl-cosim/src/cstructs.py
+++ b/vadl-cosim/src/cstructs.py
@@ -1,0 +1,273 @@
+# SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+The following classes represent the equally defined c-structs in the cosimulation QEMU plugin.
+They are used to transfer data from a QEMU-client to the broker using shared memory.
+See `BrokerSHM(Structure)` as the "entrypoint" of this class-hierarchy.
+
+Hint: Use the annotate-fields.py script to help generate parts of these python classes.
+"""
+
+from ctypes import c_char, c_int, c_uint, c_uint64, c_uint8, Structure, c_size_t, Union
+from typing import Annotated, Any
+
+
+class SHMString(Structure):
+    MAX_LEN = 256
+    _fields_ = [("len", c_size_t), ("value", c_char * MAX_LEN)]
+
+    def __repr__(self):
+        return f"SHMString(len={self.len}, value={self.fstr()})"
+
+    def __format__(self, _: str, /) -> str:
+        return self.__repr__()
+
+    def to_dict(self):
+        return {"len": self.len, "value": self.fstr()}
+
+    def __init__(self, *args: Any, **kw: Any) -> None:
+        super().__init__(*args, **kw)
+        self.len: Annotated[int, c_size_t]
+        self.value: Annotated[bytes, c_char * self.MAX_LEN]
+
+    def fstr(self) -> str:
+        return self.value[: self.len].decode()
+
+
+class InsnData(Structure):
+    MAX_INSN_DATA_SIZE = 256
+    _fields_ = [("size", c_size_t), ("buffer", c_uint8 * MAX_INSN_DATA_SIZE)]
+
+    def __repr__(self):
+        return f"InsnData(size={self.size}, buffer={self.fbuffer()})"
+
+    def __format__(self, _: str, /) -> str:
+        return self.__repr__()
+
+    def to_dict(self):
+        return {"size": self.size, "buffer": self.fbuffer()}
+
+    def fbuffer(self) -> str:
+        bytes_formatted = [num.to_bytes() for num in self.buffer[: self.size]]
+        res = b"".join(reversed(bytes_formatted))
+        return res.hex(" ")
+
+    def __init__(self, *args: Any, **kw: Any) -> None:
+        super().__init__(*args, **kw)
+        self.size: Annotated[int, c_size_t]
+        self.buffer: Annotated[list[int], c_uint8 * self.MAX_INSN_DATA_SIZE]
+
+
+class TBInsnInfo(Structure):
+    _fields_ = [
+        ("pc", c_uint64),
+        ("size", c_size_t),
+        ("symbol", SHMString),
+        ("hwaddr", SHMString),
+        ("disas", SHMString),
+        ("data", InsnData),
+    ]
+
+    def __repr__(self):
+        return f"TBInsnInfo(pc={self.pc}, symbol={self.symbol}, hwaddr={self.hwaddr}, disas={self.disas}, data={self.data})"
+
+    def __format__(self, _: str, /) -> str:
+        return self.__repr__()
+
+    def to_dict(self):
+        return {
+            "pc": self.pc,
+            "size": self.size,
+            "symbol": self.symbol.to_dict(),
+            "hwaddr": self.hwaddr.to_dict(),
+            "disas": self.disas.to_dict(),
+            "data": self.data.to_dict(),
+        }
+
+    def __init__(self, *args: Any, **kw: Any) -> None:
+        super().__init__(*args, **kw)
+        self.pc: Annotated[int, c_uint64]
+        self.size: Annotated[int, c_size_t]
+        self.symbol: Annotated[SHMString, SHMString]
+        self.hwaddr: Annotated[SHMString, SHMString]
+        self.disas: Annotated[SHMString, SHMString]
+        self.data: Annotated[InsnData, InsnData]
+
+
+class TBInfo(Structure):
+    INSNS_INFOS_SIZE = 32
+    _fields_ = [
+        ("pc", c_uint64),
+        ("insns", c_size_t),
+        ("insns_info_size", c_size_t),
+        ("insns_info", TBInsnInfo * INSNS_INFOS_SIZE),
+    ]
+
+    def __repr__(self):
+        return f"TBInfo(pc={self.pc}, insns={self.insns}, insns_info_size={self.insns_info_size}, insns_info={self.insns_info[: self.insns_info_size]})"
+
+    def __format__(self, _: str, /) -> str:
+        return self.__repr__()
+
+    def to_dict(self):
+        return {
+            "pc": self.pc,
+            "insns": self.insns,
+            "insns_info_size": self.insns_info_size,
+            "insns_info": [
+                insn.to_dict() for insn in self.insns_info[: self.insns_info_size]
+            ],
+        }
+
+    def __init__(self, *args: Any, **kw: Any) -> None:
+        super().__init__(*args, **kw)
+        self.pc: Annotated[int, c_uint64]
+        self.insns: Annotated[int, c_size_t]
+        self.insns_info_size: Annotated[int, c_size_t]
+        self.insns_info: Annotated[list[TBInsnInfo], TBInsnInfo * self.INSNS_INFOS_SIZE]
+
+
+class BrokerSHM_TB(Structure):
+    INFOS_SIZE = 1024
+    _fields_ = [("size", c_size_t), ("infos", TBInfo * INFOS_SIZE)]
+
+    def __repr__(self):
+        return f"BrokerSHM_TB(size={self.size}, infos={self.infos[: self.size]})"
+
+    def __format__(self, _: str, /) -> str:
+        return self.__repr__()
+
+    def to_dict(self):
+        return {
+            "size": self.size,
+            "infos": [info.to_dict() for info in self.infos[: self.size]],
+        }
+
+    def __init__(self, *args: Any, **kw: Any) -> None:
+        super().__init__(*args, **kw)
+        self.size: Annotated[int, c_size_t]
+        self.infos: Annotated[list[TBInfo], TBInfo * self.INFOS_SIZE]
+
+
+class SHMRegister(Structure):
+    MAX_REGISTER_DATA_SIZE = 64
+    _fields_ = [
+        ("size", c_int),
+        ("data", c_uint8 * MAX_REGISTER_DATA_SIZE),
+        ("name", SHMString),
+    ]
+
+    def __init__(self, *args: Any, **kw: Any) -> None:
+        super().__init__(*args, **kw)
+        self.size: Annotated[int, c_int]
+        self.data: Annotated[list[int], c_uint8 * self.MAX_REGISTER_DATA_SIZE]
+        self.name: Annotated[SHMString, SHMString]
+
+    def __repr__(self):
+        return f"SHMRegister(size={self.size}, data={self.fdata()}, name={self.name})"
+
+    def __format__(self, _: str, /) -> str:
+        return self.__repr__()
+
+    def to_dict(self, gdb_map: dict[str, str]):
+        return {
+            "size": self.size,
+            "data": self.fdata(),
+            "name": self.name.to_dict(),
+            "name-mapped": self.fname(gdb_map),
+        }
+
+    def fname(self, gdb_map: dict[str, str]) -> str:
+        n = self.name.fstr()  # assume that the name is "printable"
+        if n in gdb_map:
+            return gdb_map[n]
+        else:
+            return n
+
+    def fdata(self) -> str:
+        bytes_formatted = [num.to_bytes() for num in self.data[: self.size]]
+        res = b"".join(reversed(bytes_formatted))
+        return res.hex(" ")
+
+
+class SHMCPU(Structure):
+    MAX_CPU_REGISTERS = 256
+    _fields_ = [
+        ("idx", c_uint),
+        ("registers_size", c_size_t),
+        ("registers", SHMRegister * MAX_CPU_REGISTERS),
+    ]
+
+    def __repr__(self):
+        return f"SHMCPU(idx={self.idx}, registers_size={self.registers_size}, registers={self.registers[: self.registers_size]})"
+
+    def __format__(self, _: str, /) -> str:
+        return self.__repr__()
+
+    def to_dict(self, gdb_map: dict[str, str]):
+        return {
+            "idx": self.idx,
+            "registers_size": self.registers_size,
+            "registers": [
+                reg.to_dict(gdb_map) for reg in self.registers[: self.registers_size]
+            ],
+        }
+
+    def __init__(self, *args: Any, **kw: Any) -> None:
+        super().__init__(*args, **kw)
+        self.idx: Annotated[int, c_uint]
+        self.registers_size: Annotated[int, c_size_t]
+        self.registers: Annotated[
+            list[SHMRegister], SHMRegister * self.MAX_CPU_REGISTERS
+        ]
+
+
+class BrokerSHM_Exec(Structure):
+    MAX_CPU_COUNT = 8
+    _fields_ = [
+        ("init_mask", c_int),
+        ("cpus", SHMCPU * MAX_CPU_COUNT),
+        ("insn_info", TBInsnInfo),
+    ]
+
+    def __repr__(self):
+        return f"BrokerSHM_Exec(init_mask={self.init_mask}, cpus={self.cpus[:]}, insn_info={self.insn_info})"
+
+    def __format__(self, _: str, /) -> str:
+        return self.__repr__()
+
+    def to_dict(self, gdb_map: dict[str, str]):
+        return {
+            "init_mask": self.init_mask,
+            "cpus": [cpu.to_dict(gdb_map) for cpu in self.cpus[:]],
+            "insn_info": self.insn_info.to_dict(),
+        }
+
+    def __init__(self, *args: Any, **kw: Any) -> None:
+        super().__init__(*args, **kw)
+        self.init_mask: Annotated[int, c_int]
+        self.cpus: Annotated[list[SHMCPU], SHMCPU * self.MAX_CPU_COUNT]
+        self.insn_info: Annotated[TBInsnInfo, TBInsnInfo]
+
+
+class BrokerSHM(Union):
+    _fields_ = [("shm_tb", BrokerSHM_TB), ("shm_exec", BrokerSHM_Exec)]
+
+    def __init__(self, *args: Any, **kw: Any) -> None:
+        super().__init__(*args, **kw)
+        self.shm_tb: Annotated[BrokerSHM_TB, BrokerSHM_TB]
+        self.shm_exec: Annotated[BrokerSHM_Exec, BrokerSHM_Exec]

--- a/vadl-cosim/src/cstructs.py
+++ b/vadl-cosim/src/cstructs.py
@@ -22,13 +22,22 @@ See `BrokerSHM(Structure)` as the "entrypoint" of this class-hierarchy.
 Hint: Use the annotate-fields.py script to help generate parts of these python classes.
 """
 
-from ctypes import c_char, c_int, c_uint, c_uint64, c_uint8, Structure, c_size_t, Union
+from ctypes import Structure, Union, c_char, c_int, c_size_t, c_uint, c_uint8, c_uint64
 from typing import Annotated, Any
+
+SHMSTRING_MAX_LEN = 1024
+TBINFO_ENTRIES = 1024
+TBINSNINFO_ENTRIES = 64
+
+MAX_REGISTER_NAME_SIZE = 256
+MAX_REGISTER_DATA_SIZE = 256
+MAX_CPU_REGISTERS = 256
+MAX_CPU_COUNT = 8
+MAX_INSN_DATA_SIZE = 64
 
 
 class SHMString(Structure):
-    MAX_LEN = 256
-    _fields_ = [("len", c_size_t), ("value", c_char * MAX_LEN)]
+    _fields_ = [("len", c_size_t), ("value", c_char * SHMSTRING_MAX_LEN)]
 
     def __repr__(self):
         return f"SHMString(len={self.len}, value={self.fstr()})"
@@ -42,14 +51,13 @@ class SHMString(Structure):
     def __init__(self, *args: Any, **kw: Any) -> None:
         super().__init__(*args, **kw)
         self.len: Annotated[int, c_size_t]
-        self.value: Annotated[bytes, c_char * self.MAX_LEN]
+        self.value: Annotated[bytes, c_char * SHMSTRING_MAX_LEN]
 
     def fstr(self) -> str:
-        return self.value[: self.len].decode()
+        return self.value[: self.len].decode(errors="backslashreplace")
 
 
 class InsnData(Structure):
-    MAX_INSN_DATA_SIZE = 256
     _fields_ = [("size", c_size_t), ("buffer", c_uint8 * MAX_INSN_DATA_SIZE)]
 
     def __repr__(self):
@@ -69,7 +77,7 @@ class InsnData(Structure):
     def __init__(self, *args: Any, **kw: Any) -> None:
         super().__init__(*args, **kw)
         self.size: Annotated[int, c_size_t]
-        self.buffer: Annotated[list[int], c_uint8 * self.MAX_INSN_DATA_SIZE]
+        self.buffer: Annotated[list[int], c_uint8 * MAX_INSN_DATA_SIZE]
 
 
 class TBInsnInfo(Structure):
@@ -109,7 +117,6 @@ class TBInsnInfo(Structure):
 
 
 class TBInfo(Structure):
-    TBINSNINFO_ENTRIES = 32
     _fields_ = [
         ("pc", c_uint64),
         ("insns_info_size", c_size_t),
@@ -131,15 +138,17 @@ class TBInfo(Structure):
             ],
         }
 
+    def insns_info_list(self) -> list[TBInsnInfo]:
+        return self.insns_info[: self.insns_info_size]
+
     def __init__(self, *args: Any, **kw: Any) -> None:
         super().__init__(*args, **kw)
         self.pc: Annotated[int, c_uint64]
         self.insns_info_size: Annotated[int, c_size_t]
-        self.insns_info: Annotated[list[TBInsnInfo], TBInsnInfo * self.INSNS_INFOS_SIZE]
+        self.insns_info: Annotated[list[TBInsnInfo], TBInsnInfo * TBINSNINFO_ENTRIES]
 
 
 class SHMRegister(Structure):
-    MAX_REGISTER_DATA_SIZE = 64
     _fields_ = [
         ("size", c_int),
         ("data", c_uint8 * MAX_REGISTER_DATA_SIZE),
@@ -149,7 +158,7 @@ class SHMRegister(Structure):
     def __init__(self, *args: Any, **kw: Any) -> None:
         super().__init__(*args, **kw)
         self.size: Annotated[int, c_int]
-        self.data: Annotated[list[int], c_uint8 * self.MAX_REGISTER_DATA_SIZE]
+        self.data: Annotated[list[int], c_uint8 * MAX_REGISTER_DATA_SIZE]
         self.name: Annotated[SHMString, SHMString]
 
     def __repr__(self):
@@ -180,7 +189,6 @@ class SHMRegister(Structure):
 
 
 class SHMCPU(Structure):
-    MAX_CPU_REGISTERS = 256
     _fields_ = [
         ("idx", c_uint),
         ("registers_size", c_size_t),
@@ -202,17 +210,17 @@ class SHMCPU(Structure):
             ],
         }
 
+    def registers_list(self) -> list[SHMRegister]:
+        return self.registers[: self.registers_size]
+
     def __init__(self, *args: Any, **kw: Any) -> None:
         super().__init__(*args, **kw)
         self.idx: Annotated[int, c_uint]
         self.registers_size: Annotated[int, c_size_t]
-        self.registers: Annotated[
-            list[SHMRegister], SHMRegister * self.MAX_CPU_REGISTERS
-        ]
+        self.registers: Annotated[list[SHMRegister], SHMRegister * MAX_CPU_REGISTERS]
 
 
 class BrokerSHM_TB(Structure):
-    MAX_CPU_COUNT = 8
     _fields_ = [
         ("init_mask", c_int),
         ("cpus", SHMCPU * MAX_CPU_COUNT),
@@ -235,12 +243,11 @@ class BrokerSHM_TB(Structure):
     def __init__(self, *args: Any, **kw: Any) -> None:
         super().__init__(*args, **kw)
         self.init_mask: Annotated[int, c_int]
-        self.cpus: Annotated[list[SHMCPU], SHMCPU * self.MAX_CPU_COUNT]
+        self.cpus: Annotated[list[SHMCPU], SHMCPU * MAX_CPU_COUNT]
         self.tb_info: Annotated[TBInfo, TBInfo]
 
 
 class BrokerSHM_Exec(Structure):
-    MAX_CPU_COUNT = 8
     _fields_ = [
         ("init_mask", c_int),
         ("cpus", SHMCPU * MAX_CPU_COUNT),
@@ -263,7 +270,7 @@ class BrokerSHM_Exec(Structure):
     def __init__(self, *args: Any, **kw: Any) -> None:
         super().__init__(*args, **kw)
         self.init_mask: Annotated[int, c_int]
-        self.cpus: Annotated[list[SHMCPU], SHMCPU * self.MAX_CPU_COUNT]
+        self.cpus: Annotated[list[SHMCPU], SHMCPU * MAX_CPU_COUNT]
         self.insn_info: Annotated[TBInsnInfo, TBInsnInfo]
 
 

--- a/vadl-cosim/src/qemu_ipc.py
+++ b/vadl-cosim/src/qemu_ipc.py
@@ -1,0 +1,173 @@
+import logging
+import mmap
+import multiprocessing
+import os
+import subprocess
+from ctypes import sizeof
+from dataclasses import dataclass
+from typing import Optional
+
+import posix_ipc as ipc  # type: ignore[import-not-found]
+
+from src.config import Client, Config
+from src.cstructs import BrokerSHM
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class QEMUClient:
+    id: int
+    shm: ipc.SharedMemory
+    shm_struct: BrokerSHM
+    sem_server: ipc.Semaphore
+    sem_client: ipc.Semaphore
+    is_open: bool
+    process: Optional[multiprocessing.Process]
+    name: Optional[str]
+
+    def run(self) -> bool:
+        """
+        Releases the client to run for one execution-step.
+        Returns True if the client successfully ran,
+        False indicates that the client crashed or finished executing
+        in both cases the client is marked as closed
+        by setting self.is_open = False
+        """
+        try:
+            self.sem_client.release()
+
+            # wait at most 0.1 second, if an error occurs: assume that the client finished (crashing = finishing)
+            self.sem_server.acquire(0.1)
+            return True
+        except ipc.BusyError:
+            logger.debug(
+                f"BusyError: noticed that client #{self.id} shutdown. marking as closed"
+            )
+            self.is_open = False
+            return False
+
+
+"""
+Setup and Cleanup functions for the QEMU/C IPC
+"""
+
+
+def create_client(config: Config, client_cfg: Client, i: int) -> QEMUClient:
+    shm = ipc.SharedMemory(f"/cosimulation-shm-{i}", ipc.O_CREX, size=sizeof(BrokerSHM))
+    mm = mmap.mmap(shm.fd, sizeof(BrokerSHM))
+    shm_struct = BrokerSHM.from_buffer(mm)
+
+    sem_server = ipc.Semaphore(f"/cosimulation-sem-server-{i}", ipc.O_CREX)
+    sem_client = ipc.Semaphore(f"/cosimulation-sem-client-{i}", ipc.O_CREX)
+    logger.info(f"created shm and sems, spawning client with id: {i}")
+
+    executable_path = client_cfg.exec
+
+    plugin_path = config.qemu.plugin
+    client_mode = ""
+    if (
+        config.testing.protocol.layer == "tb"
+        or config.testing.protocol.layer == "tb-strict"
+    ):
+        client_mode = "tb"
+    else:
+        client_mode = config.testing.protocol.layer
+
+    plugin_args = [f"client-id={i}", f"mode={client_mode}"]
+    if client_cfg.name is not None:
+        plugin_args += [f"client-name={client_cfg.name}"]
+
+    plugin = ",".join([plugin_path] + plugin_args)
+
+    default_args = [
+        f"-{client_cfg.pass_test_exec_to}",
+        config.testing.test_exec,
+        "-plugin",
+        plugin,
+    ]
+    args = default_args + client_cfg.additional_args
+    logger.info(f"starting client: {' '.join([executable_path, *args])}")
+    client = QEMUClient(
+        i,
+        shm,
+        shm_struct,
+        sem_server=sem_server,
+        sem_client=sem_client,
+        is_open=True,
+        process=None,
+        name=client_cfg.name,
+    )
+    client.process = run_with_callback(
+        [executable_path, *args], on_client_complete, config, client
+    )
+
+    return client
+
+
+def run_with_callback(
+    command, on_complete, config: Config, client: QEMUClient
+) -> multiprocessing.Process:
+    """
+    Starts a QEMU-client using pythons multiprocessing.Process
+    After completion, the client is marked as done using client.is_open = False
+    Both stdout and stderr for each client is redirected to a dedicated file.
+    """
+
+    def runner():
+        stdout_path = os.path.join(config.logging.dir, f"client-{client.id}-stdout.txt")
+        stderr_path = os.path.join(config.logging.dir, f"client-{client.id}-stderr.txt")
+        stdout_file = open(stdout_path, "w")
+        stderr_file = open(stderr_path, "w")
+        process = subprocess.Popen(command, stdout=stdout_file, stderr=stderr_file)
+        process.wait()
+        stdout_file.close()
+        stderr_file.close()
+        on_complete(process.returncode, config, client)
+
+    p = multiprocessing.Process(target=runner)
+    p.start()
+    return p
+
+
+def on_client_complete(returncode: int, config: Config, client: QEMUClient):
+    logger.info(f"Process (client: {client.id}) finished with code: {returncode}")
+    client.is_open = False
+
+
+def cleanup_sem(config: Config, client: QEMUClient):
+    logger.debug(f"cleanup_sem of client #{client.id} start")
+    try:
+        client.sem_client.unlink()
+        client.sem_server.unlink()
+        client.sem_client.close()
+        client.sem_server.close()
+    except ipc.ExistentialError:
+        pass  # ignore
+    logger.debug(f"cleanup_sem of client #{client.id} done")
+
+
+def cleanup_smh(config: Config, client: QEMUClient):
+    try:
+        client.shm.close_fd()
+        client.shm.unlink()
+    except ipc.ExistentialError:
+        pass  # ignore
+
+
+def close_client(config: Config, client: QEMUClient):
+    logger.info(f"Closing client: {client.id}")
+    if client.process is not None:
+        client.process.terminate()
+
+
+def cleanup_client(config: Config, client: QEMUClient):
+    cleanup_sem(config, client)
+    cleanup_smh(config, client)
+    close_client(config, client)
+
+
+def cleanup(config: Config, clients: list[QEMUClient]):
+    logger.info("cleaning up shm and sems for each client")
+    for client in clients:
+        cleanup_client(config, client)

--- a/vadl-cosim/vadl-cosim.py
+++ b/vadl-cosim/vadl-cosim.py
@@ -9,15 +9,26 @@ def default_config_file() -> str:
     dir_path = os.path.dirname(os.path.realpath(__file__))
     return f"{dir_path}/config.toml"
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     logger = logging.getLogger(__name__)
     parser = argparse.ArgumentParser(
         prog="Cosimulation Broker",
-        description="Executes two (or more) qemu-instances in parallel which need to use the cosimulation plugin to connect to the broker."
+        description="Executes two (or more) qemu-instances in parallel which need to use the cosimulation plugin to connect to the broker.",
     )
 
-    parser.add_argument('-c', '--config', type=str, help="Path to the (toml) config file, default is: ./config.toml", default=default_config_file())
-    parser.add_argument('--test-exec', type=str, help="Defines where the test-executable is passed to when starting the QEMU-client")
+    parser.add_argument(
+        "-c",
+        "--config",
+        type=str,
+        help="Path to the (toml) config file, default is: ./config.toml",
+        default=default_config_file(),
+    )
+    parser.add_argument(
+        "--test-exec",
+        type=str,
+        help="Defines where the test-executable is passed to when starting the QEMU-client",
+    )
 
     args = parser.parse_args()
 
@@ -28,12 +39,17 @@ if __name__ == '__main__':
 
     if args.test_exec is not None:
         config.testing.test_exec = args.test_exec
- 
+
     if config.logging.enable:
         filemode = "w" if config.logging.clear_on_rerun else "a"
         filename = os.path.join(config.logging.dir, config.logging.file)
         os.makedirs(os.path.dirname(filename), exist_ok=True)
-        logging.basicConfig(filename=filename, filemode=filemode, level=config.logging.level, format='[%(filename)s:%(lineno)s - %(funcName)20s() ] %(message)s')
+        logging.basicConfig(
+            filename=filename,
+            filemode=filemode,
+            level=config.logging.level,
+            format="[%(filename)s:%(lineno)s - %(funcName)20s() ] %(message)s",
+        )
     else:
         logging.disable()
 
@@ -41,4 +57,3 @@ if __name__ == '__main__':
         cosimulation_broker.start(config)
     else:
         logger.info(f"Dry-Run. Config: {config}")
-

--- a/vadl/main/resources/templates/iss/contrib/plugins/cosimulation.c
+++ b/vadl/main/resources/templates/iss/contrib/plugins/cosimulation.c
@@ -224,7 +224,7 @@ static SHMCPU get_cpu_state(unsigned int cpu_index) {
       memcpy(shm_reg.data, buf->data, shm_reg.size);
     }
 
-    g_free(buf);
+    g_byte_array_unref(buf);
 
     shm_cpu.registers[reg_idx] = shm_reg;
   }

--- a/vadl/main/resources/templates/iss/contrib/plugins/cosimulation.c
+++ b/vadl/main/resources/templates/iss/contrib/plugins/cosimulation.c
@@ -237,7 +237,8 @@ static void open_sems(void) {
       g_strdup_printf("cosimulation-sem-client-%s", args.client_id);
   sem_client = sem_open(sem_client_name, O_RDWR);
   if (sem_client == SEM_FAILED) {
-    g_error("failed to open sem_client for client: %s", args.client_id);
+    char* err = strerror(errno);
+    g_error("failed to open sem_client for client: %s -> %s", args.client_id, err);
     return;
   }
 
@@ -245,7 +246,8 @@ static void open_sems(void) {
       g_strdup_printf("cosimulation-sem-server-%s", args.client_id);
   sem_server = sem_open(sem_server_name, O_RDWR);
   if (sem_server == SEM_FAILED) {
-    g_error("failed to open sem_server for client: %s", args.client_id);
+    char* err = strerror(errno);
+    g_error("failed to open sem_server for client: %s -> %s", args.client_id, err);
     return;
   }
 }
@@ -260,19 +262,22 @@ static BrokerSHM *connect_to_broker(void) {
   gchar *shm_name = g_strdup_printf("/cosimulation-shm-%s", args.client_id);
   int shm_fd = shm_open(shm_name, O_RDWR, 0600);
   if (shm_fd == -1) {
-    g_error("failed to open shared memory for client: %s", args.client_id);
+    char* err = strerror(errno);
+    g_error("failed to open shared memory for client: %s -> %s", args.client_id, err);
     return NULL;
   }
 
   if (ftruncate(shm_fd, sizeof(BrokerSHM)) == -1) {
-    g_error("failed to truncate shared memory for client: %s", args.client_id);
+    char* err = strerror(errno);
+    g_error("failed to truncate shared memory for client: %s -> %s", args.client_id, err);
     return NULL;
   }
 
   BrokerSHM *shm = mmap(NULL, sizeof(BrokerSHM), PROT_READ | PROT_WRITE,
                         MAP_SHARED, shm_fd, 0);
   if (shm == MAP_FAILED) {
-    g_error("failed to mmap shared memory for client: %s", args.client_id);
+    char* err = strerror(errno);
+    g_error("failed to mmap shared memory for client: %s -> %s", args.client_id, err);
     return NULL;
   }
 

--- a/vadl/main/resources/templates/iss/contrib/plugins/cosimulation.c
+++ b/vadl/main/resources/templates/iss/contrib/plugins/cosimulation.c
@@ -36,15 +36,15 @@ QEMU_PLUGIN_EXPORT int qemu_plugin_version = QEMU_PLUGIN_VERSION;
 // adjust as needed
 // NOTE: try to keep these values as small as possible to minimize memory usage
 //       if set too small then crashes and/or invalid state can occur
-#define SHMSTRING_MAX_LEN 256
+#define SHMSTRING_MAX_LEN 1024
 #define TBINFO_ENTRIES 1024
-#define TBINSNINFO_ENTRIES 32
+#define TBINSNINFO_ENTRIES 64
 
-#define MAX_REGISTER_NAME_SIZE 64
-#define MAX_REGISTER_DATA_SIZE 64
+#define MAX_REGISTER_NAME_SIZE 256
+#define MAX_REGISTER_DATA_SIZE 256
 #define MAX_CPU_REGISTERS 256
 #define MAX_CPU_COUNT 8
-#define MAX_INSN_DATA_SIZE 4
+#define MAX_INSN_DATA_SIZE 64
 
 static qemu_plugin_id_t plugin_id;
 
@@ -216,7 +216,7 @@ static SHMCPU get_cpu_state(unsigned int cpu_index) {
     shm_reg.size = qemu_plugin_read_register(reg->handle, buf);
 
     if (reg->name != NULL) {
-      strncpy(shm_reg.name.value, reg->name, SHMSTRING_MAX_LEN);
+      strncpy(shm_reg.name.value, reg->name, SHMSTRING_MAX_LEN - 1);
       shm_reg.name.len = strlen(shm_reg.name.value);
     }
 
@@ -237,8 +237,9 @@ static void open_sems(void) {
       g_strdup_printf("cosimulation-sem-client-%s", args.client_id);
   sem_client = sem_open(sem_client_name, O_RDWR);
   if (sem_client == SEM_FAILED) {
-    char* err = strerror(errno);
-    g_error("failed to open sem_client for client: %s -> %s", args.client_id, err);
+    char *err = strerror(errno);
+    g_error("failed to open sem_client for client: %s -> %s", args.client_id,
+            err);
     return;
   }
 
@@ -246,8 +247,9 @@ static void open_sems(void) {
       g_strdup_printf("cosimulation-sem-server-%s", args.client_id);
   sem_server = sem_open(sem_server_name, O_RDWR);
   if (sem_server == SEM_FAILED) {
-    char* err = strerror(errno);
-    g_error("failed to open sem_server for client: %s -> %s", args.client_id, err);
+    char *err = strerror(errno);
+    g_error("failed to open sem_server for client: %s -> %s", args.client_id,
+            err);
     return;
   }
 }
@@ -262,22 +264,25 @@ static BrokerSHM *connect_to_broker(void) {
   gchar *shm_name = g_strdup_printf("/cosimulation-shm-%s", args.client_id);
   int shm_fd = shm_open(shm_name, O_RDWR, 0600);
   if (shm_fd == -1) {
-    char* err = strerror(errno);
-    g_error("failed to open shared memory for client: %s -> %s", args.client_id, err);
+    char *err = strerror(errno);
+    g_error("failed to open shared memory for client: %s -> %s", args.client_id,
+            err);
     return NULL;
   }
 
   if (ftruncate(shm_fd, sizeof(BrokerSHM)) == -1) {
-    char* err = strerror(errno);
-    g_error("failed to truncate shared memory for client: %s -> %s", args.client_id, err);
+    char *err = strerror(errno);
+    g_error("failed to truncate shared memory for client: %s -> %s",
+            args.client_id, err);
     return NULL;
   }
 
   BrokerSHM *shm = mmap(NULL, sizeof(BrokerSHM), PROT_READ | PROT_WRITE,
                         MAP_SHARED, shm_fd, 0);
   if (shm == MAP_FAILED) {
-    char* err = strerror(errno);
-    g_error("failed to mmap shared memory for client: %s -> %s", args.client_id, err);
+    char *err = strerror(errno);
+    g_error("failed to mmap shared memory for client: %s -> %s", args.client_id,
+            err);
     return NULL;
   }
 
@@ -291,20 +296,20 @@ static TBInsnInfo get_tbinsn_info(struct qemu_plugin_insn *insn) {
 
   const char *insn_symbol = qemu_plugin_insn_symbol(insn);
   if (insn_symbol != NULL) {
-    strncpy(insn_info.symbol.value, insn_symbol, SHMSTRING_MAX_LEN);
+    strncpy(insn_info.symbol.value, insn_symbol, SHMSTRING_MAX_LEN - 1);
     insn_info.symbol.len = strlen(insn_info.symbol.value);
   }
 
   void *insn_hwaddr = qemu_plugin_insn_haddr(insn);
   if (insn_hwaddr != NULL) {
     char *hwaddrfmt = g_strdup_printf("%p", insn_hwaddr);
-    strncpy(insn_info.hwaddr.value, hwaddrfmt, SHMSTRING_MAX_LEN);
+    strncpy(insn_info.hwaddr.value, hwaddrfmt, SHMSTRING_MAX_LEN - 1);
     insn_info.hwaddr.len = strlen(insn_info.hwaddr.value);
   }
 
   char *insn_disas = qemu_plugin_insn_disas(insn);
   if (insn_disas != NULL) {
-    strncpy(insn_info.disas.value, insn_disas, SHMSTRING_MAX_LEN);
+    strncpy(insn_info.disas.value, insn_disas, SHMSTRING_MAX_LEN - 1);
     insn_info.disas.len = strlen(insn_info.disas.value);
   }
 
@@ -324,7 +329,7 @@ static TBInfo get_tb_info(struct qemu_plugin_tb *tb) {
   uint64_t pc = qemu_plugin_tb_vaddr(tb);
   size_t insns = qemu_plugin_tb_n_insns(tb);
 
-  TBInfo tbinfo;
+  TBInfo tbinfo = {0};
   tbinfo.pc = pc;
 
   PLUGIN_ASSERT(insns <= TBINSNINFO_ENTRIES,
@@ -332,14 +337,18 @@ static TBInfo get_tb_info(struct qemu_plugin_tb *tb) {
                 insns, TBINSNINFO_ENTRIES);
   for (int i = 0; i < insns; i++) {
     struct qemu_plugin_insn *insn = qemu_plugin_tb_get_insn(tb, i);
+    PLUGIN_ASSERT(insn != NULL, "insn must not be null: %d", i);
     tbinfo.insns_info[i] = get_tbinsn_info(insn);
   }
 
   tbinfo.insns_info_size = insns;
+
   return tbinfo;
 }
 
 static void vcpu_insn_exec(unsigned int cpu_index, void *udata) {
+  TBInsnInfo *tbinsn_info = udata;
+  PLUGIN_PRINTLN("vcpu_insn_exec: before wait: (PC=%lu) %s", tbinsn_info->pc, tbinsn_info->disas.value);
   sem_wait(sem_client);
 
   SHMCPU cpu = get_cpu_state(cpu_index);
@@ -347,11 +356,15 @@ static void vcpu_insn_exec(unsigned int cpu_index, void *udata) {
   shm->shm_exec.cpus[cpu_index] = cpu;
   shm->shm_exec.init_mask |= (1 << cpu_index);
 
-  TBInsnInfo *tbinsn_info = udata;
+  PLUGIN_PRINTLN("vcpu_insn_exec: PC = %lu", tbinsn_info->pc);
+
   shm->shm_exec.insn_info = *tbinsn_info;
-  g_free(tbinsn_info);
+
+  // TODO: we cannot free here because the same callback might be used multiple times when a tb gets reused
+  // g_free(tbinsn_info);
 
   sem_post(sem_server);
+  PLUGIN_PRINTLN("vcpu_insn_exec: after post");
 }
 
 static void vcpu_tb_exec(unsigned int cpu_index, void *udata) {
@@ -363,17 +376,16 @@ static void vcpu_tb_exec(unsigned int cpu_index, void *udata) {
   shm->shm_tb.init_mask |= (1 << cpu_index);
 
   TBInfo *tb_info = udata;
-  shm->shm_tb.tb_info = *tb_info ;
-  g_free(tb_info);
+  shm->shm_tb.tb_info = *tb_info;
+
+  // TODO: we cannot free here because the same callback might be used multiple times when a tb gets reused
+  // g_free(tb_info);
 
   sem_post(sem_server);
 }
 
 static void vcpu_tb_trans(qemu_plugin_id_t id, struct qemu_plugin_tb *tb) {
   if (args.mode == TB_MODE) {
-    // TODO: move TB info collection to qemu_plugin_register_vcpu_tb_exec_cb,
-    // this function should just manage the cb based on the modes
-
     TBInfo *tbinfo = g_new0(TBInfo, 1);
     *tbinfo = get_tb_info(tb);
     qemu_plugin_register_vcpu_tb_exec_cb(tb, vcpu_tb_exec,


### PR DESCRIPTION
This PR implements cosimulation at the translation-block layer, both `tb` and `tb-strict` are added as values to the `testing.protocol.layer` configuration option:

- `tb-strict`: Assumes that equivalent translation-blocks are generated by all QEMU-clients - any divergences result in a test-fail.
- `tb`: Translation-blocks do not have to be equivalent, rather the PC is compared. This allows for clients with differently generated TBs but equivalent instructions. 

For `tb`, the clients currently synchronize as follows:

1. Each client gets one execution step, the PC before the exec and after is collected and added to a list.
2. After every client ran once, a call to `sync_clients` is made:
3. The largest PC (after exec-step) is selected.
4. All clients with a after-exec PC smaller than the maximum are added into a queue.
5. While there are clients in the queue:
5.1 Run the client once and check the PC after it has run
5.2 if it is still **smaller** than the max PC, re-add it to the queue
5.3 if it is **equal** than the max PC, then the client is synchronized and not re-added to the queue
5.4 if it is **larger**  than the previous max PC, then this is currently not accounted for and the test will fail

The synchronization is done once the queue is empty - leading to a state-comparison and then going back to step 1.

The synchronization currently assumes that there will always be a common available sync-point between all clients, this is usually some sort of jump instruction since TBs should never contain a jump in the middle of the block.

However, if there is no TB from one client which is a "superset" of the other TBs from the other clients then this sync-algorithm will fail, specifically at step 5.4.

If step 5.4 never gets executed then this synchronization is probably ideal, since it would maximize the number of state comparisons - which is desired for lock-stepping. Otherwise (if this becomes an issue) I would need re-synchronize the clients based on the new max PC - which might lead to very late synchronization points at worst, which would hardly make it a lock-step test. 