### PR TITLE
lcb: Extend MCInstExpander

### DIFF
--- a/sys/aarch64/aarch64.vadl
+++ b/sys/aarch64/aarch64.vadl
@@ -1287,14 +1287,12 @@ instruction set architecture AArch64Base = {
 
   model MemoryRegPairInstr (i: InstrWithFunct, size: Id, isLoad: Bool, memstmts: Stats): IsaDefs = {
     // TODO check SP alignment
-    // TODO add BigEndian variant
-    [undefined when : match: Ex ( $isLoad = true => rt2 = rt ; _=> false)]
+    [undefined when : match: Ex ( $isLoad = true => rt2 = rn ; _=> false)]
     instruction $i.id: MemoryPairFormat = 
       let addr = S(rn) + AsId (off, $size) in { $memstmts }
     $MemoryRegPairEncAsm ($i; ""; $size; $isLoad; 0b101'010; ("[", XSizeSP(rn), Imm7decimal(imm7), "]"))
     // TODO check SP alignment
-    // TODO add BigEndian variant
-    [undefined when : match: Ex ( $isLoad = true => rt2 = rt || rn != 31 && (rt = rn || rt2 = rn); _=> false)]
+    [undefined when : match: Ex ( $isLoad = true => rt2 = rn || rn != 31 && (rt = rn || rt2 = rn); _=> false)]
     instruction AsId ($i.id, "Pre"): MemoryPairFormat =
       let addr = S(rn) + AsId (off, $size) in {
           $memstmts
@@ -1302,8 +1300,7 @@ instruction set architecture AArch64Base = {
         }
     $MemoryRegPairEncAsm ($i; "Pre"; $size; $isLoad; 0b101'011; ("[", XSizeSP(rn), Imm7decimal(imm7), "]!"))
     // TODO check SP alignment
-    // TODO add BigEndian variant
-    [undefined when : match: Ex ( $isLoad = true => rt2 = rt || rn != 31 && (rt = rn || rt2 = rn); _=> false)]
+    [undefined when : match: Ex ( $isLoad = true => rt2 = rn || rn != 31 && (rt = rn || rt2 = rn); _=> false)]
     instruction AsId ( $i.id, "Pst"): MemoryPairFormat =
       let addr = S(rn) in {
           $memstmts

--- a/vadl/main/vadl/lcb/codegen/expansion/CompilerInstructionExpansionCodeGenerator.java
+++ b/vadl/main/vadl/lcb/codegen/expansion/CompilerInstructionExpansionCodeGenerator.java
@@ -18,6 +18,8 @@ package vadl.lcb.codegen.expansion;
 
 import static java.util.Objects.requireNonNull;
 import static vadl.error.DiagUtils.throwNotAllowed;
+import static vadl.lcb.codegen.expansion.CompilerInstructionExpansionCodeGenerator.COMPILER_INSTRUCTION;
+import static vadl.lcb.codegen.expansion.CompilerInstructionExpansionCodeGenerator.INSTRUCTION_SYMBOL;
 import static vadl.viam.ViamError.ensure;
 import static vadl.viam.ViamError.ensureNonNull;
 import static vadl.viam.ViamError.ensurePresent;
@@ -29,13 +31,18 @@ import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.annotation.Nullable;
 import vadl.cppCodeGen.FunctionCodeGenerator;
 import vadl.cppCodeGen.SymbolTable;
 import vadl.cppCodeGen.context.CGenContext;
 import vadl.cppCodeGen.context.CNodeContext;
 import vadl.cppCodeGen.context.CNodeWithBaggageContext;
 import vadl.cppCodeGen.model.GcbCppAccessFunction;
+import vadl.cppCodeGen.model.GcbCppEncodeFunction;
 import vadl.cppCodeGen.model.GcbCppFunctionWithBody;
 import vadl.error.Diagnostic;
 import vadl.gcb.passes.IdentifyFieldUsagePass;
@@ -43,17 +50,22 @@ import vadl.gcb.passes.relocation.model.HasRelocationComputationAndUpdate;
 import vadl.gcb.valuetypes.TargetName;
 import vadl.gcb.valuetypes.VariantKind;
 import vadl.lcb.passes.llvmLowering.domain.LlvmLoweringRecord;
+import vadl.lcb.passes.llvmLowering.tablegen.model.ReferencesFormatField;
+import vadl.lcb.passes.llvmLowering.tablegen.model.ReferencesImmediateOperand;
 import vadl.lcb.passes.llvmLowering.tablegen.model.TableGenImmediateRecord;
 import vadl.lcb.passes.relocation.GenerateLinkerComponentsPass;
+import vadl.lcb.template.utils.ImmediateEncodingFunctionProvider;
+import vadl.pass.PassResults;
+import vadl.utils.Either;
 import vadl.utils.Pair;
 import vadl.viam.CompilerInstruction;
-import vadl.viam.Definition;
 import vadl.viam.Format;
 import vadl.viam.Function;
 import vadl.viam.Identifier;
 import vadl.viam.Instruction;
 import vadl.viam.PrintableInstruction;
 import vadl.viam.PseudoInstruction;
+import vadl.viam.RegisterTensor;
 import vadl.viam.Relocation;
 import vadl.viam.graph.HasRegisterTensor;
 import vadl.viam.graph.Node;
@@ -73,7 +85,6 @@ import vadl.viam.graph.dependency.LabelNode;
 import vadl.viam.graph.dependency.ReadArtificialResNode;
 import vadl.viam.graph.dependency.ReadMemNode;
 import vadl.viam.graph.dependency.ReadRegTensorNode;
-import vadl.viam.graph.dependency.ZeroExtendNode;
 import vadl.viam.passes.CfgTraverser;
 
 /**
@@ -81,21 +92,25 @@ import vadl.viam.passes.CfgTraverser;
  * creates the CPP code which creates the code to expand the pseudo instruction.
  */
 public class CompilerInstructionExpansionCodeGenerator extends FunctionCodeGenerator {
-  private static final String FIELD = "field";
-  private static final String INSTRUCTION_CALL_NODE = "instructionCallNode";
-  private static final String INSTRUCTION = "instruction";
-  private static final String INSTRUCTION_SYMBOL = "instructionSymbol";
-  private static final String FIELD_VALUES = "fieldValues";
+  static final String FIELD = "field";
+  static final String INSTRUCTION_CALL_NODE = "instructionCallNode";
+  static final String INSTRUCTION = "instruction";
+  static final String INSTRUCTION_SYMBOL = "instructionSymbol";
+  static final String FIELD_VALUES = "fieldValues";
+  static final String COMPILER_INSTRUCTION = "compilerInstruction";
 
+  private final PassResults passResults;
   private final TargetName targetName;
   private final IdentifyFieldUsagePass.ImmediateDetectionContainer fieldUsages;
-  private final Map<FieldInInstruction, GcbCppFunctionWithBody> immediateDecodingsByField;
   private final List<HasRelocationComputationAndUpdate> relocations;
   private final CompilerInstruction compilerInstruction;
   private final SymbolTable symbolTable;
   private final GenerateLinkerComponentsPass.VariantKindStore variantKindStore;
   private final IdentityHashMap<Instruction, LlvmLoweringRecord.Machine> machineInstructionRecords;
   private final IdentityHashMap<NewLabelNode, String> labelSymbolNameLookup;
+  private final Map<Pair<PrintableInstruction, Format.FieldAccess>, GcbCppFunctionWithBody>
+      decodingFunctions;
+  private final Map<TableGenImmediateRecord, GcbCppAccessFunction> immediateDecodings;
 
   record FieldInInstruction(PrintableInstruction instruction, Format.Field field) {
 
@@ -105,6 +120,7 @@ public class CompilerInstructionExpansionCodeGenerator extends FunctionCodeGener
    * Constructor.
    */
   public CompilerInstructionExpansionCodeGenerator(
+      PassResults passResults,
       TargetName targetName,
       IdentifyFieldUsagePass.ImmediateDetectionContainer fieldUsages,
       Map<TableGenImmediateRecord, GcbCppAccessFunction> immediateDecodings,
@@ -114,6 +130,7 @@ public class CompilerInstructionExpansionCodeGenerator extends FunctionCodeGener
       Function function,
       IdentityHashMap<Instruction, LlvmLoweringRecord.Machine> machineInstructionRecords) {
     super(function);
+    this.passResults = passResults;
     this.targetName = targetName;
     this.fieldUsages = fieldUsages;
     this.relocations = relocations;
@@ -122,13 +139,14 @@ public class CompilerInstructionExpansionCodeGenerator extends FunctionCodeGener
     this.variantKindStore = variantKindStore;
     this.machineInstructionRecords = machineInstructionRecords;
     this.labelSymbolNameLookup = new IdentityHashMap<>();
-    this.immediateDecodingsByField = immediateDecodings
+    this.immediateDecodings = immediateDecodings;
+    this.decodingFunctions = immediateDecodings
         .entrySet()
-        .stream().map(x -> new Pair<>(
-            new FieldInInstruction(x.getKey().instructionRef(),
-                x.getKey().fieldAccessRef().fieldRef()),
-            x.getValue()))
-        .collect(Collectors.toMap(Pair::left, Pair::right));
+        .stream()
+        .collect(Collectors.toMap(x -> {
+          var key = x.getKey();
+          return Pair.of(key.instructionRef(), key.fieldAccessRef());
+        }, Map.Entry::getValue));
   }
 
   @Override
@@ -147,95 +165,6 @@ public class CompilerInstructionExpansionCodeGenerator extends FunctionCodeGener
   }
 
   @Override
-  public void handle(CGenContext<Node> ctx, FuncParamNode toHandle) {
-    var field = ((CNodeWithBaggageContext) ctx).get(FIELD, Format.Field.class);
-    var instructionSymbol = ((CNodeWithBaggageContext) ctx).getString(INSTRUCTION_SYMBOL);
-    var instruction = ((CNodeWithBaggageContext) ctx).get(INSTRUCTION, Instruction.class);
-    var instructionCallNode =
-        ((CNodeWithBaggageContext) ctx).get(INSTRUCTION_CALL_NODE, InstrCallNode.class);
-
-    var pseudoInstructionIndex =
-        getOperandIndexFromCompilerInstruction(field, toHandle, toHandle.parameter().identifier);
-
-    var usage = fieldUsages.getFieldUsages(instruction).get(field);
-    ensure(usage != null, "usage must not be null");
-    ensure(usage.size() == 1, () -> {
-      throw Diagnostic.error(
-          "Cannot expand pseudo instruction because the usage of the field is unclear",
-          field.location()).build();
-    });
-
-    switch (usage.get(0)) {
-      case IMMEDIATE -> {
-        // There are two cases:
-        // (1) in one case, the operand is an immediate then we must create an immediate operand.
-
-        ctx.ln("// We don't know whether the operand is an immediate or label?")
-            .ln("// We find it out during parsing.")
-            .ln("if(instruction.getOperand(%d).isImm()) {", pseudoInstructionIndex)
-            .spacedIn()
-            .ln(
-                String.format(
-                    "%s.addOperand(MCOperand::createImm(instruction.getOperand(%d).getImm())); "
-                        + "// %s",
-                    instructionSymbol,
-                    pseudoInstructionIndex,
-                    field.identifier.simpleName()))
-            .spaceOut()
-            .ln("}")
-            .ln("else {")
-            .spacedIn();
-
-        // (2) the other case is when it is a label or an immediate with a modifier.
-
-        var argumentSymbol = symbolTable.getNextVariable();
-        ctx.ln("const MCExpr* %s = MCOperandToMCExpr(instruction.getOperand(%d));", argumentSymbol,
-            pseudoInstructionIndex);
-
-        var argumentImmSymbol = symbolTable.getNextVariable();
-
-        String variant = "VK_None";
-
-        if (!instructionCallNode.isParameterFieldAccess(field)) {
-          var variants = variantKindStore.decodeVariantKindsByField(instruction, field);
-
-          ensure(variants.size() == 1, () -> Diagnostic.error(
-              "There are unexpectedly multiple variant kinds for the pseudo expansion available.",
-              toHandle.location()));
-
-          variant = ensurePresent(
-              requireNonNull(variants).stream().filter(VariantKind::isImmediate).findFirst(),
-              () -> Diagnostic.error(
-                  "Expected a variant for an immediate. But haven't " + "found any",
-                  toHandle.location())).value();
-        }
-
-        ctx.ln(
-            "MCOperand %s = MCOperand::createExpr(%sMCExpr::create(%s, "
-                + "%sMCExpr::VariantKind::%s, " + "Ctx));", argumentImmSymbol, targetName.value(),
-            argumentSymbol, targetName.value(),
-            requireNonNull(variant));
-        ctx.ln(String.format("%s.addOperand(%s); // %s", instructionSymbol, argumentImmSymbol,
-            field.identifier.simpleName()));
-
-        ctx
-            .spaceOut()
-            .ln("}");
-      }
-      case REGISTER -> {
-        ctx.ln("%s = instruction.getOperand(%d).getImm();", field.identifier.simpleName(),
-            pseudoInstructionIndex);
-        ctx.ln("%s.addOperand(instruction.getOperand(%d)); // %s",
-            instructionSymbol,
-            pseudoInstructionIndex,
-            field.identifier.simpleName());
-      }
-      default -> throw Diagnostic.error("Cannot detect the usage of this field",
-          instructionCallNode.location().join(field.location())).build();
-    }
-  }
-
-  @Override
   protected void handle(CGenContext<Node> ctx, FieldAccessRefNode toHandle) {
     throwNotAllowed(toHandle, "Format field accesses");
   }
@@ -248,292 +177,6 @@ public class CompilerInstructionExpansionCodeGenerator extends FunctionCodeGener
   @Override
   protected void handle(CGenContext<Node> ctx, AsmBuiltInCall toHandle) {
     throwNotAllowed(toHandle, "Asm builtin calls");
-  }
-
-  @Override
-  public void handle(CGenContext<Node> ctx, ConstantNode toHandle) {
-    var field = ((CNodeWithBaggageContext) ctx).get(FIELD, Format.Field.class);
-    var instruction = ((CNodeWithBaggageContext) ctx).get(INSTRUCTION, Instruction.class);
-    var instructionSymbol = ((CNodeWithBaggageContext) ctx).getString(INSTRUCTION_SYMBOL);
-    var instructionCallNode =
-        ((CNodeWithBaggageContext) ctx).get(INSTRUCTION_CALL_NODE, InstrCallNode.class);
-
-    var usage = fieldUsages.getFieldUsages(instruction).get(field);
-    ensure(usage != null, "usage must not be null");
-
-    ensure(usage.size() == 1, () -> {
-      throw Diagnostic.error(
-          "Cannot expand pseudo instruction because the usage of the field is unclear",
-          field.location()).build();
-    });
-
-    switch (usage.getFirst()) {
-      case IMMEDIATE -> {
-        var immediateValueString = String.valueOf(toHandle.constant().asVal().intValue());
-
-        if (!instructionCallNode.isParameterFieldAccess(field)) {
-          var decodingFunction =
-              immediateDecodingsByField.get(new FieldInInstruction(instruction, field));
-          ensure(decodingFunction != null, "decodingFunction must not be null");
-          var decodingFunctionName = decodingFunction.header().functionName().lower();
-          immediateValueString = decodingFunctionName + "(" + immediateValueString + ")";
-        }
-
-        context.ln("%s = %s; // Assign to field", field.identifier.simpleName(),
-            immediateValueString);
-        context.ln("%s.addOperand(MCOperand::createImm(%s)); // %s", instructionSymbol,
-            field.identifier.simpleName(), field.identifier.simpleName());
-      }
-      case REGISTER -> {
-        // We know that `field` is used as a register index.
-        // But we don't know which register file.
-        // We look for the `field` in the machine instruction's behavior and return the usages.
-        var registerFiles = instruction.behavior().getNodes(FieldRefNode.class)
-            .filter(x -> x.formatField().equals(field)).flatMap(
-                fieldRefNode -> fieldRefNode.usages()
-                    .filter(y -> y instanceof HasRegisterTensor z && z.hasRegisterFile()))
-            .map(x -> ((HasRegisterTensor) x).registerTensor()).distinct().toList();
-
-        ensure(registerFiles.size() == 1,
-            () -> Diagnostic.error("Found multiple or none register files for this field.",
-                field.location()).note(
-                "The pseudo instruction expansion requires one register file to detect "
-                    + "the register file name. In this particular case is the field used by "
-                    + "multiple register files or none and we don't know which name to use."));
-
-        var registerFile =
-            ensurePresent(registerFiles.stream().findFirst(), "Expected one register file");
-
-        context.ln("%s = %s::%s%s;", field.identifier.simpleName(),
-            targetName.value(),
-            registerFile.identifier.simpleName(),
-            toHandle.constant().asVal().intValue());
-        context.ln("%s.addOperand(MCOperand::createReg(%s)); // %s", instructionSymbol,
-            field.identifier.simpleName(),
-            field.identifier.simpleName());
-      }
-      default -> throw Diagnostic.error("Cannot generate cpp code for this argument",
-          field.location()).build();
-    }
-  }
-
-  @Override
-  public void handle(CGenContext<Node> ctx, FuncCallNode toHandle) {
-    var instruction = ((CNodeWithBaggageContext) ctx).get(INSTRUCTION, Instruction.class);
-    var instructionCallNode =
-        ((CNodeWithBaggageContext) ctx).get(INSTRUCTION_CALL_NODE, InstrCallNode.class);
-    var instructionSymbol = ((CNodeWithBaggageContext) ctx).getString(INSTRUCTION_SYMBOL);
-    var field = ((CNodeWithBaggageContext) ctx).get(FIELD, Format.Field.class);
-    var relocation = (Relocation) toHandle.function();
-
-
-    if (toHandle.arguments().get(0) instanceof FuncParamNode funcParamNode) {
-      /*
-        Here is the argument to `pcrel_lo` the `FuncParamNode`.
-
-        pseudo instruction XXX ( rd: Index, symbol: Bits<32> ) =
-        {
-            LD { rd = rd, rs1 = rd, imm = pcrel_lo( symbol ) }
-        }
-      */
-
-      var parameterName = funcParamNode.parameter().identifier;
-      var pseudoInstructionIndex =
-          getOperandIndexFromCompilerInstruction(field, toHandle, parameterName);
-      var relocationRef =
-          ensurePresent(relocations.stream().filter(x -> x.relocation() == relocation).findFirst(),
-              () -> Diagnostic.error("Cannot find relocation", relocation.location()));
-
-      ctx.ln("if(instruction.getOperand(%d).isImm()) {", pseudoInstructionIndex)
-          .spacedIn();
-
-      // There two cases now.
-      // (1) If the parameter in the grammar is not a field access function then we need to decode
-      // (2) Otherwise, we don't do anything.
-
-      // This is the first case where we emit a variant
-      var argumentImmSymbol = symbolTable.getNextVariable();
-      var appliedSymbol = symbolTable.getNextVariable();
-      ctx.ln("%s = instruction.getOperand(%d).getImm();", field.identifier.simpleName(),
-          pseudoInstructionIndex);
-      ctx.ln("auto %s = %sBaseInfo::%s(%s);",
-          appliedSymbol,
-          targetName.value(),
-          relocationRef.valueRelocation().functionName().lower(),
-          field.identifier.simpleName()
-      );
-
-      // We want to store the decoded value into the MCInst.
-      // So when the pseudo instruction defines argument is a field
-      // then we need to decode it.
-      // If the argument is a field access then we don't need to do anything.
-      if (!instructionCallNode.isParameterFieldAccess(field)) {
-        var immediateValueString = generateDecodingFunctionExpr(immediateDecodingsByField,
-            new FieldInInstruction(instruction, field));
-
-        ctx.ln("MCOperand %s = MCOperand::createExpr(MCConstantExpr::create(%s, Ctx));",
-            argumentImmSymbol, immediateValueString);
-        // -- end (1) case
-      } else {
-        // This is the second case where we don't emit anything
-        // only the raw value of the pseudo instruction
-
-        ctx.ln(
-            "MCOperand %s = MCOperand::createExpr(MCConstantExpr::create(%s, Ctx));",
-            argumentImmSymbol, appliedSymbol);
-
-        // -- end (2) case
-      }
-
-      ctx.ln(String.format("%s.addOperand(%s); // %s", instructionSymbol, argumentImmSymbol,
-          field.identifier.simpleName()));
-
-      ctx.spaceOut()
-          .ln("}")
-          .ln("else {")
-          .spacedIn();
-
-      var argumentSymbol = symbolTable.getNextVariable();
-      ctx.ln("const MCExpr* %s = MCOperandToMCExpr(instruction.getOperand(%d));", argumentSymbol,
-          pseudoInstructionIndex);
-      handleRelocationOperand(ctx, argumentSymbol, relocation);
-
-      ctx.spaceOut()
-          .ln("}");
-    } else if (toHandle.arguments().get(0) instanceof LabelNode labelNode) {
-      /*
-      Here is the argument to `pcrel_lo` the `LabelNode`.
-
-      pseudo instruction XXX ( rd: Index, symbol: Bits<32> ) =
-      {
-          new_label ( label )
-          LD { rd = rd, rs1 = rd, imm = pcrel_lo( label ) }
-      }
-      */
-
-      var newLabelNode =
-          labelNode.usages().filter(x -> x instanceof NewLabelNode).findFirst().orElseThrow();
-      var labelSymbolName =
-          ensureNonNull(labelSymbolNameLookup.get(newLabelNode), "must not be null");
-
-      var argumentSymbol = symbolTable.getNextVariable();
-      ctx.ln(
-          "const MCExpr* %s = MCOperandToMCExpr(MCOperand::createExpr("
-              + "MCSymbolRefExpr::create(%s, Ctx)));",
-          argumentSymbol, labelSymbolName);
-
-      handleRelocationOperand(ctx, argumentSymbol, relocation);
-    } else {
-      throw Diagnostic.error("Cannot handle node", toHandle.location()).build();
-    }
-  }
-
-  private String generateDecodingFunctionExpr(
-      Map<FieldInInstruction, GcbCppFunctionWithBody> immediateDecodingsByField,
-      FieldInInstruction fieldInInstruction) {
-    var decodingFunction =
-        immediateDecodingsByField.get(fieldInInstruction);
-    ensure(decodingFunction != null, "decodingFunction must not be null");
-    var fieldAccess = ((GcbCppAccessFunction) decodingFunction).fieldAccess();
-    var decodingFunctionName = decodingFunction.header().functionName().lower();
-
-    // Generate the field values which are used by the field access function.
-    fieldAccess.fieldRefs().forEach(requiredField -> {
-
-    });
-
-    // Check whether the order is the same.
-    Streams.zip(fieldAccess.fieldRefs().stream(),
-            Arrays.stream(decodingFunction.header().parameters()),
-            (a, b) -> Pair.of(a.identifier.simpleName(), b.simpleName()))
-        .forEach(pair -> {
-          ensure(pair.left().equals(pair.right()), () -> Diagnostic.error(
-              "Something odd happened. We encountered an error where the order of "
-                  + "the parameters is not correct. The encoding would be wrongly calculated",
-              fieldInInstruction.field().location()));
-        });
-
-    // Generate the function call to decode with all arguments.
-    // An argument is a field.
-    var arguments = fieldAccess.fieldRefs().stream()
-        .map(Definition::simpleName)
-        .collect(Collectors.joining(", "));
-    return decodingFunctionName + "(" + arguments + ")";
-  }
-
-  private void handleRelocationOperand(CGenContext<Node> ctx, String argumentSymbol,
-                                       Relocation relocation) {
-    final var instruction = ((CNodeWithBaggageContext) ctx).get(INSTRUCTION, Instruction.class);
-    final var instructionSymbol = ((CNodeWithBaggageContext) ctx).getString(INSTRUCTION_SYMBOL);
-    final var field = ((CNodeWithBaggageContext) ctx).get(FIELD, Format.Field.class);
-    final var instructionCallNode =
-        ((CNodeWithBaggageContext) ctx).get(INSTRUCTION_CALL_NODE, InstrCallNode.class);
-
-    var argumentRelocationSymbol = symbolTable.getNextVariable();
-    var elfRelocation = relocations.stream().filter(x -> x.relocation() == relocation).findFirst();
-    ensure(elfRelocation.isPresent(), "elfRelocation must exist");
-    var variant = elfRelocation.get().variantKind().value();
-
-    ctx.ln("const MCExpr* %s = %sMCExpr::create(%s, %sMCExpr::VariantKind::%s, Ctx);",
-        argumentRelocationSymbol, targetName.value(), argumentSymbol,
-        targetName.value(), variant);
-
-    String mcExprSymbol = argumentRelocationSymbol;
-
-    // build a nested MCExpr with the decode variant
-    // to call the decoding function
-    if (!instructionCallNode.isParameterFieldAccess(field)) {
-      var decodeVariants = variantKindStore.decodeVariantKindsByField(instruction, field);
-      ensure(decodeVariants.size() == 1, () -> Diagnostic.error(
-          "There are unexpectedly multiple variant kinds for the pseudo expansion available.",
-          field.location()));
-
-      var decodeVariant = ensurePresent(
-          requireNonNull(decodeVariants).stream().filter(VariantKind::isImmediate).findFirst(),
-          () -> Diagnostic.error(
-              "Expected a variant for an immediate. But haven't " + "found any",
-              field.location())).value();
-
-      mcExprSymbol = symbolTable.getNextVariable();
-
-      ctx.ln(
-          "const MCExpr* %s = %sMCExpr::create(%s, %sMCExpr::VariantKind::%s, Ctx);",
-          mcExprSymbol, targetName.value(), argumentRelocationSymbol,
-          targetName.value(), decodeVariant);
-    }
-
-    var operandSymbol = symbolTable.getNextVariable();
-    ctx.ln("MCOperand %s = MCOperand::createExpr(%s);", operandSymbol, mcExprSymbol);
-    ctx.ln(String.format("%s.addOperand(%s); // %s", instructionSymbol, operandSymbol,
-        field.identifier.simpleName()));
-  }
-
-  /**
-   * Trying to get the index from {@code pseudoInstruction.parameters} based on the given
-   * {@code parameter}. This index is important because it is the index of the pseudo instruction's
-   * operands which will be used for the pseudo instruction's expansion.
-   * For example, you have pseudo instruction {@code X(arg1, arg2) } which has two arguments. You
-   * have to know that {@code arg2} has index {@code 1} to correctly map it to a machine
-   * instruction later.
-   */
-  private int getOperandIndexFromCompilerInstruction(Format.Field field, ExpressionNode argument,
-                                                     Identifier parameter) {
-    for (int i = 0; i < compilerInstruction.parameters().length; i++) {
-      if (parameter.simpleName()
-          .equals(compilerInstruction.parameters()[i].identifier.simpleName())) {
-        return i;
-      }
-    }
-
-    throw Diagnostic.error(
-            String.format("Cannot assign field '%s' because the field is not a field.",
-                field.identifier.simpleName()), parameter.location())
-        .locationDescription(argument.location(), "Trying to match this argument.")
-        .locationDescription(field.location(), "Trying to assign this field.")
-        .locationDescription(compilerInstruction.location(),
-            "This pseudo instruction is affected.")
-        .help("The parameter '%s' must match any pseudo instruction's parameter names",
-            parameter.simpleName()).build();
   }
 
   @Override
@@ -559,7 +202,11 @@ public class CompilerInstructionExpansionCodeGenerator extends FunctionCodeGener
             context.ln("auto %s = 0;", field.identifier.simpleName());
           });
 
-          writeInstructionCall(context, symbolTableFieldValues, instrCallNode, sym);
+          writeInstructionCall(context,
+              compilerInstruction,
+              symbolTableFieldValues,
+              instrCallNode,
+              sym);
           context.spaceOut()
               .ln("}")
               .ln("result.push_back(%s);", sym)
@@ -584,49 +231,143 @@ public class CompilerInstructionExpansionCodeGenerator extends FunctionCodeGener
   }
 
   private void writeInstructionCall(CNodeContext context,
+                                    CompilerInstruction compilerInstruction,
                                     HashMap<Format.Field, String> symbolTableFieldValues,
                                     InstrCallNode instrCallNode,
                                     String instructionSymbol) {
-    var pairs =
-        Streams.zip(instrCallNode.getParamFields().stream(), instrCallNode.arguments().stream(),
+    var fieldAccessesAndArgumentPair =
+        Streams.zip(instrCallNode.getParamFieldsOrAccesses().stream(),
+            instrCallNode.arguments().stream(),
             Pair::of).toList();
 
-    var reorderedPairs = reorderParameters(instrCallNode.target(), pairs);
+    var reorderParameters =
+        reorderParameters(instrCallNode.target(), fieldAccessesAndArgumentPair);
 
-    reorderedPairs.forEach(pair -> {
-      /*
-        pseudo instruction CALL( symbol : Bits<32> ) =
-         {
-              LUI{ rd = 1 as Bits5, imm = hi20( symbol ) }
-              ...
-         }
+    // Before we add the operands, we have to compute the fields
+    // because field access functions might use multiple fields.
+    context.ln("// GenerateRawFieldsHandler");
+    reorderParameters.forEach(pair -> {
+      var fieldOrAccessFunction = pair.left();
+      var expr = pair.right();
 
-         E.g. rd is the field and 1 is the argument.
-      */
-
-      var field = pair.left();
-      var argument = pair.right();
-
-      var newContext = new CNodeWithBaggageContext(context).put(FIELD, field)
+      var newContext = new CNodeWithBaggageContext(context)
+          .put(COMPILER_INSTRUCTION, compilerInstruction)
           .put(INSTRUCTION_CALL_NODE, instrCallNode).put(INSTRUCTION, instrCallNode.target())
           .put(INSTRUCTION_SYMBOL, instructionSymbol)
           .put(FIELD_VALUES, symbolTableFieldValues);
 
-      if (argument instanceof ConstantNode cn) {
-        handle(newContext, cn);
-      } else if (argument instanceof FuncCallNode fn) {
-        ensure(fn.function() instanceof Relocation,
-            () -> Diagnostic.error("Function must be a relocation", fn.location()));
-        handle(newContext, fn);
-      } else if (argument instanceof FuncParamNode fn) {
-        handle(newContext, fn);
-      } else if (argument instanceof ZeroExtendNode zn) {
-        handle(newContext, zn);
-      } else {
-        throw Diagnostic.error("Not implemented for this node type.", argument.location())
-            .build();
-      }
+      var firstPass = new GenerateRawFieldsHandler(fieldUsages, targetName,
+          this.compilerInstruction);
+      firstPass.handle(newContext,
+          instrCallNode,
+          fieldOrAccessFunction.isRight() ? fieldOrAccessFunction.right() : null,
+          fieldOrAccessFunction.isLeft() ? fieldOrAccessFunction.left() : null,
+          expr);
     });
+
+    context.ln("// DecodeFieldAccessesHandler");
+
+    reorderParameters.forEach(pair -> {
+      var fieldOrAccessFunction = pair.left();
+      var expr = pair.right();
+
+      var newContext = new CNodeWithBaggageContext(context)
+          .put(COMPILER_INSTRUCTION, compilerInstruction)
+          .put(INSTRUCTION_CALL_NODE, instrCallNode).put(INSTRUCTION, instrCallNode.target())
+          .put(INSTRUCTION_SYMBOL, instructionSymbol)
+          .put(FIELD_VALUES, symbolTableFieldValues);
+
+      var pass = new DecodeFieldAccessesHandler(passResults,
+          fieldUsages,
+          targetName,
+          this.compilerInstruction,
+          relocations,
+          decodingFunctions,
+          machineInstructionRecords);
+      pass.handle(newContext,
+          instrCallNode,
+          fieldOrAccessFunction.isRight() ? fieldOrAccessFunction.right() : null,
+          fieldOrAccessFunction.isLeft() ? fieldOrAccessFunction.left() : null,
+          expr);
+    });
+
+    context.ln("// AddingOperands");
+
+    int addedOperands = 0;
+    for (var pair : reorderParameters) {
+      var fieldOrAccessFunction = pair.left();
+      var expr = pair.right();
+
+      var newContext = new CNodeWithBaggageContext(context)
+          .put(COMPILER_INSTRUCTION, compilerInstruction)
+          .put(INSTRUCTION_CALL_NODE, instrCallNode).put(INSTRUCTION, instrCallNode.target())
+          .put(INSTRUCTION_SYMBOL, instructionSymbol)
+          .put(FIELD_VALUES, symbolTableFieldValues);
+
+      var pass =
+          new AddingOperands(targetName,
+              fieldUsages,
+              symbolTable,
+              relocations,
+              variantKindStore,
+              decodingFunctions,
+              machineInstructionRecords,
+              immediateDecodings,
+              labelSymbolNameLookup,
+              addedOperands);
+      pass.handle(newContext,
+          instrCallNode,
+          fieldOrAccessFunction.isRight() ? fieldOrAccessFunction.right() : null,
+          fieldOrAccessFunction.isLeft() ? fieldOrAccessFunction.left() : null,
+          expr);
+
+      addedOperands = pass.getAddedOperand();
+    }
+  }
+
+  /**
+   * Generate an expression for the given {@code field} based on the {@code cn}.
+   *
+   * @param instrCallNode
+   * @param field         is the field (or the field behind a field access function) which is
+   *                      assigned in the instruction call in the pseudo instruction.
+   * @param cn            is the constant node which is assigned.
+   * @return an expression.
+   */
+  private String generateFieldValue(InstrCallNode instrCallNode,
+                                    Format.Field field,
+                                    ConstantNode cn) {
+    // Based on the usage, we know that we have to generate an immediate or a register.
+    var usages = fieldUsages.getFieldUsages(instrCallNode.target()).get(field);
+    ensure(usages != null && usages.size() == 1, () -> {
+      throw Diagnostic.error(
+          "Cannot expand pseudo instruction because the usage of the field is unclear",
+          field.location()).build();
+    });
+    var usage = Objects.requireNonNull(usages).getFirst();
+
+    // The cn might be
+    // rd = 1 or imm = 1 or immS = 1
+    // By switching over the usage, we know what it is.
+    switch (usage) {
+      case IMMEDIATE -> {
+        // We have a case distinction.
+        // We either have an assignment to a field or an assignment to field access function.
+
+        if (instrCallNode.isParameterField(field)) {
+          // It's an assigment to a field, therefore we have to decode the value since
+          // the MCInst only stores decoded values.
+          // We store the raw the value of the field, and then we decode the value.
+          // But we decode it later because the first pass only creates the raw values.
+
+          context.ln("%s = %s;", field.identifier.simpleName(), cn.constant().asVal().intValue());
+        } else {
+
+        }
+      }
+    }
+
+    return "";
   }
 
   /**
@@ -634,23 +375,43 @@ public class CompilerInstructionExpansionCodeGenerator extends FunctionCodeGener
    * This function looks at the {@link LlvmLoweringRecord} of the corresponding instruction
    * and reorders the list according to the order of outputs and inputs.
    */
-  private List<Pair<Format.Field, ExpressionNode>> reorderParameters(
+  private List<Pair<Either<Format.Field, Format.FieldAccess>, ExpressionNode>> reorderParameters(
       Instruction instruction,
-      List<Pair<Format.Field, ExpressionNode>> pairs) {
-    var result = new ArrayList<Pair<Format.Field, ExpressionNode>>();
-    var lookup = pairs.stream().collect(Collectors.toMap(Pair::left, Pair::right));
+      List<Pair<Either<Format.Field, Format.FieldAccess>, ExpressionNode>> pairs) {
+    var result = new ArrayList<Pair<Either<Format.Field, Format.FieldAccess>, ExpressionNode>>();
+    var lookupFields = pairs.stream().filter(x -> x.left().isLeft())
+        .collect(Collectors.toMap(x -> x.left().left(), Pair::right));
+    var lookupFieldAccesses = pairs.stream().filter(x -> x.left().isRight())
+        .collect(Collectors.toMap(x -> x.left().right(), Pair::right));
 
     var llvmRecord = ensureNonNull(machineInstructionRecords.get(instruction),
         () -> Diagnostic.error("Cannot find llvmRecord for instruction used in pseudo instruction",
             instruction.location()));
 
-    var order = llvmRecord.info().outputInputOperandsFormatFields();
+    var order = llvmRecord.info().outputInputOperands();
 
     for (var item : order) {
-      var l = ensureNonNull(lookup.get(item),
-          () -> Diagnostic.error("Cannot find format's field in pseudo instruction",
-              item.location()));
-      result.add(Pair.of(item, l));
+      if (item instanceof ReferencesImmediateOperand referencesImmediateOperand) {
+        var fieldAccess = referencesImmediateOperand.immediateOperand().fieldAccessRef();
+
+        // Does the InstrCallNode have a reference to a field access or to a field?
+        if (lookupFieldAccesses.containsKey(fieldAccess)) {
+          var value = lookupFieldAccesses.get(fieldAccess);
+          result.add(Pair.of(new Either<>(null, fieldAccess), value));
+        } else {
+          fieldAccess.fieldRefs().forEach(field -> {
+            if (lookupFields.containsKey(field)) {
+              var value = lookupFields.get(field);
+              result.add(Pair.of(new Either<>(field, null), value));
+            }
+          });
+        }
+      } else if (item instanceof ReferencesFormatField referencesFormatField) {
+        if (lookupFields.containsKey(referencesFormatField.formatField())) {
+          var value = lookupFields.get(referencesFormatField.formatField());
+          result.add(Pair.of(new Either<>(referencesFormatField.formatField(), null), value));
+        }
+      }
     }
 
     return result;
@@ -662,5 +423,1004 @@ public class CompilerInstructionExpansionCodeGenerator extends FunctionCodeGener
         compilerInstruction.identifier.lower(), function.simpleName())
         + "(const MCInst& instruction, std::function<void(const MCInst &)> callback, "
         + "std::function<void(MCSymbol* )> callbackSymbol ) const";
+  }
+}
+
+interface CaseHandler {
+  /*
+    The expansion generator has two necessary passes.
+    First, it generates the fields with the raw values.
+    Second, it applies the decoding functions and adds the raw or decoded values as operand to
+    the instruction.
+
+    Every pseudo instruction contains multiple instructions.
+    Each instruction is a InstrCallNode with arguments.
+    The methods here handle different cases under which condition code should be emitted.
+
+    -> rd = 0        : Register assignment and expression is a constant
+    -> rd = symbol   : Register assignment and expression is a FuncParamNode
+    -> rd = func(XXX): Register assignment and expression is a FuncCallNode
+
+    For all these cases, we need to decode the value for the field access functions.
+    -> imm = 0        : Field assignment and expression is a constant
+    -> imm = symbol   : Field assignment and expression is a FuncParamNode
+    -> imm = func(XXX): Field assignment and expression is a FuncCallNode
+
+    -> immS = 0        : Field access assignment and expression is a constant
+    -> immS = symbol   : Field access assignment and expression is a FuncParamNode
+    -> immS = func(XXX): Field access assignment and expression is a FuncCallNode
+   */
+
+  void fieldUsedAsRegisterAndExpressionConstant(CNodeWithBaggageContext newContext,
+                                                InstrCallNode instrCallNode,
+                                                Format.Field field,
+                                                ConstantNode cn);
+
+  void fieldUsedAsRegisterAndExpressionFuncParamNode(CNodeWithBaggageContext newContext,
+                                                     InstrCallNode instrCallNode,
+                                                     Format.Field field,
+                                                     FuncParamNode funcParamNode);
+
+  void fieldUsedAsRegisterAndExpressionFuncCallNode(CNodeWithBaggageContext newContext,
+                                                    InstrCallNode instrCallNode,
+                                                    Format.Field field,
+                                                    FuncCallNode funcCallNode);
+
+  void fieldUsedAsImmediateAndFieldAssignmentAndExpressionConstant(
+      CNodeWithBaggageContext newContext, InstrCallNode instrCallNode, Format.Field field,
+      ConstantNode cn);
+
+  void fieldUsedAsImmediateAndFieldAssignmentAndExpressionFuncParamNode(
+      CNodeWithBaggageContext newContext, InstrCallNode instrCallNode, Format.Field field,
+      FuncParamNode funcParamNode);
+
+  void fieldUsedAsImmediateAndFieldAssignmentAndExpressionFuncCallNode(
+      CNodeWithBaggageContext newContext, InstrCallNode instrCallNode, Format.Field field,
+      FuncCallNode funcCallNode);
+
+  void fieldUsedAsImmediateAndFieldAccessAssignmentAndExpressionConstant(
+      CNodeWithBaggageContext newContext, InstrCallNode instrCallNode,
+      Format.FieldAccess fieldAccess,
+      ConstantNode cn);
+
+  void fieldUsedAsImmediateAndFieldAccessAssignmentAndExpressionFuncParamNode(
+      CNodeWithBaggageContext newContext, InstrCallNode instrCallNode,
+      Format.FieldAccess fieldAccess,
+      FuncParamNode funcParamNode);
+
+  void fieldUsedAsImmediateAndFieldAccessAssignmentAndExpressionFuncCallNode(
+      CNodeWithBaggageContext newContext, InstrCallNode instrCallNode,
+      Format.FieldAccess fieldAccess,
+      FuncCallNode funcCallNode);
+
+  default void handle(CNodeWithBaggageContext newContext,
+                      InstrCallNode instrCallNode,
+                      @Nullable Format.FieldAccess fieldAccess,
+                      @Nullable Format.Field field,
+                      ExpressionNode expr) {
+    // The field argument is a field or a field behind a field access function.
+    var isAssignmentToFieldAccessFunction = fieldAccess != null;
+    var isAssignmentToField = field != null;
+    var isFieldUsedAsImmediate = isImmediate(instrCallNode, field);
+    var isFieldAccessUsedAsImmediate = isImmediate(instrCallNode, fieldAccess);
+    var isFieldUsedAsRegister = !isFieldUsedAsImmediate && !isFieldAccessUsedAsImmediate;
+
+    if (isFieldUsedAsRegister && expr instanceof ConstantNode cn) {
+      fieldUsedAsRegisterAndExpressionConstant(newContext, instrCallNode,
+          Objects.requireNonNull(field), cn);
+    } else if (isFieldUsedAsRegister && expr instanceof FuncParamNode funcParamNode) {
+      fieldUsedAsRegisterAndExpressionFuncParamNode(
+          newContext,
+          instrCallNode,
+          Objects.requireNonNull(field),
+          funcParamNode);
+    } else if (isFieldUsedAsRegister && isAssignmentToField
+        && expr instanceof FuncCallNode funcCallNode) {
+      fieldUsedAsRegisterAndExpressionFuncCallNode(
+          newContext,
+          instrCallNode,
+          Objects.requireNonNull(field),
+          funcCallNode);
+    } else if (isFieldUsedAsImmediate && expr instanceof ConstantNode cn) {
+      fieldUsedAsImmediateAndFieldAssignmentAndExpressionConstant(
+          newContext,
+          instrCallNode,
+          Objects.requireNonNull(field),
+          cn);
+    } else if (isFieldUsedAsImmediate && expr instanceof FuncParamNode funcParamNode) {
+      fieldUsedAsImmediateAndFieldAssignmentAndExpressionFuncParamNode(
+          newContext,
+          instrCallNode,
+          Objects.requireNonNull(field),
+          funcParamNode);
+    } else if (isFieldUsedAsImmediate && expr instanceof FuncCallNode funcCallNode) {
+      fieldUsedAsImmediateAndFieldAssignmentAndExpressionFuncCallNode(
+          newContext,
+          instrCallNode,
+          Objects.requireNonNull(field),
+          funcCallNode);
+    } else if (
+        isAssignmentToFieldAccessFunction
+            && expr instanceof ConstantNode cn) {
+      fieldUsedAsImmediateAndFieldAccessAssignmentAndExpressionConstant(
+          newContext,
+          instrCallNode,
+          Objects.requireNonNull(fieldAccess),
+          cn);
+    } else if (isAssignmentToFieldAccessFunction
+        && expr instanceof FuncParamNode funcParamNode) {
+      fieldUsedAsImmediateAndFieldAccessAssignmentAndExpressionFuncParamNode(
+          newContext,
+          instrCallNode,
+          Objects.requireNonNull(fieldAccess),
+          funcParamNode);
+    } else if (isAssignmentToFieldAccessFunction
+        && expr instanceof FuncCallNode funcCallNode) {
+      fieldUsedAsImmediateAndFieldAccessAssignmentAndExpressionFuncCallNode(
+          newContext,
+          instrCallNode,
+          Objects.requireNonNull(fieldAccess),
+          funcCallNode);
+    }
+  }
+
+  private boolean isImmediate(InstrCallNode instrCallNode, @Nullable Format.Field field) {
+    if (field == null) {
+      return false;
+    }
+
+    var usage = fieldUsages().getFieldUsages(instrCallNode.target()).get(field);
+    ensure(usage != null, "usage must not be null");
+    ensure(usage.size() == 1, () -> {
+      throw Diagnostic.error(
+          "Cannot expand pseudo instruction because the usage of the field is unclear",
+          field.location()).build();
+    });
+    return usage.getFirst() == IdentifyFieldUsagePass.FieldUsage.IMMEDIATE;
+  }
+
+  private boolean isImmediate(InstrCallNode instrCallNode,
+                              @Nullable Format.FieldAccess fieldAccess) {
+    if (fieldAccess == null) {
+      return false;
+    }
+
+    // At the moment, all field accesses are immediates.
+    return true;
+  }
+
+  default RegisterTensor getRegisterFile(
+      Instruction instruction,
+      Format.Field field
+  ) {
+    // We know that `field` is used as a register index.
+    // But we don't know which register file.
+    // We look for the `field` in the machine instruction's behavior and return the usages.
+    var registerFiles = instruction.behavior().getNodes(FieldRefNode.class)
+        .filter(x -> x.formatField().equals(field)).flatMap(
+            fieldRefNode -> fieldRefNode.usages()
+                .filter(y -> y instanceof HasRegisterTensor z && z.hasRegisterFile()))
+        .map(x -> ((HasRegisterTensor) x).registerTensor()).distinct().toList();
+
+    ensure(registerFiles.size() == 1,
+        () -> Diagnostic.error("Found multiple or none register files for this field.",
+            field.location()).note(
+            "The pseudo instruction expansion requires one register file to detect "
+                + "the register file name. In this particular case is the field used by "
+                + "multiple register files or none and we don't know which name to use."));
+
+    return
+        ensurePresent(registerFiles.stream().findFirst(), "Expected one register file");
+  }
+
+  /**
+   * Trying to get the index from {@code pseudoInstruction.parameters} based on the given
+   * {@code parameter}. This index is important because it is the index of the pseudo instruction's
+   * operands which will be used for the pseudo instruction's expansion.
+   * For example, you have pseudo instruction {@code X(arg1, arg2) } which has two arguments. You
+   * have to know that {@code arg2} has index {@code 1} to correctly map it to a machine
+   * instruction later.
+   */
+  default int getOperandIndexFromCompilerInstruction(
+      CompilerInstruction compilerInstruction,
+      Format.Field field,
+      ExpressionNode argument,
+      Identifier parameter) {
+    for (int i = 0; i < compilerInstruction.parameters().length; i++) {
+      if (parameter.simpleName()
+          .equals(compilerInstruction.parameters()[i].identifier.simpleName())) {
+        return i;
+      }
+    }
+
+    throw Diagnostic.error(
+            String.format("Cannot assign field '%s' because the field is not a field.",
+                field.identifier.simpleName()), parameter.location())
+        .locationDescription(argument.location(), "Trying to match this argument.")
+        .locationDescription(field.location(), "Trying to assign this field.")
+        .locationDescription(compilerInstruction.location(),
+            "This pseudo instruction is affected.")
+        .help("The parameter '%s' must match any pseudo instruction's parameter names",
+            parameter.simpleName()).build();
+  }
+
+  /**
+   * Trying to get the index from {@code pseudoInstruction.parameters} based on the given
+   * {@code parameter}. This index is important because it is the index of the pseudo instruction's
+   * operands which will be used for the pseudo instruction's expansion.
+   * For example, you have pseudo instruction {@code X(arg1, arg2) } which has two arguments. You
+   * have to know that {@code arg2} has index {@code 1} to correctly map it to a machine
+   * instruction later.
+   */
+  default int getOperandIndexFromCompilerInstruction(
+      CompilerInstruction compilerInstruction,
+      Format.FieldAccess fieldAccess,
+      ExpressionNode argument,
+      Identifier parameter) {
+    for (int i = 0; i < compilerInstruction.parameters().length; i++) {
+      if (parameter.simpleName()
+          .equals(compilerInstruction.parameters()[i].identifier.simpleName())) {
+        return i;
+      }
+    }
+
+    throw Diagnostic.error(
+            String.format("Cannot assign field '%s' because the field access is not a field access.",
+                fieldAccess.identifier.simpleName()), parameter.location())
+        .locationDescription(argument.location(), "Trying to match this argument.")
+        .locationDescription(fieldAccess.location(), "Trying to assign this field access function.")
+        .locationDescription(compilerInstruction.location(),
+            "This pseudo instruction is affected.")
+        .help("The parameter '%s' must match any pseudo instruction's parameter names",
+            parameter.simpleName()).build();
+  }
+
+  IdentifyFieldUsagePass.ImmediateDetectionContainer fieldUsages();
+}
+
+class GenerateRawFieldsHandler implements CaseHandler {
+
+  private final IdentifyFieldUsagePass.ImmediateDetectionContainer fieldUsages;
+  private final TargetName targetName;
+  private final CompilerInstruction compilerInstruction;
+
+  GenerateRawFieldsHandler(
+      IdentifyFieldUsagePass.ImmediateDetectionContainer fieldUsages,
+      TargetName targetName,
+      CompilerInstruction compilerInstruction) {
+    this.fieldUsages = fieldUsages;
+    this.targetName = targetName;
+    this.compilerInstruction = compilerInstruction;
+  }
+
+  @Override
+  public void fieldUsedAsRegisterAndExpressionConstant(CNodeWithBaggageContext ctx,
+                                                       InstrCallNode instrCallNode,
+                                                       Format.Field field, ConstantNode cn) {
+    var registerFile = getRegisterFile(instrCallNode.target(), field);
+    var register =
+        String.format("%s::%s%s",
+            targetName.value(),
+            registerFile.identifier.simpleName(),
+            cn.constant().asVal().intValue());
+    ctx.ln("%s = %s;", field.identifier.simpleName(), register);
+  }
+
+  @Override
+  public void fieldUsedAsRegisterAndExpressionFuncParamNode(CNodeWithBaggageContext ctx,
+                                                            InstrCallNode instrCallNode,
+                                                            Format.Field field,
+                                                            FuncParamNode funcParamNode) {
+    var pseudoInstructionIndex =
+        getOperandIndexFromCompilerInstruction(compilerInstruction, field, funcParamNode,
+            funcParamNode.parameter().identifier);
+    ctx.ln("%s = instruction.getOperand(%d).getReg();", field.identifier.simpleName(),
+        pseudoInstructionIndex);
+  }
+
+  @Override
+  public void fieldUsedAsRegisterAndExpressionFuncCallNode(CNodeWithBaggageContext ctx,
+                                                           InstrCallNode instrCallNode,
+                                                           Format.Field field,
+                                                           FuncCallNode funcCallNode) {
+    throw Diagnostic.error("Not implemented", field.location()).build();
+  }
+
+  @Override
+  public void fieldUsedAsImmediateAndFieldAssignmentAndExpressionConstant(
+      CNodeWithBaggageContext ctx, InstrCallNode instrCallNode, Format.Field field,
+      ConstantNode cn) {
+    var value = cn.constant().asVal().intValue();
+    ctx.ln("%s = %s;", field.identifier.simpleName(), value);
+  }
+
+  @Override
+  public void fieldUsedAsImmediateAndFieldAssignmentAndExpressionFuncParamNode(
+      CNodeWithBaggageContext ctx, InstrCallNode instrCallNode, Format.Field field,
+      FuncParamNode funcParamNode) {
+    var pseudoInstructionIndex =
+        getOperandIndexFromCompilerInstruction(compilerInstruction, field, funcParamNode,
+            funcParamNode.parameter().identifier);
+    ctx.ln("if(instruction.getOperand(%d).isImm()) {", pseudoInstructionIndex)
+        .spacedIn()
+        .ln("%s = instruction.getOperand(%d).getImm();", field.identifier.simpleName(),
+            pseudoInstructionIndex)
+        .spaceOut()
+        .ln("}");
+  }
+
+  @Override
+  public void fieldUsedAsImmediateAndFieldAssignmentAndExpressionFuncCallNode(
+      CNodeWithBaggageContext ctx, InstrCallNode instrCallNode, Format.Field field,
+      FuncCallNode funcCallNode) {
+    if (funcCallNode.arguments().getFirst() instanceof FuncParamNode funcParamNode) {
+      var pseudoInstructionIndex =
+          getOperandIndexFromCompilerInstruction(compilerInstruction, field,
+              funcParamNode,
+              funcParamNode.parameter().identifier);
+
+      ctx.ln("if(instruction.getOperand(%d).isImm()) {", pseudoInstructionIndex)
+          .spacedIn()
+          .ln("%s = instruction.getOperand(%d).getImm();", field.identifier.simpleName(),
+              pseudoInstructionIndex)
+          .spaceOut()
+          .ln("}");
+    }
+  }
+
+  @Override
+  public void fieldUsedAsImmediateAndFieldAccessAssignmentAndExpressionConstant(
+      CNodeWithBaggageContext ctx,
+      InstrCallNode instrCallNode,
+      Format.FieldAccess fieldAccess,
+      ConstantNode cn) {
+    // We don't assign the field in this pass, but the field access function.
+    var value = cn.constant().asVal().intValue();
+    ctx.ln("auto %s = %s;", fieldAccess.identifier.simpleName(), value);
+  }
+
+  @Override
+  public void fieldUsedAsImmediateAndFieldAccessAssignmentAndExpressionFuncParamNode(
+      CNodeWithBaggageContext ctx,
+      InstrCallNode instrCallNode,
+      Format.FieldAccess fieldAccess,
+      FuncParamNode funcParamNode) {
+    var pseudoInstructionIndex =
+        getOperandIndexFromCompilerInstruction(compilerInstruction, fieldAccess.fieldRef(),
+            funcParamNode,
+            funcParamNode.parameter().identifier);
+    ctx.ln("auto %s = instruction.getOperand(%d).getImm();", fieldAccess.identifier.simpleName(),
+        pseudoInstructionIndex);
+  }
+
+  @Override
+  public void fieldUsedAsImmediateAndFieldAccessAssignmentAndExpressionFuncCallNode(
+      CNodeWithBaggageContext ctx, InstrCallNode instrCallNode, Format.FieldAccess fieldAccess,
+      FuncCallNode funcCallNode) {
+
+    if (funcCallNode.arguments().getFirst() instanceof FuncParamNode funcParamNode) {
+      var pseudoInstructionIndex =
+          getOperandIndexFromCompilerInstruction(compilerInstruction, fieldAccess.fieldRef(),
+              funcParamNode,
+              funcParamNode.parameter().identifier);
+      ctx.ln("auto %s = instruction.getOperand(%d).getImm();", fieldAccess.identifier.simpleName(),
+          pseudoInstructionIndex);
+    }
+  }
+
+  @Override
+  public IdentifyFieldUsagePass.ImmediateDetectionContainer fieldUsages() {
+    return fieldUsages;
+  }
+}
+
+class DecodeFieldAccessesHandler implements CaseHandler {
+
+  private final PassResults passResults;
+  private final IdentifyFieldUsagePass.ImmediateDetectionContainer fieldUsages;
+  private final TargetName targetName;
+  private final CompilerInstruction compilerInstruction;
+  private final List<HasRelocationComputationAndUpdate> relocations;
+  private final Map<Pair<PrintableInstruction, Format.FieldAccess>, GcbCppFunctionWithBody>
+      decodingFunctions;
+  private final IdentityHashMap<Instruction, LlvmLoweringRecord.Machine> machineInstructionRecords;
+
+  DecodeFieldAccessesHandler(
+      PassResults passResult,
+      IdentifyFieldUsagePass.ImmediateDetectionContainer fieldUsages,
+      TargetName targetName,
+      CompilerInstruction compilerInstruction,
+      List<HasRelocationComputationAndUpdate> relocations,
+      Map<Pair<PrintableInstruction, Format.FieldAccess>, GcbCppFunctionWithBody>
+          decodingFunctions,
+
+      IdentityHashMap<Instruction, LlvmLoweringRecord.Machine> machineInstructionRecords) {
+    this.passResults = passResult;
+    this.fieldUsages = fieldUsages;
+    this.targetName = targetName;
+    this.compilerInstruction = compilerInstruction;
+    this.decodingFunctions = decodingFunctions;
+    this.relocations = relocations;
+    this.machineInstructionRecords = machineInstructionRecords;
+  }
+
+  @Override
+  public void fieldUsedAsRegisterAndExpressionConstant(CNodeWithBaggageContext ctx,
+                                                       InstrCallNode instrCallNode,
+                                                       Format.Field field, ConstantNode cn) {
+
+  }
+
+  @Override
+  public void fieldUsedAsRegisterAndExpressionFuncParamNode(CNodeWithBaggageContext ctx,
+                                                            InstrCallNode instrCallNode,
+                                                            Format.Field field,
+                                                            FuncParamNode funcParamNode) {
+
+  }
+
+  @Override
+  public void fieldUsedAsRegisterAndExpressionFuncCallNode(CNodeWithBaggageContext ctx,
+                                                           InstrCallNode instrCallNode,
+                                                           Format.Field field,
+                                                           FuncCallNode funcCallNode) {
+  }
+
+  @Override
+  public void fieldUsedAsImmediateAndFieldAssignmentAndExpressionConstant(
+      CNodeWithBaggageContext ctx, InstrCallNode instrCallNode, Format.Field field,
+      ConstantNode cn) {
+
+  }
+
+  @Override
+  public void fieldUsedAsImmediateAndFieldAssignmentAndExpressionFuncParamNode(
+      CNodeWithBaggageContext ctx, InstrCallNode instrCallNode, Format.Field field,
+      FuncParamNode funcParamNode) {
+
+  }
+
+  @Override
+  public void fieldUsedAsImmediateAndFieldAssignmentAndExpressionFuncCallNode(
+      CNodeWithBaggageContext ctx, InstrCallNode instrCallNode, Format.Field field,
+      FuncCallNode funcCallNode) {
+  }
+
+  @Override
+  public void fieldUsedAsImmediateAndFieldAccessAssignmentAndExpressionConstant(
+      CNodeWithBaggageContext ctx,
+      InstrCallNode instrCallNode,
+      Format.FieldAccess fieldAccess,
+      ConstantNode cn) {
+  }
+
+  @Override
+  public void fieldUsedAsImmediateAndFieldAccessAssignmentAndExpressionFuncParamNode(
+      CNodeWithBaggageContext ctx,
+      InstrCallNode instrCallNode,
+      Format.FieldAccess fieldAccess,
+      FuncParamNode funcParamNode) {
+
+  }
+
+  @Override
+  public void fieldUsedAsImmediateAndFieldAccessAssignmentAndExpressionFuncCallNode(
+      CNodeWithBaggageContext ctx, InstrCallNode instrCallNode, Format.FieldAccess fieldAccess,
+      FuncCallNode funcCallNode) {
+    // immS = lo(symbol)
+    ensure(funcCallNode.function() instanceof Relocation, () ->
+        Diagnostic.error("Only supporting relocation functions at the moment",
+            funcCallNode.location()));
+    ensure(funcCallNode.function().parameters().length == 1, () ->
+        Diagnostic.error("Only supporting functions with one argument at the moment",
+            funcCallNode.location()));
+    var relocation = (Relocation) funcCallNode.function();
+
+    // First apply relocation function then decode the value.
+    var relocationRef =
+        ensurePresent(relocations.stream().filter(x -> x.relocation() == relocation).findFirst(),
+            () -> Diagnostic.error("Cannot find relocation", relocation.location()));
+
+    if (funcCallNode.arguments().getFirst() instanceof FuncParamNode funcParamNode) {
+      // There are two cases:
+      // (1) the `symbol` in `immS = lo(symbol)` is actually an immediate
+      // (2) the `symbol` in `immS = lo(symbol)` is an unknown address
+      // The (1) case is easy because we cannot handle that.
+      // For (2) case, we need to create an MCExpr with the variant kinds.
+      // Since both types don't match, we assign for (2) the value `0`.
+
+      var pseudoInstructionIndex =
+          getOperandIndexFromCompilerInstruction(compilerInstruction, fieldAccess, funcCallNode,
+              funcParamNode.parameter().identifier);
+      ctx.ln("if(instruction.getOperand(%d).isImm()) {", pseudoInstructionIndex)
+          .spacedIn();
+
+      // Assign the field access
+      ctx.ln("%s = %sBaseInfo::%s(instruction.getOperand(%d).getImm());",
+          fieldAccess.identifier.simpleName(),
+          targetName.value(),
+          relocationRef.valueRelocation().functionName().lower(),
+          pseudoInstructionIndex);
+
+      var encodingFunctions =
+          Objects.requireNonNull(
+              ImmediateEncodingFunctionProvider.generateEncodeFunctions(passResults)
+                  .get(instrCallNode.target()));
+
+      fieldAccess.format().fieldEncodingsOf(Set.of(fieldAccess))
+          .forEach(fieldEncoding -> {
+            for (var encodingFunction : encodingFunctions) {
+              if (encodingFunction.field() == fieldEncoding.targetField()) {
+                encodeField(ctx, fieldEncoding, encodingFunction);
+              }
+            }
+          });
+
+      ctx
+          .spaceOut()
+          .ln("}");
+    }
+  }
+
+  private void encodeField(
+      CNodeWithBaggageContext ctx,
+      Format.FieldEncoding fieldEncoding,
+      GcbCppEncodeFunction encodingFunction) {
+    var fieldToEncode = fieldEncoding.targetField();
+    var encodingFunctionName = encodingFunction.header().functionName().lower();
+
+    var params = Arrays.stream(encodingFunction.header().parameters())
+        .map(param -> param.identifier.simpleName()).collect(
+            Collectors.joining(", "));
+
+    ctx.ln("%s = %s(%s)", fieldToEncode.identifier.simpleName(), encodingFunctionName, params);
+  }
+
+  @Override
+  public IdentifyFieldUsagePass.ImmediateDetectionContainer fieldUsages() {
+    return fieldUsages;
+  }
+}
+
+class AddingOperands implements CaseHandler {
+  private final TargetName targetName;
+  private final IdentifyFieldUsagePass.ImmediateDetectionContainer fieldUsages;
+  private final SymbolTable symbolTable;
+  private final List<HasRelocationComputationAndUpdate> relocations;
+  private final GenerateLinkerComponentsPass.VariantKindStore variantKindStore;
+  private final Map<Pair<PrintableInstruction, Format.FieldAccess>, GcbCppFunctionWithBody>
+      decodingFunctions;
+  private final Map<Instruction, LlvmLoweringRecord.Machine> machineInstructionRecords;
+  private final Map<Pair<PrintableInstruction, Format.FieldAccess>, GcbCppAccessFunction>
+      immediateDecodings;
+  private final Map<NewLabelNode, String> labelSymbolNameLookup;
+  // Tracks how many operands were already added.
+  private int addedOperand;
+
+  public int getAddedOperand() {
+    return addedOperand;
+  }
+
+  public AddingOperands(
+      TargetName targetName,
+      IdentifyFieldUsagePass.ImmediateDetectionContainer fieldUsages,
+      SymbolTable symbolTable,
+      List<HasRelocationComputationAndUpdate> relocations,
+      GenerateLinkerComponentsPass.VariantKindStore variantKindStore,
+      Map<Pair<PrintableInstruction, Format.FieldAccess>, GcbCppFunctionWithBody> decodingFunctions,
+      Map<Instruction, LlvmLoweringRecord.Machine> machineInstructionRecords,
+      Map<TableGenImmediateRecord, GcbCppAccessFunction> immediateDecodings,
+      Map<NewLabelNode, String> labelSymbolNameLookup,
+      int addedOperands) {
+    this.targetName = targetName;
+    this.fieldUsages = fieldUsages;
+    this.symbolTable = symbolTable;
+    this.relocations = relocations;
+    this.variantKindStore = variantKindStore;
+    this.decodingFunctions = decodingFunctions;
+    this.machineInstructionRecords = machineInstructionRecords;
+    this.immediateDecodings = immediateDecodings
+        .entrySet()
+        .stream()
+        .collect(Collectors.toMap(x -> {
+          var key = x.getKey();
+          return Pair.of(key.instructionRef(), key.fieldAccessRef());
+        }, Map.Entry::getValue));
+    this.labelSymbolNameLookup = labelSymbolNameLookup;
+    this.addedOperand = addedOperands;
+  }
+
+  @Override
+  public void fieldUsedAsRegisterAndExpressionConstant(CNodeWithBaggageContext ctx,
+                                                       InstrCallNode instrCallNode,
+                                                       Format.Field field,
+                                                       ConstantNode cn) {
+    var instructionSymbol = ctx.getString(INSTRUCTION_SYMBOL);
+    ctx.ln("%s.addOperand(MCOperand::createReg(%s));",
+        instructionSymbol,
+        field.identifier.simpleName());
+    addedOperand++;
+  }
+
+  @Override
+  public void fieldUsedAsRegisterAndExpressionFuncParamNode(CNodeWithBaggageContext ctx,
+                                                            InstrCallNode instrCallNode,
+                                                            Format.Field field,
+                                                            FuncParamNode funcParamNode) {
+    var compilerInstruction =
+        ctx.get(COMPILER_INSTRUCTION, CompilerInstruction.class);
+    var instructionSymbol = ctx.getString(INSTRUCTION_SYMBOL);
+
+    var pseudoInstructionIndex =
+        getOperandIndexFromCompilerInstruction(compilerInstruction,
+            field,
+            funcParamNode,
+            funcParamNode.parameter().identifier);
+    ctx.ln("%s.addOperand(instruction.getOperand(%d)); // %s",
+        instructionSymbol,
+        pseudoInstructionIndex,
+        field.identifier.simpleName());
+    addedOperand++;
+  }
+
+  @Override
+  public void fieldUsedAsRegisterAndExpressionFuncCallNode(CNodeWithBaggageContext ctx,
+                                                           InstrCallNode instrCallNode,
+                                                           Format.Field field,
+                                                           FuncCallNode funcCallNode) {
+    throw Diagnostic.error("not supported", funcCallNode.location()).build();
+  }
+
+  @Override
+  public void fieldUsedAsImmediateAndFieldAssignmentAndExpressionConstant(
+      CNodeWithBaggageContext ctx, InstrCallNode instrCallNode, Format.Field field,
+      ConstantNode cn) {
+    var instructionSymbol = ctx.getString(INSTRUCTION_SYMBOL);
+    ctx.ln("%s.addOperand(MCOperand::createImm(%s));", instructionSymbol,
+        field.identifier.simpleName());
+    addedOperand++;
+  }
+
+  @Override
+  public void fieldUsedAsImmediateAndFieldAssignmentAndExpressionFuncParamNode(
+      CNodeWithBaggageContext ctx, InstrCallNode instrCallNode, Format.Field field,
+      FuncParamNode funcParamNode) {
+    var compilerInstruction =
+        ctx.get(COMPILER_INSTRUCTION, CompilerInstruction.class);
+    var instructionSymbol = ctx.getString(INSTRUCTION_SYMBOL);
+    var pseudoInstructionIndex =
+        getOperandIndexFromCompilerInstruction(compilerInstruction,
+            field,
+            funcParamNode,
+            funcParamNode.parameter().identifier);
+
+    // There are two cases:
+    // (1) in one case, the operand is an immediate then we must create an immediate operand.
+    ctx.ln("// We don't know whether the operand is an immediate or label?")
+        .ln("// We find it out during parsing.")
+        .ln("if(instruction.getOperand(%d).isImm()) {", pseudoInstructionIndex)
+        .spacedIn()
+        .ln("%s = instruction.getOperand(%d).getImm();", field.identifier.simpleName(),
+            pseudoInstructionIndex)
+        .ln(
+            String.format(
+                "%s.addOperand(MCOperand::createImm(instruction.getOperand(%d).getImm()));"
+                    + "// %s",
+                instructionSymbol,
+                pseudoInstructionIndex,
+                field.identifier.simpleName()))
+        .spaceOut()
+        .ln("}")
+        .ln("else {")
+        .spacedIn();
+
+    // (2) the other case is when it is a label or an immediate with a modifier.
+    var argumentSymbol = symbolTable.getNextVariable();
+    ctx.ln("const MCExpr* %s = MCOperandToMCExpr(instruction.getOperand(%d));", argumentSymbol,
+        pseudoInstructionIndex);
+
+    var variants = variantKindStore.decodeVariantKindsByField(instrCallNode.target(), field);
+    ensure(variants.size() == 1, () -> Diagnostic.error(
+        "There are unexpectedly multiple variant kinds for the pseudo expansion available.",
+        funcParamNode.location()));
+
+    var variant = ensurePresent(
+        requireNonNull(variants).stream().filter(VariantKind::isImmediate).findFirst(),
+        () -> Diagnostic.error(
+            "Expected a variant for an immediate. But haven't " + "found any",
+            funcParamNode.location())).value();
+
+    var argumentImmSymbol = symbolTable.getNextVariable();
+    ctx.ln(
+        "MCOperand %s = MCOperand::createExpr(%sMCExpr::create(%s, "
+            + "%sMCExpr::VariantKind::%s, " + "Ctx));", argumentImmSymbol,
+        targetName.value(),
+        argumentSymbol,
+        targetName.value(),
+        variant);
+    ctx.ln(String.format("%s.addOperand(%s); // %s", instructionSymbol, argumentImmSymbol,
+        field.identifier.simpleName()));
+
+    ctx
+        .spaceOut()
+        .ln("}");
+    addedOperand++;
+  }
+
+  @Override
+  public void fieldUsedAsImmediateAndFieldAssignmentAndExpressionFuncCallNode(
+      CNodeWithBaggageContext ctx,
+      InstrCallNode instrCallNode,
+      Format.Field field,
+      FuncCallNode funcCallNode) {
+    // imm = lo(symbol)
+
+    var compilerInstruction =
+        ctx.get(COMPILER_INSTRUCTION, CompilerInstruction.class);
+    var instructionSymbol = ctx.getString(INSTRUCTION_SYMBOL);
+
+    ensure(funcCallNode.function() instanceof Relocation, () ->
+        Diagnostic.error("Only supporting relocation functions at the moment",
+            funcCallNode.location()));
+    ensure(funcCallNode.function().parameters().length == 1, () ->
+        Diagnostic.error("Only supporting functions with one argument at the moment",
+            funcCallNode.location()));
+    var relocation = (Relocation) funcCallNode.function();
+    var relocationRef =
+        ensurePresent(relocations.stream().filter(x -> x.relocation() == relocation).findFirst(),
+            () -> Diagnostic.error("Cannot find relocation", relocation.location()));
+    var elfRelocation = relocations.stream().filter(x -> x.relocation() == relocation).findFirst();
+    ensure(elfRelocation.isPresent(), "elfRelocation must exist");
+    var variant = elfRelocation.get().variantKind().value();
+
+    if (funcCallNode.arguments().getFirst() instanceof FuncParamNode funcParamNode) {
+      // There are two cases:
+      // (1) the `symbol` in `imm = lo(symbol)` is actually an immediate
+      // (2) the `symbol` in `imm = lo(symbol)` is an unknown address
+      // The (1) case is easy because we cannot handle that.
+      // For (2) case, we need to create an MCExpr with the variant kinds.
+      // Since both types don't match, we assign for (2) the value `0`.
+
+      var pseudoInstructionIndex =
+          getOperandIndexFromCompilerInstruction(compilerInstruction, field, funcCallNode,
+              funcParamNode.parameter().identifier);
+
+      ctx.ln("if(instruction.getOperand(%d).isImm()) {", pseudoInstructionIndex)
+          .spacedIn()
+          .ln("%s = instruction.getOperand(%d).getImm();", field.identifier.simpleName(),
+              pseudoInstructionIndex)
+          .ln("%s = %sBaseInfo::%s(%s);",
+              field.identifier.simpleName(),
+              targetName.value(),
+              relocationRef.valueRelocation().functionName().lower(),
+              field.identifier.simpleName());
+
+      // Then decode
+      var record = Objects.requireNonNull(machineInstructionRecords.get(instrCallNode.target()));
+      var operands = Stream.concat(record.info().outputs().stream(),
+          record.info().inputs().stream()).toList();
+      var operand = operands.get(addedOperand);
+      ensure(operand instanceof ReferencesImmediateOperand,
+          () -> Diagnostic.error("Expected that operand references immediate",
+              funcParamNode.location()));
+      var immediateOperand = ((ReferencesImmediateOperand) operand).immediateOperand();
+      var decodingMethod = immediateOperand.rawDecoderMethod().lower();
+      var parameters =
+          Arrays.stream(Objects.requireNonNull(immediateDecodings.get(
+                      Pair.of(immediateOperand.instructionRef(), immediateOperand.fieldAccessRef())))
+                  .header().parameters())
+              .map(x -> x.identifier.simpleName()).collect(Collectors.joining(", "));
+
+      ctx.ln(String.format("%s.addOperand(MCOperand::createImm(%s(%s)));", instructionSymbol,
+          decodingMethod,
+          parameters));
+
+      ctx.spaceOut()
+          .ln("}")
+          .ln("else {")
+          .spacedIn();
+
+      String expressionStr =
+          String.format("MCOperandToMCExpr(instruction.getOperand(%d))", pseudoInstructionIndex);
+
+      // Apply relocation / variant kind
+      expressionStr = String.format("%sMCExpr::create(%s, %sMCExpr::VariantKind::%s, Ctx)",
+          targetName.value(),
+          expressionStr,
+          targetName.value(),
+          variant
+      );
+
+      // Apply decode
+      var variants = variantKindStore.decodeVariantKindsByField(instrCallNode.target(), field);
+
+      ensure(variants.size() == 1, () -> Diagnostic.error(
+          "There are unexpectedly multiple variant kinds for the pseudo expansion available.",
+          funcCallNode.location()));
+
+      variant = ensurePresent(
+          requireNonNull(variants).stream().filter(VariantKind::isImmediate).findFirst(),
+          () -> Diagnostic.error(
+              "Expected a variant for an immediate. But haven't " + "found any",
+              funcCallNode.location())).value();
+
+      // Decoding
+      expressionStr = String.format("%sMCExpr::create(%s, %sMCExpr::VariantKind::%s, Ctx)",
+          targetName.value(),
+          expressionStr,
+          targetName.value(),
+          variant
+      );
+
+      ctx.ln(String.format("%s.addOperand(MCOperand::createExpr(%s)); // %s", instructionSymbol,
+          expressionStr,
+          field.identifier.simpleName()));
+
+      ctx.spaceOut()
+          .ln("}");
+    } else if (funcCallNode.arguments().getFirst() instanceof LabelNode labelNode) {
+       /*
+      Here is the argument to `pcrel_lo` the `LabelNode`.
+
+      pseudo instruction XXX ( rd: Index, symbol: Bits<32> ) =
+      {
+          new_label ( label )
+          LD { rd = rd, rs1 = rd, imm = pcrel_lo( label ) }
+      }
+      */
+
+      var newLabelNode =
+          labelNode.usages().filter(x -> x instanceof NewLabelNode).findFirst().orElseThrow();
+      var labelSymbolName =
+          ensureNonNull(labelSymbolNameLookup.get(newLabelNode), "must not be null");
+
+      var expressionStr = String.format("MCSymbolRefExpr::create(%s, Ctx)", labelSymbolName);
+
+      // Apply relocation / variant kind
+      expressionStr = String.format("%sMCExpr::create(%s, %sMCExpr::VariantKind::%s, Ctx)",
+          targetName.value(),
+          expressionStr,
+          targetName.value(),
+          variant
+      );
+
+      // Apply decode
+      var variants = variantKindStore.decodeVariantKindsByField(instrCallNode.target(), field);
+
+      ensure(variants.size() == 1, () -> Diagnostic.error(
+          "There are unexpectedly multiple variant kinds for the pseudo expansion available.",
+          funcCallNode.location()));
+
+      variant = ensurePresent(
+          requireNonNull(variants).stream().filter(VariantKind::isImmediate).findFirst(),
+          () -> Diagnostic.error(
+              "Expected a variant for an immediate. But haven't " + "found any",
+              funcCallNode.location())).value();
+
+      // Decoding
+      expressionStr = String.format("%sMCExpr::create(%s, %sMCExpr::VariantKind::%s, Ctx)",
+          targetName.value(),
+          expressionStr,
+          targetName.value(),
+          variant
+      );
+
+      ctx.ln(String.format("%s.addOperand(MCOperand::createExpr(%s)); // %s", instructionSymbol,
+          expressionStr,
+          field.identifier.simpleName()));
+    } else {
+      throw Diagnostic.error("not supported", funcCallNode.location()).build();
+    }
+
+    addedOperand++;
+  }
+
+  @Override
+  public void fieldUsedAsImmediateAndFieldAccessAssignmentAndExpressionConstant(
+      CNodeWithBaggageContext ctx,
+      InstrCallNode instrCallNode,
+      Format.FieldAccess fieldAccess,
+      ConstantNode cn) {
+    var instructionSymbol = ctx.getString(INSTRUCTION_SYMBOL);
+    ctx.ln(String.format("%s.addOperand(MCOperand::createExpr(%s));",
+        instructionSymbol,
+        fieldAccess.identifier.simpleName()));
+    addedOperand++;
+  }
+
+  @Override
+  public void fieldUsedAsImmediateAndFieldAccessAssignmentAndExpressionFuncParamNode(
+      CNodeWithBaggageContext ctx, InstrCallNode instrCallNode,
+      Format.FieldAccess fieldAccess, FuncParamNode funcParamNode) {
+    var compilerInstruction = ctx.get(COMPILER_INSTRUCTION, CompilerInstruction.class);
+    var instructionSymbol = ctx.getString(INSTRUCTION_SYMBOL);
+    var pseudoInstructionIndex =
+        getOperandIndexFromCompilerInstruction(compilerInstruction, fieldAccess, funcParamNode,
+            funcParamNode.parameter().identifier);
+
+    ctx.ln(String.format("%s.addOperand(instruction.getOperand(%d));",
+        instructionSymbol,
+        pseudoInstructionIndex));
+    addedOperand++;
+  }
+
+  @Override
+  public void fieldUsedAsImmediateAndFieldAccessAssignmentAndExpressionFuncCallNode(
+      CNodeWithBaggageContext ctx, InstrCallNode instrCallNode,
+      Format.FieldAccess fieldAccess, FuncCallNode funcCallNode) {
+    // immS = lo(symbol)
+
+    var compilerInstruction =
+        ctx.get(COMPILER_INSTRUCTION, CompilerInstruction.class);
+    var instructionSymbol = ctx.getString(INSTRUCTION_SYMBOL);
+
+    ensure(funcCallNode.function() instanceof Relocation, () ->
+        Diagnostic.error("Only supporting relocation functions at the moment",
+            funcCallNode.location()));
+    ensure(funcCallNode.function().parameters().length == 1, () ->
+        Diagnostic.error("Only supporting functions with one argument at the moment",
+            funcCallNode.location()));
+    var relocation = (Relocation) funcCallNode.function();
+    var relocationRef =
+        ensurePresent(relocations.stream().filter(x -> x.relocation() == relocation).findFirst(),
+            () -> Diagnostic.error("Cannot find relocation", relocation.location()));
+    var elfRelocation = relocations.stream().filter(x -> x.relocation() == relocation).findFirst();
+    ensure(elfRelocation.isPresent(), "elfRelocation must exist");
+    var variant = elfRelocation.get().variantKind().value();
+
+    if (funcCallNode.arguments().getFirst() instanceof FuncParamNode funcParamNode) {
+      // There are two cases:
+      // (1) the `symbol` in `imm = lo(symbol)` is actually an immediate
+      // (2) the `symbol` in `imm = lo(symbol)` is an unknown address
+      // The (1) case is easy because we cannot handle that.
+      // For (2) case, we need to create an MCExpr with the variant kinds.
+      // Since both types don't match, we assign for (2) the value `0`.
+
+      var pseudoInstructionIndex =
+          getOperandIndexFromCompilerInstruction(compilerInstruction, fieldAccess, funcCallNode,
+              funcParamNode.parameter().identifier);
+
+      ctx.ln("if(instruction.getOperand(%d).isImm()) {", pseudoInstructionIndex)
+          .spacedIn();
+
+      String appliedFunction = String.format("%sBaseInfo::%s(%s)",
+          targetName.value(),
+          relocationRef.valueRelocation().functionName().lower(),
+          fieldAccess.identifier.simpleName()
+      );
+
+      ctx.ln(String.format("%s.addOperand(MCOperand::createImm(%s));", instructionSymbol,
+              appliedFunction))
+          .spaceOut()
+          .ln("}")
+          .ln("else {")
+          .spacedIn();
+
+      String expressionStr =
+          String.format("MCOperandToMCExpr(instruction.getOperand(%d))", pseudoInstructionIndex);
+
+      // Apply relocation / variant kind
+      expressionStr = String.format("%sMCExpr::create(%s, %sMCExpr::VariantKind::%s, Ctx)",
+          targetName.value(),
+          expressionStr,
+          targetName.value(),
+          variant
+      );
+
+      ctx.ln(String.format("%s.addOperand(MCOperand::createExpr(%s)); // %s", instructionSymbol,
+          expressionStr,
+          fieldAccess.identifier.simpleName()));
+
+      ctx.spaceOut()
+          .ln("}");
+    } else {
+      throw Diagnostic.error("not supported", funcCallNode.location()).build();
+    }
+    addedOperand++;
+  }
+
+  @Override
+  public IdentifyFieldUsagePass.ImmediateDetectionContainer fieldUsages() {
+    return fieldUsages;
   }
 }

--- a/vadl/main/vadl/lcb/codegen/expansion/CompilerInstructionExpansionCodeGenerator.java
+++ b/vadl/main/vadl/lcb/codegen/expansion/CompilerInstructionExpansionCodeGenerator.java
@@ -718,11 +718,16 @@ class GenerateRawFieldsHandler implements CaseHandler {
       Format.FieldAccess fieldAccess,
       FuncParamNode funcParamNode) {
     var pseudoInstructionIndex =
-        getOperandIndexFromCompilerInstruction(compilerInstruction, fieldAccess.fieldRef(),
+        getOperandIndexFromCompilerInstruction(compilerInstruction,
+            fieldAccess,
             funcParamNode,
             funcParamNode.parameter().identifier);
-    ctx.ln("auto %s = instruction.getOperand(%d).getImm();", fieldAccess.identifier.simpleName(),
-        pseudoInstructionIndex);
+    ctx.ln("if(instruction.getOperand(%d).isImm()) {", pseudoInstructionIndex)
+        .spacedIn()
+        .ln("auto %s = instruction.getOperand(%d).getImm();", fieldAccess.identifier.simpleName(),
+            pseudoInstructionIndex)
+        .spaceOut()
+        .ln("}");
   }
 
   @Override

--- a/vadl/main/vadl/lcb/codegen/expansion/CompilerInstructionExpansionCodeGenerator.java
+++ b/vadl/main/vadl/lcb/codegen/expansion/CompilerInstructionExpansionCodeGenerator.java
@@ -595,11 +595,12 @@ interface CaseHandler {
       }
     }
 
-    throw Diagnostic.error(
-            String.format("Cannot assign field '%s' because the field access is not a field access.",
-                fieldAccess.identifier.simpleName()), parameter.location())
+    throw Diagnostic.error(String.format("Cannot assign field '%s' because the field access is "
+                + "not a field access.",
+            fieldAccess.identifier.simpleName()), parameter.location())
         .locationDescription(argument.location(), "Trying to match this argument.")
-        .locationDescription(fieldAccess.location(), "Trying to assign this field access function.")
+        .locationDescription(fieldAccess.location(),
+            "Trying to assign this field access function.")
         .locationDescription(compilerInstruction.location(),
             "This pseudo instruction is affected.")
         .help("The parameter '%s' must match any pseudo instruction's parameter names",
@@ -1073,9 +1074,9 @@ class AddingOperands implements CaseHandler {
       FuncCallNode funcCallNode) {
     // imm = lo(symbol)
 
-    var compilerInstruction =
+    final var compilerInstruction =
         ctx.get(COMPILER_INSTRUCTION, CompilerInstruction.class);
-    var instructionSymbol = ctx.getString(INSTRUCTION_SYMBOL);
+    final var instructionSymbol = ctx.getString(INSTRUCTION_SYMBOL);
 
     ensure(funcCallNode.function() instanceof Relocation, () ->
         Diagnostic.error("Only supporting relocation functions at the moment",
@@ -1125,7 +1126,8 @@ class AddingOperands implements CaseHandler {
       var decodingMethod = immediateOperand.rawDecoderMethod().lower();
       var parameters =
           Arrays.stream(Objects.requireNonNull(immediateDecodings.get(
-                      Pair.of(immediateOperand.instructionRef(), immediateOperand.fieldAccessRef())))
+                      Pair.of(immediateOperand.instructionRef(),
+                          immediateOperand.fieldAccessRef())))
                   .header().parameters())
               .map(x -> x.identifier.simpleName()).collect(Collectors.joining(", "));
 
@@ -1177,14 +1179,14 @@ class AddingOperands implements CaseHandler {
       ctx.spaceOut()
           .ln("}");
     } else if (funcCallNode.arguments().getFirst() instanceof LabelNode labelNode) {
-       /*
-      Here is the argument to `pcrel_lo` the `LabelNode`.
+      /*
+        Here is the argument to `pcrel_lo` the `LabelNode`.
 
-      pseudo instruction XXX ( rd: Index, symbol: Bits<32> ) =
-      {
-          new_label ( label )
-          LD { rd = rd, rs1 = rd, imm = pcrel_lo( label ) }
-      }
+        pseudo instruction XXX ( rd: Index, symbol: Bits<32> ) =
+        {
+            new_label ( label )
+            LD { rd = rd, rs1 = rd, imm = pcrel_lo( label ) }
+        }
       */
 
       var newLabelNode =
@@ -1268,9 +1270,9 @@ class AddingOperands implements CaseHandler {
       Format.FieldAccess fieldAccess, FuncCallNode funcCallNode) {
     // immS = lo(symbol)
 
-    var compilerInstruction =
+    final var compilerInstruction =
         ctx.get(COMPILER_INSTRUCTION, CompilerInstruction.class);
-    var instructionSymbol = ctx.getString(INSTRUCTION_SYMBOL);
+    final var instructionSymbol = ctx.getString(INSTRUCTION_SYMBOL);
 
     ensure(funcCallNode.function() instanceof Relocation, () ->
         Diagnostic.error("Only supporting relocation functions at the moment",

--- a/vadl/main/vadl/lcb/template/lib/Target/MCTargetDesc/EmitMCInstExpanderCppFilePass.java
+++ b/vadl/main/vadl/lcb/template/lib/Target/MCTargetDesc/EmitMCInstExpanderCppFilePass.java
@@ -156,7 +156,9 @@ public class EmitMCInstExpanderCppFilePass extends LcbTemplateRenderingPass {
 
     var base = lcbConfiguration().targetName();
     var codeGen =
-        new CompilerInstructionExpansionCodeGenerator(base,
+        new CompilerInstructionExpansionCodeGenerator(
+            passResults,
+            base,
             fieldUsages,
             ImmediateDecodingFunctionProvider.generateDecodeFunctions(passResults),
             relocations,

--- a/vadl/main/vadl/viam/graph/control/InstrCallNode.java
+++ b/vadl/main/vadl/viam/graph/control/InstrCallNode.java
@@ -131,7 +131,29 @@ public class InstrCallNode extends DirectionalNode {
    */
   public boolean isParameterFieldAccess(Format.Field field) {
     return paramFieldsOrAccesses.stream().anyMatch(
-        paramField -> paramField.isRight() && paramField.right().fieldRef().equals(field));
+        paramField -> paramField.isRight() && paramField.right().fieldRefs().contains(field));
+  }
+
+  /**
+   * Return all field accesses which reference the given {@link Format.Field}.
+   */
+  public List<Format.FieldAccess> getFieldAccessesWithFieldRefs(Format.Field field) {
+    return paramFieldsOrAccesses.stream()
+        .filter(
+            paramField -> paramField.isRight() && paramField.right().fieldRefs().contains(field))
+        .map(Either::right)
+        .toList();
+  }
+
+  /**
+   * Check if the parameter corresponding to a given field is a {@link Format.Field}.
+   *
+   * @param field the given field
+   * @return true if the parameter is a {@link Format.Field}, false otherwise
+   */
+  public boolean isParameterField(Format.Field field) {
+    return paramFieldsOrAccesses.stream().anyMatch(
+        paramField -> paramField.isLeft() && paramField.left().equals(field));
   }
 
   /**

--- a/vadl/test/vadl/lcb/riscv/riscv64/template/MCTargetDesc/EmitMCInstExpanderCppFilePassTest.java
+++ b/vadl/test/vadl/lcb/riscv/riscv64/template/MCTargetDesc/EmitMCInstExpanderCppFilePassTest.java
@@ -362,37 +362,46 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCInst b = MCInst();
            b.setOpcode(processorNameValue::AUIPC);
            {
-           // AUIPC
+              // AUIPC
+              auto rd = 0;
+              auto imm = 0;
+              // GenerateRawFieldsHandler
+              rd = instruction.getOperand(0).getReg();
+              if(instruction.getOperand(1).isImm()) {
+                 imm = instruction.getOperand(1).getImm();
+              }
+              // DecodeFieldAccessesHandler
+              // AddingOperands
               b.addOperand(instruction.getOperand(0)); // rd
               if(instruction.getOperand(1).isImm()) {
-                 auto d = processorNameValueBaseInfo::RV3264Base_got_pcrel_hi(instruction.getOperand(1).getImm());
-                 MCOperand c = MCOperand::createExpr(MCConstantExpr::create(RV3264Base_AUIPC_immUp_decode(d), Ctx));
-                 b.addOperand(c); // imm
+                 imm = instruction.getOperand(1).getImm();
+                 imm = processorNameValueBaseInfo::RV3264Base_got_pcrel_hi(imm);
+                 b.addOperand(MCOperand::createImm(RV3264Base_AUIPC_immUp_decode(imm)));
               }
               else {
-                 const MCExpr* e = MCOperandToMCExpr(instruction.getOperand(1));
-                 const MCExpr* f = processorNameValueMCExpr::create(e, processorNameValueMCExpr::VariantKind::VK_GOT_RV3264Base_got_pcrel_hi, Ctx);
-                 const MCExpr* g = processorNameValueMCExpr::create(f, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_AUIPC_immUp, Ctx);
-                 MCOperand h = MCOperand::createExpr(g);
-                 b.addOperand(h); // imm
+                 b.addOperand(MCOperand::createExpr(processorNameValueMCExpr::create(processorNameValueMCExpr::create(MCOperandToMCExpr(instruction.getOperand(1)), processorNameValueMCExpr::VariantKind::VK_GOT_RV3264Base_got_pcrel_hi, Ctx), processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_AUIPC_immUp, Ctx))); // imm
               }
            }
            result.push_back(b);
            callback(b);
-           MCInst i = MCInst();
-           i.setOpcode(processorNameValue::LD);
+           MCInst c = MCInst();
+           c.setOpcode(processorNameValue::LD);
            {
-           // LD
-              i.addOperand(instruction.getOperand(0)); // rd
-              i.addOperand(instruction.getOperand(0)); // rs1
-              const MCExpr* j = MCOperandToMCExpr(MCOperand::createExpr(MCSymbolRefExpr::create(a, Ctx)));
-              const MCExpr* k = processorNameValueMCExpr::create(j, processorNameValueMCExpr::VariantKind::VK_PCREL_RV3264Base_pcrel_lo, Ctx);
-              const MCExpr* l = processorNameValueMCExpr::create(k, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_LD_immS, Ctx);
-              MCOperand m = MCOperand::createExpr(l);
-              i.addOperand(m); // imm
+              // LD
+              auto rd = 0;
+              auto rs1 = 0;
+              auto imm = 0;
+              // GenerateRawFieldsHandler
+              rd = instruction.getOperand(0).getReg();
+              rs1 = instruction.getOperand(0).getReg();
+              // DecodeFieldAccessesHandler
+              // AddingOperands
+              c.addOperand(instruction.getOperand(0)); // rd
+              c.addOperand(instruction.getOperand(0)); // rs1
+              c.addOperand(MCOperand::createExpr(processorNameValueMCExpr::create(processorNameValueMCExpr::create(MCSymbolRefExpr::create(a, Ctx), processorNameValueMCExpr::VariantKind::VK_PCREL_RV3264Base_pcrel_lo, Ctx), processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_LD_immS, Ctx))); // imm
            }
-           result.push_back(i);
-           callback(i);
+           result.push_back(c);
+           callback(c);
            return result;
         }
         
@@ -404,44 +413,56 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCInst a = MCInst();
            a.setOpcode(processorNameValue::LUI);
            {
-           // LUI
-              a.addOperand(MCOperand::createReg(processorNameValue::X1)); // rd
+              // LUI
+              auto rd = 0;
+              auto imm = 0;
+              // GenerateRawFieldsHandler
+              rd = processorNameValue::X1;
               if(instruction.getOperand(0).isImm()) {
-                 auto c = processorNameValueBaseInfo::RV3264Base_hi(instruction.getOperand(0).getImm());
-                 MCOperand b = MCOperand::createExpr(MCConstantExpr::create(RV3264Base_LUI_immUp_decode(c), Ctx));
-                 a.addOperand(b); // imm
+                 imm = instruction.getOperand(0).getImm();
+              }
+              // DecodeFieldAccessesHandler
+              // AddingOperands
+              a.addOperand(MCOperand::createReg(rd));
+              if(instruction.getOperand(0).isImm()) {
+                 imm = instruction.getOperand(0).getImm();
+                 imm = processorNameValueBaseInfo::RV3264Base_hi(imm);
+                 a.addOperand(MCOperand::createImm(RV3264Base_LUI_immUp_decode(imm)));
               }
               else {
-                 const MCExpr* d = MCOperandToMCExpr(instruction.getOperand(0));
-                 const MCExpr* e = processorNameValueMCExpr::create(d, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264Base_hi, Ctx);
-                 const MCExpr* f = processorNameValueMCExpr::create(e, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_LUI_immUp, Ctx);
-                 MCOperand g = MCOperand::createExpr(f);
-                 a.addOperand(g); // imm
+                 a.addOperand(MCOperand::createExpr(processorNameValueMCExpr::create(processorNameValueMCExpr::create(MCOperandToMCExpr(instruction.getOperand(0)), processorNameValueMCExpr::VariantKind::VK_ABS_RV3264Base_hi, Ctx), processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_LUI_immUp, Ctx))); // imm
               }
            }
            result.push_back(a);
            callback(a);
-           MCInst h = MCInst();
-           h.setOpcode(processorNameValue::JALR);
+           MCInst b = MCInst();
+           b.setOpcode(processorNameValue::JALR);
            {
-           // JALR
-              h.addOperand(MCOperand::createReg(processorNameValue::X1)); // rd
-              h.addOperand(MCOperand::createReg(processorNameValue::X1)); // rs1
+              // JALR
+              auto rd = 0;
+              auto rs1 = 0;
+              auto imm = 0;
+              // GenerateRawFieldsHandler
+              rd = processorNameValue::X1;
+              rs1 = processorNameValue::X1;
               if(instruction.getOperand(0).isImm()) {
-                 auto j = processorNameValueBaseInfo::RV3264Base_lo(instruction.getOperand(0).getImm());
-                 MCOperand i = MCOperand::createExpr(MCConstantExpr::create(RV3264Base_JALR_immS_decode(j), Ctx));
-                 h.addOperand(i); // imm
+                 imm = instruction.getOperand(0).getImm();
+              }
+              // DecodeFieldAccessesHandler
+              // AddingOperands
+              b.addOperand(MCOperand::createReg(rd));
+              b.addOperand(MCOperand::createReg(rs1));
+              if(instruction.getOperand(0).isImm()) {
+                 imm = instruction.getOperand(0).getImm();
+                 imm = processorNameValueBaseInfo::RV3264Base_lo(imm);
+                 b.addOperand(MCOperand::createImm(RV3264Base_JALR_immS_decode(imm)));
               }
               else {
-                 const MCExpr* k = MCOperandToMCExpr(instruction.getOperand(0));
-                 const MCExpr* l = processorNameValueMCExpr::create(k, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264Base_lo, Ctx);
-                 const MCExpr* m = processorNameValueMCExpr::create(l, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_JALR_immS, Ctx);
-                 MCOperand n = MCOperand::createExpr(m);
-                 h.addOperand(n); // imm
+                 b.addOperand(MCOperand::createExpr(processorNameValueMCExpr::create(processorNameValueMCExpr::create(MCOperandToMCExpr(instruction.getOperand(0)), processorNameValueMCExpr::VariantKind::VK_ABS_RV3264Base_lo, Ctx), processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_JALR_immS, Ctx))); // imm
               }
            }
-           result.push_back(h);
-           callback(h);
+           result.push_back(b);
+           callback(b);
            return result;
         }
         
@@ -453,44 +474,56 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCInst a = MCInst();
            a.setOpcode(processorNameValue::AUIPC);
            {
-           // AUIPC
-              a.addOperand(MCOperand::createReg(processorNameValue::X6)); // rd
+              // AUIPC
+              auto rd = 0;
+              auto imm = 0;
+              // GenerateRawFieldsHandler
+              rd = processorNameValue::X6;
               if(instruction.getOperand(0).isImm()) {
-                 auto c = processorNameValueBaseInfo::RV3264Base_hi(instruction.getOperand(0).getImm());
-                 MCOperand b = MCOperand::createExpr(MCConstantExpr::create(RV3264Base_AUIPC_immUp_decode(c), Ctx));
-                 a.addOperand(b); // imm
+                 imm = instruction.getOperand(0).getImm();
+              }
+              // DecodeFieldAccessesHandler
+              // AddingOperands
+              a.addOperand(MCOperand::createReg(rd));
+              if(instruction.getOperand(0).isImm()) {
+                 imm = instruction.getOperand(0).getImm();
+                 imm = processorNameValueBaseInfo::RV3264Base_hi(imm);
+                 a.addOperand(MCOperand::createImm(RV3264Base_AUIPC_immUp_decode(imm)));
               }
               else {
-                 const MCExpr* d = MCOperandToMCExpr(instruction.getOperand(0));
-                 const MCExpr* e = processorNameValueMCExpr::create(d, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264Base_hi, Ctx);
-                 const MCExpr* f = processorNameValueMCExpr::create(e, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_AUIPC_immUp, Ctx);
-                 MCOperand g = MCOperand::createExpr(f);
-                 a.addOperand(g); // imm
+                 a.addOperand(MCOperand::createExpr(processorNameValueMCExpr::create(processorNameValueMCExpr::create(MCOperandToMCExpr(instruction.getOperand(0)), processorNameValueMCExpr::VariantKind::VK_ABS_RV3264Base_hi, Ctx), processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_AUIPC_immUp, Ctx))); // imm
               }
            }
            result.push_back(a);
            callback(a);
-           MCInst h = MCInst();
-           h.setOpcode(processorNameValue::JALR);
+           MCInst b = MCInst();
+           b.setOpcode(processorNameValue::JALR);
            {
-           // JALR
-              h.addOperand(MCOperand::createReg(processorNameValue::X0)); // rd
-              h.addOperand(MCOperand::createReg(processorNameValue::X6)); // rs1
+              // JALR
+              auto rd = 0;
+              auto rs1 = 0;
+              auto imm = 0;
+              // GenerateRawFieldsHandler
+              rd = processorNameValue::X0;
+              rs1 = processorNameValue::X6;
               if(instruction.getOperand(0).isImm()) {
-                 auto j = processorNameValueBaseInfo::RV3264Base_lo(instruction.getOperand(0).getImm());
-                 MCOperand i = MCOperand::createExpr(MCConstantExpr::create(RV3264Base_JALR_immS_decode(j), Ctx));
-                 h.addOperand(i); // imm
+                 imm = instruction.getOperand(0).getImm();
+              }
+              // DecodeFieldAccessesHandler
+              // AddingOperands
+              b.addOperand(MCOperand::createReg(rd));
+              b.addOperand(MCOperand::createReg(rs1));
+              if(instruction.getOperand(0).isImm()) {
+                 imm = instruction.getOperand(0).getImm();
+                 imm = processorNameValueBaseInfo::RV3264Base_lo(imm);
+                 b.addOperand(MCOperand::createImm(RV3264Base_JALR_immS_decode(imm)));
               }
               else {
-                 const MCExpr* k = MCOperandToMCExpr(instruction.getOperand(0));
-                 const MCExpr* l = processorNameValueMCExpr::create(k, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264Base_lo, Ctx);
-                 const MCExpr* m = processorNameValueMCExpr::create(l, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_JALR_immS, Ctx);
-                 MCOperand n = MCOperand::createExpr(m);
-                 h.addOperand(n); // imm
+                 b.addOperand(MCOperand::createExpr(processorNameValueMCExpr::create(processorNameValueMCExpr::create(MCOperandToMCExpr(instruction.getOperand(0)), processorNameValueMCExpr::VariantKind::VK_ABS_RV3264Base_lo, Ctx), processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_JALR_immS, Ctx))); // imm
               }
            }
-           result.push_back(h);
-           callback(h);
+           result.push_back(b);
+           callback(b);
            return result;
         }
         
@@ -502,10 +535,19 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCInst a = MCInst();
            a.setOpcode(processorNameValue::JALR);
            {
-           // JALR
-              a.addOperand(MCOperand::createReg(processorNameValue::X0)); // rd
-              a.addOperand(MCOperand::createReg(processorNameValue::X1)); // rs1
-              a.addOperand(MCOperand::createImm(RV3264Base_JALR_immS_decode(0))); // imm
+              // JALR
+              auto rs1 = 0;
+              auto rd = 0;
+              auto imm = 0;
+              // GenerateRawFieldsHandler
+              rd = processorNameValue::X0;
+              rs1 = processorNameValue::X1;
+              imm = 0;
+              // DecodeFieldAccessesHandler
+              // AddingOperands
+              a.addOperand(MCOperand::createReg(rd));
+              a.addOperand(MCOperand::createReg(rs1));
+              a.addOperand(MCOperand::createImm(imm));
            }
            result.push_back(a);
            callback(a);
@@ -520,16 +562,16 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCInst a = MCInst();
            a.setOpcode(processorNameValue::JAL);
            {
-           // JAL
-              a.addOperand(MCOperand::createReg(processorNameValue::X0)); // rd
-              if(instruction.getOperand(0).isImm()) {
-                 a.addOperand(MCOperand::createImm(instruction.getOperand(0).getImm())); // imm
-              }
-              else {
-                 const MCExpr* b = MCOperandToMCExpr(instruction.getOperand(0));
-                 MCOperand c = MCOperand::createExpr(processorNameValueMCExpr::create(b, processorNameValueMCExpr::VariantKind::VK_None, Ctx));
-                 a.addOperand(c); // imm
-              }
+              // JAL
+              auto rd = 0;
+              auto imm = 0;
+              // GenerateRawFieldsHandler
+              rd = processorNameValue::X0;
+              auto immS = instruction.getOperand(0).getImm();
+              // DecodeFieldAccessesHandler
+              // AddingOperands
+              a.addOperand(MCOperand::createReg(rd));
+              a.addOperand(instruction.getOperand(0));
            }
            result.push_back(a);
            callback(a);
@@ -544,10 +586,19 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCInst a = MCInst();
            a.setOpcode(processorNameValue::ADDI);
            {
-           // ADDI
-              a.addOperand(MCOperand::createReg(processorNameValue::X0)); // rd
-              a.addOperand(MCOperand::createReg(processorNameValue::X0)); // rs1
-              a.addOperand(MCOperand::createImm(RV3264Base_ADDI_immS_decode(0))); // imm
+              // ADDI
+              auto rd = 0;
+              auto rs1 = 0;
+              auto imm = 0;
+              // GenerateRawFieldsHandler
+              rd = processorNameValue::X0;
+              rs1 = processorNameValue::X0;
+              imm = 0;
+              // DecodeFieldAccessesHandler
+              // AddingOperands
+              a.addOperand(MCOperand::createReg(rd));
+              a.addOperand(MCOperand::createReg(rs1));
+              a.addOperand(MCOperand::createImm(imm));
            }
            result.push_back(a);
            callback(a);
@@ -562,10 +613,19 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCInst a = MCInst();
            a.setOpcode(processorNameValue::ADDI);
            {
-           // ADDI
+              // ADDI
+              auto rd = 0;
+              auto rs1 = 0;
+              auto imm = 0;
+              // GenerateRawFieldsHandler
+              rd = instruction.getOperand(0).getReg();
+              rs1 = instruction.getOperand(1).getReg();
+              imm = 0;
+              // DecodeFieldAccessesHandler
+              // AddingOperands
               a.addOperand(instruction.getOperand(0)); // rd
               a.addOperand(instruction.getOperand(1)); // rs1
-              a.addOperand(MCOperand::createImm(RV3264Base_ADDI_immS_decode(0))); // imm
+              a.addOperand(MCOperand::createImm(imm));
            }
            result.push_back(a);
            callback(a);
@@ -580,10 +640,19 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCInst a = MCInst();
            a.setOpcode(processorNameValue::XORI);
            {
-           // XORI
+              // XORI
+              auto rd = 0;
+              auto rs1 = 0;
+              auto imm = 0;
+              // GenerateRawFieldsHandler
+              rd = instruction.getOperand(0).getReg();
+              rs1 = instruction.getOperand(1).getReg();
+              imm = 4095;
+              // DecodeFieldAccessesHandler
+              // AddingOperands
               a.addOperand(instruction.getOperand(0)); // rd
               a.addOperand(instruction.getOperand(1)); // rs1
-              a.addOperand(MCOperand::createImm(RV3264Base_XORI_immS_decode(4095))); // imm
+              a.addOperand(MCOperand::createImm(imm));
            }
            result.push_back(a);
            callback(a);
@@ -598,9 +667,18 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCInst a = MCInst();
            a.setOpcode(processorNameValue::SUB);
            {
-           // SUB
+              // SUB
+              auto rd = 0;
+              auto rs1 = 0;
+              auto rs2 = 0;
+              // GenerateRawFieldsHandler
+              rd = instruction.getOperand(0).getReg();
+              rs1 = processorNameValue::X0;
+              rs2 = instruction.getOperand(1).getReg();
+              // DecodeFieldAccessesHandler
+              // AddingOperands
               a.addOperand(instruction.getOperand(0)); // rd
-              a.addOperand(MCOperand::createReg(processorNameValue::X0)); // rs1
+              a.addOperand(MCOperand::createReg(rs1));
               a.addOperand(instruction.getOperand(1)); // rs2
            }
            result.push_back(a);
@@ -616,9 +694,18 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCInst a = MCInst();
            a.setOpcode(processorNameValue::SLTU);
            {
-           // SLTU
+              // SLTU
+              auto rd = 0;
+              auto rs1 = 0;
+              auto rs2 = 0;
+              // GenerateRawFieldsHandler
+              rd = instruction.getOperand(0).getReg();
+              rs1 = processorNameValue::X0;
+              rs2 = instruction.getOperand(1).getReg();
+              // DecodeFieldAccessesHandler
+              // AddingOperands
               a.addOperand(instruction.getOperand(0)); // rd
-              a.addOperand(MCOperand::createReg(processorNameValue::X0)); // rs1
+              a.addOperand(MCOperand::createReg(rs1));
               a.addOperand(instruction.getOperand(1)); // rs2
            }
            result.push_back(a);
@@ -634,10 +721,19 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCInst a = MCInst();
            a.setOpcode(processorNameValue::SLT);
            {
-           // SLT
+              // SLT
+              auto rd = 0;
+              auto rs1 = 0;
+              auto rs2 = 0;
+              // GenerateRawFieldsHandler
+              rd = instruction.getOperand(0).getReg();
+              rs1 = instruction.getOperand(1).getReg();
+              rs2 = processorNameValue::X0;
+              // DecodeFieldAccessesHandler
+              // AddingOperands
               a.addOperand(instruction.getOperand(0)); // rd
               a.addOperand(instruction.getOperand(1)); // rs1
-              a.addOperand(MCOperand::createReg(processorNameValue::X0)); // rs2
+              a.addOperand(MCOperand::createReg(rs2));
            }
            result.push_back(a);
            callback(a);
@@ -652,9 +748,18 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCInst a = MCInst();
            a.setOpcode(processorNameValue::SLT);
            {
-           // SLT
+              // SLT
+              auto rd = 0;
+              auto rs1 = 0;
+              auto rs2 = 0;
+              // GenerateRawFieldsHandler
+              rd = instruction.getOperand(0).getReg();
+              rs1 = processorNameValue::X0;
+              rs2 = instruction.getOperand(1).getReg();
+              // DecodeFieldAccessesHandler
+              // AddingOperands
               a.addOperand(instruction.getOperand(0)); // rd
-              a.addOperand(MCOperand::createReg(processorNameValue::X0)); // rs1
+              a.addOperand(MCOperand::createReg(rs1));
               a.addOperand(instruction.getOperand(1)); // rs2
            }
            result.push_back(a);
@@ -670,17 +775,19 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCInst a = MCInst();
            a.setOpcode(processorNameValue::BEQ);
            {
-           // BEQ
+              // BEQ
+              auto rs1 = 0;
+              auto rs2 = 0;
+              auto imm = 0;
+              // GenerateRawFieldsHandler
+              rs1 = instruction.getOperand(0).getReg();
+              rs2 = processorNameValue::X0;
+              auto immS = instruction.getOperand(1).getImm();
+              // DecodeFieldAccessesHandler
+              // AddingOperands
               a.addOperand(instruction.getOperand(0)); // rs1
-              a.addOperand(MCOperand::createReg(processorNameValue::X0)); // rs2
-              if(instruction.getOperand(1).isImm()) {
-                 a.addOperand(MCOperand::createImm(instruction.getOperand(1).getImm())); // imm
-              }
-              else {
-                 const MCExpr* b = MCOperandToMCExpr(instruction.getOperand(1));
-                 MCOperand c = MCOperand::createExpr(processorNameValueMCExpr::create(b, processorNameValueMCExpr::VariantKind::VK_None, Ctx));
-                 a.addOperand(c); // imm
-              }
+              a.addOperand(MCOperand::createReg(rs2));
+              a.addOperand(instruction.getOperand(1));
            }
            result.push_back(a);
            callback(a);
@@ -695,17 +802,19 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCInst a = MCInst();
            a.setOpcode(processorNameValue::BNE);
            {
-           // BNE
+              // BNE
+              auto rs1 = 0;
+              auto rs2 = 0;
+              auto imm = 0;
+              // GenerateRawFieldsHandler
+              rs1 = instruction.getOperand(0).getReg();
+              rs2 = processorNameValue::X0;
+              auto immS = instruction.getOperand(1).getImm();
+              // DecodeFieldAccessesHandler
+              // AddingOperands
               a.addOperand(instruction.getOperand(0)); // rs1
-              a.addOperand(MCOperand::createReg(processorNameValue::X0)); // rs2
-              if(instruction.getOperand(1).isImm()) {
-                 a.addOperand(MCOperand::createImm(instruction.getOperand(1).getImm())); // imm
-              }
-              else {
-                 const MCExpr* b = MCOperandToMCExpr(instruction.getOperand(1));
-                 MCOperand c = MCOperand::createExpr(processorNameValueMCExpr::create(b, processorNameValueMCExpr::VariantKind::VK_None, Ctx));
-                 a.addOperand(c); // imm
-              }
+              a.addOperand(MCOperand::createReg(rs2));
+              a.addOperand(instruction.getOperand(1));
            }
            result.push_back(a);
            callback(a);
@@ -720,17 +829,19 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCInst a = MCInst();
            a.setOpcode(processorNameValue::BGE);
            {
-           // BGE
-              a.addOperand(MCOperand::createReg(processorNameValue::X0)); // rs1
+              // BGE
+              auto rs1 = 0;
+              auto rs2 = 0;
+              auto imm = 0;
+              // GenerateRawFieldsHandler
+              rs1 = processorNameValue::X0;
+              rs2 = instruction.getOperand(0).getReg();
+              auto immS = instruction.getOperand(1).getImm();
+              // DecodeFieldAccessesHandler
+              // AddingOperands
+              a.addOperand(MCOperand::createReg(rs1));
               a.addOperand(instruction.getOperand(0)); // rs2
-              if(instruction.getOperand(1).isImm()) {
-                 a.addOperand(MCOperand::createImm(instruction.getOperand(1).getImm())); // imm
-              }
-              else {
-                 const MCExpr* b = MCOperandToMCExpr(instruction.getOperand(1));
-                 MCOperand c = MCOperand::createExpr(processorNameValueMCExpr::create(b, processorNameValueMCExpr::VariantKind::VK_None, Ctx));
-                 a.addOperand(c); // imm
-              }
+              a.addOperand(instruction.getOperand(1));
            }
            result.push_back(a);
            callback(a);
@@ -745,17 +856,19 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCInst a = MCInst();
            a.setOpcode(processorNameValue::BGE);
            {
-           // BGE
+              // BGE
+              auto rs1 = 0;
+              auto rs2 = 0;
+              auto imm = 0;
+              // GenerateRawFieldsHandler
+              rs1 = instruction.getOperand(0).getReg();
+              rs2 = processorNameValue::X0;
+              auto immS = instruction.getOperand(1).getImm();
+              // DecodeFieldAccessesHandler
+              // AddingOperands
               a.addOperand(instruction.getOperand(0)); // rs1
-              a.addOperand(MCOperand::createReg(processorNameValue::X0)); // rs2
-              if(instruction.getOperand(1).isImm()) {
-                 a.addOperand(MCOperand::createImm(instruction.getOperand(1).getImm())); // imm
-              }
-              else {
-                 const MCExpr* b = MCOperandToMCExpr(instruction.getOperand(1));
-                 MCOperand c = MCOperand::createExpr(processorNameValueMCExpr::create(b, processorNameValueMCExpr::VariantKind::VK_None, Ctx));
-                 a.addOperand(c); // imm
-              }
+              a.addOperand(MCOperand::createReg(rs2));
+              a.addOperand(instruction.getOperand(1));
            }
            result.push_back(a);
            callback(a);
@@ -770,17 +883,19 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCInst a = MCInst();
            a.setOpcode(processorNameValue::BLT);
            {
-           // BLT
+              // BLT
+              auto rs1 = 0;
+              auto rs2 = 0;
+              auto imm = 0;
+              // GenerateRawFieldsHandler
+              rs1 = instruction.getOperand(0).getReg();
+              rs2 = processorNameValue::X0;
+              auto immS = instruction.getOperand(1).getImm();
+              // DecodeFieldAccessesHandler
+              // AddingOperands
               a.addOperand(instruction.getOperand(0)); // rs1
-              a.addOperand(MCOperand::createReg(processorNameValue::X0)); // rs2
-              if(instruction.getOperand(1).isImm()) {
-                 a.addOperand(MCOperand::createImm(instruction.getOperand(1).getImm())); // imm
-              }
-              else {
-                 const MCExpr* b = MCOperandToMCExpr(instruction.getOperand(1));
-                 MCOperand c = MCOperand::createExpr(processorNameValueMCExpr::create(b, processorNameValueMCExpr::VariantKind::VK_None, Ctx));
-                 a.addOperand(c); // imm
-              }
+              a.addOperand(MCOperand::createReg(rs2));
+              a.addOperand(instruction.getOperand(1));
            }
            result.push_back(a);
            callback(a);
@@ -795,17 +910,19 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCInst a = MCInst();
            a.setOpcode(processorNameValue::BLT);
            {
-           // BLT
-              a.addOperand(MCOperand::createReg(processorNameValue::X0)); // rs1
+              // BLT
+              auto rs1 = 0;
+              auto rs2 = 0;
+              auto imm = 0;
+              // GenerateRawFieldsHandler
+              rs1 = processorNameValue::X0;
+              rs2 = instruction.getOperand(0).getReg();
+              auto immS = instruction.getOperand(1).getImm();
+              // DecodeFieldAccessesHandler
+              // AddingOperands
+              a.addOperand(MCOperand::createReg(rs1));
               a.addOperand(instruction.getOperand(0)); // rs2
-              if(instruction.getOperand(1).isImm()) {
-                 a.addOperand(MCOperand::createImm(instruction.getOperand(1).getImm())); // imm
-              }
-              else {
-                 const MCExpr* b = MCOperandToMCExpr(instruction.getOperand(1));
-                 MCOperand c = MCOperand::createExpr(processorNameValueMCExpr::create(b, processorNameValueMCExpr::VariantKind::VK_None, Ctx));
-                 a.addOperand(c); // imm
-              }
+              a.addOperand(instruction.getOperand(1));
            }
            result.push_back(a);
            callback(a);
@@ -820,44 +937,56 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCInst a = MCInst();
            a.setOpcode(processorNameValue::LUI);
            {
-           // LUI
+              // LUI
+              auto rd = 0;
+              auto imm = 0;
+              // GenerateRawFieldsHandler
+              rd = instruction.getOperand(0).getReg();
+              if(instruction.getOperand(1).isImm()) {
+                 imm = instruction.getOperand(1).getImm();
+              }
+              // DecodeFieldAccessesHandler
+              // AddingOperands
               a.addOperand(instruction.getOperand(0)); // rd
               if(instruction.getOperand(1).isImm()) {
-                 auto c = processorNameValueBaseInfo::RV3264Base_hi(instruction.getOperand(1).getImm());
-                 MCOperand b = MCOperand::createExpr(MCConstantExpr::create(RV3264Base_LUI_immUp_decode(c), Ctx));
-                 a.addOperand(b); // imm
+                 imm = instruction.getOperand(1).getImm();
+                 imm = processorNameValueBaseInfo::RV3264Base_hi(imm);
+                 a.addOperand(MCOperand::createImm(RV3264Base_LUI_immUp_decode(imm)));
               }
               else {
-                 const MCExpr* d = MCOperandToMCExpr(instruction.getOperand(1));
-                 const MCExpr* e = processorNameValueMCExpr::create(d, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264Base_hi, Ctx);
-                 const MCExpr* f = processorNameValueMCExpr::create(e, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_LUI_immUp, Ctx);
-                 MCOperand g = MCOperand::createExpr(f);
-                 a.addOperand(g); // imm
+                 a.addOperand(MCOperand::createExpr(processorNameValueMCExpr::create(processorNameValueMCExpr::create(MCOperandToMCExpr(instruction.getOperand(1)), processorNameValueMCExpr::VariantKind::VK_ABS_RV3264Base_hi, Ctx), processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_LUI_immUp, Ctx))); // imm
               }
            }
            result.push_back(a);
            callback(a);
-           MCInst h = MCInst();
-           h.setOpcode(processorNameValue::ADDI);
+           MCInst b = MCInst();
+           b.setOpcode(processorNameValue::ADDI);
            {
-           // ADDI
-              h.addOperand(instruction.getOperand(0)); // rd
-              h.addOperand(instruction.getOperand(0)); // rs1
+              // ADDI
+              auto rd = 0;
+              auto rs1 = 0;
+              auto imm = 0;
+              // GenerateRawFieldsHandler
+              rd = instruction.getOperand(0).getReg();
+              rs1 = instruction.getOperand(0).getReg();
               if(instruction.getOperand(1).isImm()) {
-                 auto j = processorNameValueBaseInfo::RV3264Base_lo(instruction.getOperand(1).getImm());
-                 MCOperand i = MCOperand::createExpr(MCConstantExpr::create(RV3264Base_ADDI_immS_decode(j), Ctx));
-                 h.addOperand(i); // imm
+                 imm = instruction.getOperand(1).getImm();
+              }
+              // DecodeFieldAccessesHandler
+              // AddingOperands
+              b.addOperand(instruction.getOperand(0)); // rd
+              b.addOperand(instruction.getOperand(0)); // rs1
+              if(instruction.getOperand(1).isImm()) {
+                 imm = instruction.getOperand(1).getImm();
+                 imm = processorNameValueBaseInfo::RV3264Base_lo(imm);
+                 b.addOperand(MCOperand::createImm(RV3264Base_ADDI_immS_decode(imm)));
               }
               else {
-                 const MCExpr* k = MCOperandToMCExpr(instruction.getOperand(1));
-                 const MCExpr* l = processorNameValueMCExpr::create(k, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264Base_lo, Ctx);
-                 const MCExpr* m = processorNameValueMCExpr::create(l, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_ADDI_immS, Ctx);
-                 MCOperand n = MCOperand::createExpr(m);
-                 h.addOperand(n); // imm
+                 b.addOperand(MCOperand::createExpr(processorNameValueMCExpr::create(processorNameValueMCExpr::create(MCOperandToMCExpr(instruction.getOperand(1)), processorNameValueMCExpr::VariantKind::VK_ABS_RV3264Base_lo, Ctx), processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_ADDI_immS, Ctx))); // imm
               }
            }
-           result.push_back(h);
-           callback(h);
+           result.push_back(b);
+           callback(b);
            return result;
         }
         
@@ -869,44 +998,56 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCInst a = MCInst();
            a.setOpcode(processorNameValue::AUIPC);
            {
-           // AUIPC
+              // AUIPC
+              auto rd = 0;
+              auto imm = 0;
+              // GenerateRawFieldsHandler
+              rd = instruction.getOperand(0).getReg();
+              if(instruction.getOperand(1).isImm()) {
+                 imm = instruction.getOperand(1).getImm();
+              }
+              // DecodeFieldAccessesHandler
+              // AddingOperands
               a.addOperand(instruction.getOperand(0)); // rd
               if(instruction.getOperand(1).isImm()) {
-                 auto c = processorNameValueBaseInfo::RV3264Base_got_pcrel_hi(instruction.getOperand(1).getImm());
-                 MCOperand b = MCOperand::createExpr(MCConstantExpr::create(RV3264Base_AUIPC_immUp_decode(c), Ctx));
-                 a.addOperand(b); // imm
+                 imm = instruction.getOperand(1).getImm();
+                 imm = processorNameValueBaseInfo::RV3264Base_got_pcrel_hi(imm);
+                 a.addOperand(MCOperand::createImm(RV3264Base_AUIPC_immUp_decode(imm)));
               }
               else {
-                 const MCExpr* d = MCOperandToMCExpr(instruction.getOperand(1));
-                 const MCExpr* e = processorNameValueMCExpr::create(d, processorNameValueMCExpr::VariantKind::VK_GOT_RV3264Base_got_pcrel_hi, Ctx);
-                 const MCExpr* f = processorNameValueMCExpr::create(e, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_AUIPC_immUp, Ctx);
-                 MCOperand g = MCOperand::createExpr(f);
-                 a.addOperand(g); // imm
+                 a.addOperand(MCOperand::createExpr(processorNameValueMCExpr::create(processorNameValueMCExpr::create(MCOperandToMCExpr(instruction.getOperand(1)), processorNameValueMCExpr::VariantKind::VK_GOT_RV3264Base_got_pcrel_hi, Ctx), processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_AUIPC_immUp, Ctx))); // imm
               }
            }
            result.push_back(a);
            callback(a);
-           MCInst h = MCInst();
-           h.setOpcode(processorNameValue::LW);
+           MCInst b = MCInst();
+           b.setOpcode(processorNameValue::LW);
            {
-           // LW
-              h.addOperand(instruction.getOperand(0)); // rd
-              h.addOperand(instruction.getOperand(0)); // rs1
+              // LW
+              auto rd = 0;
+              auto rs1 = 0;
+              auto imm = 0;
+              // GenerateRawFieldsHandler
+              rd = instruction.getOperand(0).getReg();
+              rs1 = instruction.getOperand(0).getReg();
               if(instruction.getOperand(1).isImm()) {
-                 auto j = processorNameValueBaseInfo::RV3264Base_pcrel_lo(instruction.getOperand(1).getImm());
-                 MCOperand i = MCOperand::createExpr(MCConstantExpr::create(RV3264Base_LW_immS_decode(j), Ctx));
-                 h.addOperand(i); // imm
+                 imm = instruction.getOperand(1).getImm();
+              }
+              // DecodeFieldAccessesHandler
+              // AddingOperands
+              b.addOperand(instruction.getOperand(0)); // rd
+              b.addOperand(instruction.getOperand(0)); // rs1
+              if(instruction.getOperand(1).isImm()) {
+                 imm = instruction.getOperand(1).getImm();
+                 imm = processorNameValueBaseInfo::RV3264Base_pcrel_lo(imm);
+                 b.addOperand(MCOperand::createImm(RV3264Base_LW_immS_decode(imm)));
               }
               else {
-                 const MCExpr* k = MCOperandToMCExpr(instruction.getOperand(1));
-                 const MCExpr* l = processorNameValueMCExpr::create(k, processorNameValueMCExpr::VariantKind::VK_PCREL_RV3264Base_pcrel_lo, Ctx);
-                 const MCExpr* m = processorNameValueMCExpr::create(l, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_LW_immS, Ctx);
-                 MCOperand n = MCOperand::createExpr(m);
-                 h.addOperand(n); // imm
+                 b.addOperand(MCOperand::createExpr(processorNameValueMCExpr::create(processorNameValueMCExpr::create(MCOperandToMCExpr(instruction.getOperand(1)), processorNameValueMCExpr::VariantKind::VK_PCREL_RV3264Base_pcrel_lo, Ctx), processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_LW_immS, Ctx))); // imm
               }
            }
-           result.push_back(h);
-           callback(h);
+           result.push_back(b);
+           callback(b);
            return result;
         }
         
@@ -920,37 +1061,46 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCInst b = MCInst();
            b.setOpcode(processorNameValue::AUIPC);
            {
-           // AUIPC
+              // AUIPC
+              auto rd = 0;
+              auto imm = 0;
+              // GenerateRawFieldsHandler
+              rd = instruction.getOperand(0).getReg();
+              if(instruction.getOperand(1).isImm()) {
+                 imm = instruction.getOperand(1).getImm();
+              }
+              // DecodeFieldAccessesHandler
+              // AddingOperands
               b.addOperand(instruction.getOperand(0)); // rd
               if(instruction.getOperand(1).isImm()) {
-                 auto d = processorNameValueBaseInfo::RV3264Base_pcrel_hi(instruction.getOperand(1).getImm());
-                 MCOperand c = MCOperand::createExpr(MCConstantExpr::create(RV3264Base_AUIPC_immUp_decode(d), Ctx));
-                 b.addOperand(c); // imm
+                 imm = instruction.getOperand(1).getImm();
+                 imm = processorNameValueBaseInfo::RV3264Base_pcrel_hi(imm);
+                 b.addOperand(MCOperand::createImm(RV3264Base_AUIPC_immUp_decode(imm)));
               }
               else {
-                 const MCExpr* e = MCOperandToMCExpr(instruction.getOperand(1));
-                 const MCExpr* f = processorNameValueMCExpr::create(e, processorNameValueMCExpr::VariantKind::VK_PCREL_RV3264Base_pcrel_hi, Ctx);
-                 const MCExpr* g = processorNameValueMCExpr::create(f, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_AUIPC_immUp, Ctx);
-                 MCOperand h = MCOperand::createExpr(g);
-                 b.addOperand(h); // imm
+                 b.addOperand(MCOperand::createExpr(processorNameValueMCExpr::create(processorNameValueMCExpr::create(MCOperandToMCExpr(instruction.getOperand(1)), processorNameValueMCExpr::VariantKind::VK_PCREL_RV3264Base_pcrel_hi, Ctx), processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_AUIPC_immUp, Ctx))); // imm
               }
            }
            result.push_back(b);
            callback(b);
-           MCInst i = MCInst();
-           i.setOpcode(processorNameValue::ADDI);
+           MCInst c = MCInst();
+           c.setOpcode(processorNameValue::ADDI);
            {
-           // ADDI
-              i.addOperand(instruction.getOperand(0)); // rd
-              i.addOperand(instruction.getOperand(0)); // rs1
-              const MCExpr* j = MCOperandToMCExpr(MCOperand::createExpr(MCSymbolRefExpr::create(a, Ctx)));
-              const MCExpr* k = processorNameValueMCExpr::create(j, processorNameValueMCExpr::VariantKind::VK_PCREL_RV3264Base_pcrel_lo, Ctx);
-              const MCExpr* l = processorNameValueMCExpr::create(k, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_ADDI_immS, Ctx);
-              MCOperand m = MCOperand::createExpr(l);
-              i.addOperand(m); // imm
+              // ADDI
+              auto rd = 0;
+              auto rs1 = 0;
+              auto imm = 0;
+              // GenerateRawFieldsHandler
+              rd = instruction.getOperand(0).getReg();
+              rs1 = instruction.getOperand(0).getReg();
+              // DecodeFieldAccessesHandler
+              // AddingOperands
+              c.addOperand(instruction.getOperand(0)); // rd
+              c.addOperand(instruction.getOperand(0)); // rs1
+              c.addOperand(MCOperand::createExpr(processorNameValueMCExpr::create(processorNameValueMCExpr::create(MCSymbolRefExpr::create(a, Ctx), processorNameValueMCExpr::VariantKind::VK_PCREL_RV3264Base_pcrel_lo, Ctx), processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_ADDI_immS, Ctx))); // imm
            }
-           result.push_back(i);
-           callback(i);
+           result.push_back(c);
+           callback(c);
            return result;
         }
         
@@ -962,44 +1112,56 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCInst a = MCInst();
            a.setOpcode(processorNameValue::LUI);
            {
-           // LUI
+              // LUI
+              auto rd = 0;
+              auto imm = 0;
+              // GenerateRawFieldsHandler
+              rd = instruction.getOperand(0).getReg();
+              if(instruction.getOperand(1).isImm()) {
+                 imm = instruction.getOperand(1).getImm();
+              }
+              // DecodeFieldAccessesHandler
+              // AddingOperands
               a.addOperand(instruction.getOperand(0)); // rd
               if(instruction.getOperand(1).isImm()) {
-                 auto c = processorNameValueBaseInfo::RV3264Base_hi(instruction.getOperand(1).getImm());
-                 MCOperand b = MCOperand::createExpr(MCConstantExpr::create(RV3264Base_LUI_immUp_decode(c), Ctx));
-                 a.addOperand(b); // imm
+                 imm = instruction.getOperand(1).getImm();
+                 imm = processorNameValueBaseInfo::RV3264Base_hi(imm);
+                 a.addOperand(MCOperand::createImm(RV3264Base_LUI_immUp_decode(imm)));
               }
               else {
-                 const MCExpr* d = MCOperandToMCExpr(instruction.getOperand(1));
-                 const MCExpr* e = processorNameValueMCExpr::create(d, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264Base_hi, Ctx);
-                 const MCExpr* f = processorNameValueMCExpr::create(e, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_LUI_immUp, Ctx);
-                 MCOperand g = MCOperand::createExpr(f);
-                 a.addOperand(g); // imm
+                 a.addOperand(MCOperand::createExpr(processorNameValueMCExpr::create(processorNameValueMCExpr::create(MCOperandToMCExpr(instruction.getOperand(1)), processorNameValueMCExpr::VariantKind::VK_ABS_RV3264Base_hi, Ctx), processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_LUI_immUp, Ctx))); // imm
               }
            }
            result.push_back(a);
            callback(a);
-           MCInst h = MCInst();
-           h.setOpcode(processorNameValue::ADDI);
+           MCInst b = MCInst();
+           b.setOpcode(processorNameValue::ADDI);
            {
-           // ADDI
-              h.addOperand(instruction.getOperand(0)); // rd
-              h.addOperand(instruction.getOperand(0)); // rs1
+              // ADDI
+              auto rd = 0;
+              auto rs1 = 0;
+              auto imm = 0;
+              // GenerateRawFieldsHandler
+              rd = instruction.getOperand(0).getReg();
+              rs1 = instruction.getOperand(0).getReg();
               if(instruction.getOperand(1).isImm()) {
-                 auto j = processorNameValueBaseInfo::RV3264Base_lo(instruction.getOperand(1).getImm());
-                 MCOperand i = MCOperand::createExpr(MCConstantExpr::create(RV3264Base_ADDI_immS_decode(j), Ctx));
-                 h.addOperand(i); // imm
+                 imm = instruction.getOperand(1).getImm();
+              }
+              // DecodeFieldAccessesHandler
+              // AddingOperands
+              b.addOperand(instruction.getOperand(0)); // rd
+              b.addOperand(instruction.getOperand(0)); // rs1
+              if(instruction.getOperand(1).isImm()) {
+                 imm = instruction.getOperand(1).getImm();
+                 imm = processorNameValueBaseInfo::RV3264Base_lo(imm);
+                 b.addOperand(MCOperand::createImm(RV3264Base_ADDI_immS_decode(imm)));
               }
               else {
-                 const MCExpr* k = MCOperandToMCExpr(instruction.getOperand(1));
-                 const MCExpr* l = processorNameValueMCExpr::create(k, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264Base_lo, Ctx);
-                 const MCExpr* m = processorNameValueMCExpr::create(l, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_ADDI_immS, Ctx);
-                 MCOperand n = MCOperand::createExpr(m);
-                 h.addOperand(n); // imm
+                 b.addOperand(MCOperand::createExpr(processorNameValueMCExpr::create(processorNameValueMCExpr::create(MCOperandToMCExpr(instruction.getOperand(1)), processorNameValueMCExpr::VariantKind::VK_ABS_RV3264Base_lo, Ctx), processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_ADDI_immS, Ctx))); // imm
               }
            }
-           result.push_back(h);
-           callback(h);
+           result.push_back(b);
+           callback(b);
            return result;
         }
         
@@ -1011,44 +1173,56 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCInst a = MCInst();
            a.setOpcode(processorNameValue::LUI);
            {
-           // LUI
+              // LUI
+              auto rd = 0;
+              auto imm = 0;
+              // GenerateRawFieldsHandler
+              rd = instruction.getOperand(0).getReg();
+              if(instruction.getOperand(1).isImm()) {
+                 imm = instruction.getOperand(1).getImm();
+              }
+              // DecodeFieldAccessesHandler
+              // AddingOperands
               a.addOperand(instruction.getOperand(0)); // rd
               if(instruction.getOperand(1).isImm()) {
-                 auto c = processorNameValueBaseInfo::RV3264Base_hi(instruction.getOperand(1).getImm());
-                 MCOperand b = MCOperand::createExpr(MCConstantExpr::create(RV3264Base_LUI_immUp_decode(c), Ctx));
-                 a.addOperand(b); // imm
+                 imm = instruction.getOperand(1).getImm();
+                 imm = processorNameValueBaseInfo::RV3264Base_hi(imm);
+                 a.addOperand(MCOperand::createImm(RV3264Base_LUI_immUp_decode(imm)));
               }
               else {
-                 const MCExpr* d = MCOperandToMCExpr(instruction.getOperand(1));
-                 const MCExpr* e = processorNameValueMCExpr::create(d, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264Base_hi, Ctx);
-                 const MCExpr* f = processorNameValueMCExpr::create(e, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_LUI_immUp, Ctx);
-                 MCOperand g = MCOperand::createExpr(f);
-                 a.addOperand(g); // imm
+                 a.addOperand(MCOperand::createExpr(processorNameValueMCExpr::create(processorNameValueMCExpr::create(MCOperandToMCExpr(instruction.getOperand(1)), processorNameValueMCExpr::VariantKind::VK_ABS_RV3264Base_hi, Ctx), processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_LUI_immUp, Ctx))); // imm
               }
            }
            result.push_back(a);
            callback(a);
-           MCInst h = MCInst();
-           h.setOpcode(processorNameValue::ADDI);
+           MCInst b = MCInst();
+           b.setOpcode(processorNameValue::ADDI);
            {
-           // ADDI
-              h.addOperand(instruction.getOperand(0)); // rd
-              h.addOperand(instruction.getOperand(0)); // rs1
+              // ADDI
+              auto rd = 0;
+              auto rs1 = 0;
+              auto imm = 0;
+              // GenerateRawFieldsHandler
+              rd = instruction.getOperand(0).getReg();
+              rs1 = instruction.getOperand(0).getReg();
               if(instruction.getOperand(1).isImm()) {
-                 auto j = processorNameValueBaseInfo::RV3264Base_lo(instruction.getOperand(1).getImm());
-                 MCOperand i = MCOperand::createExpr(MCConstantExpr::create(RV3264Base_ADDI_immS_decode(j), Ctx));
-                 h.addOperand(i); // imm
+                 imm = instruction.getOperand(1).getImm();
+              }
+              // DecodeFieldAccessesHandler
+              // AddingOperands
+              b.addOperand(instruction.getOperand(0)); // rd
+              b.addOperand(instruction.getOperand(0)); // rs1
+              if(instruction.getOperand(1).isImm()) {
+                 imm = instruction.getOperand(1).getImm();
+                 imm = processorNameValueBaseInfo::RV3264Base_lo(imm);
+                 b.addOperand(MCOperand::createImm(RV3264Base_ADDI_immS_decode(imm)));
               }
               else {
-                 const MCExpr* k = MCOperandToMCExpr(instruction.getOperand(1));
-                 const MCExpr* l = processorNameValueMCExpr::create(k, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264Base_lo, Ctx);
-                 const MCExpr* m = processorNameValueMCExpr::create(l, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_ADDI_immS, Ctx);
-                 MCOperand n = MCOperand::createExpr(m);
-                 h.addOperand(n); // imm
+                 b.addOperand(MCOperand::createExpr(processorNameValueMCExpr::create(processorNameValueMCExpr::create(MCOperandToMCExpr(instruction.getOperand(1)), processorNameValueMCExpr::VariantKind::VK_ABS_RV3264Base_lo, Ctx), processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_ADDI_immS, Ctx))); // imm
               }
            }
-           result.push_back(h);
-           callback(h);
+           result.push_back(b);
+           callback(b);
            return result;
         }
         
@@ -1060,44 +1234,56 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCInst a = MCInst();
            a.setOpcode(processorNameValue::LUI);
            {
-           // LUI
+              // LUI
+              auto rd = 0;
+              auto imm = 0;
+              // GenerateRawFieldsHandler
+              rd = instruction.getOperand(0).getReg();
+              if(instruction.getOperand(1).isImm()) {
+                 imm = instruction.getOperand(1).getImm();
+              }
+              // DecodeFieldAccessesHandler
+              // AddingOperands
               a.addOperand(instruction.getOperand(0)); // rd
               if(instruction.getOperand(1).isImm()) {
-                 auto c = processorNameValueBaseInfo::RV3264Base_hi(instruction.getOperand(1).getImm());
-                 MCOperand b = MCOperand::createExpr(MCConstantExpr::create(RV3264Base_LUI_immUp_decode(c), Ctx));
-                 a.addOperand(b); // imm
+                 imm = instruction.getOperand(1).getImm();
+                 imm = processorNameValueBaseInfo::RV3264Base_hi(imm);
+                 a.addOperand(MCOperand::createImm(RV3264Base_LUI_immUp_decode(imm)));
               }
               else {
-                 const MCExpr* d = MCOperandToMCExpr(instruction.getOperand(1));
-                 const MCExpr* e = processorNameValueMCExpr::create(d, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264Base_hi, Ctx);
-                 const MCExpr* f = processorNameValueMCExpr::create(e, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_LUI_immUp, Ctx);
-                 MCOperand g = MCOperand::createExpr(f);
-                 a.addOperand(g); // imm
+                 a.addOperand(MCOperand::createExpr(processorNameValueMCExpr::create(processorNameValueMCExpr::create(MCOperandToMCExpr(instruction.getOperand(1)), processorNameValueMCExpr::VariantKind::VK_ABS_RV3264Base_hi, Ctx), processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_LUI_immUp, Ctx))); // imm
               }
            }
            result.push_back(a);
            callback(a);
-           MCInst h = MCInst();
-           h.setOpcode(processorNameValue::ADDI);
+           MCInst b = MCInst();
+           b.setOpcode(processorNameValue::ADDI);
            {
-           // ADDI
-              h.addOperand(instruction.getOperand(0)); // rd
-              h.addOperand(instruction.getOperand(0)); // rs1
+              // ADDI
+              auto rd = 0;
+              auto rs1 = 0;
+              auto imm = 0;
+              // GenerateRawFieldsHandler
+              rd = instruction.getOperand(0).getReg();
+              rs1 = instruction.getOperand(0).getReg();
               if(instruction.getOperand(1).isImm()) {
-                 auto j = processorNameValueBaseInfo::RV3264Base_lo(instruction.getOperand(1).getImm());
-                 MCOperand i = MCOperand::createExpr(MCConstantExpr::create(RV3264Base_ADDI_immS_decode(j), Ctx));
-                 h.addOperand(i); // imm
+                 imm = instruction.getOperand(1).getImm();
+              }
+              // DecodeFieldAccessesHandler
+              // AddingOperands
+              b.addOperand(instruction.getOperand(0)); // rd
+              b.addOperand(instruction.getOperand(0)); // rs1
+              if(instruction.getOperand(1).isImm()) {
+                 imm = instruction.getOperand(1).getImm();
+                 imm = processorNameValueBaseInfo::RV3264Base_lo(imm);
+                 b.addOperand(MCOperand::createImm(RV3264Base_ADDI_immS_decode(imm)));
               }
               else {
-                 const MCExpr* k = MCOperandToMCExpr(instruction.getOperand(1));
-                 const MCExpr* l = processorNameValueMCExpr::create(k, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264Base_lo, Ctx);
-                 const MCExpr* m = processorNameValueMCExpr::create(l, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_ADDI_immS, Ctx);
-                 MCOperand n = MCOperand::createExpr(m);
-                 h.addOperand(n); // imm
+                 b.addOperand(MCOperand::createExpr(processorNameValueMCExpr::create(processorNameValueMCExpr::create(MCOperandToMCExpr(instruction.getOperand(1)), processorNameValueMCExpr::VariantKind::VK_ABS_RV3264Base_lo, Ctx), processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_ADDI_immS, Ctx))); // imm
               }
            }
-           result.push_back(h);
-           callback(h);
+           result.push_back(b);
+           callback(b);
            return result;
         }
         
@@ -1109,11 +1295,25 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCInst a = MCInst();
            a.setOpcode(processorNameValue::ADDI);
            {
-           // ADDI
-              a.addOperand(instruction.getOperand(0)); // rd
-              a.addOperand(MCOperand::createReg(processorNameValue::X0)); // rs1
+              // ADDI
+              auto rd = 0;
+              auto rs1 = 0;
+              auto imm = 0;
+              // GenerateRawFieldsHandler
+              rd = instruction.getOperand(0).getReg();
+              rs1 = processorNameValue::X0;
               if(instruction.getOperand(1).isImm()) {
-                 a.addOperand(MCOperand::createImm(instruction.getOperand(1).getImm())); // imm
+                 imm = instruction.getOperand(1).getImm();
+              }
+              // DecodeFieldAccessesHandler
+              // AddingOperands
+              a.addOperand(instruction.getOperand(0)); // rd
+              a.addOperand(MCOperand::createReg(rs1));
+              // We don't know whether the operand is an immediate or label?
+              // We find it out during parsing.
+              if(instruction.getOperand(1).isImm()) {
+                 imm = instruction.getOperand(1).getImm();
+                 a.addOperand(MCOperand::createImm(instruction.getOperand(1).getImm()));// imm
               }
               else {
                  const MCExpr* b = MCOperandToMCExpr(instruction.getOperand(1));
@@ -1134,11 +1334,25 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            MCInst a = MCInst();
            a.setOpcode(processorNameValue::ADDI);
            {
-           // ADDI
+              // ADDI
+              auto rd = 0;
+              auto rs1 = 0;
+              auto imm = 0;
+              // GenerateRawFieldsHandler
+              rd = instruction.getOperand(0).getReg();
+              rs1 = instruction.getOperand(1).getReg();
+              if(instruction.getOperand(2).isImm()) {
+                 imm = instruction.getOperand(2).getImm();
+              }
+              // DecodeFieldAccessesHandler
+              // AddingOperands
               a.addOperand(instruction.getOperand(0)); // rd
               a.addOperand(instruction.getOperand(1)); // rs1
+              // We don't know whether the operand is an immediate or label?
+              // We find it out during parsing.
               if(instruction.getOperand(2).isImm()) {
-                 a.addOperand(MCOperand::createImm(instruction.getOperand(2).getImm())); // imm
+                 imm = instruction.getOperand(2).getImm();
+                 a.addOperand(MCOperand::createImm(instruction.getOperand(2).getImm()));// imm
               }
               else {
                  const MCExpr* b = MCOperandToMCExpr(instruction.getOperand(2));

--- a/vadl/test/vadl/lcb/riscv/riscv64/template/MCTargetDesc/EmitMCInstExpanderCppFilePassTest.java
+++ b/vadl/test/vadl/lcb/riscv/riscv64/template/MCTargetDesc/EmitMCInstExpanderCppFilePassTest.java
@@ -361,30 +361,36 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            callbackSymbol(a);
            MCInst b = MCInst();
            b.setOpcode(processorNameValue::AUIPC);
-           b.addOperand(instruction.getOperand(0));
-           if(instruction.getOperand(1).isImm()) {
-              auto d = processorNameValueBaseInfo::RV3264Base_got_pcrel_hi(instruction.getOperand(1).getImm());
-              MCOperand c = MCOperand::createExpr(processorNameValueMCExpr::create(MCConstantExpr::create(d, Ctx), processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_AUIPC_immUp, Ctx));
-              b.addOperand(c);
-           }
-           else {
-              const MCExpr* e = MCOperandToMCExpr(instruction.getOperand(1));
-              const MCExpr* f = processorNameValueMCExpr::create(e, processorNameValueMCExpr::VariantKind::VK_GOT_RV3264Base_got_pcrel_hi, Ctx);
-              const MCExpr* g = processorNameValueMCExpr::create(f, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_AUIPC_immUp, Ctx);
-              MCOperand h = MCOperand::createExpr(g);
-              b.addOperand(h);
+           {
+           // AUIPC
+              b.addOperand(instruction.getOperand(0)); // rd
+              if(instruction.getOperand(1).isImm()) {
+                 auto d = processorNameValueBaseInfo::RV3264Base_got_pcrel_hi(instruction.getOperand(1).getImm());
+                 MCOperand c = MCOperand::createExpr(MCConstantExpr::create(RV3264Base_AUIPC_immUp_decode(d), Ctx));
+                 b.addOperand(c); // imm
+              }
+              else {
+                 const MCExpr* e = MCOperandToMCExpr(instruction.getOperand(1));
+                 const MCExpr* f = processorNameValueMCExpr::create(e, processorNameValueMCExpr::VariantKind::VK_GOT_RV3264Base_got_pcrel_hi, Ctx);
+                 const MCExpr* g = processorNameValueMCExpr::create(f, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_AUIPC_immUp, Ctx);
+                 MCOperand h = MCOperand::createExpr(g);
+                 b.addOperand(h); // imm
+              }
            }
            result.push_back(b);
            callback(b);
            MCInst i = MCInst();
            i.setOpcode(processorNameValue::LD);
-           i.addOperand(instruction.getOperand(0));
-           i.addOperand(instruction.getOperand(0));
-           const MCExpr* j = MCOperandToMCExpr(MCOperand::createExpr(MCSymbolRefExpr::create(a, Ctx)));
-           const MCExpr* k = processorNameValueMCExpr::create(j, processorNameValueMCExpr::VariantKind::VK_PCREL_RV3264Base_pcrel_lo, Ctx);
-           const MCExpr* l = processorNameValueMCExpr::create(k, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_LD_immS, Ctx);
-           MCOperand m = MCOperand::createExpr(l);
-           i.addOperand(m);
+           {
+           // LD
+              i.addOperand(instruction.getOperand(0)); // rd
+              i.addOperand(instruction.getOperand(0)); // rs1
+              const MCExpr* j = MCOperandToMCExpr(MCOperand::createExpr(MCSymbolRefExpr::create(a, Ctx)));
+              const MCExpr* k = processorNameValueMCExpr::create(j, processorNameValueMCExpr::VariantKind::VK_PCREL_RV3264Base_pcrel_lo, Ctx);
+              const MCExpr* l = processorNameValueMCExpr::create(k, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_LD_immS, Ctx);
+              MCOperand m = MCOperand::createExpr(l);
+              i.addOperand(m); // imm
+           }
            result.push_back(i);
            callback(i);
            return result;
@@ -397,36 +403,42 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            std::vector< MCInst > result;
            MCInst a = MCInst();
            a.setOpcode(processorNameValue::LUI);
-           a.addOperand(MCOperand::createReg(processorNameValue::X1));
-           if(instruction.getOperand(0).isImm()) {
-              auto c = processorNameValueBaseInfo::RV3264Base_hi(instruction.getOperand(0).getImm());
-              MCOperand b = MCOperand::createExpr(processorNameValueMCExpr::create(MCConstantExpr::create(c, Ctx), processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_LUI_immUp, Ctx));
-              a.addOperand(b);
-           }
-           else {
-              const MCExpr* d = MCOperandToMCExpr(instruction.getOperand(0));
-              const MCExpr* e = processorNameValueMCExpr::create(d, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264Base_hi, Ctx);
-              const MCExpr* f = processorNameValueMCExpr::create(e, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_LUI_immUp, Ctx);
-              MCOperand g = MCOperand::createExpr(f);
-              a.addOperand(g);
+           {
+           // LUI
+              a.addOperand(MCOperand::createReg(processorNameValue::X1)); // rd
+              if(instruction.getOperand(0).isImm()) {
+                 auto c = processorNameValueBaseInfo::RV3264Base_hi(instruction.getOperand(0).getImm());
+                 MCOperand b = MCOperand::createExpr(MCConstantExpr::create(RV3264Base_LUI_immUp_decode(c), Ctx));
+                 a.addOperand(b); // imm
+              }
+              else {
+                 const MCExpr* d = MCOperandToMCExpr(instruction.getOperand(0));
+                 const MCExpr* e = processorNameValueMCExpr::create(d, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264Base_hi, Ctx);
+                 const MCExpr* f = processorNameValueMCExpr::create(e, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_LUI_immUp, Ctx);
+                 MCOperand g = MCOperand::createExpr(f);
+                 a.addOperand(g); // imm
+              }
            }
            result.push_back(a);
            callback(a);
            MCInst h = MCInst();
            h.setOpcode(processorNameValue::JALR);
-           h.addOperand(MCOperand::createReg(processorNameValue::X1));
-           h.addOperand(MCOperand::createReg(processorNameValue::X1));
-           if(instruction.getOperand(0).isImm()) {
-              auto j = processorNameValueBaseInfo::RV3264Base_lo(instruction.getOperand(0).getImm());
-              MCOperand i = MCOperand::createExpr(processorNameValueMCExpr::create(MCConstantExpr::create(j, Ctx), processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_JALR_immS, Ctx));
-              h.addOperand(i);
-           }
-           else {
-              const MCExpr* k = MCOperandToMCExpr(instruction.getOperand(0));
-              const MCExpr* l = processorNameValueMCExpr::create(k, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264Base_lo, Ctx);
-              const MCExpr* m = processorNameValueMCExpr::create(l, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_JALR_immS, Ctx);
-              MCOperand n = MCOperand::createExpr(m);
-              h.addOperand(n);
+           {
+           // JALR
+              h.addOperand(MCOperand::createReg(processorNameValue::X1)); // rd
+              h.addOperand(MCOperand::createReg(processorNameValue::X1)); // rs1
+              if(instruction.getOperand(0).isImm()) {
+                 auto j = processorNameValueBaseInfo::RV3264Base_lo(instruction.getOperand(0).getImm());
+                 MCOperand i = MCOperand::createExpr(MCConstantExpr::create(RV3264Base_JALR_immS_decode(j), Ctx));
+                 h.addOperand(i); // imm
+              }
+              else {
+                 const MCExpr* k = MCOperandToMCExpr(instruction.getOperand(0));
+                 const MCExpr* l = processorNameValueMCExpr::create(k, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264Base_lo, Ctx);
+                 const MCExpr* m = processorNameValueMCExpr::create(l, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_JALR_immS, Ctx);
+                 MCOperand n = MCOperand::createExpr(m);
+                 h.addOperand(n); // imm
+              }
            }
            result.push_back(h);
            callback(h);
@@ -440,36 +452,42 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            std::vector< MCInst > result;
            MCInst a = MCInst();
            a.setOpcode(processorNameValue::AUIPC);
-           a.addOperand(MCOperand::createReg(processorNameValue::X6));
-           if(instruction.getOperand(0).isImm()) {
-              auto c = processorNameValueBaseInfo::RV3264Base_hi(instruction.getOperand(0).getImm());
-              MCOperand b = MCOperand::createExpr(processorNameValueMCExpr::create(MCConstantExpr::create(c, Ctx), processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_AUIPC_immUp, Ctx));
-              a.addOperand(b);
-           }
-           else {
-              const MCExpr* d = MCOperandToMCExpr(instruction.getOperand(0));
-              const MCExpr* e = processorNameValueMCExpr::create(d, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264Base_hi, Ctx);
-              const MCExpr* f = processorNameValueMCExpr::create(e, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_AUIPC_immUp, Ctx);
-              MCOperand g = MCOperand::createExpr(f);
-              a.addOperand(g);
+           {
+           // AUIPC
+              a.addOperand(MCOperand::createReg(processorNameValue::X6)); // rd
+              if(instruction.getOperand(0).isImm()) {
+                 auto c = processorNameValueBaseInfo::RV3264Base_hi(instruction.getOperand(0).getImm());
+                 MCOperand b = MCOperand::createExpr(MCConstantExpr::create(RV3264Base_AUIPC_immUp_decode(c), Ctx));
+                 a.addOperand(b); // imm
+              }
+              else {
+                 const MCExpr* d = MCOperandToMCExpr(instruction.getOperand(0));
+                 const MCExpr* e = processorNameValueMCExpr::create(d, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264Base_hi, Ctx);
+                 const MCExpr* f = processorNameValueMCExpr::create(e, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_AUIPC_immUp, Ctx);
+                 MCOperand g = MCOperand::createExpr(f);
+                 a.addOperand(g); // imm
+              }
            }
            result.push_back(a);
            callback(a);
            MCInst h = MCInst();
            h.setOpcode(processorNameValue::JALR);
-           h.addOperand(MCOperand::createReg(processorNameValue::X0));
-           h.addOperand(MCOperand::createReg(processorNameValue::X6));
-           if(instruction.getOperand(0).isImm()) {
-              auto j = processorNameValueBaseInfo::RV3264Base_lo(instruction.getOperand(0).getImm());
-              MCOperand i = MCOperand::createExpr(processorNameValueMCExpr::create(MCConstantExpr::create(j, Ctx), processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_JALR_immS, Ctx));
-              h.addOperand(i);
-           }
-           else {
-              const MCExpr* k = MCOperandToMCExpr(instruction.getOperand(0));
-              const MCExpr* l = processorNameValueMCExpr::create(k, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264Base_lo, Ctx);
-              const MCExpr* m = processorNameValueMCExpr::create(l, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_JALR_immS, Ctx);
-              MCOperand n = MCOperand::createExpr(m);
-              h.addOperand(n);
+           {
+           // JALR
+              h.addOperand(MCOperand::createReg(processorNameValue::X0)); // rd
+              h.addOperand(MCOperand::createReg(processorNameValue::X6)); // rs1
+              if(instruction.getOperand(0).isImm()) {
+                 auto j = processorNameValueBaseInfo::RV3264Base_lo(instruction.getOperand(0).getImm());
+                 MCOperand i = MCOperand::createExpr(MCConstantExpr::create(RV3264Base_JALR_immS_decode(j), Ctx));
+                 h.addOperand(i); // imm
+              }
+              else {
+                 const MCExpr* k = MCOperandToMCExpr(instruction.getOperand(0));
+                 const MCExpr* l = processorNameValueMCExpr::create(k, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264Base_lo, Ctx);
+                 const MCExpr* m = processorNameValueMCExpr::create(l, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_JALR_immS, Ctx);
+                 MCOperand n = MCOperand::createExpr(m);
+                 h.addOperand(n); // imm
+              }
            }
            result.push_back(h);
            callback(h);
@@ -483,9 +501,12 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            std::vector< MCInst > result;
            MCInst a = MCInst();
            a.setOpcode(processorNameValue::JALR);
-           a.addOperand(MCOperand::createReg(processorNameValue::X0));
-           a.addOperand(MCOperand::createReg(processorNameValue::X1));
-           a.addOperand(MCOperand::createImm(RV3264Base_JALR_immS_decode(0)));
+           {
+           // JALR
+              a.addOperand(MCOperand::createReg(processorNameValue::X0)); // rd
+              a.addOperand(MCOperand::createReg(processorNameValue::X1)); // rs1
+              a.addOperand(MCOperand::createImm(RV3264Base_JALR_immS_decode(0))); // imm
+           }
            result.push_back(a);
            callback(a);
            return result;
@@ -498,14 +519,17 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            std::vector< MCInst > result;
            MCInst a = MCInst();
            a.setOpcode(processorNameValue::JAL);
-           a.addOperand(MCOperand::createReg(processorNameValue::X0));
-           if(instruction.getOperand(0).isImm()) {
-              a.addOperand(MCOperand::createImm(instruction.getOperand(0).getImm()));
-           }
-           else {
-              const MCExpr* b = MCOperandToMCExpr(instruction.getOperand(0));
-              MCOperand c = MCOperand::createExpr(processorNameValueMCExpr::create(b, processorNameValueMCExpr::VariantKind::VK_None, Ctx));
-              a.addOperand(c);
+           {
+           // JAL
+              a.addOperand(MCOperand::createReg(processorNameValue::X0)); // rd
+              if(instruction.getOperand(0).isImm()) {
+                 a.addOperand(MCOperand::createImm(instruction.getOperand(0).getImm())); // imm
+              }
+              else {
+                 const MCExpr* b = MCOperandToMCExpr(instruction.getOperand(0));
+                 MCOperand c = MCOperand::createExpr(processorNameValueMCExpr::create(b, processorNameValueMCExpr::VariantKind::VK_None, Ctx));
+                 a.addOperand(c); // imm
+              }
            }
            result.push_back(a);
            callback(a);
@@ -519,9 +543,12 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            std::vector< MCInst > result;
            MCInst a = MCInst();
            a.setOpcode(processorNameValue::ADDI);
-           a.addOperand(MCOperand::createReg(processorNameValue::X0));
-           a.addOperand(MCOperand::createReg(processorNameValue::X0));
-           a.addOperand(MCOperand::createImm(RV3264Base_ADDI_immS_decode(0)));
+           {
+           // ADDI
+              a.addOperand(MCOperand::createReg(processorNameValue::X0)); // rd
+              a.addOperand(MCOperand::createReg(processorNameValue::X0)); // rs1
+              a.addOperand(MCOperand::createImm(RV3264Base_ADDI_immS_decode(0))); // imm
+           }
            result.push_back(a);
            callback(a);
            return result;
@@ -534,9 +561,12 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            std::vector< MCInst > result;
            MCInst a = MCInst();
            a.setOpcode(processorNameValue::ADDI);
-           a.addOperand(instruction.getOperand(0));
-           a.addOperand(instruction.getOperand(1));
-           a.addOperand(MCOperand::createImm(RV3264Base_ADDI_immS_decode(0)));
+           {
+           // ADDI
+              a.addOperand(instruction.getOperand(0)); // rd
+              a.addOperand(instruction.getOperand(1)); // rs1
+              a.addOperand(MCOperand::createImm(RV3264Base_ADDI_immS_decode(0))); // imm
+           }
            result.push_back(a);
            callback(a);
            return result;
@@ -549,9 +579,12 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            std::vector< MCInst > result;
            MCInst a = MCInst();
            a.setOpcode(processorNameValue::XORI);
-           a.addOperand(instruction.getOperand(0));
-           a.addOperand(instruction.getOperand(1));
-           a.addOperand(MCOperand::createImm(RV3264Base_XORI_immS_decode(4095)));
+           {
+           // XORI
+              a.addOperand(instruction.getOperand(0)); // rd
+              a.addOperand(instruction.getOperand(1)); // rs1
+              a.addOperand(MCOperand::createImm(RV3264Base_XORI_immS_decode(4095))); // imm
+           }
            result.push_back(a);
            callback(a);
            return result;
@@ -564,9 +597,12 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            std::vector< MCInst > result;
            MCInst a = MCInst();
            a.setOpcode(processorNameValue::SUB);
-           a.addOperand(instruction.getOperand(0));
-           a.addOperand(MCOperand::createReg(processorNameValue::X0));
-           a.addOperand(instruction.getOperand(1));
+           {
+           // SUB
+              a.addOperand(instruction.getOperand(0)); // rd
+              a.addOperand(MCOperand::createReg(processorNameValue::X0)); // rs1
+              a.addOperand(instruction.getOperand(1)); // rs2
+           }
            result.push_back(a);
            callback(a);
            return result;
@@ -579,9 +615,12 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            std::vector< MCInst > result;
            MCInst a = MCInst();
            a.setOpcode(processorNameValue::SLTU);
-           a.addOperand(instruction.getOperand(0));
-           a.addOperand(MCOperand::createReg(processorNameValue::X0));
-           a.addOperand(instruction.getOperand(1));
+           {
+           // SLTU
+              a.addOperand(instruction.getOperand(0)); // rd
+              a.addOperand(MCOperand::createReg(processorNameValue::X0)); // rs1
+              a.addOperand(instruction.getOperand(1)); // rs2
+           }
            result.push_back(a);
            callback(a);
            return result;
@@ -594,9 +633,12 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            std::vector< MCInst > result;
            MCInst a = MCInst();
            a.setOpcode(processorNameValue::SLT);
-           a.addOperand(instruction.getOperand(0));
-           a.addOperand(instruction.getOperand(1));
-           a.addOperand(MCOperand::createReg(processorNameValue::X0));
+           {
+           // SLT
+              a.addOperand(instruction.getOperand(0)); // rd
+              a.addOperand(instruction.getOperand(1)); // rs1
+              a.addOperand(MCOperand::createReg(processorNameValue::X0)); // rs2
+           }
            result.push_back(a);
            callback(a);
            return result;
@@ -609,9 +651,12 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            std::vector< MCInst > result;
            MCInst a = MCInst();
            a.setOpcode(processorNameValue::SLT);
-           a.addOperand(instruction.getOperand(0));
-           a.addOperand(MCOperand::createReg(processorNameValue::X0));
-           a.addOperand(instruction.getOperand(1));
+           {
+           // SLT
+              a.addOperand(instruction.getOperand(0)); // rd
+              a.addOperand(MCOperand::createReg(processorNameValue::X0)); // rs1
+              a.addOperand(instruction.getOperand(1)); // rs2
+           }
            result.push_back(a);
            callback(a);
            return result;
@@ -624,15 +669,18 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            std::vector< MCInst > result;
            MCInst a = MCInst();
            a.setOpcode(processorNameValue::BEQ);
-           a.addOperand(instruction.getOperand(0));
-           a.addOperand(MCOperand::createReg(processorNameValue::X0));
-           if(instruction.getOperand(1).isImm()) {
-              a.addOperand(MCOperand::createImm(instruction.getOperand(1).getImm()));
-           }
-           else {
-              const MCExpr* b = MCOperandToMCExpr(instruction.getOperand(1));
-              MCOperand c = MCOperand::createExpr(processorNameValueMCExpr::create(b, processorNameValueMCExpr::VariantKind::VK_None, Ctx));
-              a.addOperand(c);
+           {
+           // BEQ
+              a.addOperand(instruction.getOperand(0)); // rs1
+              a.addOperand(MCOperand::createReg(processorNameValue::X0)); // rs2
+              if(instruction.getOperand(1).isImm()) {
+                 a.addOperand(MCOperand::createImm(instruction.getOperand(1).getImm())); // imm
+              }
+              else {
+                 const MCExpr* b = MCOperandToMCExpr(instruction.getOperand(1));
+                 MCOperand c = MCOperand::createExpr(processorNameValueMCExpr::create(b, processorNameValueMCExpr::VariantKind::VK_None, Ctx));
+                 a.addOperand(c); // imm
+              }
            }
            result.push_back(a);
            callback(a);
@@ -646,15 +694,18 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            std::vector< MCInst > result;
            MCInst a = MCInst();
            a.setOpcode(processorNameValue::BNE);
-           a.addOperand(instruction.getOperand(0));
-           a.addOperand(MCOperand::createReg(processorNameValue::X0));
-           if(instruction.getOperand(1).isImm()) {
-              a.addOperand(MCOperand::createImm(instruction.getOperand(1).getImm()));
-           }
-           else {
-              const MCExpr* b = MCOperandToMCExpr(instruction.getOperand(1));
-              MCOperand c = MCOperand::createExpr(processorNameValueMCExpr::create(b, processorNameValueMCExpr::VariantKind::VK_None, Ctx));
-              a.addOperand(c);
+           {
+           // BNE
+              a.addOperand(instruction.getOperand(0)); // rs1
+              a.addOperand(MCOperand::createReg(processorNameValue::X0)); // rs2
+              if(instruction.getOperand(1).isImm()) {
+                 a.addOperand(MCOperand::createImm(instruction.getOperand(1).getImm())); // imm
+              }
+              else {
+                 const MCExpr* b = MCOperandToMCExpr(instruction.getOperand(1));
+                 MCOperand c = MCOperand::createExpr(processorNameValueMCExpr::create(b, processorNameValueMCExpr::VariantKind::VK_None, Ctx));
+                 a.addOperand(c); // imm
+              }
            }
            result.push_back(a);
            callback(a);
@@ -668,15 +719,18 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            std::vector< MCInst > result;
            MCInst a = MCInst();
            a.setOpcode(processorNameValue::BGE);
-           a.addOperand(MCOperand::createReg(processorNameValue::X0));
-           a.addOperand(instruction.getOperand(0));
-           if(instruction.getOperand(1).isImm()) {
-              a.addOperand(MCOperand::createImm(instruction.getOperand(1).getImm()));
-           }
-           else {
-              const MCExpr* b = MCOperandToMCExpr(instruction.getOperand(1));
-              MCOperand c = MCOperand::createExpr(processorNameValueMCExpr::create(b, processorNameValueMCExpr::VariantKind::VK_None, Ctx));
-              a.addOperand(c);
+           {
+           // BGE
+              a.addOperand(MCOperand::createReg(processorNameValue::X0)); // rs1
+              a.addOperand(instruction.getOperand(0)); // rs2
+              if(instruction.getOperand(1).isImm()) {
+                 a.addOperand(MCOperand::createImm(instruction.getOperand(1).getImm())); // imm
+              }
+              else {
+                 const MCExpr* b = MCOperandToMCExpr(instruction.getOperand(1));
+                 MCOperand c = MCOperand::createExpr(processorNameValueMCExpr::create(b, processorNameValueMCExpr::VariantKind::VK_None, Ctx));
+                 a.addOperand(c); // imm
+              }
            }
            result.push_back(a);
            callback(a);
@@ -690,15 +744,18 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            std::vector< MCInst > result;
            MCInst a = MCInst();
            a.setOpcode(processorNameValue::BGE);
-           a.addOperand(instruction.getOperand(0));
-           a.addOperand(MCOperand::createReg(processorNameValue::X0));
-           if(instruction.getOperand(1).isImm()) {
-              a.addOperand(MCOperand::createImm(instruction.getOperand(1).getImm()));
-           }
-           else {
-              const MCExpr* b = MCOperandToMCExpr(instruction.getOperand(1));
-              MCOperand c = MCOperand::createExpr(processorNameValueMCExpr::create(b, processorNameValueMCExpr::VariantKind::VK_None, Ctx));
-              a.addOperand(c);
+           {
+           // BGE
+              a.addOperand(instruction.getOperand(0)); // rs1
+              a.addOperand(MCOperand::createReg(processorNameValue::X0)); // rs2
+              if(instruction.getOperand(1).isImm()) {
+                 a.addOperand(MCOperand::createImm(instruction.getOperand(1).getImm())); // imm
+              }
+              else {
+                 const MCExpr* b = MCOperandToMCExpr(instruction.getOperand(1));
+                 MCOperand c = MCOperand::createExpr(processorNameValueMCExpr::create(b, processorNameValueMCExpr::VariantKind::VK_None, Ctx));
+                 a.addOperand(c); // imm
+              }
            }
            result.push_back(a);
            callback(a);
@@ -712,15 +769,18 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            std::vector< MCInst > result;
            MCInst a = MCInst();
            a.setOpcode(processorNameValue::BLT);
-           a.addOperand(instruction.getOperand(0));
-           a.addOperand(MCOperand::createReg(processorNameValue::X0));
-           if(instruction.getOperand(1).isImm()) {
-              a.addOperand(MCOperand::createImm(instruction.getOperand(1).getImm()));
-           }
-           else {
-              const MCExpr* b = MCOperandToMCExpr(instruction.getOperand(1));
-              MCOperand c = MCOperand::createExpr(processorNameValueMCExpr::create(b, processorNameValueMCExpr::VariantKind::VK_None, Ctx));
-              a.addOperand(c);
+           {
+           // BLT
+              a.addOperand(instruction.getOperand(0)); // rs1
+              a.addOperand(MCOperand::createReg(processorNameValue::X0)); // rs2
+              if(instruction.getOperand(1).isImm()) {
+                 a.addOperand(MCOperand::createImm(instruction.getOperand(1).getImm())); // imm
+              }
+              else {
+                 const MCExpr* b = MCOperandToMCExpr(instruction.getOperand(1));
+                 MCOperand c = MCOperand::createExpr(processorNameValueMCExpr::create(b, processorNameValueMCExpr::VariantKind::VK_None, Ctx));
+                 a.addOperand(c); // imm
+              }
            }
            result.push_back(a);
            callback(a);
@@ -734,15 +794,18 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            std::vector< MCInst > result;
            MCInst a = MCInst();
            a.setOpcode(processorNameValue::BLT);
-           a.addOperand(MCOperand::createReg(processorNameValue::X0));
-           a.addOperand(instruction.getOperand(0));
-           if(instruction.getOperand(1).isImm()) {
-              a.addOperand(MCOperand::createImm(instruction.getOperand(1).getImm()));
-           }
-           else {
-              const MCExpr* b = MCOperandToMCExpr(instruction.getOperand(1));
-              MCOperand c = MCOperand::createExpr(processorNameValueMCExpr::create(b, processorNameValueMCExpr::VariantKind::VK_None, Ctx));
-              a.addOperand(c);
+           {
+           // BLT
+              a.addOperand(MCOperand::createReg(processorNameValue::X0)); // rs1
+              a.addOperand(instruction.getOperand(0)); // rs2
+              if(instruction.getOperand(1).isImm()) {
+                 a.addOperand(MCOperand::createImm(instruction.getOperand(1).getImm())); // imm
+              }
+              else {
+                 const MCExpr* b = MCOperandToMCExpr(instruction.getOperand(1));
+                 MCOperand c = MCOperand::createExpr(processorNameValueMCExpr::create(b, processorNameValueMCExpr::VariantKind::VK_None, Ctx));
+                 a.addOperand(c); // imm
+              }
            }
            result.push_back(a);
            callback(a);
@@ -756,36 +819,42 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            std::vector< MCInst > result;
            MCInst a = MCInst();
            a.setOpcode(processorNameValue::LUI);
-           a.addOperand(instruction.getOperand(0));
-           if(instruction.getOperand(1).isImm()) {
-              auto c = processorNameValueBaseInfo::RV3264Base_hi(instruction.getOperand(1).getImm());
-              MCOperand b = MCOperand::createExpr(processorNameValueMCExpr::create(MCConstantExpr::create(c, Ctx), processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_LUI_immUp, Ctx));
-              a.addOperand(b);
-           }
-           else {
-              const MCExpr* d = MCOperandToMCExpr(instruction.getOperand(1));
-              const MCExpr* e = processorNameValueMCExpr::create(d, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264Base_hi, Ctx);
-              const MCExpr* f = processorNameValueMCExpr::create(e, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_LUI_immUp, Ctx);
-              MCOperand g = MCOperand::createExpr(f);
-              a.addOperand(g);
+           {
+           // LUI
+              a.addOperand(instruction.getOperand(0)); // rd
+              if(instruction.getOperand(1).isImm()) {
+                 auto c = processorNameValueBaseInfo::RV3264Base_hi(instruction.getOperand(1).getImm());
+                 MCOperand b = MCOperand::createExpr(MCConstantExpr::create(RV3264Base_LUI_immUp_decode(c), Ctx));
+                 a.addOperand(b); // imm
+              }
+              else {
+                 const MCExpr* d = MCOperandToMCExpr(instruction.getOperand(1));
+                 const MCExpr* e = processorNameValueMCExpr::create(d, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264Base_hi, Ctx);
+                 const MCExpr* f = processorNameValueMCExpr::create(e, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_LUI_immUp, Ctx);
+                 MCOperand g = MCOperand::createExpr(f);
+                 a.addOperand(g); // imm
+              }
            }
            result.push_back(a);
            callback(a);
            MCInst h = MCInst();
            h.setOpcode(processorNameValue::ADDI);
-           h.addOperand(instruction.getOperand(0));
-           h.addOperand(instruction.getOperand(0));
-           if(instruction.getOperand(1).isImm()) {
-              auto j = processorNameValueBaseInfo::RV3264Base_lo(instruction.getOperand(1).getImm());
-              MCOperand i = MCOperand::createExpr(processorNameValueMCExpr::create(MCConstantExpr::create(j, Ctx), processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_ADDI_immS, Ctx));
-              h.addOperand(i);
-           }
-           else {
-              const MCExpr* k = MCOperandToMCExpr(instruction.getOperand(1));
-              const MCExpr* l = processorNameValueMCExpr::create(k, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264Base_lo, Ctx);
-              const MCExpr* m = processorNameValueMCExpr::create(l, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_ADDI_immS, Ctx);
-              MCOperand n = MCOperand::createExpr(m);
-              h.addOperand(n);
+           {
+           // ADDI
+              h.addOperand(instruction.getOperand(0)); // rd
+              h.addOperand(instruction.getOperand(0)); // rs1
+              if(instruction.getOperand(1).isImm()) {
+                 auto j = processorNameValueBaseInfo::RV3264Base_lo(instruction.getOperand(1).getImm());
+                 MCOperand i = MCOperand::createExpr(MCConstantExpr::create(RV3264Base_ADDI_immS_decode(j), Ctx));
+                 h.addOperand(i); // imm
+              }
+              else {
+                 const MCExpr* k = MCOperandToMCExpr(instruction.getOperand(1));
+                 const MCExpr* l = processorNameValueMCExpr::create(k, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264Base_lo, Ctx);
+                 const MCExpr* m = processorNameValueMCExpr::create(l, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_ADDI_immS, Ctx);
+                 MCOperand n = MCOperand::createExpr(m);
+                 h.addOperand(n); // imm
+              }
            }
            result.push_back(h);
            callback(h);
@@ -799,36 +868,42 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            std::vector< MCInst > result;
            MCInst a = MCInst();
            a.setOpcode(processorNameValue::AUIPC);
-           a.addOperand(instruction.getOperand(0));
-           if(instruction.getOperand(1).isImm()) {
-              auto c = processorNameValueBaseInfo::RV3264Base_got_pcrel_hi(instruction.getOperand(1).getImm());
-              MCOperand b = MCOperand::createExpr(processorNameValueMCExpr::create(MCConstantExpr::create(c, Ctx), processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_AUIPC_immUp, Ctx));
-              a.addOperand(b);
-           }
-           else {
-              const MCExpr* d = MCOperandToMCExpr(instruction.getOperand(1));
-              const MCExpr* e = processorNameValueMCExpr::create(d, processorNameValueMCExpr::VariantKind::VK_GOT_RV3264Base_got_pcrel_hi, Ctx);
-              const MCExpr* f = processorNameValueMCExpr::create(e, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_AUIPC_immUp, Ctx);
-              MCOperand g = MCOperand::createExpr(f);
-              a.addOperand(g);
+           {
+           // AUIPC
+              a.addOperand(instruction.getOperand(0)); // rd
+              if(instruction.getOperand(1).isImm()) {
+                 auto c = processorNameValueBaseInfo::RV3264Base_got_pcrel_hi(instruction.getOperand(1).getImm());
+                 MCOperand b = MCOperand::createExpr(MCConstantExpr::create(RV3264Base_AUIPC_immUp_decode(c), Ctx));
+                 a.addOperand(b); // imm
+              }
+              else {
+                 const MCExpr* d = MCOperandToMCExpr(instruction.getOperand(1));
+                 const MCExpr* e = processorNameValueMCExpr::create(d, processorNameValueMCExpr::VariantKind::VK_GOT_RV3264Base_got_pcrel_hi, Ctx);
+                 const MCExpr* f = processorNameValueMCExpr::create(e, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_AUIPC_immUp, Ctx);
+                 MCOperand g = MCOperand::createExpr(f);
+                 a.addOperand(g); // imm
+              }
            }
            result.push_back(a);
            callback(a);
            MCInst h = MCInst();
            h.setOpcode(processorNameValue::LW);
-           h.addOperand(instruction.getOperand(0));
-           h.addOperand(instruction.getOperand(0));
-           if(instruction.getOperand(1).isImm()) {
-              auto j = processorNameValueBaseInfo::RV3264Base_pcrel_lo(instruction.getOperand(1).getImm());
-              MCOperand i = MCOperand::createExpr(processorNameValueMCExpr::create(MCConstantExpr::create(j, Ctx), processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_LW_immS, Ctx));
-              h.addOperand(i);
-           }
-           else {
-              const MCExpr* k = MCOperandToMCExpr(instruction.getOperand(1));
-              const MCExpr* l = processorNameValueMCExpr::create(k, processorNameValueMCExpr::VariantKind::VK_PCREL_RV3264Base_pcrel_lo, Ctx);
-              const MCExpr* m = processorNameValueMCExpr::create(l, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_LW_immS, Ctx);
-              MCOperand n = MCOperand::createExpr(m);
-              h.addOperand(n);
+           {
+           // LW
+              h.addOperand(instruction.getOperand(0)); // rd
+              h.addOperand(instruction.getOperand(0)); // rs1
+              if(instruction.getOperand(1).isImm()) {
+                 auto j = processorNameValueBaseInfo::RV3264Base_pcrel_lo(instruction.getOperand(1).getImm());
+                 MCOperand i = MCOperand::createExpr(MCConstantExpr::create(RV3264Base_LW_immS_decode(j), Ctx));
+                 h.addOperand(i); // imm
+              }
+              else {
+                 const MCExpr* k = MCOperandToMCExpr(instruction.getOperand(1));
+                 const MCExpr* l = processorNameValueMCExpr::create(k, processorNameValueMCExpr::VariantKind::VK_PCREL_RV3264Base_pcrel_lo, Ctx);
+                 const MCExpr* m = processorNameValueMCExpr::create(l, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_LW_immS, Ctx);
+                 MCOperand n = MCOperand::createExpr(m);
+                 h.addOperand(n); // imm
+              }
            }
            result.push_back(h);
            callback(h);
@@ -844,30 +919,36 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            callbackSymbol(a);
            MCInst b = MCInst();
            b.setOpcode(processorNameValue::AUIPC);
-           b.addOperand(instruction.getOperand(0));
-           if(instruction.getOperand(1).isImm()) {
-              auto d = processorNameValueBaseInfo::RV3264Base_pcrel_hi(instruction.getOperand(1).getImm());
-              MCOperand c = MCOperand::createExpr(processorNameValueMCExpr::create(MCConstantExpr::create(d, Ctx), processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_AUIPC_immUp, Ctx));
-              b.addOperand(c);
-           }
-           else {
-              const MCExpr* e = MCOperandToMCExpr(instruction.getOperand(1));
-              const MCExpr* f = processorNameValueMCExpr::create(e, processorNameValueMCExpr::VariantKind::VK_PCREL_RV3264Base_pcrel_hi, Ctx);
-              const MCExpr* g = processorNameValueMCExpr::create(f, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_AUIPC_immUp, Ctx);
-              MCOperand h = MCOperand::createExpr(g);
-              b.addOperand(h);
+           {
+           // AUIPC
+              b.addOperand(instruction.getOperand(0)); // rd
+              if(instruction.getOperand(1).isImm()) {
+                 auto d = processorNameValueBaseInfo::RV3264Base_pcrel_hi(instruction.getOperand(1).getImm());
+                 MCOperand c = MCOperand::createExpr(MCConstantExpr::create(RV3264Base_AUIPC_immUp_decode(d), Ctx));
+                 b.addOperand(c); // imm
+              }
+              else {
+                 const MCExpr* e = MCOperandToMCExpr(instruction.getOperand(1));
+                 const MCExpr* f = processorNameValueMCExpr::create(e, processorNameValueMCExpr::VariantKind::VK_PCREL_RV3264Base_pcrel_hi, Ctx);
+                 const MCExpr* g = processorNameValueMCExpr::create(f, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_AUIPC_immUp, Ctx);
+                 MCOperand h = MCOperand::createExpr(g);
+                 b.addOperand(h); // imm
+              }
            }
            result.push_back(b);
            callback(b);
            MCInst i = MCInst();
            i.setOpcode(processorNameValue::ADDI);
-           i.addOperand(instruction.getOperand(0));
-           i.addOperand(instruction.getOperand(0));
-           const MCExpr* j = MCOperandToMCExpr(MCOperand::createExpr(MCSymbolRefExpr::create(a, Ctx)));
-           const MCExpr* k = processorNameValueMCExpr::create(j, processorNameValueMCExpr::VariantKind::VK_PCREL_RV3264Base_pcrel_lo, Ctx);
-           const MCExpr* l = processorNameValueMCExpr::create(k, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_ADDI_immS, Ctx);
-           MCOperand m = MCOperand::createExpr(l);
-           i.addOperand(m);
+           {
+           // ADDI
+              i.addOperand(instruction.getOperand(0)); // rd
+              i.addOperand(instruction.getOperand(0)); // rs1
+              const MCExpr* j = MCOperandToMCExpr(MCOperand::createExpr(MCSymbolRefExpr::create(a, Ctx)));
+              const MCExpr* k = processorNameValueMCExpr::create(j, processorNameValueMCExpr::VariantKind::VK_PCREL_RV3264Base_pcrel_lo, Ctx);
+              const MCExpr* l = processorNameValueMCExpr::create(k, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_ADDI_immS, Ctx);
+              MCOperand m = MCOperand::createExpr(l);
+              i.addOperand(m); // imm
+           }
            result.push_back(i);
            callback(i);
            return result;
@@ -880,36 +961,42 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            std::vector< MCInst > result;
            MCInst a = MCInst();
            a.setOpcode(processorNameValue::LUI);
-           a.addOperand(instruction.getOperand(0));
-           if(instruction.getOperand(1).isImm()) {
-              auto c = processorNameValueBaseInfo::RV3264Base_hi(instruction.getOperand(1).getImm());
-              MCOperand b = MCOperand::createExpr(processorNameValueMCExpr::create(MCConstantExpr::create(c, Ctx), processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_LUI_immUp, Ctx));
-              a.addOperand(b);
-           }
-           else {
-              const MCExpr* d = MCOperandToMCExpr(instruction.getOperand(1));
-              const MCExpr* e = processorNameValueMCExpr::create(d, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264Base_hi, Ctx);
-              const MCExpr* f = processorNameValueMCExpr::create(e, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_LUI_immUp, Ctx);
-              MCOperand g = MCOperand::createExpr(f);
-              a.addOperand(g);
+           {
+           // LUI
+              a.addOperand(instruction.getOperand(0)); // rd
+              if(instruction.getOperand(1).isImm()) {
+                 auto c = processorNameValueBaseInfo::RV3264Base_hi(instruction.getOperand(1).getImm());
+                 MCOperand b = MCOperand::createExpr(MCConstantExpr::create(RV3264Base_LUI_immUp_decode(c), Ctx));
+                 a.addOperand(b); // imm
+              }
+              else {
+                 const MCExpr* d = MCOperandToMCExpr(instruction.getOperand(1));
+                 const MCExpr* e = processorNameValueMCExpr::create(d, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264Base_hi, Ctx);
+                 const MCExpr* f = processorNameValueMCExpr::create(e, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_LUI_immUp, Ctx);
+                 MCOperand g = MCOperand::createExpr(f);
+                 a.addOperand(g); // imm
+              }
            }
            result.push_back(a);
            callback(a);
            MCInst h = MCInst();
            h.setOpcode(processorNameValue::ADDI);
-           h.addOperand(instruction.getOperand(0));
-           h.addOperand(instruction.getOperand(0));
-           if(instruction.getOperand(1).isImm()) {
-              auto j = processorNameValueBaseInfo::RV3264Base_lo(instruction.getOperand(1).getImm());
-              MCOperand i = MCOperand::createExpr(processorNameValueMCExpr::create(MCConstantExpr::create(j, Ctx), processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_ADDI_immS, Ctx));
-              h.addOperand(i);
-           }
-           else {
-              const MCExpr* k = MCOperandToMCExpr(instruction.getOperand(1));
-              const MCExpr* l = processorNameValueMCExpr::create(k, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264Base_lo, Ctx);
-              const MCExpr* m = processorNameValueMCExpr::create(l, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_ADDI_immS, Ctx);
-              MCOperand n = MCOperand::createExpr(m);
-              h.addOperand(n);
+           {
+           // ADDI
+              h.addOperand(instruction.getOperand(0)); // rd
+              h.addOperand(instruction.getOperand(0)); // rs1
+              if(instruction.getOperand(1).isImm()) {
+                 auto j = processorNameValueBaseInfo::RV3264Base_lo(instruction.getOperand(1).getImm());
+                 MCOperand i = MCOperand::createExpr(MCConstantExpr::create(RV3264Base_ADDI_immS_decode(j), Ctx));
+                 h.addOperand(i); // imm
+              }
+              else {
+                 const MCExpr* k = MCOperandToMCExpr(instruction.getOperand(1));
+                 const MCExpr* l = processorNameValueMCExpr::create(k, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264Base_lo, Ctx);
+                 const MCExpr* m = processorNameValueMCExpr::create(l, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_ADDI_immS, Ctx);
+                 MCOperand n = MCOperand::createExpr(m);
+                 h.addOperand(n); // imm
+              }
            }
            result.push_back(h);
            callback(h);
@@ -923,36 +1010,42 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            std::vector< MCInst > result;
            MCInst a = MCInst();
            a.setOpcode(processorNameValue::LUI);
-           a.addOperand(instruction.getOperand(0));
-           if(instruction.getOperand(1).isImm()) {
-              auto c = processorNameValueBaseInfo::RV3264Base_hi(instruction.getOperand(1).getImm());
-              MCOperand b = MCOperand::createExpr(processorNameValueMCExpr::create(MCConstantExpr::create(c, Ctx), processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_LUI_immUp, Ctx));
-              a.addOperand(b);
-           }
-           else {
-              const MCExpr* d = MCOperandToMCExpr(instruction.getOperand(1));
-              const MCExpr* e = processorNameValueMCExpr::create(d, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264Base_hi, Ctx);
-              const MCExpr* f = processorNameValueMCExpr::create(e, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_LUI_immUp, Ctx);
-              MCOperand g = MCOperand::createExpr(f);
-              a.addOperand(g);
+           {
+           // LUI
+              a.addOperand(instruction.getOperand(0)); // rd
+              if(instruction.getOperand(1).isImm()) {
+                 auto c = processorNameValueBaseInfo::RV3264Base_hi(instruction.getOperand(1).getImm());
+                 MCOperand b = MCOperand::createExpr(MCConstantExpr::create(RV3264Base_LUI_immUp_decode(c), Ctx));
+                 a.addOperand(b); // imm
+              }
+              else {
+                 const MCExpr* d = MCOperandToMCExpr(instruction.getOperand(1));
+                 const MCExpr* e = processorNameValueMCExpr::create(d, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264Base_hi, Ctx);
+                 const MCExpr* f = processorNameValueMCExpr::create(e, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_LUI_immUp, Ctx);
+                 MCOperand g = MCOperand::createExpr(f);
+                 a.addOperand(g); // imm
+              }
            }
            result.push_back(a);
            callback(a);
            MCInst h = MCInst();
            h.setOpcode(processorNameValue::ADDI);
-           h.addOperand(instruction.getOperand(0));
-           h.addOperand(instruction.getOperand(0));
-           if(instruction.getOperand(1).isImm()) {
-              auto j = processorNameValueBaseInfo::RV3264Base_lo(instruction.getOperand(1).getImm());
-              MCOperand i = MCOperand::createExpr(processorNameValueMCExpr::create(MCConstantExpr::create(j, Ctx), processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_ADDI_immS, Ctx));
-              h.addOperand(i);
-           }
-           else {
-              const MCExpr* k = MCOperandToMCExpr(instruction.getOperand(1));
-              const MCExpr* l = processorNameValueMCExpr::create(k, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264Base_lo, Ctx);
-              const MCExpr* m = processorNameValueMCExpr::create(l, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_ADDI_immS, Ctx);
-              MCOperand n = MCOperand::createExpr(m);
-              h.addOperand(n);
+           {
+           // ADDI
+              h.addOperand(instruction.getOperand(0)); // rd
+              h.addOperand(instruction.getOperand(0)); // rs1
+              if(instruction.getOperand(1).isImm()) {
+                 auto j = processorNameValueBaseInfo::RV3264Base_lo(instruction.getOperand(1).getImm());
+                 MCOperand i = MCOperand::createExpr(MCConstantExpr::create(RV3264Base_ADDI_immS_decode(j), Ctx));
+                 h.addOperand(i); // imm
+              }
+              else {
+                 const MCExpr* k = MCOperandToMCExpr(instruction.getOperand(1));
+                 const MCExpr* l = processorNameValueMCExpr::create(k, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264Base_lo, Ctx);
+                 const MCExpr* m = processorNameValueMCExpr::create(l, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_ADDI_immS, Ctx);
+                 MCOperand n = MCOperand::createExpr(m);
+                 h.addOperand(n); // imm
+              }
            }
            result.push_back(h);
            callback(h);
@@ -966,36 +1059,42 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            std::vector< MCInst > result;
            MCInst a = MCInst();
            a.setOpcode(processorNameValue::LUI);
-           a.addOperand(instruction.getOperand(0));
-           if(instruction.getOperand(1).isImm()) {
-              auto c = processorNameValueBaseInfo::RV3264Base_hi(instruction.getOperand(1).getImm());
-              MCOperand b = MCOperand::createExpr(processorNameValueMCExpr::create(MCConstantExpr::create(c, Ctx), processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_LUI_immUp, Ctx));
-              a.addOperand(b);
-           }
-           else {
-              const MCExpr* d = MCOperandToMCExpr(instruction.getOperand(1));
-              const MCExpr* e = processorNameValueMCExpr::create(d, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264Base_hi, Ctx);
-              const MCExpr* f = processorNameValueMCExpr::create(e, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_LUI_immUp, Ctx);
-              MCOperand g = MCOperand::createExpr(f);
-              a.addOperand(g);
+           {
+           // LUI
+              a.addOperand(instruction.getOperand(0)); // rd
+              if(instruction.getOperand(1).isImm()) {
+                 auto c = processorNameValueBaseInfo::RV3264Base_hi(instruction.getOperand(1).getImm());
+                 MCOperand b = MCOperand::createExpr(MCConstantExpr::create(RV3264Base_LUI_immUp_decode(c), Ctx));
+                 a.addOperand(b); // imm
+              }
+              else {
+                 const MCExpr* d = MCOperandToMCExpr(instruction.getOperand(1));
+                 const MCExpr* e = processorNameValueMCExpr::create(d, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264Base_hi, Ctx);
+                 const MCExpr* f = processorNameValueMCExpr::create(e, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_LUI_immUp, Ctx);
+                 MCOperand g = MCOperand::createExpr(f);
+                 a.addOperand(g); // imm
+              }
            }
            result.push_back(a);
            callback(a);
            MCInst h = MCInst();
            h.setOpcode(processorNameValue::ADDI);
-           h.addOperand(instruction.getOperand(0));
-           h.addOperand(instruction.getOperand(0));
-           if(instruction.getOperand(1).isImm()) {
-              auto j = processorNameValueBaseInfo::RV3264Base_lo(instruction.getOperand(1).getImm());
-              MCOperand i = MCOperand::createExpr(processorNameValueMCExpr::create(MCConstantExpr::create(j, Ctx), processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_ADDI_immS, Ctx));
-              h.addOperand(i);
-           }
-           else {
-              const MCExpr* k = MCOperandToMCExpr(instruction.getOperand(1));
-              const MCExpr* l = processorNameValueMCExpr::create(k, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264Base_lo, Ctx);
-              const MCExpr* m = processorNameValueMCExpr::create(l, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_ADDI_immS, Ctx);
-              MCOperand n = MCOperand::createExpr(m);
-              h.addOperand(n);
+           {
+           // ADDI
+              h.addOperand(instruction.getOperand(0)); // rd
+              h.addOperand(instruction.getOperand(0)); // rs1
+              if(instruction.getOperand(1).isImm()) {
+                 auto j = processorNameValueBaseInfo::RV3264Base_lo(instruction.getOperand(1).getImm());
+                 MCOperand i = MCOperand::createExpr(MCConstantExpr::create(RV3264Base_ADDI_immS_decode(j), Ctx));
+                 h.addOperand(i); // imm
+              }
+              else {
+                 const MCExpr* k = MCOperandToMCExpr(instruction.getOperand(1));
+                 const MCExpr* l = processorNameValueMCExpr::create(k, processorNameValueMCExpr::VariantKind::VK_ABS_RV3264Base_lo, Ctx);
+                 const MCExpr* m = processorNameValueMCExpr::create(l, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_ADDI_immS, Ctx);
+                 MCOperand n = MCOperand::createExpr(m);
+                 h.addOperand(n); // imm
+              }
            }
            result.push_back(h);
            callback(h);
@@ -1009,15 +1108,18 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            std::vector< MCInst > result;
            MCInst a = MCInst();
            a.setOpcode(processorNameValue::ADDI);
-           a.addOperand(instruction.getOperand(0));
-           a.addOperand(MCOperand::createReg(processorNameValue::X0));
-           if(instruction.getOperand(1).isImm()) {
-              a.addOperand(MCOperand::createImm(instruction.getOperand(1).getImm()));
-           }
-           else {
-              const MCExpr* b = MCOperandToMCExpr(instruction.getOperand(1));
-              MCOperand c = MCOperand::createExpr(processorNameValueMCExpr::create(b, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_ADDI_immS, Ctx));
-              a.addOperand(c);
+           {
+           // ADDI
+              a.addOperand(instruction.getOperand(0)); // rd
+              a.addOperand(MCOperand::createReg(processorNameValue::X0)); // rs1
+              if(instruction.getOperand(1).isImm()) {
+                 a.addOperand(MCOperand::createImm(instruction.getOperand(1).getImm())); // imm
+              }
+              else {
+                 const MCExpr* b = MCOperandToMCExpr(instruction.getOperand(1));
+                 MCOperand c = MCOperand::createExpr(processorNameValueMCExpr::create(b, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_ADDI_immS, Ctx));
+                 a.addOperand(c); // imm
+              }
            }
            result.push_back(a);
            callback(a);
@@ -1031,15 +1133,18 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
            std::vector< MCInst > result;
            MCInst a = MCInst();
            a.setOpcode(processorNameValue::ADDI);
-           a.addOperand(instruction.getOperand(0));
-           a.addOperand(instruction.getOperand(1));
-           if(instruction.getOperand(2).isImm()) {
-              a.addOperand(MCOperand::createImm(instruction.getOperand(2).getImm()));
-           }
-           else {
-              const MCExpr* b = MCOperandToMCExpr(instruction.getOperand(2));
-              MCOperand c = MCOperand::createExpr(processorNameValueMCExpr::create(b, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_ADDI_immS, Ctx));
-              a.addOperand(c);
+           {
+           // ADDI
+              a.addOperand(instruction.getOperand(0)); // rd
+              a.addOperand(instruction.getOperand(1)); // rs1
+              if(instruction.getOperand(2).isImm()) {
+                 a.addOperand(MCOperand::createImm(instruction.getOperand(2).getImm())); // imm
+              }
+              else {
+                 const MCExpr* b = MCOperandToMCExpr(instruction.getOperand(2));
+                 MCOperand c = MCOperand::createExpr(processorNameValueMCExpr::create(b, processorNameValueMCExpr::VariantKind::VK_DECODE_RV3264Base_ADDI_immS, Ctx));
+                 a.addOperand(c); // imm
+              }
            }
            result.push_back(a);
            callback(a);

--- a/vadl/test/vadl/lcb/riscv/riscv64/template/MCTargetDesc/EmitMCInstExpanderCppFilePassTest.java
+++ b/vadl/test/vadl/lcb/riscv/riscv64/template/MCTargetDesc/EmitMCInstExpanderCppFilePassTest.java
@@ -567,7 +567,9 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
               auto imm = 0;
               // GenerateRawFieldsHandler
               rd = processorNameValue::X0;
-              auto immS = instruction.getOperand(0).getImm();
+              if(instruction.getOperand(0).isImm()) {
+                 auto immS = instruction.getOperand(0).getImm();
+              }
               // DecodeFieldAccessesHandler
               // AddingOperands
               a.addOperand(MCOperand::createReg(rd));
@@ -782,7 +784,9 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
               // GenerateRawFieldsHandler
               rs1 = instruction.getOperand(0).getReg();
               rs2 = processorNameValue::X0;
-              auto immS = instruction.getOperand(1).getImm();
+              if(instruction.getOperand(1).isImm()) {
+                 auto immS = instruction.getOperand(1).getImm();
+              }
               // DecodeFieldAccessesHandler
               // AddingOperands
               a.addOperand(instruction.getOperand(0)); // rs1
@@ -809,7 +813,9 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
               // GenerateRawFieldsHandler
               rs1 = instruction.getOperand(0).getReg();
               rs2 = processorNameValue::X0;
-              auto immS = instruction.getOperand(1).getImm();
+              if(instruction.getOperand(1).isImm()) {
+                 auto immS = instruction.getOperand(1).getImm();
+              }
               // DecodeFieldAccessesHandler
               // AddingOperands
               a.addOperand(instruction.getOperand(0)); // rs1
@@ -836,7 +842,9 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
               // GenerateRawFieldsHandler
               rs1 = processorNameValue::X0;
               rs2 = instruction.getOperand(0).getReg();
-              auto immS = instruction.getOperand(1).getImm();
+              if(instruction.getOperand(1).isImm()) {
+                 auto immS = instruction.getOperand(1).getImm();
+              }
               // DecodeFieldAccessesHandler
               // AddingOperands
               a.addOperand(MCOperand::createReg(rs1));
@@ -863,7 +871,9 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
               // GenerateRawFieldsHandler
               rs1 = instruction.getOperand(0).getReg();
               rs2 = processorNameValue::X0;
-              auto immS = instruction.getOperand(1).getImm();
+              if(instruction.getOperand(1).isImm()) {
+                 auto immS = instruction.getOperand(1).getImm();
+              }
               // DecodeFieldAccessesHandler
               // AddingOperands
               a.addOperand(instruction.getOperand(0)); // rs1
@@ -890,7 +900,9 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
               // GenerateRawFieldsHandler
               rs1 = instruction.getOperand(0).getReg();
               rs2 = processorNameValue::X0;
-              auto immS = instruction.getOperand(1).getImm();
+              if(instruction.getOperand(1).isImm()) {
+                 auto immS = instruction.getOperand(1).getImm();
+              }
               // DecodeFieldAccessesHandler
               // AddingOperands
               a.addOperand(instruction.getOperand(0)); // rs1
@@ -917,7 +929,9 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
               // GenerateRawFieldsHandler
               rs1 = processorNameValue::X0;
               rs2 = instruction.getOperand(0).getReg();
-              auto immS = instruction.getOperand(1).getImm();
+              if(instruction.getOperand(1).isImm()) {
+                 auto immS = instruction.getOperand(1).getImm();
+              }
               // DecodeFieldAccessesHandler
               // AddingOperands
               a.addOperand(MCOperand::createReg(rs1));


### PR DESCRIPTION
This PR extends the MCInstExpander to support multiple fields in the decoding function.