### PR TITLE
lcb: Bugfixes Aarch64

### DIFF
--- a/vadl/main/vadl/gcb/passes/MachineInstructionLabel.java
+++ b/vadl/main/vadl/gcb/passes/MachineInstructionLabel.java
@@ -86,7 +86,8 @@ public enum MachineInstructionLabel {
   UNCONDITIONAL JUMPS
    */
   JALR,
-  JAL,
+  JAL, // the difference between JAL and J is that JAL also writes a linking register.
+  J,
   /*
   CONDITIONAL MOVE
    */

--- a/vadl/main/vadl/lcb/passes/isaMatching/IsaMachineInstructionMatchingPass.java
+++ b/vadl/main/vadl/lcb/passes/isaMatching/IsaMachineInstructionMatchingPass.java
@@ -107,6 +107,7 @@ import vadl.viam.matching.impl.AnyReadRegisterFileMatcher;
 import vadl.viam.matching.impl.BuiltInMatcher;
 import vadl.viam.matching.impl.FieldAccessRefMatcher;
 import vadl.viam.matching.impl.IsReadRegMatcher;
+import vadl.viam.matching.impl.ReadRegisterCounterMatcher;
 import vadl.viam.matching.impl.WriteResourceMatcherForValue;
 import vadl.viam.passes.functionInliner.FunctionInlinerPass;
 import vadl.viam.passes.functionInliner.UninlinedGraph;
@@ -159,7 +160,8 @@ public class IsaMachineInstructionMatchingPass extends Pass implements IsaMatchi
     }
 
     var pc = isa.pc();
-    ensure(pc != null && pc.registerTensor().isSingleRegister(),
+    ensureNonNull(pc, () -> Diagnostic.error("PC must not be null", isa.location()));
+    ensure(pc.registerTensor().isSingleRegister(),
         () -> Diagnostic.error("Only counter to single registers are supported.",
             Objects.requireNonNull(isa.pc()).location()));
 
@@ -283,6 +285,8 @@ public class IsaMachineInstructionMatchingPass extends Pass implements IsaMatchi
         instruction.attachExtension(new MachineInstructionCtx(MachineInstructionLabel.JALR, ty));
       } else if (findJal(behavior, pc)) {
         instruction.attachExtension(new MachineInstructionCtx(MachineInstructionLabel.JAL, ty));
+      } else if (findJ(behavior, pc)) {
+        instruction.attachExtension(new MachineInstructionCtx(MachineInstructionLabel.J, ty));
       }
     });
 
@@ -560,6 +564,37 @@ public class IsaMachineInstructionMatchingPass extends Pass implements IsaMatchi
     );
 
     return writesPc.size() == 1 && writesRegFile.size() == 1 && !inputRegister.isEmpty();
