### PR TITLE
lcb: Removed warning

### DIFF
--- a/vadl/main/vadl/lcb/passes/llvmLowering/strategies/LlvmInstructionLoweringStrategy.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/strategies/LlvmInstructionLoweringStrategy.java
@@ -202,9 +202,6 @@ public abstract class LlvmInstructionLoweringStrategy {
     var copy = unmodifiedBehavior.copy();
 
     if (!checkIfNoControlFlow(copy) && !checkIfNotAllowedDataflowNodes(copy)) {
-      DeferredDiagnosticStore.add(
-          Diagnostic.warning("Instruction is not lowerable and will be skipped",
-              instruction.location()).build());
       return Optional.empty();
     }
 


### PR DESCRIPTION
Removed it because it fills the entire screen with warnings for AArch64.