### PR TITLE
iss: Optimize selects with constant condition

### DIFF
--- a/vadl/main/vadl/iss/codegen/IssCMixins.java
+++ b/vadl/main/vadl/iss/codegen/IssCMixins.java
@@ -19,6 +19,7 @@ package vadl.iss.codegen;
 import vadl.cppCodeGen.context.CGenContext;
 import vadl.iss.passes.nodes.IssConstExtractNode;
 import vadl.iss.passes.nodes.IssGhostCastNode;
+import vadl.iss.passes.nodes.IssSelectNode;
 import vadl.iss.passes.nodes.IssValExtractNode;
 import vadl.iss.passes.opDecomposition.nodes.IssMul2Node;
 import vadl.iss.passes.opDecomposition.nodes.IssMulhNode;
@@ -69,6 +70,14 @@ public interface IssCMixins {
     default void handle(CGenContext<Node> ctx, IssGhostCastNode toHandle) {
       // just emit the inner value
       ctx.gen(toHandle.value());
+    }
+
+    @Handler
+    @SuppressWarnings("MissingJavadocMethod")
+    default void handle(CGenContext<Node> ctx, IssSelectNode toHandle) {
+      // IssSelectNodes are always turned into TCG nodes (TcgConstSelect or TcgMovCond).
+      // If the original SelectNode was not scheduled, it got not converted to an IssSelectNode.
+      throw new IllegalStateException("The IssSelectNode should never be generated as C code.");
     }
 
     @Handler

--- a/vadl/main/vadl/iss/passes/IssNormalizationPass.java
+++ b/vadl/main/vadl/iss/passes/IssNormalizationPass.java
@@ -30,6 +30,7 @@ import javax.annotation.Nullable;
 import vadl.configuration.IssConfiguration;
 import vadl.iss.passes.nodes.IssConstExtractNode;
 import vadl.iss.passes.nodes.IssGhostCastNode;
+import vadl.iss.passes.nodes.IssSelectNode;
 import vadl.iss.passes.nodes.IssStaticPcRegNode;
 import vadl.iss.passes.nodes.IssValExtractNode;
 import vadl.iss.passes.opDecomposition.nodes.IssMul2Node;
@@ -733,6 +734,11 @@ class IssNormalizer implements VadlBuiltInNoStatusDispatcher<BuiltInCall> {
 
   @Handler
   void handle(IssConstExtractNode toHandle) {
+    throw graphError(toHandle, "Node should not occur here");
+  }
+
+  @Handler
+  void handle(IssSelectNode toHandle) {
     throw graphError(toHandle, "Node should not occur here");
   }
 

--- a/vadl/main/vadl/iss/passes/TcgPassUtils.java
+++ b/vadl/main/vadl/iss/passes/TcgPassUtils.java
@@ -87,4 +87,25 @@ public class TcgPassUtils {
       return null;
     }
   }
+
+  /**
+   * Returns a {@link BuiltInTable.BuiltIn} for a given {@link TcgCondition}.
+   * E.g., on LT it returns the SLTH built-in.
+   */
+  public static BuiltInTable.BuiltIn builtInOf(TcgCondition condition) {
+    return switch (condition) {
+      case EQ -> BuiltInTable.EQU;
+      case NE -> BuiltInTable.NEQ;
+      case LT -> BuiltInTable.SLTH;
+      case GE -> BuiltInTable.SGEQ;
+      case LE -> BuiltInTable.SLEQ;
+      case GT -> BuiltInTable.SGTH;
+      case LTU -> BuiltInTable.ULTH;
+      case GEU -> BuiltInTable.UGEQ;
+      case LEU -> BuiltInTable.ULEQ;
+      case GTU -> BuiltInTable.UGTH;
+      case TSTNE -> BuiltInTable.AND;
+      case TSTEQ -> throw new IllegalArgumentException("No built-in for TSTEQ");
+    };
+  }
 }

