### PR TITLE
viam: Added optimisation for SliceNode

### DIFF
--- a/vadl/main/vadl/viam/graph/dependency/SliceNode.java
+++ b/vadl/main/vadl/viam/graph/dependency/SliceNode.java
@@ -123,6 +123,17 @@ public class SliceNode extends ExpressionNode implements Canonicalizable {
 
   @Override
   public Node canonical() {
+    // If value's type is equal to the slice's type then it makes no sense to slice.
+    var parts = slice.parts().toList();
+    if (parts.size() == 1) {
+      var part = parts.getFirst();
+      var sliceMsb = part.msb();
+      var sliceLsb = part.lsb();
+      if (sliceLsb == 0 && value.type().asDataType().bitWidth() - 1 == sliceMsb) {
+        return value;
+      }
+    }
+
     if (!(value instanceof ConstantNode constantNode)) {
       return this;
     }


### PR DESCRIPTION
When slice node's type has the same bounds like the value node, then the slice node is obsolete and can be deleted.