### PR TITLE
iss: Fix CPU state register overflow

### DIFF
--- a/vadl/main/resources/templates/iss/target/gen-arch/cpu.h
+++ b/vadl/main/resources/templates/iss/target/gen-arch/cpu.h
@@ -23,7 +23,7 @@ extern const char * const [(${gen_arch_lower})]_cpu_[(${reg.name_lower})]_names[
 typedef struct CPUArchState {
   // CPU registers
   [# th:each="reg, iterState : ${register_tensors}"]
-  [(${reg.value_c_type})] [(${reg.name_lower})][(${reg.c_array_def})];
+  uint[(${reg.cpu_state_type_width})]_t [(${reg.name_lower})][(${reg.c_array_def})];
   [/]
 
   // Exception arguments (intermediate store during exception handling)

--- a/vadl/main/vadl/iss/passes/IssInfoRetrievalPass.java
+++ b/vadl/main/vadl/iss/passes/IssInfoRetrievalPass.java
@@ -55,7 +55,7 @@ public class IssInfoRetrievalPass extends AbstractIssPass {
     }
 
     isa.registerTensors().forEach(r -> {
-      r.attachExtension(new RegInfo());
+      r.attachExtension(new RegInfo(configuration()));
     });
 
     return null;

--- a/vadl/main/vadl/iss/passes/extensions/RegInfo.java
+++ b/vadl/main/vadl/iss/passes/extensions/RegInfo.java
@@ -24,6 +24,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import javax.annotation.Nullable;
+import vadl.configuration.IssConfiguration;
 import vadl.cppCodeGen.CppTypeMap;
 import vadl.template.Renderable;
 import vadl.viam.Definition;
@@ -36,8 +37,14 @@ import vadl.viam.RegisterTensor;
  */
 public class RegInfo extends DefinitionExtension<RegisterTensor> implements Renderable {
 
+
   @Nullable
   private Map<String, Object> renderObj;
+  private IssConfiguration config;
+
+  public RegInfo(IssConfiguration config) {
+    this.config = config;
+  }
 
   public RegisterTensor reg() {
     return extendingDef();
@@ -75,6 +82,15 @@ public class RegInfo extends DefinitionExtension<RegisterTensor> implements Rend
     return CppTypeMap.nextFittingUInt(reg().resultType(reg().maxNumberOfAccessIndices()));
   }
 
+  /**
+   * The type of the CPU state register field must be the same size as the corresponding
+   * TCG variable, otherwise there would be an overflow when QEMU synchronizes the
+   * TCG variables with the CPU state object.
+   */
+  public int cpuStateTypeWidth() {
+    return config.targetSize().width;
+  }
+
   @Override
   @SuppressWarnings("VariableDeclarationUsageDistance")
   public Map<String, Object> renderObj() {
@@ -90,6 +106,7 @@ public class RegInfo extends DefinitionExtension<RegisterTensor> implements Rend
       renderObj.put("index_dims", dims);
       renderObj.put("value_width", resultType.bitWidth());
       renderObj.put("value_c_type", valueCType());
+      renderObj.put("cpu_state_type_width", cpuStateTypeWidth());
       renderObj.put("names", names());
       renderObj.put("constraints", renderConstraints(dims));
       renderObj.put("getter_params", renderParams.isEmpty() ? "" : ", " + renderParams);

--- a/vadl/test/resources/scripts/iss_qemu/main.py
+++ b/vadl/test/resources/scripts/iss_qemu/main.py
@@ -20,7 +20,7 @@ def reset_terminal():
         try:
             subprocess.run(["stty", "sane"], check=True)
         except subprocess.CalledProcessError as e:
-            print(f"Warning: Failed to reset terminal state: {e}", file=sys.stderr)
+          pass
 
 async def main(testsuite_path: argparse.FileType):
     test_config = load_config(testsuite_path)

--- a/vadl/test/resources/testSource/sys/aarch64/aarch64.vadl
+++ b/vadl/test/resources/testSource/sys/aarch64/aarch64.vadl
@@ -65,16 +65,10 @@ instruction set architecture AArch64Base = {
   alias register SP : Address = S(31) // stack pointer
   alias register LR : Address = S(30) // link register (return address)
 
-  format ConditionFlags: Bits<4> = {  // condition flags register format
-//    res1  : Bits<32>,               // reserved, zero
-      N     : Bits1                   // Negative
-    , Z     : Bits1                   // Zero
-    , C     : Bits1                   // Carry
-    , V     : Bits1                   // oVerflow
-//  , res0  : Bits<28>                // reserved, zero
-    }
-
-  register NZCV : ConditionFlags      // condition flags register
+  register NZCV_N : Bits1             // Negative
+  register NZCV_Z : Bits1             // Zero
+  register NZCV_C : Bits1             // Carry
+  register NZCV_V : Bits1             // oVerflow
 
   enumeration CondCode : Bits<4> =    // condition code encodings, do not change order
     { EQ                              // EQual                    Z == 1
@@ -97,20 +91,20 @@ instruction set architecture AArch64Base = {
 
   function conditionHolds (cond: Bits<4>) -> Bool = // evaluate condition code
     match cond with
-      { CondCode::EQ => NZCV.Z  = 1
-      , CondCode::NE => NZCV.Z  = 0
-      , CondCode::CS => NZCV.C  = 1
-      , CondCode::CC => NZCV.C  = 0
-      , CondCode::MI => NZCV.N  = 1
-      , CondCode::PL => NZCV.N  = 0
-      , CondCode::VS => NZCV.V  = 1
-      , CondCode::VC => NZCV.V  = 0
-      , CondCode::HI => NZCV.C  = 1 && NZCV.Z = 0
-      , CondCode::LS => NZCV.C  = 0 || NZCV.Z = 1
-      , CondCode::GE => NZCV.N  = NZCV.V
-      , CondCode::LT => NZCV.N != NZCV.V
-      , CondCode::GT => NZCV.N  = NZCV.V && NZCV.Z = 0
-      , CondCode::LE => NZCV.N != NZCV.V || NZCV.Z = 1
+      { CondCode::EQ => NZCV_Z  = 1
+      , CondCode::NE => NZCV_Z  = 0
+      , CondCode::CS => NZCV_C  = 1
+      , CondCode::CC => NZCV_C  = 0
+      , CondCode::MI => NZCV_N  = 1
+      , CondCode::PL => NZCV_N  = 0
+      , CondCode::VS => NZCV_V  = 1
+      , CondCode::VC => NZCV_V  = 0
+      , CondCode::HI => NZCV_C  = 1 && NZCV_Z = 0
+      , CondCode::LS => NZCV_C  = 0 || NZCV_Z = 1
+      , CondCode::GE => NZCV_N  = NZCV_V
+      , CondCode::LT => NZCV_N != NZCV_V
+      , CondCode::GT => NZCV_N  = NZCV_V && NZCV_Z = 0
+      , CondCode::LE => NZCV_N != NZCV_V || NZCV_Z = 1
       , _            => true
       }
 
@@ -122,6 +116,11 @@ instruction set architecture AArch64Base = {
   enumeration Size =                  // bit size values for operation size, do not rename elements
     { WSize = SizeW                   // 32 is size for WSize operations
     , XSize = SizeX                   // 64 is size for XSize operations
+    }
+
+  enumeration ShiftSize =             // shift size values for operation size, do not rename elements
+    { WSize = 5                       // 5 is size for WSize shift immediate values
+    , XSize = 6                       // 6 is size for XSize shift immediate values
     }
 
   enumeration FF: Bits1 =             // flag field values, do not change order
@@ -225,12 +224,18 @@ instruction set architecture AArch64Base = {
 
   // set all flags
   model SetFlags (): Stats = {
-    NZCV := (flags.negative, flags.zero, flags.carry, flags.overflow)
+    NZCV_N := flags.negative
+    NZCV_Z := flags.zero
+    NZCV_C := flags.carry
+    NZCV_V := flags.overflow
     }
 
   // set NZ flags, clear CV flags
   model SetNZClearCVFlags (): Stats = {
-    NZCV := (flags.negative, flags.zero, false, false)
+    NZCV_N := flags.negative
+    NZCV_Z := flags.zero
+    NZCV_C := false
+    NZCV_V := false
     }
 
   // assigns zero extended word result to destination expression
@@ -326,7 +331,7 @@ instruction set architecture AArch64Base = {
     }
 
   model ExtInstrStr (i: InstrWithFunct, ext: Str): InstrWithFunct = {
-    (AsId ($i.id,  $ext); $i.mnemo; $i.opcode; $i.funct)
+    (AsId ($i.id, $ext); $i.mnemo; $i.opcode; $i.funct)
     }
 
   model AddSubImmInstr (i: InstrWithFunct, size: Id, f: Flags): IsaDefs = {
@@ -386,14 +391,14 @@ instruction set architecture AArch64Base = {
 
   model AddSubCarryInstr (i: InstrWithFunct, size: Id): IsaDefs = {
     instruction $i.id: ThreeRegOpFormat =
-      let result, flags = VADL::$i.funct(X(rn) as Bits<Size::$size>, X(rm) as Bits<Size::$size>, NZCV.C) in
+      let result, flags = VADL::$i.funct(X(rn) as Bits<Size::$size>, X(rm) as Bits<Size::$size>, NZCV_C) in
         X(rd) := result as Bits<Size::$size> as BitsX
     $ThreeRegOpEncAsm ($i; $size)
     }
 
   model AddSubCarryFlagInstr (i: InstrWithFunct, size: Id): IsaDefs = {
     instruction $i.id: ThreeRegOpFormat =
-      let result, flags = VADL::$i.funct(X(rn) as Bits<Size::$size>, X(rm) as Bits<Size::$size>, NZCV.C) in {
+      let result, flags = VADL::$i.funct(X(rn) as Bits<Size::$size>, X(rm) as Bits<Size::$size>, NZCV_C) in {
         X(rd) := result as Bits<Size::$size> as BitsX
         $SetFlags()
         }
@@ -909,8 +914,12 @@ instruction set architecture AArch64Base = {
         then let result, flags = VADL::$i.funct(X(rn) as Bits<Size::$size>, $ex) in {
           $SetFlags()
           }
-        else
-          NZCV := nzcv
+        else {
+          NZCV_N := nzcv(3)
+          NZCV_Z := nzcv(2)
+          NZCV_C := nzcv(1)
+          NZCV_V := nzcv(0)
+          }
     encoding $i.id = { op = $i.opcode, sf = SF::$size, cc = CondCode::$c.cc }
     assembly $i.id = ( $i.mnemo, ' ', $size(rn), $asm, ', #', decimal(nzcv), ', ', $c.mext )
     }
@@ -1031,20 +1040,20 @@ instruction set architecture AArch64Base = {
     }
 
   model CondInstr (modelid: InstrWithCond, i: InstrWithFunct): IsaDefs = {
-    $ExtendCondInstr ($modelid; $i; (EQ ; "eq" ; NZCV.Z  = 1                    ))
-    $ExtendCondInstr ($modelid; $i; (NE ; "ne" ; NZCV.Z  = 0                    ))
-    $ExtendCondInstr ($modelid; $i; (CS ; "cs" ; NZCV.C  = 1                    ))
-    $ExtendCondInstr ($modelid; $i; (CC ; "cc" ; NZCV.C  = 0                    ))
-    $ExtendCondInstr ($modelid; $i; (MI ; "mi" ; NZCV.N  = 1                    ))
-    $ExtendCondInstr ($modelid; $i; (PL ; "pl" ; NZCV.N  = 0                    ))
-    $ExtendCondInstr ($modelid; $i; (VS ; "vs" ; NZCV.V  = 1                    ))
-    $ExtendCondInstr ($modelid; $i; (VC ; "vc" ; NZCV.V  = 0                    ))
-    $ExtendCondInstr ($modelid; $i; (HI ; "hi" ; NZCV.C  = 1 && NZCV.Z = 0      ))
-    $ExtendCondInstr ($modelid; $i; (LS ; "ls" ; NZCV.C  = 0 || NZCV.Z = 1      ))
-    $ExtendCondInstr ($modelid; $i; (GE ; "ge" ; NZCV.N  = NZCV.V               ))
-    $ExtendCondInstr ($modelid; $i; (LT ; "lt" ; NZCV.N != NZCV.V               ))
-    $ExtendCondInstr ($modelid; $i; (GT ; "gt" ; NZCV.N  = NZCV.V && NZCV.Z = 0 ))
-    $ExtendCondInstr ($modelid; $i; (LE ; "le" ; NZCV.N != NZCV.V || NZCV.Z = 1 ))
+    $ExtendCondInstr ($modelid; $i; (EQ ; "eq" ; NZCV_Z  = 1                    ))
+    $ExtendCondInstr ($modelid; $i; (NE ; "ne" ; NZCV_Z  = 0                    ))
+    $ExtendCondInstr ($modelid; $i; (CS ; "cs" ; NZCV_C  = 1                    ))
+    $ExtendCondInstr ($modelid; $i; (CC ; "cc" ; NZCV_C  = 0                    ))
+    $ExtendCondInstr ($modelid; $i; (MI ; "mi" ; NZCV_N  = 1                    ))
+    $ExtendCondInstr ($modelid; $i; (PL ; "pl" ; NZCV_N  = 0                    ))
+    $ExtendCondInstr ($modelid; $i; (VS ; "vs" ; NZCV_V  = 1                    ))
+    $ExtendCondInstr ($modelid; $i; (VC ; "vc" ; NZCV_V  = 0                    ))
+    $ExtendCondInstr ($modelid; $i; (HI ; "hi" ; NZCV_C  = 1 && NZCV_Z = 0      ))
+    $ExtendCondInstr ($modelid; $i; (LS ; "ls" ; NZCV_C  = 0 || NZCV_Z = 1      ))
+    $ExtendCondInstr ($modelid; $i; (GE ; "ge" ; NZCV_N  = NZCV_V               ))
+    $ExtendCondInstr ($modelid; $i; (LT ; "lt" ; NZCV_N != NZCV_V               ))
+    $ExtendCondInstr ($modelid; $i; (GT ; "gt" ; NZCV_N  = NZCV_V && NZCV_Z = 0 ))
+    $ExtendCondInstr ($modelid; $i; (LE ; "le" ; NZCV_N != NZCV_V || NZCV_Z = 1 ))
     $ExtendCondInstr ($modelid; $i; (AL ; "al" ; true                           ))
     $ExtendCondInstr ($modelid; $i; (NV ; "nv" ; true                           ))
     }
@@ -1293,6 +1302,39 @@ instruction set architecture AArch64Base = {
     $MemoryRegPairInstr ($i; XSize; false; MEM<8> (addr) := X(rt)              MEM<8> (addr + 8) := X(rt2))
     }
 
+
+// pseudo instruction models ***************************************************
+
+  model PseudoMulInstr (i: InstrWithFunct, size: Id): IsaDefs = {
+    pseudo instruction $i.id (rd: Index, rn: Index, rm: Index) = {
+      $i.funct {rd = rd, rn = rn, rm = rm, ra = $i.opcode}
+      }
+    assembly $i.id = ($i.mnemo, " ", $size(rd), ", ", $size(rn), ", ", $size(rm))
+    }
+
+  model Pseudo3OpInstr (i: InstrWithFunct, size: Id): IsaDefs = {
+    pseudo instruction $i.id (rd: Index, rn: Index, rm: Index) = {
+      $i.funct {rd = rd, rn = rn, rm = rm}
+      }
+    assembly $i.id = ($i.mnemo, " ", $size(rd), ", ", $size(rn), ", ", $size(rm))
+    }
+
+  model PseudoShiftRightInstr (i: InstrWithFunct, size: Id): IsaDefs = {
+    pseudo instruction $i.id (rd: Index, rn: Index, shift: Bits6) = {
+      $i.funct {rd = rd, rn = rn, immr = shift as Bits<ShiftSize::$size> as Bits6, imms = Size::$size - 1}
+      }
+    assembly $i.id = ($i.mnemo, " ", $size(rd), ", ", $size(rn), ", #", decimal(shift))
+    }
+
+  model PseudoShiftLeftInstr (i: InstrWithFunct, size: Id): IsaDefs = {
+    pseudo instruction $i.id (rd: Index, rn: Index, shift: Bits6) = {
+      $i.funct{rd = rd, rn = rn, immr = - shift as Bits<ShiftSize::$size> as Bits6,
+                 imms = Size::$size - 1 - shift as Bits<ShiftSize::$size> as Bits6}
+      }
+    assembly $i.id = ($i.mnemo, " ", $size(rd), ", ", $size(rn), ", #", decimal(shift))
+    }
+
+
 // instruction enriching models ************************************************
 
   model InstrWX (modelid: InstrWithFunctSize, i: InstrWithFunct): IsaDefs = {
@@ -1310,6 +1352,15 @@ instruction set architecture AArch64Base = {
   model InstrWXRegShift (modelid: InstrWithFunctSizeRegShift, i: InstrWithFunct): IsaDefs = {
     $LogicRegShiftInstr ($modelid; $ExtInstrStr ($i; "W"); WSize)
     $LogicRegShiftInstr ($modelid; $ExtInstrStr ($i; "X"); XSize)
+    }
+
+  model ExtPseudoStr (i: InstrWithFunct, ext: Str): InstrWithFunct = {
+    (AsId ($i.id, $ext); $i.mnemo; $i.opcode; AsId ($i.funct, $ext))
+    }
+
+  model PseudoWX (modelid: InstrWithFunctSize, i: InstrWithFunct): IsaDefs = {
+    $modelid ($ExtPseudoStr ($i;  "W"); WSize)
+    $modelid ($ExtPseudoStr ($i;  "X"); XSize)
     }
 
 
@@ -1416,6 +1467,14 @@ instruction set architecture AArch64Base = {
   $StorePairInstrW     (                        (STPW   ; "stp"   ; 0b0000                ; BitsX      ))
   $StorePairInstrX     (                        (STPX   ; "stp"   ; 0b1000                ; BitsX      ))
 
+  $PseudoWX            (PseudoMulInstr        ; (MUL    ; "mul"   ; 0b1'1111              ; MADD       ))
+  $PseudoWX            (Pseudo3OpInstr        ; (ASRV   ; "asr"   ; 0                     ; ASR        ))
+  $PseudoWX            (Pseudo3OpInstr        ; (LSRV   ; "lsr"   ; 0                     ; LSR        ))
+  $PseudoWX            (Pseudo3OpInstr        ; (LSLV   ; "lsl"   ; 0                     ; LSL        ))
+  $PseudoWX            (PseudoShiftRightInstr ; (ASRI   ; "asr"   ; 0b11'1111             ; SBFM       ))
+  $PseudoWX            (PseudoShiftRightInstr ; (LSRI   ; "lsr"   ; 0b11'1111             ; UBFM       ))
+  $PseudoWX            (PseudoShiftLeftInstr  ; (LSLI   ; "lsl"   ; 0b11'1111             ; UBFM       ))
+
 //}
 //
 //instruction set architecture AArch64Sys extending AArch64Base = {
@@ -1505,11 +1564,14 @@ instruction set architecture AArch64Base = {
   register SPSR_EL1: SavedProgramStateFormat // saved program state register exception level level 1
 
   model SaveProgramState (): Stats = {
-    SPSR_EL1 := (SPSR_EL1(63..32), NZCV, SPSR_EL1(27..4), SPSel as Bits4 | 0b0100)
+    SPSR_EL1 := (SPSR_EL1(63..32), NZCV_N, NZCV_Z, NZCV_C, NZCV_V, SPSR_EL1(27..4), SPSel as Bits4 | 0b0100)
     }
 
   model RestoreProgramState (): Stats = {
-    NZCV := SPSR_EL1.NZCV
+    NZCV_N := SPSR_EL1.NZCV(3)
+    NZCV_Z := SPSR_EL1.NZCV(2)
+    NZCV_C := SPSR_EL1.NZCV(1)
+    NZCV_V := SPSR_EL1.NZCV(0)
     }
 
   exception GeneralException (exClass: Bits6, syndrome: Bits25, continuation: Address, exOffset: Address) = {
@@ -1590,7 +1652,7 @@ instruction set architecture AArch64Base = {
   model MrsRegInstr (i: InstrNoFunct): IsaDefs = {
     instruction $i.id: MoveSystemRegFormat =
       if sysreg = SysRegEncode::NZCV
-        then X(rt) := NZCV as BitsX << 28
+        then X(rt) := (NZCV_N, NZCV_Z, NZCV_C, NZCV_V) as BitsX << 28
         else if CurrentEL = 0
         then raise $UndefinedException ()
         else match sysreg with
@@ -1618,7 +1680,12 @@ instruction set architecture AArch64Base = {
   model MsrRegInstr (i: InstrNoFunct): IsaDefs = {
     instruction $i.id: MoveSystemRegFormat =
       if sysreg = SysRegEncode::NZCV
-        then NZCV := X(rt)(31..28)
+        then {
+          NZCV_N := X(rt)(31)
+          NZCV_Z := X(rt)(30)
+          NZCV_C := X(rt)(29)
+          NZCV_V := X(rt)(28)
+          }
         else if CurrentEL = 0
         then raise $UndefinedException ()
         else match sysreg with

--- a/vadl/test/resources/testSource/sys/aarch64/virt.vadl
+++ b/vadl/test/resources/testSource/sys/aarch64/virt.vadl
@@ -9,7 +9,7 @@ processor Virt implements A64 = {
   reset = {
     PC := 0x0
     // in upstream QEMU the ZF is set to 1 by default
-    NZCV.Z := 1
+    NZCV_Z := 1
   }
 
   [ firmware ]

--- a/vadl/test/vadl/iss/AutoAssembler.java
+++ b/vadl/test/vadl/iss/AutoAssembler.java
@@ -27,9 +27,12 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiFunction;
 import java.util.stream.IntStream;
+import javax.annotation.Nullable;
 import net.jqwik.api.Arbitraries;
-import org.testcontainers.shaded.org.checkerframework.checker.nullness.qual.Nullable;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.arbitraries.BigIntegerArbitrary;
 import vadl.TestUtils;
 import vadl.iss.passes.nodes.TcgVRefNode;
 import vadl.iss.passes.tcgLowering.TcgV;
@@ -49,8 +52,12 @@ import vadl.viam.passes.functionInliner.Inliner;
 public class AutoAssembler {
 
   final Disassembler disassembler;
-  private List<Integer> allowedRegIndices;
+  private List<BigInteger> allowedRegIndices;
   private final ByteOrder byteOrder;
+
+  @Nullable
+  private BiFunction<Format.Field, BigIntegerArbitrary, Arbitrary<BigInteger>>
+      customFieldConstrainFn;
 
   public AutoAssembler(Disassembler disassembler, ByteOrder byteOrder) {
     this.disassembler = disassembler;
@@ -63,7 +70,22 @@ public class AutoAssembler {
   }
 
   public AutoAssembler allowRegisterIndices(List<Integer> allowedRegIndices) {
-    this.allowedRegIndices = allowedRegIndices;
+    this.allowedRegIndices = allowedRegIndices.stream().map(BigInteger::valueOf).toList();
+    return this;
+  }
+
+  public AutoAssembler registerFieldConstrain(
+      BiFunction<Format.Field, BigIntegerArbitrary, Arbitrary<BigInteger>> constrainer) {
+    if (customFieldConstrainFn != null) {
+      throw new IllegalStateException(
+          "There is already an assignment checker for this AutoAssembler");
+    }
+    this.customFieldConstrainFn = constrainer;
+    return this;
+  }
+
+  public AutoAssembler clearRegisteredAssignmentChecker() {
+    this.customFieldConstrainFn = null;
     return this;
   }
 
@@ -78,7 +100,7 @@ public class AutoAssembler {
     do {
       assignment = genAssignment(enc, regs);
     } while (!testAssignment(instruction, assignment) && tries++ < 10);
-    
+
     if (tries >= 10) {
       throw new IllegalStateException("Couldn't find OK assignment within 10 tries.");
     }
@@ -107,14 +129,17 @@ public class AutoAssembler {
     for (var f : encoding.fieldEncodings()) {
       assignment.put(f.formatField(), f.constant().integer());
     }
+    BiFunction<Format.Field, BigIntegerArbitrary, Arbitrary<BigInteger>> constrainFn =
+        customFieldConstrainFn != null ? customFieldConstrainFn : (field, val) -> val;
     for (var reg : registers.entrySet()) {
       var field = reg.getValue();
       // select register indices
       var i = Arbitraries.of(allowedRegIndices).sample();
-      assignment.put(field, BigInteger.valueOf(i));
+      assignment.put(field, i);
     }
     for (var f : encoding.nonEncodedFormatFields()) {
-      assignment.computeIfAbsent(f, k -> TestUtils.arbitraryBits(k.size()).sample());
+      assignment.computeIfAbsent(f, k ->
+          constrainFn.apply(f, TestUtils.arbitraryBits(k.size())).sample());
     }
     return assignment;
   }

--- a/vadl/test/vadl/iss/AutoAssembler.java
+++ b/vadl/test/vadl/iss/AutoAssembler.java
@@ -51,6 +51,8 @@ import vadl.viam.passes.functionInliner.Inliner;
 
 public class AutoAssembler {
 
+  private static final int MAX_TRIES = 100;
+
   final Disassembler disassembler;
   private List<BigInteger> allowedRegIndices;
   private final ByteOrder byteOrder;
@@ -99,10 +101,11 @@ public class AutoAssembler {
     Map<Format.Field, BigInteger> assignment;
     do {
       assignment = genAssignment(enc, regs);
-    } while (!testAssignment(instruction, assignment) && tries++ < 10);
+    } while (!testAssignment(instruction, assignment) && tries++ < MAX_TRIES);
 
-    if (tries >= 10) {
-      throw new IllegalStateException("Couldn't find OK assignment within 10 tries.");
+    if (tries >= MAX_TRIES) {
+      throw new IllegalStateException(
+          "Couldn't find OK assignment within " + MAX_TRIES + " tries.");
     }
 
     // find destination and source registers

--- a/vadl/test/vadl/iss/aarch64/IssA64InstrTest.java
+++ b/vadl/test/vadl/iss/aarch64/IssA64InstrTest.java
@@ -165,6 +165,13 @@ public class IssA64InstrTest extends AbstractIssAarch64InstrTest {
   }
 
   @TestFactory
+  Stream<DynamicTest> testCCMP() throws IOException {
+    // CCMP (immediate): Conditional compare (immediate)
+    return runTestsWith(makeTestCasesFromPrefixes("CCMPI"));
+  }
+
+
+  @TestFactory
   Stream<DynamicTest> testCSINC() throws IOException {
     // CSINC: Conditional select increment.
     return runTestsWith(makeTestCasesFromPrefixes("CSINC"));

--- a/vadl/test/vadl/iss/aarch64/IssA64InstrTest.java
+++ b/vadl/test/vadl/iss/aarch64/IssA64InstrTest.java
@@ -19,6 +19,7 @@ package vadl.iss.aarch64;
 import java.io.IOException;
 import java.nio.ByteOrder;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -49,6 +50,8 @@ public class IssA64InstrTest extends AbstractIssAarch64InstrTest {
   InstructionSetArchitecture isa;
   @LazyInit
   AutoAssembler autoAssembler;
+
+  HashSet<Instruction> testedInstrs = new HashSet<>();
 
   @Override
   public int getTestPerInstruction() {
@@ -82,6 +85,15 @@ public class IssA64InstrTest extends AbstractIssAarch64InstrTest {
           .allowRegisterIndices(3, 31);
     }
   }
+
+  @Test
+  void testAutoAssembler() {
+    // just test that all instructions can be assembled
+    for (var instr : isa.ownInstructions()) {
+      System.out.println(autoAssembler.produce(instr).assembly());
+    }
+  }
+
 
   @TestFactory
   Stream<DynamicTest> testADC() throws IOException {
@@ -133,9 +145,23 @@ public class IssA64InstrTest extends AbstractIssAarch64InstrTest {
     ));
   }
 
+  // TODO: Test ANDSImm (decoding to complicated to find correct constraint)
+
+  @TestFactory
+  Stream<DynamicTest> testANDSShifted() throws IOException {
+    // ANDS (shifted register): Bitwise AND (shifted register), setting flags
+    return runTestsWith(makeTestCasesFromPrefixes("ANDSW", "ANDSX"));
+  }
+
   @TestFactory
   Stream<DynamicTest> testASR() throws IOException {
     return runTestsWith(makeTestCasesFromPrefixes("ASRW", "ASRX"));
+  }
+
+  @TestFactory
+  Stream<DynamicTest> testBICS() throws IOException {
+    // Bitwise bit clear (shifted register), setting flags
+    return runTestsWith(makeTestCasesFromPrefixes("BICS"));
   }
 
   @TestFactory
@@ -165,6 +191,17 @@ public class IssA64InstrTest extends AbstractIssAarch64InstrTest {
   @TestFactory
   Stream<DynamicTest> testMOVK() throws IOException {
     return runTestsWith(makeTestCasesFromPrefixes("MOVK"));
+  }
+
+
+  @TestFactory
+  Stream<DynamicTest> testSBC() throws IOException {
+    return runTestsWith(makeTestCases("SBCW", "SBCX"));
+  }
+
+  @TestFactory
+  Stream<DynamicTest> testSBCS() throws IOException {
+    return runTestsWith(makeTestCasesFromPrefixes("SBCS"));
   }
 
 
@@ -209,16 +246,6 @@ public class IssA64InstrTest extends AbstractIssAarch64InstrTest {
     ));
   }
 
-
-  @Test
-  void testAutoAssembler() {
-    // just test that all instructions can be assembled
-    for (var instr : isa.ownInstructions()) {
-      System.out.println(autoAssembler.produce(instr).assembly());
-    }
-  }
-
-
   private List<Function<Integer, IssTestUtils.TestCase>> makeTestCasesFromPrefixes(
       String... instrPrefix) {
     var instrs = findInstrsWithPrefixes(instrPrefix).toArray(String[]::new);
@@ -247,6 +274,11 @@ public class IssA64InstrTest extends AbstractIssAarch64InstrTest {
   private IssTestUtils.TestCase makeTestCase(String instrName, int id) {
     var instr =
         TestUtils.findDefinitionByNameIn("AArch64Base::" + instrName, isa, Instruction.class);
+
+    if (testedInstrs.contains(instr)) {
+      throw new IllegalStateException("Instruction was already tested: " + instr);
+    }
+
     var result = autoAssembler.produce(instr);
     var builder = getBuilder(instrName + "_", id);
 


### PR DESCRIPTION
The CPU state register type was potentially smaller than the corresponding TCG variable, which caused an overflow when QEMU synchronized the TCG variable with the CPU state.