### PR TITLE
lcb: Fixes operand detection

### DIFF
--- a/vadl/main/vadl/ast/ViamLowering.java
+++ b/vadl/main/vadl/ast/ViamLowering.java
@@ -1195,7 +1195,7 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
     // at least one access function must use this field for its decoding
     var anyUseOfThisField = encoding.usedFieldAccesses().stream()
         .flatMap(f -> f.fieldRefs().stream())
-        .anyMatch(e -> e == field);
+        .anyMatch(e -> e.equals(field));
     ensure(anyUseOfThisField, () -> error("Invalid field access encoding", encode)
         .description(
             "At least one of the field accesses must use the target field `%s` in its access functions.",

--- a/vadl/main/vadl/gcb/passes/DetermineRegisterUsesAndDefsPass.java
+++ b/vadl/main/vadl/gcb/passes/DetermineRegisterUsesAndDefsPass.java
@@ -116,7 +116,7 @@ public class DetermineRegisterUsesAndDefsPass extends Pass {
         if (isField && isConstant) {
           var field = pair.left().left();
           var affectedNodes = copy.behavior().getNodes(FieldRefNode.class)
-              .filter(x -> x.formatField() == field)
+              .filter(x -> x.formatField().equals(field))
               .toList();
 
           for (var affected : affectedNodes) {

--- a/vadl/main/vadl/gcb/passes/GenerateValueRangeImmediatePass.java
+++ b/vadl/main/vadl/gcb/passes/GenerateValueRangeImmediatePass.java
@@ -16,7 +16,10 @@
 
 package vadl.gcb.passes;
 
+import static vadl.viam.ViamError.ensureNonNull;
+
 import java.io.IOException;
+import java.util.Map;
 import javax.annotation.Nullable;
 import vadl.configuration.GeneralConfiguration;
 import vadl.error.Diagnostic;
@@ -28,7 +31,9 @@ import vadl.viam.Format;
 import vadl.viam.Format.FieldAccess;
 import vadl.viam.Instruction;
 import vadl.viam.Specification;
+import vadl.viam.graph.Graph;
 import vadl.viam.graph.dependency.FieldAccessRefNode;
+import vadl.viam.passes.SnapshotInstructionBehaviorPass;
 
 /**
  * This pass generates the ranges for immediates.
@@ -84,6 +89,8 @@ public class GenerateValueRangeImmediatePass extends Pass {
   @Nullable
   @Override
   public Object execute(PassResults passResults, Specification viam) throws IOException {
+    var snapshots =
+        (Map<Instruction, Graph>) passResults.lastResultOf(SnapshotInstructionBehaviorPass.class);
     var fieldResult =
         (IdentifyFieldUsagePass.ImmediateDetectionContainer) passResults
             .lastResultOf(IdentifyFieldUsagePass.class);
@@ -92,9 +99,12 @@ public class GenerateValueRangeImmediatePass extends Pass {
         .forEach(instruction -> {
           var fields = fieldResult.getImmediateFields(instruction);
           var ctx = new ValueRangeCtx();
+          var snapshot = ensureNonNull(snapshots.get(instruction),
+              () -> Diagnostic.error("Cannot find snapshot for instruction",
+                  instruction.location()));
 
           fields.forEach(field -> {
-            var isSigned = isSigned(instruction, field);
+            var isSigned = isSigned(instruction, snapshot, field);
             var lowest = lowestPossibleValue(field.type().toBitsType(), isSigned);
             var highest = highestPossibleValue(field.type().toBitsType(), isSigned);
             var range = new ValueRange(lowest, highest);
@@ -112,8 +122,8 @@ public class GenerateValueRangeImmediatePass extends Pass {
    * unsigned or signed, we have to check whether there exist a {@link FieldAccess}.
    * If it does, then take its type. If not then just use the field's type.
    */
-  private boolean isSigned(Instruction instruction, Format.Field field) {
-    var fieldAccesses = instruction.behavior().getNodes(FieldAccessRefNode.class).toList();
+  private boolean isSigned(Instruction instruction, Graph snapshot, Format.Field field) {
+    var fieldAccesses = snapshot.getNodes(FieldAccessRefNode.class).toList();
     for (var fieldAccess : fieldAccesses) {
       for (var fieldRef : fieldAccess.fieldAccess().fieldRefs()) {
         if (fieldRef.equals(field)) {

--- a/vadl/main/vadl/gcb/passes/IdentifyFieldUsagePass.java
+++ b/vadl/main/vadl/gcb/passes/IdentifyFieldUsagePass.java
@@ -16,6 +16,8 @@
 
 package vadl.gcb.passes;
 
+import static vadl.viam.ViamError.ensureNonNull;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -24,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import vadl.configuration.GcbConfiguration;
 import vadl.error.Diagnostic;
@@ -37,10 +40,14 @@ import vadl.viam.Instruction;
 import vadl.viam.RegisterTensor;
 import vadl.viam.Specification;
 import vadl.viam.ViamError;
+import vadl.viam.graph.Graph;
 import vadl.viam.graph.dependency.FieldAccessRefNode;
 import vadl.viam.graph.dependency.FieldRefNode;
+import vadl.viam.graph.dependency.ReadArtificialResNode;
 import vadl.viam.graph.dependency.ReadRegTensorNode;
+import vadl.viam.graph.dependency.WriteArtificialResNode;
 import vadl.viam.graph.dependency.WriteRegTensorNode;
+import vadl.viam.passes.SnapshotInstructionBehaviorPass;
 
 /**
  * This pass goes over all instructions and determines
@@ -260,21 +267,26 @@ public class IdentifyFieldUsagePass extends Pass {
   @Nullable
   @Override
   public Object execute(PassResults passResults, Specification viam) throws IOException {
+    var snapshots =
+        (Map<Instruction, Graph>) passResults.lastResultOf(SnapshotInstructionBehaviorPass.class);
     var container = new ImmediateDetectionContainer();
 
     for (var instruction : viam.isa().stream().flatMap(isa -> isa.ownInstructions().stream())
         .toList()) {
+      var snapshot = ensureNonNull(snapshots.get(instruction),
+          () -> Diagnostic.error("Cannot find snapshot for instruction", instruction.location()));
       container.addInstruction(instruction);
-      handleFields(instruction, container);
-      handleFieldAccessFunctions(instruction, container);
+      handleFields(instruction, snapshot, container);
+      handleFieldAccessFunctions(instruction, snapshot, container);
     }
 
     return container;
   }
 
   private static void handleFieldAccessFunctions(Instruction instruction,
+                                                 Graph snapshot,
                                                  ImmediateDetectionContainer container) {
-    instruction.behavior().getNodes(FieldAccessRefNode.class)
+    snapshot.getNodes(FieldAccessRefNode.class)
         .forEach(fieldAccessRefNode -> {
           var fieldRefs = fieldAccessRefNode.fieldAccess().fieldRefs();
           container.addInstruction(instruction);
@@ -286,19 +298,35 @@ public class IdentifyFieldUsagePass extends Pass {
   }
 
   private static void handleFields(Instruction instruction,
+                                   Graph snapshot,
                                    ImmediateDetectionContainer container) {
-    instruction.behavior().getNodes(FieldRefNode.class)
+    snapshot.getNodes(FieldRefNode.class)
         .forEach(fieldRefNode -> {
           var fieldRef = fieldRefNode.formatField();
-          var registerRead = fieldRefNode.usages()
-              .filter(
-                  usage -> usage instanceof ReadRegTensorNode)
-              .map(usage -> ((ReadRegTensorNode) usage).regTensor())
+          var registerRead = Stream.concat(fieldRefNode.usages()
+                      .filter(
+                          usage -> usage instanceof ReadRegTensorNode)
+                      .map(usage -> ((ReadRegTensorNode) usage).regTensor()),
+                  fieldRefNode.usages().filter(
+                          usage -> usage instanceof ReadArtificialResNode artificialResNode
+                              && artificialResNode.resourceDefinition()
+                              .innerResourceRef() instanceof RegisterTensor)
+                      .map(usage -> (RegisterTensor)
+                          ((ReadArtificialResNode) usage).resourceDefinition().innerResourceRef())
+              )
               .findFirst();
 
-          var registerWrite = fieldRefNode.usages()
-              .filter(usage -> usage instanceof WriteRegTensorNode)
-              .map(usage -> ((WriteRegTensorNode) usage).regTensor())
+          var registerWrite = Stream.concat(fieldRefNode.usages()
+                      .filter(
+                          usage -> usage instanceof WriteRegTensorNode)
+                      .map(usage -> ((WriteRegTensorNode) usage).regTensor()),
+                  fieldRefNode.usages().filter(
+                          usage -> usage instanceof WriteArtificialResNode artificialResNode
+                              && artificialResNode.resourceDefinition()
+                              .innerResourceRef() instanceof RegisterTensor)
+                      .map(usage -> (RegisterTensor)
+                          ((WriteArtificialResNode) usage).resourceDefinition().innerResourceRef())
+              )
               .findFirst();
 
           container.addInstruction(instruction);

--- a/vadl/main/vadl/gcb/passes/operands/GenerateInstructionOperandsPass.java
+++ b/vadl/main/vadl/gcb/passes/operands/GenerateInstructionOperandsPass.java
@@ -162,6 +162,7 @@ public class GenerateInstructionOperandsPass extends Pass {
     var operands = extractWrites(behavior);
     return operands
         .stream()
+        .filter(operand -> !operand.indices().isEmpty()) // must not be register.
         .filter(operand -> {
           // Why?
           // Because LLVM cannot handle static registers in input or output operands.

--- a/vadl/main/vadl/gcb/passes/operands/GenerateInstructionOperandsPass.java
+++ b/vadl/main/vadl/gcb/passes/operands/GenerateInstructionOperandsPass.java
@@ -16,6 +16,7 @@
 
 package vadl.gcb.passes.operands;
 
+import static vadl.viam.ViamError.ensureNonNull;
 import static vadl.viam.ViamError.ensurePresent;
 
 import com.google.common.collect.Streams;
@@ -24,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
@@ -43,6 +45,7 @@ import vadl.pass.PassResults;
 import vadl.types.Type;
 import vadl.utils.Pair;
 import vadl.viam.CompilerInstruction;
+import vadl.viam.Instruction;
 import vadl.viam.PseudoInstruction;
 import vadl.viam.Specification;
 import vadl.viam.graph.Graph;
@@ -61,6 +64,7 @@ import vadl.viam.graph.dependency.ReadResourceNode;
 import vadl.viam.graph.dependency.SideEffectNode;
 import vadl.viam.graph.dependency.WriteRegTensorNode;
 import vadl.viam.graph.dependency.WriteResourceNode;
+import vadl.viam.passes.SnapshotInstructionBehaviorPass;
 
 /**
  * Generates the input and output operands for instructions.
@@ -82,17 +86,21 @@ public class GenerateInstructionOperandsPass extends Pass {
   @Nullable
   @Override
   public Object execute(PassResults passResults, Specification viam) throws IOException {
-    machineInstructions(viam);
+    machineInstructions(passResults, viam);
     pseudoInstructions(viam);
     compilerInstructions(viam);
 
     return null;
   }
 
-  private void machineInstructions(Specification viam) {
+  private void machineInstructions(PassResults passResults, Specification viam) {
+    var snapshots =
+        (Map<Instruction, Graph>) passResults.lastResultOf(SnapshotInstructionBehaviorPass.class);
     for (var instruction : viam.isa().orElseThrow().ownInstructions()) {
-      var outputOperands = getTableGenOutputOperands(instruction.behavior());
-      var inputOperands = getTableGenInputOperands(outputOperands, instruction.behavior());
+      var snapshot = ensureNonNull(snapshots.get(instruction),
+          () -> Diagnostic.error("Cannot find snapshot for instruction", instruction.location()));
+      var outputOperands = getTableGenOutputOperands(snapshot);
+      var inputOperands = getTableGenInputOperands(outputOperands, snapshot);
 
       var ctx = new InstructionOperandsCtx(inputOperands, outputOperands);
       instruction.attachExtension(ctx);
@@ -165,96 +173,24 @@ public class GenerateInstructionOperandsPass extends Pass {
         .toList();
   }
 
-  /**
-   * Most instruction's behaviors have inputs. Those are the results which the instruction requires.
-   */
   private static List<Node> getInputOperands(Graph graph) {
-    var children = new ArrayList<Node>();
-    var builtins = new ArrayList<Node>();
-    var sideEffects = graph.getNodes(SideEffectNode.class).toList();
+    // First, the registers
+    var x = graph.getNodes(ReadRegTensorNode.class).filter(k -> k.regTensor().isRegisterFile());
+    // Then, immediates
+    var y = graph.getNodes(FieldAccessRefNode.class);
+    // Then, the rest
+    var z = graph.getNodes(FuncCallNode.class).flatMap(
+        funcCallNode -> funcCallNode.function().behavior().getNodes(FuncParamNode.class));
 
-    getNodesRecursively(sideEffects, builtins, BuiltInCall.class);
+    // We need this edge case for compiler and pseudo instructions.
+    // However, we need to filter for `WriteResourceNode` and `ReadResourceNode`, so
+    // the operand is not added twice.
+    var u = graph.getNodes(PseudoFuncParamNode.class)
+        .filter(k -> k.usages()
+            .noneMatch(v -> v instanceof WriteResourceNode || v instanceof ReadResourceNode));
 
-    // First arithmetical builtins
-    builtins.stream()
-        .map(x -> (BuiltInCall) x)
-        // Heuristic to prefer arithmetic builtins
-        .filter(x -> !x.builtIn().returns(Collections.singletonList(Type.bool())).isDataType())
-        .forEach(x -> {
-          for (var arg : x.arguments()) {
-            if (arg instanceof ReadRegTensorNode readRegTensorNode && readRegTensorNode.regTensor()
-                .isRegisterFile()) {
-              children.add(arg);
-            }
-          }
-        });
-
-    // Anything else
-    builtins.stream()
-        .map(x -> (BuiltInCall) x)
-        .filter(x -> x.builtIn().returns(Collections.singletonList(Type.bool())).isDataType())
-        .forEach(x -> {
-          for (var arg : x.arguments()) {
-            if (arg instanceof ReadRegTensorNode readRegTensorNode && readRegTensorNode.regTensor()
-                .isRegisterFile()) {
-              children.add(arg);
-            }
-          }
-        });
-
-    // Field Accesses
-    builtins.stream()
-        .map(x -> (BuiltInCall) x)
-        .filter(x -> !x.builtIn().returns(Collections.singletonList(Type.bool())).isDataType())
-        .forEach(x -> {
-          for (var arg : x.arguments()) {
-            if (arg instanceof FieldAccessRefNode) {
-              children.add(arg);
-            }
-          }
-        });
-
-    // To make sure we didn't forget anything
-    var funcCalls = new ArrayList<Node>();
-    getNodesRecursively(sideEffects, children, ReadRegTensorNode.class);
-    getNodesRecursively(sideEffects, children, FieldAccessRefNode.class);
-    getNodesRecursively(sideEffects, funcCalls, FuncCallNode.class);
-    getNodesRecursively(sideEffects, children, PseudoFuncParamNode.class);
-
-    return Stream.concat(
-            children.stream()
-                .filter(node -> {
-                  if (node instanceof ReadRegTensorNode readRegTensorNode) {
-                    return readRegTensorNode.regTensor().isRegisterFile();
-                  } else if (node instanceof PseudoFuncParamNode pseudoFuncParamNode) {
-                    // We need this edge case for compiler and pseudo instructions.
-                    // However, we need to filter for `WriteResourceNode` and `ReadResourceNode`, so
-                    // the operand is not added twice.
-                    return pseudoFuncParamNode.usages()
-                        .noneMatch(
-                            v -> v instanceof WriteResourceNode || v instanceof ReadResourceNode);
-                  } else {
-                    return true;
-                  }
-                }),
-            funcCalls.stream().flatMap(
-                    funcCallNode -> ((FuncCallNode) funcCallNode).function().behavior()
-                        .getNodes(FuncParamNode.class))
-                .map(node -> (Node) node)
-        )
-        .distinct()
-        .toList();
-  }
-
-  private static <T extends Node> void getNodesRecursively(
-      List<SideEffectNode> sideEffects,
-      List<Node> children,
-      Class<T> clazz) {
-    for (var sideEffect : sideEffects) {
-      var temp = new ArrayList<T>();
-      sideEffect.collectInputsWithChildren(temp, clazz);
-      children.addAll(temp);
-    }
+    return Stream.concat(Stream.concat(Stream.concat(x, y), z), u)
+        .map(k -> (Node) k).toList();
   }
 
   /**

--- a/vadl/main/vadl/gcb/passes/operands/GenerateInstructionOperandsPass.java
+++ b/vadl/main/vadl/gcb/passes/operands/GenerateInstructionOperandsPass.java
@@ -23,7 +23,6 @@ import com.google.common.collect.Streams;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -42,26 +41,25 @@ import vadl.gcb.passes.pseudo.PseudoFuncParamNode;
 import vadl.pass.Pass;
 import vadl.pass.PassName;
 import vadl.pass.PassResults;
-import vadl.types.Type;
 import vadl.utils.Pair;
 import vadl.viam.CompilerInstruction;
 import vadl.viam.Instruction;
 import vadl.viam.PseudoInstruction;
+import vadl.viam.RegisterTensor;
 import vadl.viam.Specification;
 import vadl.viam.graph.Graph;
 import vadl.viam.graph.HasRegisterTensor;
 import vadl.viam.graph.Node;
 import vadl.viam.graph.control.InstrCallNode;
-import vadl.viam.graph.dependency.BuiltInCall;
 import vadl.viam.graph.dependency.ConstantNode;
 import vadl.viam.graph.dependency.ExpressionNode;
 import vadl.viam.graph.dependency.FieldAccessRefNode;
 import vadl.viam.graph.dependency.FieldRefNode;
 import vadl.viam.graph.dependency.FuncCallNode;
 import vadl.viam.graph.dependency.FuncParamNode;
+import vadl.viam.graph.dependency.ReadArtificialResNode;
 import vadl.viam.graph.dependency.ReadRegTensorNode;
 import vadl.viam.graph.dependency.ReadResourceNode;
-import vadl.viam.graph.dependency.SideEffectNode;
 import vadl.viam.graph.dependency.WriteRegTensorNode;
 import vadl.viam.graph.dependency.WriteResourceNode;
 import vadl.viam.passes.SnapshotInstructionBehaviorPass;
@@ -176,6 +174,9 @@ public class GenerateInstructionOperandsPass extends Pass {
   private static List<Node> getInputOperands(Graph graph) {
     // First, the registers
     var x = graph.getNodes(ReadRegTensorNode.class).filter(k -> k.regTensor().isRegisterFile());
+    var xx = graph.getNodes(ReadArtificialResNode.class).filter(
+        k -> k.resourceDefinition().innerResourceRef() instanceof RegisterTensor tensor
+            && tensor.isRegisterFile());
     // Then, immediates
     var y = graph.getNodes(FieldAccessRefNode.class);
     // Then, the rest
@@ -189,7 +190,7 @@ public class GenerateInstructionOperandsPass extends Pass {
         .filter(k -> k.usages()
             .noneMatch(v -> v instanceof WriteResourceNode || v instanceof ReadResourceNode));
 
-    return Stream.concat(Stream.concat(Stream.concat(x, y), z), u)
+    return Stream.concat(Stream.concat(Stream.concat(Stream.concat(x, xx), y), z), u)
         .map(k -> (Node) k).toList();
   }
 
@@ -212,6 +213,11 @@ public class GenerateInstructionOperandsPass extends Pass {
           if (node instanceof ReadRegTensorNode readRegTensorNode
               && readRegTensorNode.regTensor().isRegisterFile()) {
             return !readRegTensorNode.hasConstantAddress();
+          } else if (node instanceof ReadArtificialResNode artificialResNode
+              && artificialResNode.resourceDefinition()
+              .innerResourceRef() instanceof RegisterTensor tensor
+              && tensor.isRegisterFile()) {
+            return !artificialResNode.hasConstantAddress();
           }
           return true;
         })
@@ -225,6 +231,7 @@ public class GenerateInstructionOperandsPass extends Pass {
   private GcbInstructionOperand map(Node operand) {
     return switch (operand) {
       case ReadRegTensorNode node when node.regTensor().isRegisterFile() -> mapFrom(node);
+      case ReadArtificialResNode node -> mapFrom(node);
       case WriteRegTensorNode node when node.regTensor().isRegisterFile() -> mapFrom(node);
       case FuncParamNode node -> mapFrom(node);
       case FieldAccessRefNode node -> mapFrom(node);
@@ -263,6 +270,43 @@ public class GenerateInstructionOperandsPass extends Pass {
       // This is ok as long as the value of the register file at the address is also constant.
       // For example, the X0 register in RISC-V which always has a constant value.
       var constraints = Arrays.stream(node.regTensor().constraints()).toList();
+      var constraintValue = constraints.stream()
+          .filter(
+              x -> x.indices().getFirst().intValue() == constantNode.constant().asVal().intValue())
+          .findFirst();
+      var constRegisterValue = ensurePresent(constraintValue,
+          () -> Diagnostic.error("Register file with constant index has no constant value.",
+                  constantNode.location())
+              .help("Consider adding a constraint to register file for the given index."));
+      // Update the type of the constant because it needs to be upcasted.
+      // Heuristically, we take the type of the index because indices were also upcasted.
+      var constantValue = constRegisterValue.value();
+      constantValue.setType(constantNode.type());
+      return new GcbConstantOperand(constantNode, constantValue);
+    } else {
+      throw Diagnostic.error(
+          "The compiler generator needs to generate a tablegen instruction operand from this "
+              + "address for a field but it does not support it.",
+          node.address().location()).build();
+    }
+  }
+
+
+  /**
+   * Returns a {@link GcbInstructionOperand} given a {@link Node}.
+   */
+  private GcbInstructionOperand mapFrom(
+      ReadArtificialResNode node) {
+    if (node.address() instanceof FieldRefNode field) {
+      return new GcbInstructionRegisterFileOperand(node, field.formatField());
+    } else if (node.address() instanceof FuncParamNode funcParamNode) {
+      return new GcbInstructionIndexedRegisterFileOperand(node, funcParamNode);
+    } else if (node.address() instanceof ConstantNode constantNode) {
+      var tensor = (RegisterTensor) node.resourceDefinition().innerResourceRef();
+      // The register file has a constant as address.
+      // This is ok as long as the value of the register file at the address is also constant.
+      // For example, the X0 register in RISC-V which always has a constant value.
+      var constraints = Arrays.stream(tensor.constraints()).toList();
       var constraintValue = constraints.stream()
           .filter(
               x -> x.indices().getFirst().intValue() == constantNode.constant().asVal().intValue())

--- a/vadl/main/vadl/gcb/passes/operands/GenerateInstructionOperandsPass.java
+++ b/vadl/main/vadl/gcb/passes/operands/GenerateInstructionOperandsPass.java
@@ -60,6 +60,7 @@ import vadl.viam.graph.dependency.FuncParamNode;
 import vadl.viam.graph.dependency.ReadArtificialResNode;
 import vadl.viam.graph.dependency.ReadRegTensorNode;
 import vadl.viam.graph.dependency.ReadResourceNode;
+import vadl.viam.graph.dependency.WriteArtificialResNode;
 import vadl.viam.graph.dependency.WriteRegTensorNode;
 import vadl.viam.graph.dependency.WriteResourceNode;
 import vadl.viam.passes.SnapshotInstructionBehaviorPass;
@@ -233,6 +234,7 @@ public class GenerateInstructionOperandsPass extends Pass {
       case ReadRegTensorNode node when node.regTensor().isRegisterFile() -> mapFrom(node);
       case ReadArtificialResNode node -> mapFrom(node);
       case WriteRegTensorNode node when node.regTensor().isRegisterFile() -> mapFrom(node);
+      case WriteArtificialResNode node -> mapFrom(node);
       case FuncParamNode node -> mapFrom(node);
       case FieldAccessRefNode node -> mapFrom(node);
       default -> throw Diagnostic.error(
@@ -341,6 +343,19 @@ public class GenerateInstructionOperandsPass extends Pass {
     }
   }
 
+  private GcbInstructionOperand mapFrom(WriteArtificialResNode node) {
+    if (node.address() instanceof FieldRefNode field) {
+      return new GcbInstructionRegisterFileOperand(node, field.formatField());
+    } else if (node.address() instanceof FuncParamNode funcParamNode) {
+      return new GcbInstructionIndexedRegisterFileOperand(node, funcParamNode);
+    } else {
+      throw Diagnostic.error(
+          "The compiler generator needs to generate a tablegen instruction operand from this "
+              + "address for a field but it does not support it.",
+          node.address().location()).build();
+    }
+  }
+
   /**
    * It is not allowed to have a {@link GcbInstructionOperand} in the input list
    * when it is already in the output list. That's why we compute the {@code outputOperands}
@@ -375,9 +390,12 @@ public class GenerateInstructionOperandsPass extends Pass {
   /**
    * Most instruction's behaviors have outputs. Those are the results which the instruction emits.
    */
-  private List<WriteRegTensorNode> extractWrites(Graph graph) {
-    return graph.getNodes(WriteRegTensorNode.class)
-        .filter(e -> e.regTensor().isRegisterFile())
+  private List<WriteResourceNode> extractWrites(Graph graph) {
+    return Stream.concat(graph.getNodes(WriteRegTensorNode.class)
+                .filter(e -> e.regTensor().isRegisterFile()),
+            graph.getNodes(WriteArtificialResNode.class).filter(
+                e -> e.resourceDefinition().innerResourceRef() instanceof RegisterTensor tensor
+                    && tensor.isRegisterFile()))
         .toList();
   }
 

--- a/vadl/main/vadl/gcb/passes/operands/model/GcbInstructionIndexedRegisterFileOperand.java
+++ b/vadl/main/vadl/gcb/passes/operands/model/GcbInstructionIndexedRegisterFileOperand.java
@@ -19,8 +19,8 @@ package vadl.gcb.passes.operands.model;
 import java.util.Objects;
 import vadl.viam.Format;
 import vadl.viam.RegisterTensor;
-import vadl.viam.graph.dependency.ConstantNode;
 import vadl.viam.graph.dependency.FuncParamNode;
+import vadl.viam.graph.dependency.ReadArtificialResNode;
 import vadl.viam.graph.dependency.ReadRegTensorNode;
 import vadl.viam.graph.dependency.WriteRegTensorNode;
 
@@ -61,15 +61,13 @@ public class GcbInstructionIndexedRegisterFileOperand
     node.regTensor().ensure(node.regTensor().isRegisterFile(), "must be a register file");
   }
 
-  /**
-   * Constructor.
-   */
-  public GcbInstructionIndexedRegisterFileOperand(RegisterTensor registerFile,
-                                                  ConstantNode address) {
-    super(address, registerFile.identifier.simpleName(),
-        address.constant().asVal().intValue() + "");
-    this.registerFile = registerFile;
-    registerFile.ensure(registerFile.isRegisterFile(), "must be a register file");
+  public GcbInstructionIndexedRegisterFileOperand(ReadArtificialResNode node,
+                                                  FuncParamNode address) {
+    super(node, node.resourceDefinition().innerResourceRef().simpleName(),
+        address.parameter().identifier.simpleName());
+    this.registerFile = (RegisterTensor) node.resourceDefinition().innerResourceRef();
+    node.resourceDefinition().innerResourceRef()
+        .ensure(registerFile.isRegisterFile(), "must be registerfile");
   }
 
   public RegisterTensor registerFile() {

--- a/vadl/main/vadl/gcb/passes/operands/model/GcbInstructionIndexedRegisterFileOperand.java
+++ b/vadl/main/vadl/gcb/passes/operands/model/GcbInstructionIndexedRegisterFileOperand.java
@@ -22,6 +22,7 @@ import vadl.viam.RegisterTensor;
 import vadl.viam.graph.dependency.FuncParamNode;
 import vadl.viam.graph.dependency.ReadArtificialResNode;
 import vadl.viam.graph.dependency.ReadRegTensorNode;
+import vadl.viam.graph.dependency.WriteArtificialResNode;
 import vadl.viam.graph.dependency.WriteRegTensorNode;
 
 /**
@@ -62,6 +63,15 @@ public class GcbInstructionIndexedRegisterFileOperand
   }
 
   public GcbInstructionIndexedRegisterFileOperand(ReadArtificialResNode node,
+                                                  FuncParamNode address) {
+    super(node, node.resourceDefinition().innerResourceRef().simpleName(),
+        address.parameter().identifier.simpleName());
+    this.registerFile = (RegisterTensor) node.resourceDefinition().innerResourceRef();
+    node.resourceDefinition().innerResourceRef()
+        .ensure(registerFile.isRegisterFile(), "must be registerfile");
+  }
+
+  public GcbInstructionIndexedRegisterFileOperand(WriteArtificialResNode node,
                                                   FuncParamNode address) {
     super(node, node.resourceDefinition().innerResourceRef().simpleName(),
         address.parameter().identifier.simpleName());

--- a/vadl/main/vadl/gcb/passes/operands/model/GcbInstructionRegisterFileOperand.java
+++ b/vadl/main/vadl/gcb/passes/operands/model/GcbInstructionRegisterFileOperand.java
@@ -24,6 +24,7 @@ import vadl.viam.graph.dependency.FieldRefNode;
 import vadl.viam.graph.dependency.FuncParamNode;
 import vadl.viam.graph.dependency.ReadArtificialResNode;
 import vadl.viam.graph.dependency.ReadRegTensorNode;
+import vadl.viam.graph.dependency.WriteArtificialResNode;
 import vadl.viam.graph.dependency.WriteRegTensorNode;
 
 /**
@@ -74,6 +75,19 @@ public class GcbInstructionRegisterFileOperand
     this.registerFile = node.regTensor();
     this.registerFile.ensure(registerFile.isRegisterFile(), "must be registerfile");
     this.formatField = address.formatField();
+  }
+
+  /**
+   * Constructor.
+   */
+  public GcbInstructionRegisterFileOperand(WriteArtificialResNode node, Format.Field address) {
+    super(node, node.resourceDefinition().innerResourceRef().simpleName(),
+        address.identifier.simpleName());
+    this.registerFile = (RegisterTensor) node.resourceDefinition().innerResourceRef();
+    this.registerFile.ensure(registerFile.isRegisterFile(), "must be registerfile");
+    this.formatField = address;
+    node.resourceDefinition().innerResourceRef()
+        .ensure(registerFile.isRegisterFile(), "must be registerfile");
   }
 
   /**

--- a/vadl/main/vadl/gcb/passes/operands/model/GcbInstructionRegisterFileOperand.java
+++ b/vadl/main/vadl/gcb/passes/operands/model/GcbInstructionRegisterFileOperand.java
@@ -22,6 +22,7 @@ import vadl.viam.Format;
 import vadl.viam.RegisterTensor;
 import vadl.viam.graph.dependency.FieldRefNode;
 import vadl.viam.graph.dependency.FuncParamNode;
+import vadl.viam.graph.dependency.ReadArtificialResNode;
 import vadl.viam.graph.dependency.ReadRegTensorNode;
 import vadl.viam.graph.dependency.WriteRegTensorNode;
 
@@ -43,6 +44,19 @@ public class GcbInstructionRegisterFileOperand
     this.registerFile.ensure(registerFile.isRegisterFile(), "must be registerfile");
     this.formatField = address;
     node.regTensor().ensure(registerFile.isRegisterFile(), "must be registerfile");
+  }
+
+  /**
+   * Constructor.
+   */
+  public GcbInstructionRegisterFileOperand(ReadArtificialResNode node, Format.Field address) {
+    super(node, node.resourceDefinition().innerResourceRef().simpleName(),
+        address.identifier.simpleName());
+    this.registerFile = (RegisterTensor) node.resourceDefinition().innerResourceRef();
+    this.registerFile.ensure(registerFile.isRegisterFile(), "must be registerfile");
+    this.formatField = address;
+    node.resourceDefinition().innerResourceRef()
+        .ensure(registerFile.isRegisterFile(), "must be registerfile");
   }
 
   /**

--- a/vadl/main/vadl/lcb/codegen/assembly/AssemblyInstructionPrinterImmediateHandler.java
+++ b/vadl/main/vadl/lcb/codegen/assembly/AssemblyInstructionPrinterImmediateHandler.java
@@ -211,7 +211,8 @@ public class AssemblyInstructionPrinterImmediateHandler
 
       var usage = usages.getFirst();
       var indexInOperands = ensurePresent(indexInInputsOrOutputs(node.formatField()),
-          () -> Diagnostic.error("Cannot find operand.", node.location()));
+          () -> Diagnostic.error("Cannot find operand: " + node.formatField().simpleName(),
+              node.location()));
       if (usage == IdentifyFieldUsagePass.FieldUsage.IMMEDIATE) {
         ctx.wr("MI->getOperand(%s).getImm()", indexInOperands);
       } else if (usage == IdentifyFieldUsagePass.FieldUsage.REGISTER) {

--- a/vadl/main/vadl/lcb/codegen/assembly/AssemblyInstructionPrinterImmediateHandler.java
+++ b/vadl/main/vadl/lcb/codegen/assembly/AssemblyInstructionPrinterImmediateHandler.java
@@ -32,6 +32,7 @@ import vadl.gcb.passes.IdentifyFieldUsagePass;
 import vadl.gcb.passes.operands.ReferencesFormatField;
 import vadl.gcb.passes.operands.model.GcbDefaultInstructionOperand;
 import vadl.gcb.passes.operands.model.GcbInstructionBareSymbolOperand;
+import vadl.gcb.passes.operands.model.GcbInstructionImmediateOperand;
 import vadl.javaannotations.DispatchFor;
 import vadl.javaannotations.Handler;
 import vadl.lcb.passes.llvmLowering.CreateFunctionsFromImmediatesPass;
@@ -690,6 +691,9 @@ public class AssemblyInstructionPrinterImmediateHandler
       if (operand instanceof ReferencesFormatField x
           && x.referencesField(needle)) {
         return Optional.of(i);
+      } else if (operand instanceof GcbInstructionImmediateOperand immediateOperand
+          && immediateOperand.fieldAccess().fieldRefs().contains(needle)) {
+        return Optional.of(i);
       }
     }
 
@@ -704,6 +708,9 @@ public class AssemblyInstructionPrinterImmediateHandler
       var operand = operands.get(i);
       if (operand instanceof ReferencesImmediateOperand x
           && x.immediateOperand().fieldAccessRef().equals(needle)) {
+        return Optional.of(i);
+      } else if (operand instanceof GcbInstructionImmediateOperand immediateOperand
+          && immediateOperand.fieldAccess().equals(needle)) {
         return Optional.of(i);
       }
     }

--- a/vadl/main/vadl/lcb/codegen/expansion/CompilerInstructionExpansionCodeGenerator.java
+++ b/vadl/main/vadl/lcb/codegen/expansion/CompilerInstructionExpansionCodeGenerator.java
@@ -881,7 +881,7 @@ class DecodeFieldAccessesHandler implements CaseHandler {
       fieldAccess.format().fieldEncodingsOf(Set.of(fieldAccess))
           .forEach(fieldEncoding -> {
             for (var encodingFunction : encodingFunctions) {
-              if (encodingFunction.field() == fieldEncoding.targetField()) {
+              if (encodingFunction.field().equals(fieldEncoding.targetField())) {
                 encodeField(ctx, fieldEncoding, encodingFunction);
               }
             }

--- a/vadl/main/vadl/lcb/passes/llvmLowering/strategies/LlvmInstructionLoweringStrategy.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/strategies/LlvmInstructionLoweringStrategy.java
@@ -401,9 +401,6 @@ public abstract class LlvmInstructionLoweringStrategy {
       Instruction instruction,
       Graph graph) {
     if (!graph.getNodes(LlvmUnlowerableSD.class).toList().isEmpty()) {
-      DeferredDiagnosticStore.add(
-          Diagnostic.warning("Instruction is not lowerable and will be skipped",
-              instruction.location()).build());
       return true;
     }
 
@@ -411,10 +408,6 @@ public abstract class LlvmInstructionLoweringStrategy {
     // has no concept of register in the IR.
     if (graph.getNodes(ReadRegTensorNode.class)
         .anyMatch(n -> n.regTensor().isSingleRegister())) {
-      DeferredDiagnosticStore.add(
-          Diagnostic.warning(
-              "Instruction is not lowerable because it tries to match fixed registers.",
-              instruction.location()).build());
       return true;
     }
 

--- a/vadl/main/vadl/lcb/passes/llvmLowering/tablegen/model/TableGenMachineInstruction.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/tablegen/model/TableGenMachineInstruction.java
@@ -237,7 +237,7 @@ public class TableGenMachineInstruction extends TableGenInstruction {
             .filter(x -> x instanceof ReferencesImmediateOperand)
             .map(x ->
                 ((ReferencesImmediateOperand) x).immediateOperand().fieldAccessRef())
-            .filter(y -> y.fieldRefs().stream().anyMatch(z -> z == field))
+            .filter(y -> y.fieldRefs().stream().anyMatch(z -> z.equals(field)))
             .findFirst();
     return fieldAccess;
   }

--- a/vadl/main/vadl/pass/PassOrders.java
+++ b/vadl/main/vadl/pass/PassOrders.java
@@ -30,14 +30,14 @@ import vadl.configuration.IssConfiguration;
 import vadl.configuration.LcbConfiguration;
 import vadl.dump.CollectBehaviorDotGraphPass;
 import vadl.dump.HtmlDumpPass;
-import vadl.gcb.passes.DetectRegisterIndicesPass;
+import vadl.viam.passes.DetectRegisterIndicesPass;
 import vadl.gcb.passes.DetermineRegisterUsesAndDefsPass;
 import vadl.gcb.passes.DetermineRelocationTypeForFieldPass;
 import vadl.gcb.passes.GenerateCompilerRegistersPass;
 import vadl.gcb.passes.GenerateValueRangeImmediatePass;
 import vadl.gcb.passes.IdentifyFieldUsagePass;
 import vadl.gcb.passes.InstructionPatternPruningPass;
-import vadl.gcb.passes.NormalizeFieldsToFieldAccessFunctionsPass;
+import vadl.viam.passes.NormalizeFieldsToFieldAccessFunctionsPass;
 import vadl.gcb.passes.PredicateFunctionInlinerPass;
 import vadl.gcb.passes.SetMissingConfigurationValuesPass;
 import vadl.gcb.passes.assembly.AssemblyConcatBuiltinMergingPass;
@@ -169,7 +169,10 @@ public class PassOrders {
     order.add(new ViamCreationPass(configuration));
     order.add(new ViamVerificationPass(configuration));
 
+    order.add(new DetectRegisterIndicesPass(configuration));
+    order.add(new NormalizeFieldsToFieldAccessFunctionsPass(configuration));
     order.add(new SnapshotInstructionBehaviorPass(configuration));
+
     order.add(new RemoveUnusedStatusFlagsFromBuiltinsPass(configuration));
     order.add(new StatusBuiltInInlinePass(configuration));
 
@@ -220,8 +223,6 @@ public class PassOrders {
     order.add(new GenerateCompilerRegistersPass(gcbConfiguration));
     // skip inlining of field access
     order.skip(FieldAccessInlinerPass.class);
-    order.add(new DetectRegisterIndicesPass(gcbConfiguration));
-    order.add(new NormalizeFieldsToFieldAccessFunctionsPass(gcbConfiguration));
     order.add(new IdentifyFieldUsagePass(gcbConfiguration));
     order.add(new DetermineRelocationTypeForFieldPass(gcbConfiguration));
     order.add(new GenerateValueRangeImmediatePass(gcbConfiguration));
@@ -433,6 +434,7 @@ public class PassOrders {
 
     // skip inlining of field access
     order.skip(FieldAccessInlinerPass.class);
+    order.skip(NormalizeFieldsToFieldAccessFunctionsPass.class);
 
     // iss function passes
     order
@@ -574,6 +576,8 @@ public class PassOrders {
    */
   public static PassOrder rtl(GeneralConfiguration config) throws IOException {
     var order = viam(config);
+
+    order.skip(NormalizeFieldsToFieldAccessFunctionsPass.class);
 
     // TODO: Remove once frontend creates it
     order.add(new DummyMiaPass(config));

--- a/vadl/main/vadl/utils/Disassembler.java
+++ b/vadl/main/vadl/utils/Disassembler.java
@@ -143,7 +143,7 @@ class InstructionPrinter {
   private String registerNameFromField(Format.Field field, Constant.Value value,
                                        SourceLocation fieldLocation) {
     var referencedResources = insn.source().behavior().getNodes(FieldRefNode.class)
-        .filter(f -> f.formatField() == field)
+        .filter(f -> f.formatField().equals(field))
         .flatMap(vadl.viam.graph.Node::usages)
         .filter(n -> n instanceof ReadResourceNode || n instanceof WriteResourceNode)
         .map(n -> {

--- a/vadl/main/vadl/viam/Format.java
+++ b/vadl/main/vadl/viam/Format.java
@@ -321,6 +321,20 @@ public class Format extends Definition implements DefProp.WithType {
 
       return function;
     }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      Field field = (Field) o;
+      return this.identifier.equals(field.identifier);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(this.identifier);
+    }
   }
 
 

--- a/vadl/main/vadl/viam/graph/dependency/WriteResourceNode.java
+++ b/vadl/main/vadl/viam/graph/dependency/WriteResourceNode.java
@@ -69,7 +69,7 @@ public abstract class WriteResourceNode extends SideEffectNode {
   }
 
   /**
-   * Checks whether the {@code address} of the node is constant and therefore statically knonw.
+   * Checks whether the {@code address} of the node is constant and therefore statically known.
    */
   public boolean hasConstantAddress() {
     if (hasAddress()) {

--- a/vadl/main/vadl/viam/passes/DetectRegisterIndicesPass.java
+++ b/vadl/main/vadl/viam/passes/DetectRegisterIndicesPass.java
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-package vadl.gcb.passes;
+package vadl.viam.passes;
 
 import java.io.IOException;
 import java.util.HashSet;

--- a/vadl/main/vadl/viam/passes/DetectRegisterIndicesPass.java
+++ b/vadl/main/vadl/viam/passes/DetectRegisterIndicesPass.java
@@ -25,13 +25,13 @@ import vadl.pass.PassName;
 import vadl.pass.PassResults;
 import vadl.viam.Specification;
 import vadl.viam.graph.dependency.FieldRefNode;
-import vadl.viam.graph.dependency.ReadRegTensorNode;
-import vadl.viam.graph.dependency.WriteRegTensorNode;
+import vadl.viam.graph.dependency.ReadResourceNode;
+import vadl.viam.graph.dependency.WriteResourceNode;
 
 /**
  * Detect whether the {@link FieldRefNode} is used as a register index.
- * It is detected as register index when a usage is {@link ReadRegTensorNode}
- * or {@link WriteRegTensorNode}.
+ * It is detected as register index when a usage is {@link ReadResourceNode}
+ * or {@link WriteResourceNode}.
  */
 public class DetectRegisterIndicesPass extends Pass {
   public DetectRegisterIndicesPass(GeneralConfiguration configuration) {
@@ -57,8 +57,8 @@ public class DetectRegisterIndicesPass extends Pass {
           var fields = behavior.getNodes(FieldRefNode.class).toList();
 
           for (var field : fields) {
-            var hasRead = field.usages().anyMatch(u -> u instanceof ReadRegTensorNode);
-            var hasWrite = field.usages().anyMatch(u -> u instanceof WriteRegTensorNode);
+            var hasRead = field.usages().anyMatch(u -> u instanceof ReadResourceNode);
+            var hasWrite = field.usages().anyMatch(u -> u instanceof WriteResourceNode);
 
             if (hasRead || hasWrite) {
               result.add(field);

--- a/vadl/main/vadl/viam/passes/NormalizeFieldsToFieldAccessFunctionsPass.java
+++ b/vadl/main/vadl/viam/passes/NormalizeFieldsToFieldAccessFunctionsPass.java
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-package vadl.gcb.passes;
+package vadl.viam.passes;
 
 import java.io.IOException;
 import java.util.HashSet;


### PR DESCRIPTION
I am still working on fixes for the operand detection. For example,

```
instruction CCMNIALW : CondCompareFormat =   if true then
  let result, flags = VADL::adds(X(rn) as Bits<Size::WSize>, immX as BitsW) in
    {
      NZCV_N := flags.negative
      NZCV_Z := flags.zero
      NZCV_C := flags.carry
      NZCV_V := flags.overflow
    }
else
  {
    NZCV_N := nzcv(3)
    NZCV_Z := nzcv(2)
    NZCV_C := nzcv(1)
    NZCV_V := nzcv(0)
  }

assembly CCMNIALW = ("ccmn", ' ', WSize(rn), (', #', decimal(rm)), ', #', decimal(nzcv), ', ', "al")
```

In the expanded macro above, the conditional is `true` which means that a pass will remove the `else` branch entirely. If registers or immediates are used then we will prune them away and they will not be considered as operands. This has created errors when they are used in the assembly printing directive. An earlier PR #388 has introduced a snapshotting pass. With this PR, other passes are now reading the unmodified instruction's behavior, so less information gets lost.