### PR TITLE
asm: Fix immediate decoding in asm parser

### DIFF
--- a/vadl/main/resources/templates/lcb/llvm/lib/Target/AsmParser/AsmParser.cpp
+++ b/vadl/main/resources/templates/lcb/llvm/lib/Target/AsmParser/AsmParser.cpp
@@ -77,28 +77,22 @@ bool [(${namespace})]AsmParser::parse_[(${instruction.name})](MCInst &Inst, Oper
     std::vector<std::string> targets;
     targets =  { [(${instruction.targets})] };
     for(auto target : targets) {
+      bool found = false;
       for(auto index = 1; index < [(${instruction.numOperands})] + 1; index++) {
         [(${namespace})]ParsedOperand& Op = static_cast<[(${namespace})]ParsedOperand&>(*Operands[ index ]);
         StringRef operandName = Op.getTarget();
-        auto isFieldOfOperand = false;
 
         [# th:each="operand : ${instruction.operands}" ]
-        [# th:if="${operand.isImmediate}"]
-        isFieldOfOperand = operandName.equals_insensitive("[(${operand.formatField})]");
-        [/]
-        if(operandName == "[(${operand.name})]" || isFieldOfOperand) {
-          if(target != "[(${operand.name})]") {
-            continue;
-          }
+        if(operandName == "[(${operand.name})]" && target == "[(${operand.targetName})]") {
+          found = true;
+
           if(!Op.isImm() || Op.getImm()->getKind() != MCExpr::ExprKind::Constant) {
               Op.addOperand(Inst);
           } else {
             int64_t opImm64 = dyn_cast<MCConstantExpr>(Op.getImm())->getValue();
 
-            [# th:if="${operand.isImmediate}"]
-            if (isFieldOfOperand) {
-              opImm64 = [(${operand.decodeMethod})](opImm64);
-            }
+            [# th:if="${operand.isFieldOperand}"]
+            opImm64 = [(${operand.decodeMethod})](opImm64);
             [/]
 
             [# th:if="${operand.requiresPredicate}" ]
@@ -115,8 +109,10 @@ bool [(${namespace})]AsmParser::parse_[(${instruction.name})](MCInst &Inst, Oper
           }
           break;
         }
-        [/]
 
+        [/]
+      }
+      if (!found) {
         [(${namespace})]ParsedOperand& mnemonic = static_cast<[(${namespace})]ParsedOperand&>(*Operands[0]);
         Parser.Error(mnemonic.getStartLoc(), "Could not find index for operand '" + target + "'");
         return true;

--- a/vadl/main/resources/templates/lcb/llvm/lib/Target/AsmParser/AsmParser.cpp
+++ b/vadl/main/resources/templates/lcb/llvm/lib/Target/AsmParser/AsmParser.cpp
@@ -48,7 +48,7 @@ void convertToMapAndConstraints(unsigned Kind, const OperandVector &Operands) ov
 void reportError(OperandVector &Operands);
 
 [# th:each="instruction : ${instructions}" ]
-void parse_[(${instruction.name})](MCInst &Inst, OperandVector &Operands);
+bool parse_[(${instruction.name})](MCInst &Inst, OperandVector &Operands);
 [/]
 
 public:
@@ -68,7 +68,7 @@ void [(${namespace})]AsmParser::reportError(OperandVector &Operands) {
 }
 
 [# th:each="instruction : ${instructions}" ]
-void [(${namespace})]AsmParser::parse_[(${instruction.name})](MCInst &Inst, OperandVector &Operands) {
+bool [(${namespace})]AsmParser::parse_[(${instruction.name})](MCInst &Inst, OperandVector &Operands) {
     if(Operands.size() - 1 != [(${instruction.numOperands})]) {
       reportError(Operands);
     }
@@ -80,23 +80,32 @@ void [(${namespace})]AsmParser::parse_[(${instruction.name})](MCInst &Inst, Oper
       for(auto index = 1; index < [(${instruction.numOperands})] + 1; index++) {
         [(${namespace})]ParsedOperand& Op = static_cast<[(${namespace})]ParsedOperand&>(*Operands[ index ]);
         StringRef operandName = Op.getTarget();
-
-        if(target != operandName) {
-          continue;
-        }
+        auto isFieldOfOperand = false;
 
         [# th:each="operand : ${instruction.operands}" ]
-        if(operandName == "[(${operand.name})]") {
+        [# th:if="${operand.isImmediate}"]
+        isFieldOfOperand = operandName.equals_insensitive("[(${operand.formatField})]");
+        [/]
+        if(operandName == "[(${operand.name})]" || isFieldOfOperand) {
+          if(target != "[(${operand.name})]") {
+            continue;
+          }
           if(!Op.isImm() || Op.getImm()->getKind() != MCExpr::ExprKind::Constant) {
               Op.addOperand(Inst);
           } else {
             int64_t opImm64 = dyn_cast<MCConstantExpr>(Op.getImm())->getValue();
 
+            [# th:if="${operand.isImmediate}"]
+            if (isFieldOfOperand) {
+              opImm64 = [(${operand.decodeMethod})](opImm64);
+            }
+            [/]
+
             [# th:if="${operand.requiresPredicate}" ]
             if(![(${operand.predicateMethod})](opImm64)) {
               std::string error = "Invalid immediate operand for [(${operand.name})]. The predicate does not hold.";
               Parser.Error(Op.getStartLoc(), error);
-              return;
+              return true;
             }
             [/]
 
@@ -104,15 +113,16 @@ void [(${namespace})]AsmParser::parse_[(${instruction.name})](MCInst &Inst, Oper
             auto operand = [(${namespace})]ParsedOperand::CreateImm(constantExpr, Op.getStartLoc(), Op.getEndLoc());
             operand.addOperand(Inst);
           }
-          continue;
+          break;
         }
         [/]
 
         [(${namespace})]ParsedOperand& mnemonic = static_cast<[(${namespace})]ParsedOperand&>(*Operands[0]);
         Parser.Error(mnemonic.getStartLoc(), "Could not find index for operand '" + target + "'");
-        return;
+        return true;
       }
     }
+    return false;
 }
 [/]
 
@@ -138,7 +148,9 @@ bool [(${namespace})]AsmParser::MatchAndEmitInstruction(SMLoc IDLoc,
     switch(Opcode) {
         [# th:each="instruction : ${instructions}" ]
         case [(${namespace})]::[(${instruction.name})]:
-          parse_[(${instruction.name})](Inst, Operands);
+          if(parse_[(${instruction.name})](Inst, Operands)) {
+            return true; // returning true signals error occurred
+          }
          break;
         [/]
     }

--- a/vadl/main/vadl/lcb/template/lib/Target/AsmParser/EmitAsmParserCppFilePass.java
+++ b/vadl/main/vadl/lcb/template/lib/Target/AsmParser/EmitAsmParserCppFilePass.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import vadl.configuration.LcbConfiguration;
+import vadl.error.Diagnostic;
 import vadl.gcb.passes.operands.model.GcbDefaultInstructionOperand;
 import vadl.lcb.passes.llvmLowering.GenerateTableGenMachineInstructionRecordPass;
 import vadl.lcb.passes.llvmLowering.GenerateTableGenPseudoInstructionRecordPass;
@@ -72,21 +73,19 @@ public class EmitAsmParserCppFilePass extends LcbTemplateRenderingPass {
   }
 
   record TableGenOperand(String name,
-                         int index,
                          boolean requiresPredicate,
                          String predicateMethod,
-                         boolean isImmediate,
-                         String formatField,
+                         boolean isFieldOperand,
+                         String targetName,
                          String decodeMethod) implements Renderable {
 
     @Override
     public Map<String, Object> renderObj() {
       return Map.of("name", name,
-          "index", index,
           "requiresPredicate", requiresPredicate,
           "predicateMethod", predicateMethod,
-          "isImmediate", isImmediate,
-          "formatField", formatField,
+          "isFieldOperand", isFieldOperand,
+          "targetName", targetName,
           "decodeMethod", decodeMethod);
     }
   }
@@ -128,12 +127,13 @@ public class EmitAsmParserCppFilePass extends LcbTemplateRenderingPass {
         .map(instruction -> {
           var name = instruction.getName();
           var operands = createOperands(instruction);
-          int numOperands = operands.size();
+          var targets = targets(instruction);
+          int numOperands = targets.size();
           return new ParseInstruction(name,
               operands,
               numOperands,
-              operands.stream()
-                  .map(x -> "\"" + x.name + "\"")
+              targets.stream()
+                  .map(t -> "\"" + t + "\"")
                   .collect(Collectors.joining(", "))
           );
         })
@@ -143,18 +143,35 @@ public class EmitAsmParserCppFilePass extends LcbTemplateRenderingPass {
         .map(instruction -> {
           var name = instruction.getName();
           var operands = createOperands(instruction);
-          int numOperands = operands.size();
+          var targets = targets(instruction);
+          int numOperands = targets.size();
           return new ParseInstruction(name,
               operands,
               numOperands,
-              operands.stream()
-                  .map(x -> "\"" + x.name + "\"")
+              targets.stream()
+                  .map(t -> "\"" + t + "\"")
                   .collect(Collectors.joining(", "))
           );
         })
         .toList();
 
     return Stream.concat(machine.stream(), pseudo.stream()).toList();
+  }
+
+  private List<String> targets(TableGenInstruction instruction) {
+    var targets = new ArrayList<String>();
+
+    for (var output : instruction.getOutOperands()) {
+      var casted = (GcbDefaultInstructionOperand) output;
+      targets.add(casted.name());
+    }
+
+    for (var input : instruction.getInOperands()) {
+      var casted = (GcbDefaultInstructionOperand) input;
+      targets.add(casted.name());
+    }
+
+    return targets;
   }
 
   /**
@@ -181,13 +198,11 @@ public class EmitAsmParserCppFilePass extends LcbTemplateRenderingPass {
    */
   private List<TableGenOperand> createOperands(TableGenInstruction instruction) {
     var result = new ArrayList<TableGenOperand>();
-    int indexOffset = 1;
     // Output
     for (var output : instruction.getOutOperands()) {
       var casted = (GcbDefaultInstructionOperand) output;
-      var operand = new TableGenOperand(casted.name(), indexOffset, false, "", false, "", "");
+      var operand = new TableGenOperand(casted.name(), false, "", false, casted.name(), "");
       result.add(operand);
-      indexOffset++;
     }
 
     // Inputs
@@ -195,38 +210,63 @@ public class EmitAsmParserCppFilePass extends LcbTemplateRenderingPass {
       var casted = (GcbDefaultInstructionOperand) input;
       if (input instanceof TableGenInstructionImmediateOperand immediateOperand) {
 
-        var operand = new TableGenOperand(immediateOperand.name(),
-            indexOffset,
+        var formatFields = immediateOperand.formatFields();
+        if (formatFields.size() != 1) {
+          throw Diagnostic.error(
+              "The AsmParser cannot deal with access functions with multiple fields.",
+              input.origin().location()).build();
+        }
+
+        var fieldAccessOperand = new TableGenOperand(immediateOperand.name(),
+            true,
+            immediateOperand.immediateOperand().predicateMethod().lower(),
+            false,
+            immediateOperand.name(),
+            ""
+        );
+        result.add(fieldAccessOperand);
+
+        var fieldOperand = new TableGenOperand(
+            formatFields.get(0).simpleName(),
             true,
             immediateOperand.immediateOperand().predicateMethod().lower(),
             true,
-            immediateOperand.formatFields().get(0).simpleName(),
+            immediateOperand.name(),
             immediateOperand.immediateOperand().rawDecoderMethod().lower()
         );
-        result.add(operand);
+        result.add(fieldOperand);
       } else if (input instanceof TableGenInstructionLabelOperand immediateOperand) {
+
+        var formatFields = immediateOperand.formatFields();
+        if (formatFields.size() != 1) {
+          throw Diagnostic.error(
+              "The AsmParser cannot deal with access functions with multiple fields.",
+              input.origin().location()).build();
+        }
+
         var operand = new TableGenOperand(immediateOperand.name(),
-            indexOffset,
             true,
             immediateOperand.immediateOperand().predicateMethod().lower(),
-            true,
-            immediateOperand.formatFields().get(0).simpleName(),
-            immediateOperand.immediateOperand().rawDecoderMethod().lower()
-        );
-        result.add(operand);
-      } else {
-        var operand = new TableGenOperand(casted.name(),
-            indexOffset,
             false,
-            "",
-            false,
-            "",
+            immediateOperand.name(),
             ""
         );
         result.add(operand);
+
+        var fieldOperand = new TableGenOperand(
+            formatFields.get(0).simpleName(),
+            true,
+            immediateOperand.immediateOperand().predicateMethod().lower(),
+            true,
+            immediateOperand.name(),
+            immediateOperand.immediateOperand().rawDecoderMethod().lower()
+        );
+        result.add(fieldOperand);
+      } else {
+        var operand = new TableGenOperand(casted.name(), false, "", false, casted.name(), "");
+        result.add(operand);
       }
 
-      indexOffset++;
     }
 
     return result;
@@ -235,52 +275,31 @@ public class EmitAsmParserCppFilePass extends LcbTemplateRenderingPass {
 
   private List<TableGenOperand> createOperands(TableGenPseudoInstruction instruction) {
     var result = new ArrayList<TableGenOperand>();
-    int indexOffset = 1;
 
     // Output
     for (var output : instruction.getOutOperands()) {
       var casted = (GcbDefaultInstructionOperand) output;
-      var operand = new TableGenOperand(casted.name(), indexOffset, false, "", false, "", "");
+      var operand = new TableGenOperand(casted.name(), false, "", false, casted.name(), "");
       result.add(operand);
-      indexOffset++;
     }
 
     // Inputs
     for (var input : instruction.getInOperands()) {
       var casted = (GcbDefaultInstructionOperand) input;
       if (input instanceof TableGenInstructionImmediateOperand immediateOperand) {
-        var operand = new TableGenOperand(immediateOperand.name(),
-            indexOffset,
-            false,
-            "",
-            false,
-            "",
-            ""
-        );
+        var operand =
+            new TableGenOperand(immediateOperand.name(), false, "", false, immediateOperand.name(),
+                "");
         result.add(operand);
       } else if (input instanceof TableGenInstructionLabelOperand immediateOperand) {
-        var operand = new TableGenOperand(immediateOperand.name(),
-            indexOffset,
-            false,
-            "",
-            false,
-            "",
-            ""
-        );
+        var operand =
+            new TableGenOperand(immediateOperand.name(), false, "", false, immediateOperand.name(),
+                "");
         result.add(operand);
       } else {
-        var operand = new TableGenOperand(casted.name(),
-            indexOffset,
-            false,
-            "",
-            false,
-            "",
-            ""
-        );
+        var operand = new TableGenOperand(casted.name(), false, "", false, casted.name(), "");
         result.add(operand);
       }
-
-      indexOffset++;
     }
 
     return result;

--- a/vadl/main/vadl/lcb/template/lib/Target/AsmParser/EmitAsmParserCppFilePass.java
+++ b/vadl/main/vadl/lcb/template/lib/Target/AsmParser/EmitAsmParserCppFilePass.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import vadl.configuration.LcbConfiguration;
+import vadl.error.DeferredDiagnosticStore;
 import vadl.error.Diagnostic;
 import vadl.gcb.passes.operands.model.GcbDefaultInstructionOperand;
 import vadl.lcb.passes.llvmLowering.GenerateTableGenMachineInstructionRecordPass;
@@ -212,9 +213,9 @@ public class EmitAsmParserCppFilePass extends LcbTemplateRenderingPass {
 
         var formatFields = immediateOperand.formatFields();
         if (formatFields.size() != 1) {
-          throw Diagnostic.error(
+          DeferredDiagnosticStore.add(Diagnostic.warning(
               "The AsmParser cannot deal with access functions with multiple fields.",
-              input.origin().location()).build();
+              input.origin().location()).build());
         }
 
         var fieldAccessOperand = new TableGenOperand(immediateOperand.name(),
@@ -239,9 +240,9 @@ public class EmitAsmParserCppFilePass extends LcbTemplateRenderingPass {
 
         var formatFields = immediateOperand.formatFields();
         if (formatFields.size() != 1) {
-          throw Diagnostic.error(
+          DeferredDiagnosticStore.add(Diagnostic.warning(
               "The AsmParser cannot deal with access functions with multiple fields.",
-              input.origin().location()).build();
+              input.origin().location()).build());
         }
 
         var operand = new TableGenOperand(immediateOperand.name(),

--- a/vadl/main/vadl/lcb/template/lib/Target/AsmParser/EmitAsmParserCppFilePass.java
+++ b/vadl/main/vadl/lcb/template/lib/Target/AsmParser/EmitAsmParserCppFilePass.java
@@ -74,14 +74,20 @@ public class EmitAsmParserCppFilePass extends LcbTemplateRenderingPass {
   record TableGenOperand(String name,
                          int index,
                          boolean requiresPredicate,
-                         String predicateMethod) implements Renderable {
+                         String predicateMethod,
+                         boolean isImmediate,
+                         String formatField,
+                         String decodeMethod) implements Renderable {
 
     @Override
     public Map<String, Object> renderObj() {
       return Map.of("name", name,
           "index", index,
           "requiresPredicate", requiresPredicate,
-          "predicateMethod", predicateMethod);
+          "predicateMethod", predicateMethod,
+          "isImmediate", isImmediate,
+          "formatField", formatField,
+          "decodeMethod", decodeMethod);
     }
   }
 
@@ -151,13 +157,35 @@ public class EmitAsmParserCppFilePass extends LcbTemplateRenderingPass {
     return Stream.concat(machine.stream(), pseudo.stream()).toList();
   }
 
+  /**
+   * In the AsmParser we need to deal with cases where an operand in the assembly
+   * language represents the encoded value of the operand.
+   * An example is AUIPC of Risc-V:
+   * <pre>
+   *   AuipcInstruction @instruction:
+   *     mnemonic = "AUIPC" @operand
+   *     rd = Register@operand ","
+   *     imm = ImmediateOperand
+   *   ;
+   * </pre>
+   * Here the immediate operand is assigned to the field <code>imm</code>
+   * as opposed to field access <code>immS</code>, which LLVM actually expects.
+   * To meet the expectation we need to call the field access function to transform
+   * <code>imm</code> to <code>immS</code>.
+   *
+   * <p>In the current implementation this method assumes that an immediate operands access function
+   * only ever takes one format field as input.
+   * Because of this the AsmParser WILL NOT work for architectures where a field access
+   * takes multiple fields as input.
+   * </p>
+   */
   private List<TableGenOperand> createOperands(TableGenInstruction instruction) {
     var result = new ArrayList<TableGenOperand>();
     int indexOffset = 1;
     // Output
     for (var output : instruction.getOutOperands()) {
       var casted = (GcbDefaultInstructionOperand) output;
-      var operand = new TableGenOperand(casted.name(), indexOffset, false, "");
+      var operand = new TableGenOperand(casted.name(), indexOffset, false, "", false, "", "");
       result.add(operand);
       indexOffset++;
     }
@@ -166,23 +194,33 @@ public class EmitAsmParserCppFilePass extends LcbTemplateRenderingPass {
     for (var input : instruction.getInOperands()) {
       var casted = (GcbDefaultInstructionOperand) input;
       if (input instanceof TableGenInstructionImmediateOperand immediateOperand) {
+
         var operand = new TableGenOperand(immediateOperand.name(),
             indexOffset,
             true,
-            immediateOperand.immediateOperand().predicateMethod().lower()
+            immediateOperand.immediateOperand().predicateMethod().lower(),
+            true,
+            immediateOperand.formatFields().get(0).simpleName(),
+            immediateOperand.immediateOperand().rawDecoderMethod().lower()
         );
         result.add(operand);
       } else if (input instanceof TableGenInstructionLabelOperand immediateOperand) {
         var operand = new TableGenOperand(immediateOperand.name(),
             indexOffset,
             true,
-            immediateOperand.immediateOperand().predicateMethod().lower()
+            immediateOperand.immediateOperand().predicateMethod().lower(),
+            true,
+            immediateOperand.formatFields().get(0).simpleName(),
+            immediateOperand.immediateOperand().rawDecoderMethod().lower()
         );
         result.add(operand);
       } else {
         var operand = new TableGenOperand(casted.name(),
             indexOffset,
             false,
+            "",
+            false,
+            "",
             ""
         );
         result.add(operand);
@@ -202,7 +240,7 @@ public class EmitAsmParserCppFilePass extends LcbTemplateRenderingPass {
     // Output
     for (var output : instruction.getOutOperands()) {
       var casted = (GcbDefaultInstructionOperand) output;
-      var operand = new TableGenOperand(casted.name(), indexOffset, false, "");
+      var operand = new TableGenOperand(casted.name(), indexOffset, false, "", false, "", "");
       result.add(operand);
       indexOffset++;
     }
@@ -214,20 +252,29 @@ public class EmitAsmParserCppFilePass extends LcbTemplateRenderingPass {
         var operand = new TableGenOperand(immediateOperand.name(),
             indexOffset,
             false,
-            immediateOperand.immediateOperand().predicateMethod().lower()
+            "",
+            false,
+            "",
+            ""
         );
         result.add(operand);
       } else if (input instanceof TableGenInstructionLabelOperand immediateOperand) {
         var operand = new TableGenOperand(immediateOperand.name(),
             indexOffset,
             false,
-            immediateOperand.immediateOperand().predicateMethod().lower()
+            "",
+            false,
+            "",
+            ""
         );
         result.add(operand);
       } else {
         var operand = new TableGenOperand(casted.name(),
             indexOffset,
             false,
+            "",
+            false,
+            "",
             ""
         );
         result.add(operand);

--- a/vadl/test/resources/llvm/riscv/asm/rv32im/codeemitter/UType.s
+++ b/vadl/test/resources/llvm/riscv/asm/rv32im/codeemitter/UType.s
@@ -1,0 +1,10 @@
+# RUN: /src/llvm-final/build/bin/llvm-mc -arch=rv32im -show-encoding < $INPUT | /src/llvm-final/build/bin/FileCheck $INPUT
+
+LUI x1, 0x10
+# CHECK: # encoding: [0xb7,0x00,0x01,0x00]
+
+LUI x1, 0xF
+# CHECK: # encoding: [0xb7,0xf0,0x00,0x00]
+
+AUIPC x2, 10
+# CHECK: # encoding: [0x17,0xa1,0x00,0x00]

--- a/vadl/test/resources/llvm/riscv/asm/rv32im/parser/BType.s
+++ b/vadl/test/resources/llvm/riscv/asm/rv32im/parser/BType.s
@@ -1,19 +1,37 @@
 # RUN: /src/llvm-final/build/bin/llvm-mc -arch=rv32im -show-inst < $INPUT | /src/llvm-final/build/bin/FileCheck $INPUT
 
+BEQ x1, x2, 0
+# CHECK: <MCInst #{{[0-9]+}} BEQ
+# CHECK-NEXT: <MCOperand Reg:3>
+# CHECK-NEXT: <MCOperand Reg:4>
+# CHECK-NEXT: <MCOperand Imm:0>>
+
 BNE x3, x4, 2
 # CHECK: <MCInst #{{[0-9]+}} BNE
 # CHECK-NEXT: <MCOperand Reg:5>
 # CHECK-NEXT: <MCOperand Reg:6>
 # CHECK-NEXT: <MCOperand Imm:2>>
 
-BGEU x7, x8, 4
+BGE x5, x6, 4
+# CHECK: <MCInst #{{[0-9]+}} BGE
+# CHECK-NEXT: <MCOperand Reg:7>
+# CHECK-NEXT: <MCOperand Reg:8>
+# CHECK-NEXT: <MCOperand Imm:4>>
+
+BGEU x7, x8, 6
 # CHECK: <MCInst #{{[0-9]+}} BGEU
 # CHECK-NEXT: <MCOperand Reg:9>
 # CHECK-NEXT: <MCOperand Reg:10>
-# CHECK-NEXT: <MCOperand Imm:4>>
+# CHECK-NEXT: <MCOperand Imm:6>>
 
-BLTU x11, x12, 6
+BLT x9, x10, 8
+# CHECK: <MCInst #{{[0-9]+}} BLT
+# CHECK-NEXT: <MCOperand Reg:11>
+# CHECK-NEXT: <MCOperand Reg:12>
+# CHECK-NEXT: <MCOperand Imm:8>>
+
+BLTU x11, x12, 10
 # CHECK: <MCInst #{{[0-9]+}} BLTU
 # CHECK-NEXT: <MCOperand Reg:13>
 # CHECK-NEXT: <MCOperand Reg:14>
-# CHECK-NEXT: <MCOperand Imm:6>>
+# CHECK-NEXT: <MCOperand Imm:10>>

--- a/vadl/test/resources/llvm/riscv/asm/rv32im/parser/JType.s
+++ b/vadl/test/resources/llvm/riscv/asm/rv32im/parser/JType.s
@@ -2,6 +2,14 @@
 
 # RUN: /src/llvm-final/build/bin/llvm-mc -arch=rv32im -show-inst < $INPUT 2>&1 | /src/llvm-final/build/bin/FileCheck $INPUT
 
+# immediate value overflow
+JAL x16, 1048576
+# CHECK: error: Invalid immediate operand for immS. The predicate does not hold.
+
+# immediate value underflow
+JAL x16, -1048578
+# CHECK: error: Invalid immediate operand for immS. The predicate does not hold.
+
 JAL x16, 10
 # CHECK: <MCInst #{{[0-9]+}} JAL
 # CHECK-NEXT: <MCOperand Reg:18>

--- a/vadl/test/resources/llvm/riscv/asm/rv32im/parser/UType.s
+++ b/vadl/test/resources/llvm/riscv/asm/rv32im/parser/UType.s
@@ -4,3 +4,13 @@ LUI x1, %hi(0xFFFF)
 # CHECK: <MCInst #{{[0-9]+}} LUI
 # CHECK-NEXT: <MCOperand Reg:3>
 # CHECK-NEXT: <MCOperand Expr:(16)>>
+
+LUI x1, 0xF
+# CHECK: <MCInst #{{[0-9]+}} LUI
+# CHECK-NEXT: <MCOperand Reg:3>
+# CHECK-NEXT: <MCOperand Imm:61440>>
+
+AUIPC x2, 10
+# CHECK: <MCInst #{{[0-9]+}} AUIPC
+# CHECK-NEXT: <MCOperand Reg:4>
+# CHECK-NEXT: <MCOperand Imm:40960>>

--- a/vadl/test/resources/testSource/sys/risc-v/rv32im.vadl
+++ b/vadl/test/resources/testSource/sys/risc-v/rv32im.vadl
@@ -150,7 +150,7 @@ assembly description ASM for ABI = {
     LuiInstruction @instruction:
       mnemonic = "LUI" @operand
       rd = Register@operand ","
-      immUp = LuiImmediateOperand
+      imm = LuiImmediateOperand
     ;
 
     LuiImmediateOperand :
@@ -164,7 +164,7 @@ assembly description ASM for ABI = {
     AuipcInstruction @instruction:
       mnemonic = "AUIPC" @operand
       rd = Register@operand ","
-      immUp = ImmediateOperand
+      imm = ImmediateOperand
     ;
 
     LTypeIds : "LB" | "LBU" | "LH" | "LHU" | "LW" ;


### PR DESCRIPTION
This PR re-implements the immediate decoding in the assembly parser, which was missing after the refactorings of #361.

Note: This implementation only works for architectures where the decoding (= field access) functions only take a single field as input.