### PR TITLE
lcb: Remove isReMaterializable and isAsCheapAsAMove for jump instrs

### DIFF
--- a/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/LlvmInstructionLoweringUnconditionalJumpsStrategyImpl.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/LlvmInstructionLoweringUnconditionalJumpsStrategyImpl.java
@@ -69,14 +69,6 @@ public class LlvmInstructionLoweringUnconditionalJumpsStrategyImpl
         createIntermediateResult(instruction, copy, registerDefsUses));
   }
 
-  @Override
-  protected LlvmLoweringPass.Flags getFlags(Graph graph) {
-    var flags = super.getFlags(graph);
-
-    return LlvmLoweringPass.Flags.withIsRematerialisable(
-        LlvmLoweringPass.Flags.withIsAsCheapAsMove(flags));
-  }
-
   private LlvmLoweringRecord.Machine createIntermediateResult(
       Instruction instruction,
       Graph uninlinedGraph,

--- a/vadl/test/resources/snapshots/rv64im/InstrInfoTableGen.td
+++ b/vadl/test/resources/snapshots/rv64im/InstrInfoTableGen.td
@@ -2216,8 +2216,8 @@ let isCodeGenOnly      = 0;
 let mayLoad            = 0;
 let mayStore           = 0;
 let isBarrier          = 0;
-let isReMaterializable = 1;
-let isAsCheapAsAMove   = 1;
+let isReMaterializable = 0;
+let isAsCheapAsAMove   = 0;
 
 let Constraints = "";
 let AddedComplexity = 0;
@@ -4722,8 +4722,8 @@ let isCodeGenOnly = 0;
 let mayLoad       = 0;
 let mayStore      = 0;
 let isBarrier     = 1;
-let isReMaterializable = 1;
-let isAsCheapAsAMove   = 1;
+let isReMaterializable = 0;
+let isAsCheapAsAMove   = 0;
 
 let Constraints = "";
 let AddedComplexity = 0;


### PR DESCRIPTION
Closes #194.