--- a/vadl/main/vadl/iss/passes/nodes/IssSelectNode.java
+++ b/vadl/main/vadl/iss/passes/nodes/IssSelectNode.java
@@ -1,0 +1,171 @@
+// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.iss.passes.nodes;
+
+import java.util.List;
+import vadl.iss.passes.TcgPassUtils;
+import vadl.iss.passes.tcgLowering.TcgCondition;
+import vadl.javaannotations.viam.DataValue;
+import vadl.javaannotations.viam.Input;
+import vadl.viam.Constant;
+import vadl.viam.graph.GraphNodeVisitor;
+import vadl.viam.graph.GraphVisitor;
+import vadl.viam.graph.Node;
+import vadl.viam.graph.dependency.ConstantNode;
+import vadl.viam.graph.dependency.ExpressionNode;
+import vadl.viam.graph.dependency.SelectNode;
+
+/**
+ * The lowering of the {@link SelectNode}. It contains a {@link TcgCondition} as operation
+ * condition.
+ * This is the preparation for the lowering to
+ * {@link vadl.iss.passes.tcgLowering.nodes.TcgMovCondNode}.
+ * The node is created in the {@link vadl.iss.passes.IssTcgSchedulingPass} and substitutes
+ * select nodes that were scheduled.
+ *
+ * <p>This node is never rendered as C-code, as a {@link SelectNode} that was not scheduled
+ * is not turned into a {@link IssSelectNode}.
+ * If the original node was scheduled, this node is turned into a
+ * {@link vadl.iss.passes.tcgLowering.nodes.TcgMovCondNode} or
+ * {@link vadl.iss.passes.tcgLowering.nodes.TcgConstSelectNode}</p>
+ */
+public class IssSelectNode extends ExpressionNode {
+
+  @DataValue
+  private TcgCondition condition;
+
+  @Input
+  private ExpressionNode c1;
+  @Input
+  private ExpressionNode c2;
+
+  @Input
+  private ExpressionNode trueCase;
+  @Input
+  private ExpressionNode falseCase;
+
+
+  /**
+   * Constructs the IssSelectNode.
+   *
+   * @param condition the tcg condition to use
+   * @param c1        the first condition argument (lhs)
+   * @param c2        the second condition argument (rhs)
+   * @param trueCase  the expression in case of the condition being true
+   * @param falseCase the expression in case of the condition being false
+   */
+  public IssSelectNode(
+      TcgCondition condition,
+      ExpressionNode c1,
+      ExpressionNode c2,
+      ExpressionNode trueCase,
+      ExpressionNode falseCase) {
+    super(trueCase.type());
+    this.condition = condition;
+    this.c1 = c1;
+    this.c2 = c2;
+    this.trueCase = trueCase;
+    this.falseCase = falseCase;
+  }
+
+  public ExpressionNode c1() {
+    return c1;
+  }
+
+  public ExpressionNode c2() {
+    return c2;
+  }
+
+  public TcgCondition condition() {
+    return condition;
+  }
+
+  public ExpressionNode trueCase() {
+    return trueCase;
+  }
+
+  public ExpressionNode falseCase() {
+    return falseCase;
+  }
+
+  /**
+   * The condition of the original select node was <b>not</b> inlined, iff the condition
+   * EQ and the second condition operand is equal to true.
+   *
+   * @return true if the original {@link SelectNode} condition was inlined into this TCG condition,
+   *     otherwise false.
+   */
+  public boolean inlined() {
+    return !(condition == TcgCondition.EQ
+        && c2 instanceof ConstantNode c
+        && c.constant().asVal().equalValue(Constant.Value.of(true)));
+  }
+
+  /**
+   * Produces the condition expression of this select node.
+   * Based on the {@link #inlined()} check, this is either pure {@link #c1()} (as it was not
+   * inlined), or an equal comparison between {@link #c1()} and {@link #c2()}.
+   *
+   * @return expression that might contain uninitialized nodes.
+   */
+  public ExpressionNode conditionExpr() {
+    if (!inlined()) {
+      return c1;
+    }
+    return TcgPassUtils.builtInOf(condition)
+        .call(c1, c2);
+  }
+
+  @Override
+  public ExpressionNode copy() {
+    return new IssSelectNode(condition, c1.copy(), c2.copy(), trueCase.copy(), falseCase.copy());
+  }
+
+  @Override
+  public Node shallowCopy() {
+    return new IssSelectNode(condition, c1, c2, trueCase, falseCase);
+  }
+
+  @Override
+  public <T extends GraphNodeVisitor> void accept(T visitor) {
+
+  }
+
+  @Override
+  protected void collectData(List<Object> collection) {
+    super.collectData(collection);
+    collection.add(condition);
+  }
+
+  @Override
+  protected void collectInputs(List<Node> collection) {
+    super.collectInputs(collection);
+    collection.add(c1);
+    collection.add(c2);
+    collection.add(trueCase);
+    collection.add(falseCase);
+  }
+
+  @Override
+  protected void applyOnInputsUnsafe(GraphVisitor.Applier<Node> visitor) {
+    super.applyOnInputsUnsafe(visitor);
+    c1 = visitor.apply(this, c1, ExpressionNode.class);
+    c2 = visitor.apply(this, c2, ExpressionNode.class);
+    trueCase = visitor.apply(this, trueCase, ExpressionNode.class);
+    falseCase = visitor.apply(this, falseCase, ExpressionNode.class);
+  }
+}