+  }
+
+  /**
+   * Match {@link Instruction} which modifies the PC not store the result into a register.
+   */
+  private boolean findJ(UninlinedGraph behavior, Counter pcRegister) {
+    var writesPc =
+        behavior.getNodes(WriteRegTensorNode.class)
+            .filter(x -> x.regTensor().equals(pcRegister.registerTensor()))
+            .toList();
+    var writes = behavior.getNodes(WriteResourceNode.class).toList();
+    var builtins = behavior.getNodes(BuiltInCall.class).toList();
+
+    var matcher = new BuiltInMatcher(List.of(BuiltInTable.ADD), List.of(
+        new AnyChildMatcher(new ReadRegisterCounterMatcher(pcRegister)),
+        new FieldAccessRefMatcher()
+    ));
+    Set<Matcher> matchers = Set.of(
+        matcher,
+        matcher.swapOperands()
+    );
+
+    var addition = TreeMatcher.matches(
+        () -> behavior.getNodes(BuiltInCall.class).map(x -> x),
+        matchers
+    );
+
+    return writesPc.size() == 1
+        && writes.size() == 1
+        && !addition.isEmpty()
+        && builtins.size() == 1;
   }
 
   /**

--- a/vadl/main/vadl/lcb/passes/isaMatching/IsaMachineInstructionMatchingPass.java
+++ b/vadl/main/vadl/lcb/passes/isaMatching/IsaMachineInstructionMatchingPass.java
@@ -235,42 +235,34 @@ public class IsaMachineInstructionMatchingPass extends Pass implements IsaMatchi
         instruction.attachExtension(new MachineInstructionCtx(MachineInstructionLabel.SLLI, ty));
       } else if (findRR(behavior, List.of(LSR, LSRS))) {
         instruction.attachExtension(new MachineInstructionCtx(MachineInstructionLabel.SRL, ty));
-      } else if (pc != null && findBranchWithConditional(behavior, EQU)) {
+      } else if (findBranchWithConditional(behavior, EQU)) {
         instruction.attachExtension(
             new MachineInstructionCtx(MachineInstructionLabel.BEQ, Optional.empty()));
-      } else if (pc != null && findBranchWithConditional(behavior, NEQ)) {
+      } else if (findBranchWithConditional(behavior, NEQ)) {
         instruction.attachExtension(
             new MachineInstructionCtx(MachineInstructionLabel.BNEQ, Optional.empty()));
-      } else if (pc != null
-          && findBranchWithConditional(behavior, Set.of(SGEQ))) {
+      } else if (findBranchWithConditional(behavior, Set.of(SGEQ))) {
         instruction.attachExtension(
             new MachineInstructionCtx(MachineInstructionLabel.BSGEQ, Optional.empty()));
-      } else if (pc != null
-          && findBranchWithConditional(behavior, Set.of(UGEQ))) {
+      } else if (findBranchWithConditional(behavior, Set.of(UGEQ))) {
         instruction.attachExtension(
             new MachineInstructionCtx(MachineInstructionLabel.BUGEQ, Optional.empty()));
-      } else if (pc != null
-          && findBranchWithConditional(behavior, Set.of(SLEQ))) {
+      } else if (findBranchWithConditional(behavior, Set.of(SLEQ))) {
         instruction.attachExtension(
             new MachineInstructionCtx(MachineInstructionLabel.BSLEQ, Optional.empty()));
-      } else if (pc != null
-          && findBranchWithConditional(behavior, Set.of(ULEQ))) {
+      } else if (findBranchWithConditional(behavior, Set.of(ULEQ))) {
         instruction.attachExtension(
             new MachineInstructionCtx(MachineInstructionLabel.BULEQ, Optional.empty()));
-      } else if (pc != null
-          && findBranchWithConditional(behavior, Set.of(SLTH))) {
+      } else if (findBranchWithConditional(behavior, Set.of(SLTH))) {
         instruction.attachExtension(
             new MachineInstructionCtx(MachineInstructionLabel.BSLTH, Optional.empty()));
-      } else if (pc != null
-          && findBranchWithConditional(behavior, Set.of(ULTH))) {
+      } else if (findBranchWithConditional(behavior, Set.of(ULTH))) {
         instruction.attachExtension(
             new MachineInstructionCtx(MachineInstructionLabel.BULTH, Optional.empty()));
-      } else if (pc != null
-          && findBranchWithConditional(behavior, Set.of(SGTH))) {
+      } else if (findBranchWithConditional(behavior, Set.of(SGTH))) {
         instruction.attachExtension(
             new MachineInstructionCtx(MachineInstructionLabel.BSGTH, Optional.empty()));
-      } else if (pc != null
-          && findBranchWithConditional(behavior, Set.of(UGTH))) {
+      } else if (findBranchWithConditional(behavior, Set.of(UGTH))) {
         instruction.attachExtension(
             new MachineInstructionCtx(MachineInstructionLabel.BUGTH, Optional.empty()));
       } else if (findRR(behavior, List.of(SLTH))) {
@@ -287,9 +279,9 @@ public class IsaMachineInstructionMatchingPass extends Pass implements IsaMatchi
       } else if (findLoadMem(behavior)) {
         instruction.attachExtension(
             new MachineInstructionCtx(MachineInstructionLabel.LOAD_MEM, ty));
-      } else if (pc != null && findJalr(behavior, pc)) {
+      } else if (findJalr(behavior, pc)) {
         instruction.attachExtension(new MachineInstructionCtx(MachineInstructionLabel.JALR, ty));
-      } else if (pc != null && findJal(behavior, pc)) {
+      } else if (findJal(behavior, pc)) {
         instruction.attachExtension(new MachineInstructionCtx(MachineInstructionLabel.JAL, ty));
       }
     });

--- a/vadl/main/vadl/lcb/template/lib/Target/EmitInstrInfoCppFilePass.java
+++ b/vadl/main/vadl/lcb/template/lib/Target/EmitInstrInfoCppFilePass.java
@@ -218,16 +218,36 @@ public class EmitInstrInfoCppFilePass extends LcbTemplateRenderingPass {
     }
   }
 
-  private PseudoInstruction getJump(Specification specification,
-                                    Map<PseudoInstructionLabel,
-                                        List<PseudoInstruction>> pseudoMatches) {
-    var jump = Optional.ofNullable(pseudoMatches.get(PseudoInstructionLabel.J))
-        .map(x -> x.stream().findFirst().get());
-    return ensurePresent(jump,
-        () -> Diagnostic.error(
-            "Compiler generator requires a pseudo instruction for an unconditional jump",
-            specification.location()
-        ));
+  /**
+   * Return the name of the unconditional jump instruction.
+   */
+  private String getJump(Specification specification,
+                         Map<MachineInstructionLabel,
+                             List<Instruction>> instructionMatches,
+                         Map<PseudoInstructionLabel,
+                             List<PseudoInstruction>> pseudoMatches) {
+    return getJumpFromMachineInstructions(instructionMatches)
+        .or(() -> getJumpFromPseudoInstructions(pseudoMatches))
+        .orElseThrow(() -> Diagnostic.error(
+            "The compiler generator requires an instruction / a pseudo instruction which is "
+                + "an unconditional jump. We haven't found one.",
+            specification.location()).build());
+  }
+
+  private Optional<String> getJumpFromPseudoInstructions(
+      Map<PseudoInstructionLabel,
+          List<PseudoInstruction>> pseudoMatches) {
+    return Optional.ofNullable(pseudoMatches.get(PseudoInstructionLabel.J))
+        .map(x -> x.stream().findFirst().get())
+        .map(Definition::simpleName);
+  }
+
+  private Optional<String> getJumpFromMachineInstructions(
+      Map<MachineInstructionLabel,
+          List<Instruction>> machineMatches) {
+    return Optional.ofNullable(machineMatches.get(MachineInstructionLabel.J))
+        .map(x -> x.stream().findFirst().get())
+        .map(Definition::simpleName);
   }
 
   record BranchInstruction(String name, /* size of the immediate */ int bitWidth) implements
