### PR TITLE
lcb: Bugfixes for aarch64

### DIFF
--- a/vadl/main/vadl/gcb/passes/IdentifyFieldUsagePass.java
+++ b/vadl/main/vadl/gcb/passes/IdentifyFieldUsagePass.java
@@ -18,9 +18,11 @@ package vadl.gcb.passes;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import vadl.configuration.GcbConfiguration;
@@ -197,6 +199,17 @@ public class IdentifyFieldUsagePass extends Pass {
         throw new ViamError("Hashmap must not be null");
       }
       return obj;
+    }
+
+    /**
+     * Get the usages of fields by instruction.
+     */
+    public List<FieldUsage> getFieldUsages(Instruction instruction, Field field) {
+      var obj = fieldUsage.get(instruction);
+      if (obj == null) {
+        throw new ViamError("Hashmap must not be null");
+      }
+      return Optional.ofNullable(obj.get(field)).orElse(Collections.emptyList());
     }
 
     /**

--- a/vadl/main/vadl/gcb/passes/operands/model/GcbInstructionImmediateOperand.java
+++ b/vadl/main/vadl/gcb/passes/operands/model/GcbInstructionImmediateOperand.java
@@ -33,6 +33,14 @@ public class GcbInstructionImmediateOperand extends GcbDefaultInstructionOperand
     this.fieldAccess = node.fieldAccess();
   }
 
+  /**
+   * Constructor.
+   */
+  public GcbInstructionImmediateOperand(FieldAccessRefNode origin, String type, String name) {
+    super(origin, type, name);
+    this.fieldAccess = origin.fieldAccess();
+  }
+
   public Format.FieldAccess fieldAccess() {
     return fieldAccess;
   }

--- a/vadl/main/vadl/lcb/codegen/assembly/AssemblyInstructionPrinterImmediateHandler.java
+++ b/vadl/main/vadl/lcb/codegen/assembly/AssemblyInstructionPrinterImmediateHandler.java
@@ -27,6 +27,7 @@ import java.util.stream.Stream;
 import vadl.cppCodeGen.context.CGenContext;
 import vadl.cppCodeGen.context.CNodeContext;
 import vadl.error.Diagnostic;
+import vadl.gcb.passes.IdentifyFieldUsagePass;
 import vadl.gcb.passes.operands.ReferencesFormatField;
 import vadl.gcb.passes.operands.model.GcbDefaultInstructionOperand;
 import vadl.gcb.passes.operands.model.GcbInstructionBareSymbolOperand;