--- a/vadl/main/vadl/iss/passes/tcgLowering/nodes/TcgConstSelectNode.java
+++ b/vadl/main/vadl/iss/passes/tcgLowering/nodes/TcgConstSelectNode.java
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.iss.passes.tcgLowering.nodes;
+
+import java.util.List;
+import java.util.function.Function;
+import vadl.iss.passes.nodes.TcgVRefNode;
+import vadl.javaannotations.viam.Input;
+import vadl.viam.graph.GraphVisitor;
+import vadl.viam.graph.Node;
+import vadl.viam.graph.dependency.ExpressionNode;
+
+/**
+ * Represents a select node where at least one option is a TCG node/variable,
+ * but the condition is not (constant at translation time).
+ * This is translated to a ternary C operation with the result being moved to the destination.
+ * {@code tcg_gen_mov(<dest>, <c-cond> ? <true-case> : <false-case> }
+ */
+public class TcgConstSelectNode extends TcgBinaryOpNode {
+
+  @Input
+  private ExpressionNode condition;
+
+  public TcgConstSelectNode(TcgVRefNode resVar, ExpressionNode condition, TcgVRefNode trueCase,
+                            TcgVRefNode falseCase) {
+    super(resVar, trueCase, falseCase, resVar.width());
+    this.condition = condition;
+  }
+
+  @Override
+  public String tcgFunctionName() {
+    throw error("Should not be called");
+  }
+
+  @Override
+  public String cCode(Function<Node, String> nodeToCCode) {
+    return "tcg_gen_mov_" + width() + "(" + firstDest().cCode() + ", "
+        + nodeToCCode.apply(condition)
+        + " ? " + arg1().cCode()
+        + " : " + arg2().cCode() + ");";
+  }
+
+  public ExpressionNode condition() {
+    return condition;
+  }
+
+  @Override
+  public Node copy() {
+    return new TcgConstSelectNode(firstDest().copy(),
+        condition.copy(),
+        arg1.copy(),
+        arg2.copy());
+  }
+
+  @Override
+  public Node shallowCopy() {
+    return new TcgConstSelectNode(firstDest(), condition, arg1, arg2);
+  }
+
+  @Override
+  protected void collectInputs(List<Node> collection) {
+    super.collectInputs(collection);
+    collection.add(condition);
+  }
+
+  @Override
+  protected void applyOnInputsUnsafe(GraphVisitor.Applier<Node> visitor) {
+    super.applyOnInputsUnsafe(visitor);
+    condition = visitor.apply(this, condition, ExpressionNode.class);
+  }
+}

--- a/vadl/main/vadl/viam/graph/control/DirectionalNode.java
+++ b/vadl/main/vadl/viam/graph/control/DirectionalNode.java
@@ -97,19 +97,29 @@ public abstract class DirectionalNode extends ControlNode {
 
 
   /**
-   * Replaces this node with its successor, and then safely deletes this node.
+   * Replaces this node with its successor and then safely deletes this node.
    *
-   * <p>The method ensures that the node to be deleted has a predecessor, then it updates
+   * <p>The method ensures that the node to be deleted has a predecessor; then it updates
    * the predecessor's successor to bypass this node. Finally, it safely deletes this node
    * from the graph to maintain consistency.
    */
   public void replaceByNothingAndDelete() {
+    replaceByNothing();
+    safeDelete();
+  }
+
+  /**
+   * Replaces this node with its successor.
+   *
+   * <p>The method ensures that the node to be replaced has a predecessor; then it updates
+   * the predecessor's successor to bypass this node.
+   */
+  public void replaceByNothing() {
     ensure(this.predecessor() != null, "Can only remove this node if the predecessor is set!");
     // set successor to successor of predecessor
     var successor = this.next();
     replaceSuccessor(successor, null);
     predecessor().replaceSuccessor(this, successor);
-    safeDelete();
   }
 
   /**

--- a/vadl/test/vadl/iss/IssInstrTest.java
+++ b/vadl/test/vadl/iss/IssInstrTest.java
@@ -185,7 +185,7 @@ public abstract class IssInstrTest extends QemuIssTest {
                   log.getValue().stream().map((l) -> "- " + l)
                       .forEach(System.out::println);
                 }
-                for (var log : e.simLogs().entrySet()) {
+                for (var log : e.refLogs().entrySet()) {
                   System.out.println("[REF] Logs of " + log.getKey() + ": ");
                   log.getValue().stream().map((l) -> "- " + l)
                       .forEach(System.out::println);

--- a/vadl/test/vadl/iss/IssLoweringTest.java
+++ b/vadl/test/vadl/iss/IssLoweringTest.java
@@ -39,10 +39,9 @@ public class IssLoweringTest extends AbstractTest {
     var logger = (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(HtmlDumpPass.class);
     logger.setLevel(Level.DEBUG);
   }
-
-  // TODO: Remove this (it is just for testing purposes)
+  
   @Test
-  void issLoweringTest() throws IOException, DuplicatedPassKeyException {
+  void issRiscvLoweringTest() throws IOException, DuplicatedPassKeyException {
     var config =
         new IssConfiguration(new GeneralConfiguration(Path.of("build/test-output"), true));
 


### PR DESCRIPTION
Select nodes that have a translation time constant condition, but with runtime options are now translated to a `tcg_gen_mov(<dest>, <c-cond> ? <true-case> : <false-case>` instead of a `tcg_gen_condmov`.