### PR TITLE
viam: Keep source code location when copy

### DIFF
--- a/vadl/main/vadl/viam/graph/Graph.java
+++ b/vadl/main/vadl/viam/graph/Graph.java
@@ -494,6 +494,10 @@ public class Graph {
     // make shallow copy of all nodes. we will replace the links in the next step
     this.getNodes().forEach(oldNode -> {
       var newNode = oldNode.shallowCopy();
+
+      // Keep the source code location
+      newNode.setSourceLocationIfNotSet(oldNode.location());
+
       cache.put(oldNode, newNode);
     });
 


### PR DESCRIPTION
We drop the source code location at the moment. This PR extends the copy method to set location based on the copied node.