@@ -95,6 +96,7 @@ public class AssemblyInstructionPrinterImmediateHandler
     extends AbstractAssemblyInstructionPrinterHandler {
 
   private final PassResults passResults;
+  private final IdentifyFieldUsagePass.ImmediateDetectionContainer fieldUsages;
 
   /**
    * Constructor.
@@ -104,6 +106,9 @@ public class AssemblyInstructionPrinterImmediateHandler
                                                     TableGenInstruction tableGenInstruction) {
     super(instruction, tableGenInstruction);
     this.passResults = passResults;
+    this.fieldUsages =
+        (IdentifyFieldUsagePass.ImmediateDetectionContainer) passResults.lastResultOf(
+            IdentifyFieldUsagePass.class);
     this.ctx = new CNodeContext(
         builder::append,
         (ctx, node)
@@ -189,7 +194,30 @@ public class AssemblyInstructionPrinterImmediateHandler
   @Handler
   @SuppressWarnings("MissingJavadocMethod")
   public void handle(CGenContext<Node> ctx, FieldRefNode node) {
-    throw Diagnostic.error("not supported", node.location()).build();
+    if (instruction instanceof Instruction machineInstruction) {
+      var usages = fieldUsages.getFieldUsages(machineInstruction, node.formatField());
+
+      if (usages.isEmpty()) {
+        throw Diagnostic.error(
+            "The generator does not know whether this is an immediate or register access.",
+            node.location()).build();
+      } else if (usages.size() > 1) {
+        throw Diagnostic.error(
+            "The generator registered multiple register usages for this field.",
+            node.location()).build();
+      }
+
+      var usage = usages.getFirst();
+      var indexInOperands = ensurePresent(indexInInputsOrOutputs(node.formatField()),
+          () -> Diagnostic.error("Cannot find operand.", node.location()));
+      if (usage == IdentifyFieldUsagePass.FieldUsage.IMMEDIATE) {
+        ctx.wr("MI->getOperand(%s).getImm()", indexInOperands);
+      } else if (usage == IdentifyFieldUsagePass.FieldUsage.REGISTER) {
+        ctx.wr("MI->getOperand(%s).getReg()", indexInOperands);
+      }
+    } else {
+      throw Diagnostic.error("not supported", node.location()).build();
+    }
   }
 
   @Handler

--- a/vadl/main/vadl/lcb/codegen/assembly/AssemblyInstructionPrinterImmediateHandler.java
+++ b/vadl/main/vadl/lcb/codegen/assembly/AssemblyInstructionPrinterImmediateHandler.java
@@ -21,6 +21,7 @@ import static vadl.viam.ViamError.ensureNonNull;
 import static vadl.viam.ViamError.ensurePresent;
 
 import java.util.ArrayList;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -82,6 +83,7 @@ import vadl.viam.graph.dependency.WriteArtificialResNode;
 import vadl.viam.graph.dependency.WriteMemNode;
 import vadl.viam.graph.dependency.WriteRegTensorNode;
 import vadl.viam.graph.dependency.WriteStageOutputNode;
+import vadl.viam.passes.SnapshotInstructionBehaviorPass;
 
 /**
  * Generates the code blocks to construct an assembly string. This handler creates the code path
@@ -436,25 +438,21 @@ public class AssemblyInstructionPrinterImmediateHandler
                                          CGenContext<Node> ctx,
                                          int radix,
                                          SourceLocation sourceLocation) {
-    var indexInOperands = ensurePresent(indexInInputsOrOutputs(field), () ->
-        Diagnostic.error("Immediate must be part of an tablegen input or output.",
-            sourceLocation)
-    );
-
     // If this instruction is a machine instruction then ...
     if (instruction instanceof Instruction machineInstruction) {
-      var fieldEncodings = machineInstruction.fieldEncodingsByUsedFieldAccesses();
+      var originalGraph = getUnmodifiedOriginalGraph(machineInstruction);
+      var fieldEncodings = machineInstruction.fieldEncodingsByUsedFieldAccesses(originalGraph);
       var fieldEncoding =
           fieldEncodings.stream().filter(x -> x.targetField().equals(field)).findFirst();
 
       // If this field has an encoding, we are applying it.
       if (fieldEncoding.isPresent()) {
-        var encodingFunctions =
-            ensureNonNull(
-                ImmediateEncodingFunctionProvider.generateEncodeFunctions(passResults)
-                    .get(instruction),
-                () -> Diagnostic.error("Cannot find encoding functions for the instruction.",
-                    machineInstruction.location()));
+        var uncheckedEncodingFunctions =
+            ImmediateEncodingFunctionProvider.generateEncodeFunctions(passResults)
+                .get(instruction);
+        var encodingFunctions = ensureNonNull(uncheckedEncodingFunctions,
+            () -> Diagnostic.error("Cannot find encoding functions for the instruction.",
+                machineInstruction.location()));
 
         var encodingFunction = ensurePresent(
             encodingFunctions.stream().filter(x -> x.field().equals(field)).findFirst(),
@@ -488,10 +486,20 @@ public class AssemblyInstructionPrinterImmediateHandler
               + "See issue #382", field.location()).build();
         }
       } else {
+        var indexInOperands = ensurePresent(indexInInputsOrOutputs(field), () ->
+            Diagnostic.error("Immediate must be part of an tablegen input or output.",
+                sourceLocation)
+        );
+
         // Otherwise print raw field value.
         writeFieldWithRawImmediateWithRadix(indexInOperands, radix);
       }
     } else {
+      var indexInOperands = ensurePresent(indexInInputsOrOutputs(field), () ->
+          Diagnostic.error("Immediate must be part of an tablegen input or output.",
+              sourceLocation)
+      );
+
       // Otherwise print raw field value.
       writeFieldWithRawImmediateWithRadix(indexInOperands, radix);
     }
@@ -542,6 +550,19 @@ public class AssemblyInstructionPrinterImmediateHandler
       throw Diagnostic.error("There are no casting semantics defined for this builtin. "
           + "See issue #382", sourceLocation).build();
     }
+  }
+
+  /**
+   * Return the unmodified version of the instruction's behavior from the
+   * {@link SnapshotInstructionBehaviorPass}.
+   */
+  private Graph getUnmodifiedOriginalGraph(Instruction machineInstruction) {
+    var graphs =
+        (Map<Instruction, Graph>) passResults.lastResultOf(SnapshotInstructionBehaviorPass.class);
+
+    return ensureNonNull(graphs.get(machineInstruction),
+        () -> Diagnostic.error("Cannot find unmodified instruction's behavior.",
+            machineInstruction.location()));
   }
 
   /**

--- a/vadl/main/vadl/lcb/passes/llvmLowering/CreateFunctionsFromImmediatesPass.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/CreateFunctionsFromImmediatesPass.java
@@ -36,6 +36,7 @@ import vadl.cppCodeGen.model.GcbCppEncodingWrapperFunction;
 import vadl.cppCodeGen.model.GcbCppFunctionBodyLess;
 import vadl.cppCodeGen.model.GcbCppFunctionWithBody;
 import vadl.error.Diagnostic;
+import vadl.gcb.passes.operands.model.GcbInstructionImmediateOperand;
 import vadl.lcb.passes.llvmLowering.immediates.GenerateTableGenImmediateRecordPass;
 import vadl.lcb.passes.llvmLowering.tablegen.model.TableGenImmediateRecord;
 import vadl.lcb.passes.llvmLowering.tablegen.model.TableGenInstruction;
@@ -159,9 +160,9 @@ public class CreateFunctionsFromImmediatesPass extends Pass {
       var instruction = (Instruction) pair.getKey();
       var tableGenInstruction = pair.getValue();
 
-      var fieldAccesses = tableGenInstruction.immediateInputOperands().stream()
-          .map(x -> x.immediateOperand().fieldAccessRef()).collect(
-              Collectors.toSet());
+      var fieldAccesses = tableGenInstruction.gcbImmediateInputOperands().stream()
+          .map(GcbInstructionImmediateOperand::fieldAccess)
+          .collect(Collectors.toSet());
       var fieldEncodings = instruction.format().fieldEncodingsOf(fieldAccesses);
       var encodingsFunctions = encoding(instruction, tableGenInstruction, fieldEncodings);
       encodings.put(instruction, encodingsFunctions);

--- a/vadl/main/vadl/lcb/passes/llvmLowering/tablegen/model/TableGenInstruction.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/tablegen/model/TableGenInstruction.java
@@ -19,6 +19,7 @@ package vadl.lcb.passes.llvmLowering.tablegen.model;
 import java.util.List;
 import vadl.error.Diagnostic;
 import vadl.gcb.passes.RegisterRef;
+import vadl.gcb.passes.operands.model.GcbInstructionImmediateOperand;
 import vadl.gcb.passes.operands.model.GcbInstructionOperand;
 import vadl.lcb.passes.llvmLowering.LlvmLoweringPass;
 import vadl.lcb.passes.llvmLowering.tablegen.model.tableGenOperand.ReferencesImmediateOperand;
@@ -126,7 +127,8 @@ public abstract class TableGenInstruction {
   }
 
   /**
-   * Get the operands which are immediates from the input operand list.
+   * Get the operands which are immediates from the input operand list but only if the
+   * operands have been already lowered.
    *
    * @return a list of {@link ReferencesImmediateOperand}.
    */
@@ -134,6 +136,17 @@ public abstract class TableGenInstruction {
     return inOperands.stream()
         .filter(x -> x instanceof ReferencesImmediateOperand)
         .map(x -> (ReferencesImmediateOperand) x)
+        .toList();
+  }
+
+  /**
+   * Get the operands which are immediates from the input operand list. This will also work if the
+   * immediate was not lowered.
+   */
+  public List<GcbInstructionImmediateOperand> gcbImmediateInputOperands() {
+    return inOperands.stream()
+        .filter(x -> x instanceof GcbInstructionImmediateOperand)
+        .map(x -> (GcbInstructionImmediateOperand) x)
         .toList();
   }
 }