@@ -304,8 +324,7 @@ public class EmitInstrInfoCppFilePass extends LcbTemplateRenderingPass {
     var additionRI = getAdditionRI(isaMatches);
     var additionRR = getAdditionRR(isaMatches);
     var additionRegisterFile = getRegisterClassFromInstruction(additionRR);
-    // Integer of the index of the zero register in the register file.
-    var jump = getJump(specification, pseudoMatches);
+    var jumpInstructionName = getJump(specification, isaMatches, pseudoMatches);
 
     var map = new HashMap<String, Object>();
     map.put(CommonVarNames.NAMESPACE, lcbConfiguration().targetName().value().toLowerCase());
@@ -320,7 +339,7 @@ public class EmitInstrInfoCppFilePass extends LcbTemplateRenderingPass {
     map.put("additionRegisterFile", additionRegisterFile.simpleName());
     map.put("branchInstructions", getBranchInstructions(specification, passResults, fieldUsages));
     map.put("instructionSizes", instructionSizes(specification));
-    map.put("jumpInstruction", jump.simpleName());
+    map.put("jumpInstruction", jumpInstructionName);
     map.put("beq",
         getBranchInstruction(specification, passResults, MachineInstructionLabel.BEQ));
     map.put("bne", getBranchInstruction(specification, passResults,

--- a/vadl/main/vadl/lcb/template/lib/Target/EmitInstrInfoCppFilePass.java
+++ b/vadl/main/vadl/lcb/template/lib/Target/EmitInstrInfoCppFilePass.java
@@ -30,6 +30,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import vadl.configuration.LcbConfiguration;
@@ -47,12 +48,16 @@ import vadl.lcb.template.CommonVarNames;
 import vadl.lcb.template.LcbTemplateRenderingPass;
 import vadl.pass.PassResults;
 import vadl.template.Renderable;
+import vadl.types.BuiltInTable;
 import vadl.viam.Definition;
 import vadl.viam.Instruction;
 import vadl.viam.PseudoInstruction;
 import vadl.viam.RegisterTensor;
 import vadl.viam.Specification;
+import vadl.viam.graph.Node;
 import vadl.viam.graph.control.InstrCallNode;
+import vadl.viam.graph.dependency.BuiltInCall;
+import vadl.viam.graph.dependency.FieldAccessRefNode;
 import vadl.viam.graph.dependency.ReadMemNode;
 import vadl.viam.graph.dependency.ReadRegTensorNode;
 import vadl.viam.graph.dependency.WriteMemNode;
@@ -389,7 +394,7 @@ public class EmitInstrInfoCppFilePass extends LcbTemplateRenderingPass {
     var branchInstructions = new ArrayList<BranchInstruction>();
     var database = new Database(passResults, specification);
 
-    machineInstructions(fieldUsages, database, branchInstructions);
+    machineInstructions(database, branchInstructions);
     pseudoInstructions(fieldUsages, database, branchInstructions);
 
     return branchInstructions;
@@ -420,7 +425,6 @@ public class EmitInstrInfoCppFilePass extends LcbTemplateRenderingPass {
   }
 
   private static void machineInstructions(
-      IdentifyFieldUsagePass.ImmediateDetectionContainer fieldUsages,
       Database database,
       List<BranchInstruction> branchInstructions) {
     var result = database.run(new Query.Builder().machineInstructionLabels(List.of(
@@ -436,13 +440,22 @@ public class EmitInstrInfoCppFilePass extends LcbTemplateRenderingPass {
         MachineInstructionLabel.BULTH
     )).build());
 
+    final Predicate<Node> isPc = (x) -> x instanceof ReadRegTensorNode node && node.isPcAccess();
     for (var machineInstruction : result.machineInstructions()) {
-      var immediates = fieldUsages.getImmediateFields(machineInstruction);
+      var builtins = machineInstruction
+          .behavior()
+          .getNodes(BuiltInCall.class)
+          .filter(x -> x.builtIn() == BuiltInTable.ADD && x.arguments().size() == 2)
+          .filter(x -> isPc.test(x.arguments().getFirst()) || isPc.test(x.arguments().get(1)))
+          .toList();
+      var immediates = new ArrayList<FieldAccessRefNode>();
+      builtins.forEach(builtInCall -> builtInCall.collectInputsWithChildren(immediates,
+          FieldAccessRefNode.class));
       ensure(immediates.size() == 1,
           () -> Diagnostic.error("We only support branch instructions with one label.",
               machineInstruction.location()));
       var immediate = unwrap(immediates.stream().findFirst());
-      int bitWidth = immediate.size();
+      int bitWidth = immediate.fieldAccess().type().asDataType().bitWidth();
       branchInstructions.add(
           new BranchInstruction(machineInstruction.identifier.simpleName(), bitWidth));
     }

--- a/vadl/main/vadl/viam/matching/impl/ReadRegisterCounterMatcher.java
+++ b/vadl/main/vadl/viam/matching/impl/ReadRegisterCounterMatcher.java
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.viam.matching.impl;
+
+import java.util.Objects;
+import vadl.viam.Counter;
+import vadl.viam.graph.Node;
+import vadl.viam.graph.dependency.ReadRegTensorNode;
+import vadl.viam.matching.Matcher;
+
+/**
+ * Matches a {@link ReadRegTensorNode} with a given {@link vadl.viam.Counter}.
+ */
+public class ReadRegisterCounterMatcher implements Matcher {
+  private final Counter counter;
+
+  /**
+   * Constructor to match a register which has the given {@link Counter}.
+   */
+  public ReadRegisterCounterMatcher(Counter counter) {
+    this.counter = counter;
+  }
+
+  @Override
+  public boolean matches(Node node) {
+    return node instanceof ReadRegTensorNode readRegTensorNode
+        && Objects.equals(readRegTensorNode.staticCounterAccess(), counter);
+  }
+}

--- a/vadl/test/resources/testSource/lcb/riscv32_register_elimination.vadl
+++ b/vadl/test/resources/testSource/lcb/riscv32_register_elimination.vadl
@@ -137,11 +137,13 @@ instruction set architecture RV3264IM = {
   register NZCV_C : Bits1             // Carry
   register NZCV_V : Bits1             // Overflow
 
-  instruction TEMP : Rtype =
+  instruction TEMP : Rtype = {
       if NZCV_Z = 1 then
-        PC := PC + X(rs1) + X(rs2) + shamt
+        X(rs2) := X(rs1) + shamt
+        PC := PC + shamt
+    }
     encoding TEMP = { opcode = 0b011'0011, funct3 = 0b000, funct7 = 0b000'0001 }
-    assembly TEMP = (mnemonic, " ", register(rs1), ",", register(rs2), ",", decimal(shamt))
+    assembly TEMP = (mnemonic, " ", register(rs1), ",", decimal(shamt))
 
     instruction TEMP2 : Rtype = {
       NZCV_N := 1

--- a/vadl/test/vadl/lcb/aarch64/IsaMachineInstructionMatchingAarch64PassTest.java
+++ b/vadl/test/vadl/lcb/aarch64/IsaMachineInstructionMatchingAarch64PassTest.java
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.lcb.aarch64;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import vadl.gcb.passes.MachineInstructionCtx;
+import vadl.gcb.passes.MachineInstructionLabel;
+import vadl.lcb.AbstractLcbTest;
+import vadl.lcb.passes.isaMatching.IsaMachineInstructionMatchingPass;
+import vadl.pass.PassOrders;
+import vadl.pass.exception.DuplicatedPassKeyException;
+import vadl.types.BitsType;
+import vadl.types.DataType;
+import vadl.viam.Definition;
+
+public class IsaMachineInstructionMatchingAarch64PassTest extends AbstractLcbTest {
+
+  private static Stream<Arguments> getExpectedMatchings() {
+    return Stream.of(
+        Arguments.of(List.of("B", "B_AL", "B_NV"), MachineInstructionLabel.J,
+            Optional.of(DataType.bits(64)))
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("getExpectedMatchings")
+  void shouldFindMatchings(List<String> expectedInstructionName,
+                           MachineInstructionLabel label,
+                           Optional<BitsType> dataType)
+      throws IOException, DuplicatedPassKeyException {
+    // Given
+    var config = getConfiguration(false);
+    var setup = setupPassManagerAndRunSpec(
+        "sys/aarch64/aarch64-abi.vadl",
+        PassOrders.lcb(config)
+            .untilFirst(IsaMachineInstructionMatchingPass.class)
+    );
+    var passManager = setup.passManager();
+
+    // When
+    var matchings =
+        ((IsaMachineInstructionMatchingPass.Result) passManager.getPassResults()
+            .lastResultOf(IsaMachineInstructionMatchingPass.class)).labels();
+
+    // Then
+    Assertions.assertNotNull(matchings);
+    Assertions.assertFalse(matchings.isEmpty());
+    Assertions.assertNotNull(matchings.get(label));
+    var result = matchings.get(label).stream().map(Definition::simpleName).sorted().toList();
+    assertEquals(expectedInstructionName.stream().sorted().toList(), result);
+  }
+
+
+  @ParameterizedTest
+  @MethodSource("getExpectedMatchings")
+  void shouldFindMatchingsByExtension(List<String> expectedInstructionName,
+                                      MachineInstructionLabel label,
+                                      Optional<BitsType> dataType)
+      throws IOException, DuplicatedPassKeyException {
+    // Given
+    var config = getConfiguration(false);
+    var setup = setupPassManagerAndRunSpec(
+        "sys/aarch64/aarch64-abi.vadl",
+        PassOrders.lcb(config)
+            .untilFirst(IsaMachineInstructionMatchingPass.class)
+    );
+
+    // When
+    for (var instructionName : expectedInstructionName) {
+      var instruction = setup.specification().isa().get().ownInstructions()
+          .stream().filter(x -> x.identifier.simpleName().equals(instructionName))
+          .findFirst()
+          .get();
+
+      var ctx = instruction.extension(MachineInstructionCtx.class);
+
+      // Then
+      Assertions.assertNotNull(ctx);
+      Assertions.assertEquals(label, ctx.label());
+      if (dataType.isPresent()) {
+        Assertions.assertEquals(dataType.get(), ctx.type().get());
+      } else {
+        Assertions.assertTrue(ctx.type().isEmpty());
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR contains the following changes:

- adds the labelling of unconditional jumps in Aarch64 (machine instructions)
- it uses the machine instruction unconditional jump and if it cannot one then looks for a pseudo instruction unconditional jump. This covers both Aarch64 and RISCV.
- improves the heuristic to find the branch instruction's immediate and its bitwidth