### PR TITLE
lcb: Fixed name of generated field access functions

### DIFF
--- a/vadl/main/vadl/viam/passes/NormalizeFieldsToFieldAccessFunctionsPass.java
+++ b/vadl/main/vadl/viam/passes/NormalizeFieldsToFieldAccessFunctionsPass.java
@@ -83,7 +83,10 @@ public class NormalizeFieldsToFieldAccessFunctionsPass extends Pass {
 
           immediates
               .forEach(fieldRefNode -> {
-                var id = fieldRefNode.formatField().identifier.append("generated");
+                var id =
+                    instruction.format().identifier.append(
+                        instruction.identifier().last()
+                            .append(fieldRefNode.formatField().identifier.last().parts()).parts());
                 var fieldAccess = new Format.FieldAccess(
                     id,
                     createAccessFunction(id, fieldRefNode),


### PR DESCRIPTION
When a field is used as immediate, we construct a field access function automatically. To avoid naming collisions, we have to change name otherwise the generated tablegen has duplicated entries.