--- a/vadl/main/vadl/lcb/passes/llvmLowering/tablegen/model/tableGenOperand/TableGenInstructionLabelOperand.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/tablegen/model/tableGenOperand/TableGenInstructionLabelOperand.java
@@ -21,17 +21,18 @@ import static vadl.viam.ViamError.ensure;
 import java.util.List;
 import vadl.error.Diagnostic;
 import vadl.gcb.passes.operands.ReferencesFormatField;
-import vadl.gcb.passes.operands.model.GcbDefaultInstructionOperand;
+import vadl.gcb.passes.operands.model.GcbInstructionImmediateOperand;
 import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmBasicBlockSD;
 import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmFieldAccessRefNode;
 import vadl.lcb.passes.llvmLowering.tablegen.model.TableGenImmediateRecord;
 import vadl.viam.Format;
 import vadl.viam.graph.Node;
+import vadl.viam.graph.dependency.FieldAccessRefNode;
 
 /**
  * TableGen operand which references a label.
  */
-public class TableGenInstructionLabelOperand extends GcbDefaultInstructionOperand
+public class TableGenInstructionLabelOperand extends GcbInstructionImmediateOperand
     implements ReferencesFormatField, ReferencesImmediateOperand {
   private static final String AS_LABEL = "AsLabel";
 
@@ -46,7 +47,7 @@ public class TableGenInstructionLabelOperand extends GcbDefaultInstructionOperan
   public TableGenInstructionLabelOperand(Node origin,
                                          TableGenImmediateRecord immediateRecord,
                                          String variableName) {
-    super(origin, immediateRecord.rawName() + AS_LABEL, variableName);
+    super((FieldAccessRefNode) origin, immediateRecord.rawName() + AS_LABEL, variableName);
     this.immediate = immediateRecord;
   }
 

--- a/vadl/main/vadl/lcb/passes/operands/TableGenInstructionImmediateOperand.java
+++ b/vadl/main/vadl/lcb/passes/operands/TableGenInstructionImmediateOperand.java
@@ -31,7 +31,7 @@ import vadl.viam.Format;
  * of {@link GcbInstructionImmediateOperand} because we need to reference
  * {@link TableGenImmediateRecord}. However, we can only do that after the LLVM lowering.
  */
-public class TableGenInstructionImmediateOperand extends GcbDefaultInstructionOperand
+public class TableGenInstructionImmediateOperand extends GcbInstructionImmediateOperand
     implements ReferencesFormatField, ReferencesImmediateOperand {
   private final TableGenImmediateRecord immediateOperand;
 

--- a/vadl/main/vadl/pass/PassOrders.java
+++ b/vadl/main/vadl/pass/PassOrders.java
@@ -118,6 +118,7 @@ import vadl.viam.passes.ControlFlowOptimizationPass;
 import vadl.viam.passes.DuplicateWriteDetectionPass;
 import vadl.viam.passes.HardcodeLGALabelPass;
 import vadl.viam.passes.InstructionResourceAccessAnalysisPass;
+import vadl.viam.passes.SnapshotInstructionBehaviorPass;
 import vadl.viam.passes.algebraic_simplication.AlgebraicSimplificationPass;
 import vadl.viam.passes.behaviorRewrite.BehaviorRewritePass;
 import vadl.viam.passes.canonicalization.CanonicalizationPass;
@@ -168,6 +169,7 @@ public class PassOrders {
     order.add(new ViamCreationPass(configuration));
     order.add(new ViamVerificationPass(configuration));
 
+    order.add(new SnapshotInstructionBehaviorPass(configuration));
     order.add(new RemoveUnusedStatusFlagsFromBuiltinsPass(configuration));
     order.add(new StatusBuiltInInlinePass(configuration));
 

--- a/vadl/main/vadl/viam/Instruction.java
+++ b/vadl/main/vadl/viam/Instruction.java
@@ -176,12 +176,20 @@ public class Instruction extends Definition implements DefProp.WithBehavior, Pri
   /**
    * A {@link Format} has a list of all defined {@link FieldAccess}. However, an instruction has
    * not to use all of them. This functions returns a list of {@link Format.FieldEncoding} for only
-   * the {@link FieldAccess} which are used in the behavior.
+   * the {@link FieldAccess} which are used in the instruction's behavior.
    */
   public List<Format.FieldEncoding> fieldEncodingsByUsedFieldAccesses() {
-    var fieldAccesses = behaviors()
-        .stream()
-        .flatMap(x -> x.getNodes(FieldAccessRefNode.class))
+    return fieldEncodingsByUsedFieldAccesses(behavior);
+  }
+
+  /**
+   * A {@link Format} has a list of all defined {@link FieldAccess}. However, an instruction has
+   * not to use all of them. This functions returns a list of {@link Format.FieldEncoding} for only
+   * the {@link FieldAccess} which are used in the given behavior.
+   */
+  public List<Format.FieldEncoding> fieldEncodingsByUsedFieldAccesses(Graph graph) {
+    var fieldAccesses = graph
+        .getNodes(FieldAccessRefNode.class)
         .map(FieldAccessRefNode::fieldAccess)
         .collect(Collectors.toSet());
 

--- a/vadl/main/vadl/viam/passes/SnapshotInstructionBehaviorPass.java
+++ b/vadl/main/vadl/viam/passes/SnapshotInstructionBehaviorPass.java
@@ -17,6 +17,7 @@
 package vadl.viam.passes;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.IdentityHashMap;
 import javax.annotation.Nullable;
 import vadl.configuration.GeneralConfiguration;
@@ -24,6 +25,7 @@ import vadl.pass.Pass;
 import vadl.pass.PassName;
 import vadl.pass.PassResults;
 import vadl.viam.Instruction;
+import vadl.viam.InstructionSetArchitecture;
 import vadl.viam.Specification;
 import vadl.viam.graph.Graph;
 
@@ -46,7 +48,8 @@ public class SnapshotInstructionBehaviorPass extends Pass {
   public Object execute(PassResults passResults, Specification viam) throws IOException {
     var result = new IdentityHashMap<Instruction, Graph>();
 
-    for (var instruction : viam.isa().orElseThrow().ownInstructions()) {
+    for (var instruction : viam.isa().map(InstructionSetArchitecture::ownInstructions).orElse(
+        Collections.emptyList())) {
       var copy = instruction.behavior().copy();
       result.put(instruction, copy);
     }

--- a/vadl/main/vadl/viam/passes/SnapshotInstructionBehaviorPass.java
+++ b/vadl/main/vadl/viam/passes/SnapshotInstructionBehaviorPass.java
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.viam.passes;
+
+import java.io.IOException;
+import java.util.IdentityHashMap;
+import javax.annotation.Nullable;
+import vadl.configuration.GeneralConfiguration;
+import vadl.pass.Pass;
+import vadl.pass.PassName;
+import vadl.pass.PassResults;
+import vadl.viam.Instruction;
+import vadl.viam.Specification;
+import vadl.viam.graph.Graph;
+
+/**
+ * Iterates over all the instructions and saves the behavior so
+ * later passes can access the original version of the graph.
+ */
+public class SnapshotInstructionBehaviorPass extends Pass {
+  public SnapshotInstructionBehaviorPass(GeneralConfiguration configuration) {
+    super(configuration);
+  }
+
+  @Override
+  public PassName getName() {
+    return new PassName("SnapshotInstructionBehaviorPass");
+  }
+
+  @Nullable
+  @Override
+  public Object execute(PassResults passResults, Specification viam) throws IOException {
+    var result = new IdentityHashMap<Instruction, Graph>();
+
+    for (var instruction : viam.isa().orElseThrow().ownInstructions()) {
+      var copy = instruction.behavior().copy();
+      result.put(instruction, copy);
+    }
+
+    return result;
+  }
+}


### PR DESCRIPTION
It adds a new pass to snapshot the instruction's behavior before any modification happens. Additionally, a few minor changes to spot an immediate before lowering were required.

Closes #387