### PR TITLE
lcb: Setup aarch64 alias registers

### DIFF
--- a/vadl/main/resources/templates/lcb/llvm/lib/Target/RegisterInfo.td
+++ b/vadl/main/resources/templates/lcb/llvm/lib/Target/RegisterInfo.td
@@ -17,7 +17,25 @@ def [(${register.name})] : Register<"[(${register.name})]">
     [#th:block th:if="${register.hwEncodingMsb == 0}"]
     let HWEncoding = [(${register.hwEncodingValue})];
     [/th:block]
-    let isArtificial = 0;
+    let isArtificial = [(${register.isArtificial})];
+}
+[/]
+
+[# th:each="register, iterStat : ${aliasRegisters}" ]
+def [(${register.name})] : Register<"[(${register.name})]">
+{
+    let Namespace = "[(${register.namespace.value})]";
+    let AsmName = "[(${register.asmName})]";
+    let AltNames = [ [(${register.altNamesString})]  ];
+    let Aliases = [ ];
+    let SubRegs = [ ];
+    let SubRegIndices = [ ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ [(${register.dwarfNumber})] ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
+    let HWEncoding = [(${register.hwEncodingValue})];
+    let isArtificial = [(${register.isArtificial})];
 }
 [/]
 

--- a/vadl/main/vadl/gcb/passes/GenerateCompilerRegistersPass.java
+++ b/vadl/main/vadl/gcb/passes/GenerateCompilerRegistersPass.java
@@ -32,7 +32,9 @@ import vadl.gcb.valuetypes.IndexedCompilerRegister;
 import vadl.pass.Pass;
 import vadl.pass.PassName;
 import vadl.pass.PassResults;
+import vadl.utils.Pair;
 import vadl.viam.Abi;
+import vadl.viam.ArtificialResource;
 import vadl.viam.RegisterTensor;
 import vadl.viam.Specification;
 
@@ -73,8 +75,10 @@ public class GenerateCompilerRegistersPass extends Pass {
         registerClasses(viam.registerTensors().filter(RegisterTensor::isRegisterFile)
                 .toList(), abi,
             dwarfOffset);
+    var artificialResources =
+        artificialResources(viam.artificialResources().toList(), abi, registerClasses.right());
 
-    return new Output(generalRegisters, registerClasses);
+    return new Output(generalRegisters, registerClasses.left());
   }
 
   private List<CompilerRegister> generalRegisters(List<RegisterTensor> registers) {
@@ -93,13 +97,14 @@ public class GenerateCompilerRegistersPass extends Pass {
     return compilerRegisters;
   }
 
-  private List<CompilerRegisterClass> registerClasses(List<RegisterTensor> registerFiles,
-                                                      Abi abi,
-                                                      int dwarfOffset) {
+  private Pair<List<CompilerRegisterClass>, Integer> registerClasses(
+      List<RegisterTensor> registerFiles,
+      Abi abi,
+      int dwarfOffset) {
     var result = new ArrayList<CompilerRegisterClass>();
 
     for (var registerFile : registerFiles) {
-      var registers = IndexedCompilerRegister.fromRegisterFile(registerFile, abi, dwarfOffset);
+      var registers = IndexedCompilerRegister.fromRegisterFile(registerFile, abi, dwarfOffset, false);
       dwarfOffset += registers.size();
 
       var alignment = ensureNonNull(abi.registerFileAlignment().get(registerFile),
@@ -109,6 +114,30 @@ public class GenerateCompilerRegistersPass extends Pass {
       result.add(new CompilerRegisterClass(registerFile, registers, alignment));
     }
 
-    return result;
+    return Pair.of(result, dwarfOffset);
+  }
+
+  private Pair<List<CompilerRegisterClass>, Integer> artificialResources(
+      List<ArtificialResource> artificialResources,
+      Abi abi,
+      int dwarfOffset) {
+    var result = new ArrayList<CompilerRegisterClass>();
+
+    for (var registerFile : artificialResources) {
+      // If it is not a register file then continue.
+      if (registerFile.innerResourceRef() instanceof RegisterTensor registerTensor
+          && registerTensor.isRegisterFile()) {
+        var registers = IndexedCompilerRegister.fromRegisterFile(registerTensor, abi, dwarfOffset, true);
+        dwarfOffset += registers.size();
+
+        var alignment = ensureNonNull(abi.registerFileAlignment().get(registerTensor),
+            () -> Diagnostic.error("There is not alignment for the register file defined",
+                registerFile.location().join(abi.location())));
+
+        result.add(new CompilerRegisterClass(registerTensor, registers, alignment));
+      }
+    }
+
+    return Pair.of(result, dwarfOffset);
   }
 }

--- a/vadl/main/vadl/gcb/passes/GenerateCompilerRegistersPass.java
+++ b/vadl/main/vadl/gcb/passes/GenerateCompilerRegistersPass.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import vadl.configuration.GeneralConfiguration;
 import vadl.error.Diagnostic;
@@ -37,6 +38,7 @@ import vadl.viam.Abi;
 import vadl.viam.ArtificialResource;
 import vadl.viam.RegisterTensor;
 import vadl.viam.Specification;
+import vadl.viam.graph.dependency.ConstantNode;
 
 /**
  * The VIAM gives us register files, but we need separate registers.
@@ -56,10 +58,10 @@ public class GenerateCompilerRegistersPass extends Pass {
   /**
    * Output of the pass.
    */
-  public record Output(
-      List<CompilerRegister> generalRegisters,
-      List<CompilerRegisterClass> registerClasses
-  ) {
+  public record Output(List<CompilerRegister> generalRegisters,
+                       List<CompilerRegister> aliasRegisters,
+                       List<CompilerRegisterClass> registerClasses,
+                       List<CompilerRegisterClass> aliasRegisterClasses) {
 
   }
 
@@ -68,17 +70,23 @@ public class GenerateCompilerRegistersPass extends Pass {
   public Object execute(PassResults passResults, Specification viam) throws IOException {
     var abi = (Abi) viam.definitions().filter(x -> x instanceof Abi).findFirst().get();
 
-    var generalRegisters = generalRegisters(viam.registerTensors()
-        .filter(RegisterTensor::isSingleRegister).toList());
-    int dwarfOffset = generalRegisters.size();
+    var generalRegisters =
+        generalRegisters(viam.registerTensors().filter(RegisterTensor::isSingleRegister).toList());
+    var aliasRegisters =
+        aliasRegisters(viam.artificialResources().filter(ArtificialResource::isRegister).toList(),
+            generalRegisters.size());
+    int dwarfOffset = aliasRegisters.right();
     var registerClasses =
-        registerClasses(viam.registerTensors().filter(RegisterTensor::isRegisterFile)
-                .toList(), abi,
+        registerClasses(viam.registerTensors().filter(RegisterTensor::isRegisterFile).toList(), abi,
             dwarfOffset);
-    var artificialResources =
-        artificialResources(viam.artificialResources().toList(), abi, registerClasses.right());
+    var aliasRegisterFiles = aliasRegisterFiles(
+        viam.artificialResources().filter(ArtificialResource::isRegisterFile).toList(), abi,
+        registerClasses.right());
 
-    return new Output(generalRegisters, registerClasses.left());
+    return new Output(generalRegisters,
+        aliasRegisters.left(),
+        registerClasses.left(),
+        aliasRegisterFiles.left());
   }
 
   private List<CompilerRegister> generalRegisters(List<RegisterTensor> registers) {
@@ -97,14 +105,34 @@ public class GenerateCompilerRegistersPass extends Pass {
     return compilerRegisters;
   }
 
+  private Pair<List<CompilerRegister>, Integer> aliasRegisters(List<ArtificialResource> registers,
+                                                               int dwarfOffset) {
+    var compilerRegisters = new ArrayList<CompilerRegister>();
+    for (var register : registers) {
+      var address = register.readFunction().behavior().getNodes(ConstantNode.class).findFirst()
+          .map(x -> x.constant().asVal().intValue());
+
+      // The alias should be the same as the register name.
+      var alias = GeneralCompilerRegister.generateName(register);
+
+      var compilerRegister = address.isEmpty() ?
+          new GeneralCompilerRegister(register, alias, Collections.emptyList(),
+              dwarfOffset++) :
+          new GeneralCompilerRegister(register, address.get(), alias, Collections.emptyList(),
+              dwarfOffset++);
+      compilerRegisters.add(compilerRegister);
+    }
+
+    return Pair.of(compilerRegisters, dwarfOffset);
+  }
+
   private Pair<List<CompilerRegisterClass>, Integer> registerClasses(
-      List<RegisterTensor> registerFiles,
-      Abi abi,
-      int dwarfOffset) {
+      List<RegisterTensor> registerFiles, Abi abi, int dwarfOffset) {
     var result = new ArrayList<CompilerRegisterClass>();
 
     for (var registerFile : registerFiles) {
-      var registers = IndexedCompilerRegister.fromRegisterFile(registerFile, abi, dwarfOffset, false);
+      var registers =
+          IndexedCompilerRegister.fromRegisterFile(registerFile, abi, dwarfOffset, false);
       dwarfOffset += registers.size();
 
       var alignment = ensureNonNull(abi.registerFileAlignment().get(registerFile),
@@ -117,17 +145,16 @@ public class GenerateCompilerRegistersPass extends Pass {
     return Pair.of(result, dwarfOffset);
   }
 
-  private Pair<List<CompilerRegisterClass>, Integer> artificialResources(
-      List<ArtificialResource> artificialResources,
-      Abi abi,
-      int dwarfOffset) {
+  private Pair<List<CompilerRegisterClass>, Integer> aliasRegisterFiles(
+      List<ArtificialResource> artificialResources, Abi abi, int dwarfOffset) {
     var result = new ArrayList<CompilerRegisterClass>();
 
     for (var registerFile : artificialResources) {
       // If it is not a register file then continue.
       if (registerFile.innerResourceRef() instanceof RegisterTensor registerTensor
           && registerTensor.isRegisterFile()) {
-        var registers = IndexedCompilerRegister.fromRegisterFile(registerTensor, abi, dwarfOffset, true);
+        var registers =
+            IndexedCompilerRegister.fromRegisterFile(registerTensor, abi, dwarfOffset, true);
         dwarfOffset += registers.size();
 
         var alignment = ensureNonNull(abi.registerFileAlignment().get(registerTensor),

--- a/vadl/main/vadl/gcb/valuetypes/CompilerRegister.java
+++ b/vadl/main/vadl/gcb/valuetypes/CompilerRegister.java
@@ -27,6 +27,7 @@ public abstract class CompilerRegister {
   protected final List<String> altNames;
   protected final int dwarfNumber;
   protected final int hwEncodingValue;
+  protected final boolean isArtificial;
 
   /**
    * Constructor.
@@ -35,12 +36,14 @@ public abstract class CompilerRegister {
                           String asmName,
                           List<String> altNames,
                           int dwarfNumber,
-                          int hwEncodingValue) {
+                          int hwEncodingValue,
+                          boolean isArtificial) {
     this.name = name;
     this.asmName = asmName;
     this.altNames = altNames;
     this.dwarfNumber = dwarfNumber;
     this.hwEncodingValue = hwEncodingValue;
+    this.isArtificial = isArtificial;
   }
 
   public String name() {
@@ -61,5 +64,9 @@ public abstract class CompilerRegister {
 
   public int hwEncodingValue() {
     return hwEncodingValue;
+  }
+
+  public boolean isArtificial() {
+    return isArtificial;
   }
 }

--- a/vadl/main/vadl/gcb/valuetypes/GeneralCompilerRegister.java
+++ b/vadl/main/vadl/gcb/valuetypes/GeneralCompilerRegister.java
@@ -17,6 +17,7 @@
 package vadl.gcb.valuetypes;
 
 import java.util.List;
+import vadl.viam.ArtificialResource;
 import vadl.viam.RegisterTensor;
 
 /**
@@ -26,11 +27,39 @@ import vadl.viam.RegisterTensor;
  * register file.
  */
 public class GeneralCompilerRegister extends CompilerRegister {
+  /**
+   * Generate a register from a {@link RegisterTensor}. It has no {@code hwEncodingValue} because
+   * it is a separate physical register.
+   */
   public GeneralCompilerRegister(RegisterTensor register,
                                  String asmName,
                                  List<String> altNames,
                                  int dwarfNumber) {
-    super(generateName(register), asmName, altNames, dwarfNumber, 0);
+    super(generateName(register), asmName, altNames, dwarfNumber, 0, false);
+  }
+
+  /**
+   * Generate a register which is an alias to a physical register or a register file. This
+   * constructor handles a register file because it takes {@code address} as input.
+   */
+  public GeneralCompilerRegister(ArtificialResource artificialResource,
+                                 int address, /* hwEncoding */
+                                 String asmName,
+                                 List<String> altNames,
+                                 int dwarfNumber) {
+    super(generateName(artificialResource), asmName, altNames, dwarfNumber, address, true);
+  }
+
+  /**
+   * Generate a register which is an alias to a physical register or a register file. This
+   * constructor handles an alias for a physical register because the {@code hwEncodingValue} is
+   * zero.
+   */
+  public GeneralCompilerRegister(ArtificialResource artificialResource,
+                                 String asmName,
+                                 List<String> altNames,
+                                 int dwarfNumber) {
+    super(generateName(artificialResource), asmName, altNames, dwarfNumber, 0, true);
   }
 
   /**
@@ -39,5 +68,17 @@ public class GeneralCompilerRegister extends CompilerRegister {
   public static String generateName(RegisterTensor register) {
     register.ensure(register.isSingleRegister(), "must be single register");
     return register.simpleName();
+  }
+
+  /**
+   * Generate the internal compiler name from a register.
+   */
+  public static String generateName(ArtificialResource artificialResource) {
+    var registerTensor = (RegisterTensor) artificialResource.innerResourceRef();
+
+    // Either is the underlying a register or the readFunction has no inputs.
+    artificialResource.ensure(registerTensor.isSingleRegister()
+        || artificialResource.readFunction().parameters().length == 0, "must be single register");
+    return artificialResource.simpleName();
   }
 }

--- a/vadl/main/vadl/gcb/valuetypes/IndexedCompilerRegister.java
+++ b/vadl/main/vadl/gcb/valuetypes/IndexedCompilerRegister.java
@@ -46,8 +46,9 @@ public class IndexedCompilerRegister extends CompilerRegister {
                                  String asmName,
                                  List<String> altNames,
                                  int dwarfNumber,
-                                 int isArtificial) {
-    super(registerFile.generateRegisterFileName(index), asmName, altNames, dwarfNumber, index);
+                                 boolean isArtificial) {
+    super(registerFile.generateRegisterFileName(index), asmName, altNames, dwarfNumber, index,
+        isArtificial);
     this.index = index;
   }
 
@@ -86,7 +87,7 @@ public class IndexedCompilerRegister extends CompilerRegister {
       int dwarfNumber = dwarfNumberOffset + addr;
 
       registers.add(new IndexedCompilerRegister(registerFile, addr, alias, altNames, dwarfNumber,
-          isArtificial ? 1 : 0));
+          isArtificial));
     }
 
     return registers;

--- a/vadl/main/vadl/gcb/valuetypes/IndexedCompilerRegister.java
+++ b/vadl/main/vadl/gcb/valuetypes/IndexedCompilerRegister.java
@@ -45,7 +45,8 @@ public class IndexedCompilerRegister extends CompilerRegister {
                                  int index,
                                  String asmName,
                                  List<String> altNames,
-                                 int dwarfNumber) {
+                                 int dwarfNumber,
+                                 int isArtificial) {
     super(registerFile.generateRegisterFileName(index), asmName, altNames, dwarfNumber, index);
     this.index = index;
   }
@@ -58,11 +59,13 @@ public class IndexedCompilerRegister extends CompilerRegister {
    * @param abi               for the compiler.
    * @param dwarfNumberOffset is the offset for calculating the dwarf numbers because we cannot
    *                          assume that there is only one register file.
+   * @param isArtificial      registers in {@code registerFile} do not really exist.
    * @return a list of registers generated from the register file.
    */
   public static List<CompilerRegister> fromRegisterFile(RegisterTensor registerFile,
                                                         Abi abi,
-                                                        int dwarfNumberOffset) {
+                                                        int dwarfNumberOffset,
+                                                        boolean isArtificial) {
     var bitWidth = Objects.requireNonNull(registerFile.addressType()).bitWidth();
     var numberOfRegisters = (int) Math.pow(2, bitWidth);
     var all = IntStream.range(0, numberOfRegisters).boxed().collect(Collectors.toSet());
@@ -82,7 +85,8 @@ public class IndexedCompilerRegister extends CompilerRegister {
 
       int dwarfNumber = dwarfNumberOffset + addr;
 
-      registers.add(new IndexedCompilerRegister(registerFile, addr, alias, altNames, dwarfNumber));
+      registers.add(new IndexedCompilerRegister(registerFile, addr, alias, altNames, dwarfNumber,
+          isArtificial ? 1 : 0));
     }
 
     return registers;

--- a/vadl/main/vadl/lcb/passes/llvmLowering/GenerateTableGenRegistersPass.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/GenerateTableGenRegistersPass.java
@@ -29,6 +29,7 @@ import vadl.gcb.valuetypes.CompilerRegisterClass;
 import vadl.gcb.valuetypes.IndexedCompilerRegister;
 import vadl.gcb.valuetypes.ValueType;
 import vadl.lcb.passes.llvmLowering.tablegen.model.register.TableGenRegister;
+import vadl.lcb.passes.llvmLowering.tablegen.model.register.TableGenRegisterAlias;
 import vadl.lcb.passes.llvmLowering.tablegen.model.register.TableGenRegisterClass;
 import vadl.pass.Pass;
 import vadl.pass.PassName;
@@ -62,7 +63,9 @@ public class GenerateTableGenRegistersPass extends Pass {
    * Contains the output of the pass.
    */
   public record Output(List<TableGenRegisterClass> registerClasses,
+                       List<TableGenRegisterClass> aliasRegisterClasses,
                        List<TableGenRegister> registers,
+                       List<TableGenRegisterAlias> aliasRegisters,
                        List<LlvmConstraint> constraints) {
     /* `registers` do not belong to any register class. */
   }
@@ -76,16 +79,29 @@ public class GenerateTableGenRegistersPass extends Pass {
     var compilerRegisterClasses = output.registerClasses();
 
     var registerClasses = new ArrayList<TableGenRegisterClass>();
+    var aliasRegisterClasses = new ArrayList<TableGenRegisterClass>();
     var registers = new ArrayList<TableGenRegister>();
+    var aliasRegisters = new ArrayList<TableGenRegisterAlias>();
 
     for (var compilerRegister : output.generalRegisters()) {
       var register = new TableGenRegister(
           configuration.targetName(),
           compilerRegister,
           compilerRegister.hwEncodingValue(),
-          Optional.empty()
+          Optional.empty(),
+          compilerRegister.isArtificial()
       );
       registers.add(register);
+    }
+
+    for (var compilerRegister : output.aliasRegisters()) {
+      var register = new TableGenRegisterAlias(
+          configuration.targetName(),
+          compilerRegister,
+          Optional.of(compilerRegister.hwEncodingValue()),
+          compilerRegister.isArtificial()
+      );
+      aliasRegisters.add(register);
     }
 
     for (var compilerRegisterClass : compilerRegisterClasses) {
@@ -96,7 +112,8 @@ public class GenerateTableGenRegistersPass extends Pass {
             compilerRegister,
             Objects.requireNonNull(compilerRegisterClass.registerFile().addressType()).bitWidth()
                 - 1,
-            Optional.of(compilerRegister.hwEncodingValue())
+            Optional.of(compilerRegister.hwEncodingValue()),
+            compilerRegister.isArtificial()
         );
         registers.add(register);
         classRegisters.add(register);
@@ -115,7 +132,8 @@ public class GenerateTableGenRegistersPass extends Pass {
     }
 
     var constraints = getConstraints(registerClasses);
-    return new Output(registerClasses, registers, constraints);
+    return new Output(registerClasses, aliasRegisterClasses, registers, aliasRegisters,
+        constraints);
   }
 
   private List<LlvmConstraint> getConstraints(List<TableGenRegisterClass> mainRegisterClasses) {

--- a/vadl/main/vadl/lcb/passes/llvmLowering/tablegen/model/register/TableGenRegisterAlias.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/tablegen/model/register/TableGenRegisterAlias.java
@@ -24,13 +24,12 @@ import vadl.gcb.valuetypes.TargetName;
 import vadl.template.Renderable;
 
 /**
- * Represents a single register in TableGen.
+ * Represents a register alias in TableGen.
  */
-public record TableGenRegister(TargetName namespace,
-                               CompilerRegister compilerRegister,
-                               int hwEncodingMsb,
-                               Optional<Integer> index,
-                               boolean isArtificial) implements Renderable {
+public record TableGenRegisterAlias(TargetName namespace,
+                                    CompilerRegister compilerRegister,
+                                    Optional<Integer> index,
+                                    boolean isArtificial) implements Renderable {
 
   public String altNamesString() {
     return String.join(", ",
@@ -44,7 +43,6 @@ public record TableGenRegister(TargetName namespace,
     map.put("name", compilerRegister.name());
     map.put("asmName", compilerRegister.asmName());
     map.put("dwarfNumber", compilerRegister.dwarfNumber());
-    map.put("hwEncodingMsb", hwEncodingMsb);
     map.put("hwEncodingValue", compilerRegister.hwEncodingValue());
     map.put("altNamesString", altNamesString());
     map.put("isArtificial", isArtificial ? 1 : 0);

--- a/vadl/main/vadl/lcb/template/lib/Target/EmitRegisterInfoTableGenFilePass.java
+++ b/vadl/main/vadl/lcb/template/lib/Target/EmitRegisterInfoTableGenFilePass.java
@@ -126,6 +126,7 @@ public class EmitRegisterInfoTableGenFilePass extends LcbTemplateRenderingPass {
         lcbConfiguration().targetName().value().toLowerCase(),
         "pointerAlignment", DataLayoutProvider.pointerAlignment(abi),
         "registers", output.registers(),
+        "aliasRegisters", output.aliasRegisters(),
         "registerFiles", List.of(
             new WrappedRegisterFile(registerClass, allocationSeq)
         ));

--- a/vadl/main/vadl/viam/ArtificialResource.java
+++ b/vadl/main/vadl/viam/ArtificialResource.java
@@ -83,6 +83,20 @@ public class ArtificialResource extends Resource {
     return writeProcedure;
   }
 
+  /**
+   * The {@link ArtificialResource} is an alias for a register file.
+   */
+  public boolean isRegisterFile() {
+    return readFunction.parameters().length == 1;
+  }
+
+  /**
+   * The {@link ArtificialResource} is an alias for a concrete register.
+   */
+  public boolean isRegister() {
+    return readFunction.parameters().length == 0;
+  }
+
   @Override
   public void verify() {
     super.verify();

--- a/vadl/main/vadl/viam/Specification.java
+++ b/vadl/main/vadl/viam/Specification.java
@@ -112,9 +112,14 @@ public class Specification extends Definition {
    * Returns all register tensors in the ISA as a stream.
    */
   public Stream<RegisterTensor> registerTensors() {
-    return isa()
-        .map(x -> x.registerTensors().stream())
-        .orElseGet(Stream::empty);
+    return isa().stream().flatMap(x -> x.registerTensors().stream());
+  }
+
+  /**
+   * Returns all artificial resources in the ISA as a stream.
+   */
+  public Stream<ArtificialResource> artificialResources() {
+    return isa().stream().flatMap(x -> x.artificialResources().stream());
   }
 
   /**

--- a/vadl/test/resources/snapshots/aarch64/RegisterInfo.cpp
+++ b/vadl/test/resources/snapshots/aarch64/RegisterInfo.cpp
@@ -1,0 +1,2442 @@
+#include "processornamevalueRegisterInfo.h"
+#include "processornamevalueFrameLowering.h"
+#include "processornamevalueInstrInfo.h"
+#include "processornamevalueSubTarget.h"
+#include "Utils/processornamevalueBaseInfo.h"
+#include "Utils/ImmediateUtils.h"
+#include "MCTargetDesc/processornamevalueMCTargetDesc.h"
+#include "llvm/ADT/BitVector.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/CodeGen/MachineFrameInfo.h"
+#include "llvm/CodeGen/MachineFunction.h"
+#include "llvm/CodeGen/MachineInstrBuilder.h"
+#include "llvm/CodeGen/RegisterScavenging.h"
+#include "llvm/CodeGen/TargetFrameLowering.h"
+#include "llvm/CodeGen/TargetInstrInfo.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/Type.h"
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/Debug.h"
+#include <iostream>
+#include <sstream>
+
+#define DEBUG_TYPE "processornamevalueRegisterInfo"
+
+using namespace llvm;
+
+#define GET_REGINFO_TARGET_DESC
+#include "processornamevalueGenRegisterInfo.inc"
+
+void processornamevalueRegisterInfo::anchor() {}
+
+processornamevalueRegisterInfo::processornamevalueRegisterInfo()
+    : processornamevalueGenRegisterInfo( processornamevalue::S30 )
+{
+}
+
+const uint16_t * processornamevalueRegisterInfo::getCalleeSavedRegs(const MachineFunction * /*MF*/
+) const
+{
+    // defined in calling convention tablegen
+    return CSR_processornamevalue_SaveList;
+}
+
+BitVector processornamevalueRegisterInfo::getReservedRegs(const MachineFunction &MF) const
+{
+    BitVector Reserved(getNumRegs());
+
+    markSuperRegs(Reserved, processornamevalue::S29); // frame pointer
+    markSuperRegs(Reserved, processornamevalue::S31); // stack pointer
+    markSuperRegs(Reserved, processornamevalue::); // global pointer
+
+
+    markSuperRegs(Reserved, processornamevalue::); // thread pointer
+
+
+
+
+    assert(checkAllSuperRegsMarked(Reserved));
+
+    return Reserved;
+}
+
+
+bool eliminateFrameIndexADDXI
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
+{
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+
+    //
+    // try to inline the offset into the instruction
+    //
+
+    if(Offset >= 0 && Offset <= 4096 && AArch64Base_ADDXI_imm12X_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
+
+
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
+
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
+
+    return true; // failure
+}
+bool eliminateFrameIndexADDXSXSB
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
+{
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 2).isImm() && "Immediate operand position does not match expected position!" );
+
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 2);
+
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+
+    //
+    // try to inline the offset into the instruction
+    //
+
+    if(Offset >= 0 && Offset <= 8 && AArch64Base_ADDXSXSB_imm3_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
+
+
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
+
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
+
+    return true; // failure
+}
+bool eliminateFrameIndexADDXSXSH
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
+{
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 2).isImm() && "Immediate operand position does not match expected position!" );
+
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 2);
+
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+
+    //
+    // try to inline the offset into the instruction
+    //
+
+    if(Offset >= 0 && Offset <= 8 && AArch64Base_ADDXSXSH_imm3_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
+
+
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
+
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
+
+    return true; // failure
+}
+bool eliminateFrameIndexADDXSXSW
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
+{
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 2).isImm() && "Immediate operand position does not match expected position!" );
+
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 2);
+
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+
+    //
+    // try to inline the offset into the instruction
+    //
+
+    if(Offset >= 0 && Offset <= 8 && AArch64Base_ADDXSXSW_imm3_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
+
+
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
+
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
+
+    return true; // failure
+}
+bool eliminateFrameIndexADDXUXSB
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
+{
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 2).isImm() && "Immediate operand position does not match expected position!" );
+
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 2);
+
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+
+    //
+    // try to inline the offset into the instruction
+    //
+
+    if(Offset >= 0 && Offset <= 8 && AArch64Base_ADDXUXSB_imm3_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
+
+
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
+
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
+
+    return true; // failure
+}
+bool eliminateFrameIndexADDXUXSH
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
+{
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 2).isImm() && "Immediate operand position does not match expected position!" );
+
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 2);
+
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+
+    //
+    // try to inline the offset into the instruction
+    //
+
+    if(Offset >= 0 && Offset <= 8 && AArch64Base_ADDXUXSH_imm3_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
+
+
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
+
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
+
+    return true; // failure
+}
+bool eliminateFrameIndexADDXUXSW
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
+{
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 2).isImm() && "Immediate operand position does not match expected position!" );
+
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 2);
+
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+
+    //
+    // try to inline the offset into the instruction
+    //
+
+    if(Offset >= 0 && Offset <= 8 && AArch64Base_ADDXUXSW_imm3_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
+
+
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
+
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
+
+    return true; // failure
+}
+bool eliminateFrameIndexLDPSPre
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
+{
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+
+    //
+    // try to inline the offset into the instruction
+    //
+
+    if(Offset >= -64 && Offset <= 63 && AArch64Base_LDPSPre_offWSize_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
+
+
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
+
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
+
+    return true; // failure
+}
+bool eliminateFrameIndexLDPSPst
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
+{
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+
+    //
+    // try to inline the offset into the instruction
+    //
+
+    if(Offset >= -64 && Offset <= 63 && AArch64Base_LDPSPst_offWSize_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
+
+
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
+
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
+
+    return true; // failure
+}
+bool eliminateFrameIndexLDPWPre
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
+{
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+
+    //
+    // try to inline the offset into the instruction
+    //
+
+    if(Offset >= -64 && Offset <= 63 && AArch64Base_LDPWPre_offWSize_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
+
+
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
+
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
+
+    return true; // failure
+}
+bool eliminateFrameIndexLDPWPst
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
+{
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+
+    //
+    // try to inline the offset into the instruction
+    //
+
+    if(Offset >= -64 && Offset <= 63 && AArch64Base_LDPWPst_offWSize_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
+
+
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
+
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
+
+    return true; // failure
+}
+bool eliminateFrameIndexLDPXPre
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
+{
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+
+    //
+    // try to inline the offset into the instruction
+    //
+
+    if(Offset >= -64 && Offset <= 63 && AArch64Base_LDPXPre_offXSize_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
+
+
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
+
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
+
+    return true; // failure
+}
+bool eliminateFrameIndexLDPXPst
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
+{
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+
+    //
+    // try to inline the offset into the instruction
+    //
+
+    if(Offset >= -64 && Offset <= 63 && AArch64Base_LDPXPst_offXSize_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
+
+
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
+
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
+
+    return true; // failure
+}
+bool eliminateFrameIndexLDRPreB
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
+{
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+
+    //
+    // try to inline the offset into the instruction
+    //
+
+    if(Offset >= -256 && Offset <= 255 && AArch64Base_LDRPreB_offset_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
+
+
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
+
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
+
+    return true; // failure
+}
+bool eliminateFrameIndexLDRPreH
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
+{
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+
+    //
+    // try to inline the offset into the instruction
+    //
+
+    if(Offset >= -256 && Offset <= 255 && AArch64Base_LDRPreH_offset_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
+
+
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
+
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
+
+    return true; // failure
+}
+bool eliminateFrameIndexLDRPreSBW
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
+{
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+
+    //
+    // try to inline the offset into the instruction
+    //
+
+    if(Offset >= -256 && Offset <= 255 && AArch64Base_LDRPreSBW_offset_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
+
+
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
+
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
+
+    return true; // failure
+}
+bool eliminateFrameIndexLDRPreSBX
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
+{
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+
+    //
+    // try to inline the offset into the instruction
+    //
+
+    if(Offset >= -256 && Offset <= 255 && AArch64Base_LDRPreSBX_offset_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
+
+
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
+
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
+
+    return true; // failure
+}
+bool eliminateFrameIndexLDRPreSHW
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
+{
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+
+    //
+    // try to inline the offset into the instruction
+    //
+
+    if(Offset >= -256 && Offset <= 255 && AArch64Base_LDRPreSHW_offset_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
+
+
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
+
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
+
+    return true; // failure
+}
+bool eliminateFrameIndexLDRPreSHX
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
+{
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+
+    //
+    // try to inline the offset into the instruction
+    //
+
+    if(Offset >= -256 && Offset <= 255 && AArch64Base_LDRPreSHX_offset_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
+
+
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
+
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
+
+    return true; // failure
+}
+bool eliminateFrameIndexLDRPreSWX
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
+{
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+
+    //
+    // try to inline the offset into the instruction
+    //
+
+    if(Offset >= -256 && Offset <= 255 && AArch64Base_LDRPreSWX_offset_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
+
+
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
+
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
+
+    return true; // failure
+}
+bool eliminateFrameIndexLDRPreW
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
+{
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+
+    //
+    // try to inline the offset into the instruction
+    //
+
+    if(Offset >= -256 && Offset <= 255 && AArch64Base_LDRPreW_offset_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
+
+
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
+
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
+
+    return true; // failure
+}
+bool eliminateFrameIndexLDRPreX
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
+{
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+
+    //
+    // try to inline the offset into the instruction
+    //
+
+    if(Offset >= -256 && Offset <= 255 && AArch64Base_LDRPreX_offset_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
+
+
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
+
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
+
+    return true; // failure
+}
+bool eliminateFrameIndexLDRPstB
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
+{
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+
+    //
+    // try to inline the offset into the instruction
+    //
+
+    if(Offset >= -256 && Offset <= 255 && AArch64Base_LDRPstB_offset_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
+
+
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
+
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
+
+    return true; // failure
+}
+bool eliminateFrameIndexLDRPstH
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
+{
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+
+    //
+    // try to inline the offset into the instruction
+    //
+
+    if(Offset >= -256 && Offset <= 255 && AArch64Base_LDRPstH_offset_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
+
+
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
+
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
+
+    return true; // failure
+}
+bool eliminateFrameIndexLDRPstSBW
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
+{
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+
+    //
+    // try to inline the offset into the instruction
+    //
+
+    if(Offset >= -256 && Offset <= 255 && AArch64Base_LDRPstSBW_offset_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
+
+
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
+
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
+
+    return true; // failure
+}
+bool eliminateFrameIndexLDRPstSBX
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
+{
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+
+    //
+    // try to inline the offset into the instruction
+    //
+
+    if(Offset >= -256 && Offset <= 255 && AArch64Base_LDRPstSBX_offset_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
+
+
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
+
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
+
+    return true; // failure
+}
+bool eliminateFrameIndexLDRPstSHW
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
+{
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+
+    //
+    // try to inline the offset into the instruction
+    //
+
+    if(Offset >= -256 && Offset <= 255 && AArch64Base_LDRPstSHW_offset_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
+
+
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
+
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
+
+    return true; // failure
+}
+bool eliminateFrameIndexLDRPstSHX
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
+{
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+
+    //
+    // try to inline the offset into the instruction
+    //
+
+    if(Offset >= -256 && Offset <= 255 && AArch64Base_LDRPstSHX_offset_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
+
+
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
+
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
+
+    return true; // failure
+}
+bool eliminateFrameIndexLDRPstSWX
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
+{
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+
+    //
+    // try to inline the offset into the instruction
+    //
+
+    if(Offset >= -256 && Offset <= 255 && AArch64Base_LDRPstSWX_offset_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
+
+
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
+
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
+
+    return true; // failure
+}
+bool eliminateFrameIndexLDRPstW
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
+{
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+
+    //
+    // try to inline the offset into the instruction
+    //
+
+    if(Offset >= -256 && Offset <= 255 && AArch64Base_LDRPstW_offset_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
+
+
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
+
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
+
+    return true; // failure
+}
+bool eliminateFrameIndexLDRPstX
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
+{
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+
+    //
+    // try to inline the offset into the instruction
+    //
+
+    if(Offset >= -256 && Offset <= 255 && AArch64Base_LDRPstX_offset_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
+
+
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
+
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
+
+    return true; // failure
+}
+bool eliminateFrameIndexSTRPreB
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
+{
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 2).isImm() && "Immediate operand position does not match expected position!" );
+
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 2);
+
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+
+    //
+    // try to inline the offset into the instruction
+    //
+
+    if(Offset >= -256 && Offset <= 255 && AArch64Base_STRPreB_offset_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
+
+
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
+
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
+
+    return true; // failure
+}
+bool eliminateFrameIndexSTRPreH
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
+{
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 2).isImm() && "Immediate operand position does not match expected position!" );
+
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 2);
+
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+
+    //
+    // try to inline the offset into the instruction
+    //
+
+    if(Offset >= -256 && Offset <= 255 && AArch64Base_STRPreH_offset_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
+
+
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
+
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
+
+    return true; // failure
+}
+bool eliminateFrameIndexSTRPreW
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
+{
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 2).isImm() && "Immediate operand position does not match expected position!" );
+
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 2);
+
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+
+    //
+    // try to inline the offset into the instruction
+    //
+
+    if(Offset >= -256 && Offset <= 255 && AArch64Base_STRPreW_offset_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
+
+
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
+
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
+
+    return true; // failure
+}
+bool eliminateFrameIndexSTRPreX
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
+{
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 2).isImm() && "Immediate operand position does not match expected position!" );
+
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 2);
+
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+
+    //
+    // try to inline the offset into the instruction
+    //
+
+    if(Offset >= -256 && Offset <= 255 && AArch64Base_STRPreX_offset_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
+
+
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
+
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
+
+    return true; // failure
+}
+bool eliminateFrameIndexSTRPstB
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
+{
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 2).isImm() && "Immediate operand position does not match expected position!" );
+
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 2);
+
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+
+    //
+    // try to inline the offset into the instruction
+    //
+
+    if(Offset >= -256 && Offset <= 255 && AArch64Base_STRPstB_offset_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
+
+
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
+
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
+
+    return true; // failure
+}
+bool eliminateFrameIndexSTRPstH
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
+{
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 2).isImm() && "Immediate operand position does not match expected position!" );
+
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 2);
+
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+
+    //
+    // try to inline the offset into the instruction
+    //
+
+    if(Offset >= -256 && Offset <= 255 && AArch64Base_STRPstH_offset_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
+
+
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
+
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
+
+    return true; // failure
+}
+bool eliminateFrameIndexSTRPstW
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
+{
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 2).isImm() && "Immediate operand position does not match expected position!" );
+
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 2);
+
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+
+    //
+    // try to inline the offset into the instruction
+    //
+
+    if(Offset >= -256 && Offset <= 255 && AArch64Base_STRPstW_offset_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
+
+
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
+
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
+
+    return true; // failure
+}
+bool eliminateFrameIndexSTRPstX
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
+{
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 2).isImm() && "Immediate operand position does not match expected position!" );
+
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 2);
+
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+
+    //
+    // try to inline the offset into the instruction
+    //
+
+    if(Offset >= -256 && Offset <= 255 && AArch64Base_STRPstX_offset_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
+
+
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
+
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
+
+    return true; // failure
+}
+
+
+/**
+ * This method calls its own replacement class for each allowed instruction.
+ * Inside the special instruction the following steps or tries to remove the FI are done.
+ *
+ *     1. try to inline the frame index calculation into the current instruction.
+ *     2. check if we can move the immediate materialization and frame index addition
+ *        into a separate instruction with scratch register. The scratch register must be
+ *        useable with our current instruction.
+ *     3. replace the current instruction with
+ *        3.1 a more specific instruction that can load the offset
+ *        3.2 a very general instruction that uses a scratch register for computing the
+ *            desired frame index.
+ *
+ * If an instruction is not supported, an llvm_fatal_error is emitted as it should be impossible
+ * for a frame index to be an operand.
+ */
+bool processornamevalueRegisterInfo::eliminateFrameIndex(MachineBasicBlock::iterator II, int SPAdj, unsigned FIOperandNum, RegScavenger *RS) const
+{
+    MachineInstr &MI = *II;
+    const MachineFunction &MF = *MI.getParent()->getParent();
+
+    const TargetInstrInfo *TII = MF.getSubtarget().getInstrInfo();
+    const std::string mnemonic = TII->getName(MI.getOpcode()).str(); // for debug purposes
+
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    unsigned FI = FIOp.getIndex();
+    Register FrameReg;
+    StackOffset FrameIndexOffset = getFrameLowering(MF)->getFrameIndexReference(MF, FI, FrameReg);
+
+    bool error = true;
+    switch (MI.getOpcode())
+    {
+
+        case processornamevalue::ADDXI:
+        {
+          error = eliminateFrameIndexADDXI(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::ADDXSXSB:
+        {
+          error = eliminateFrameIndexADDXSXSB(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::ADDXSXSH:
+        {
+          error = eliminateFrameIndexADDXSXSH(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::ADDXSXSW:
+        {
+          error = eliminateFrameIndexADDXSXSW(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::ADDXUXSB:
+        {
+          error = eliminateFrameIndexADDXUXSB(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::ADDXUXSH:
+        {
+          error = eliminateFrameIndexADDXUXSH(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::ADDXUXSW:
+        {
+          error = eliminateFrameIndexADDXUXSW(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::LDPSPre:
+        {
+          error = eliminateFrameIndexLDPSPre(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::LDPSPst:
+        {
+          error = eliminateFrameIndexLDPSPst(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::LDPWPre:
+        {
+          error = eliminateFrameIndexLDPWPre(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::LDPWPst:
+        {
+          error = eliminateFrameIndexLDPWPst(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::LDPXPre:
+        {
+          error = eliminateFrameIndexLDPXPre(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::LDPXPst:
+        {
+          error = eliminateFrameIndexLDPXPst(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::LDRPreB:
+        {
+          error = eliminateFrameIndexLDRPreB(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::LDRPreH:
+        {
+          error = eliminateFrameIndexLDRPreH(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::LDRPreSBW:
+        {
+          error = eliminateFrameIndexLDRPreSBW(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::LDRPreSBX:
+        {
+          error = eliminateFrameIndexLDRPreSBX(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::LDRPreSHW:
+        {
+          error = eliminateFrameIndexLDRPreSHW(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::LDRPreSHX:
+        {
+          error = eliminateFrameIndexLDRPreSHX(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::LDRPreSWX:
+        {
+          error = eliminateFrameIndexLDRPreSWX(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::LDRPreW:
+        {
+          error = eliminateFrameIndexLDRPreW(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::LDRPreX:
+        {
+          error = eliminateFrameIndexLDRPreX(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::LDRPstB:
+        {
+          error = eliminateFrameIndexLDRPstB(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::LDRPstH:
+        {
+          error = eliminateFrameIndexLDRPstH(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::LDRPstSBW:
+        {
+          error = eliminateFrameIndexLDRPstSBW(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::LDRPstSBX:
+        {
+          error = eliminateFrameIndexLDRPstSBX(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::LDRPstSHW:
+        {
+          error = eliminateFrameIndexLDRPstSHW(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::LDRPstSHX:
+        {
+          error = eliminateFrameIndexLDRPstSHX(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::LDRPstSWX:
+        {
+          error = eliminateFrameIndexLDRPstSWX(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::LDRPstW:
+        {
+          error = eliminateFrameIndexLDRPstW(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::LDRPstX:
+        {
+          error = eliminateFrameIndexLDRPstX(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::STRPreB:
+        {
+          error = eliminateFrameIndexSTRPreB(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::STRPreH:
+        {
+          error = eliminateFrameIndexSTRPreH(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::STRPreW:
+        {
+          error = eliminateFrameIndexSTRPreW(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::STRPreX:
+        {
+          error = eliminateFrameIndexSTRPreX(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::STRPstB:
+        {
+          error = eliminateFrameIndexSTRPstB(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::STRPstH:
+        {
+          error = eliminateFrameIndexSTRPstH(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::STRPstW:
+        {
+          error = eliminateFrameIndexSTRPstW(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::STRPstX:
+        {
+          error = eliminateFrameIndexSTRPstX(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+
+        default:
+        {
+            /* This should be unreachable! */
+            std::string errMsg;
+            std::stringstream errMsgStream;
+            errMsgStream << "Unexpected frame index for instruction '" << mnemonic << "'";
+            errMsg = errMsgStream.str();
+            llvm_unreachable(errMsg.c_str());
+        }
+    }
+
+    if (error) // something went wrong
+    {
+        std::string errMsg;
+        std::stringstream errMsgStream;
+        errMsgStream << "Unable to eliminate frame index ('FrameIndex<" << FrameIndexOffset.getFixed() << ">')";
+        errMsgStream << " for instruction '" << mnemonic << "'";
+        errMsg = errMsgStream.str();
+        report_fatal_error(errMsg.c_str()); // if we cannot eliminate the frame index abort!
+    }
+
+    return true;
+}
+
+Register processornamevalueRegisterInfo::getFrameRegister(const MachineFunction &MF) const
+{
+    const TargetFrameLowering *TFI = getFrameLowering(MF);
+    return TFI->hasFP(MF) ? processornamevalue::S29 /* FP */ : processornamevalue::S31 /* SP */;
+}
+
+const uint32_t * processornamevalueRegisterInfo::getCallPreservedMask(const MachineFunction & /*MF*/
+                                                                   , CallingConv::ID /*CC*/
+) const
+{
+    // defined in calling convention tablegen
+    return CSR_processornamevalue_RegMask;
+}
+
+
+/*static*/ unsigned processornamevalueRegisterInfo::S(unsigned index)
+{
+  switch (index)
+  {
+
+    case 0:
+        return processornamevalue::S0;
+    case 1:
+        return processornamevalue::S1;
+    case 2:
+        return processornamevalue::S2;
+    case 3:
+        return processornamevalue::S3;
+    case 4:
+        return processornamevalue::S4;
+    case 5:
+        return processornamevalue::S5;
+    case 6:
+        return processornamevalue::S6;
+    case 7:
+        return processornamevalue::S7;
+    case 8:
+        return processornamevalue::S8;
+    case 9:
+        return processornamevalue::S9;
+    case 10:
+        return processornamevalue::S10;
+    case 11:
+        return processornamevalue::S11;
+    case 12:
+        return processornamevalue::S12;
+    case 13:
+        return processornamevalue::S13;
+    case 14:
+        return processornamevalue::S14;
+    case 15:
+        return processornamevalue::S15;
+    case 16:
+        return processornamevalue::S16;
+    case 17:
+        return processornamevalue::S17;
+    case 18:
+        return processornamevalue::S18;
+    case 19:
+        return processornamevalue::S19;
+    case 20:
+        return processornamevalue::S20;
+    case 21:
+        return processornamevalue::S21;
+    case 22:
+        return processornamevalue::S22;
+    case 23:
+        return processornamevalue::S23;
+    case 24:
+        return processornamevalue::S24;
+    case 25:
+        return processornamevalue::S25;
+    case 26:
+        return processornamevalue::S26;
+    case 27:
+        return processornamevalue::S27;
+    case 28:
+        return processornamevalue::S28;
+    case 29:
+        return processornamevalue::S29;
+    case 30:
+        return processornamevalue::S30;
+    case 31:
+        return processornamevalue::S31;
+
+    default:
+    {
+        std::string errMsg;
+        std::stringstream errMsgStream;
+        errMsgStream << "Unable to find index " << "'" << index << "'";
+        errMsgStream << " with name '«registerClass.simpleName»' !\n";
+        errMsg = errMsgStream.str();
+        report_fatal_error(errMsg.c_str());
+    }
+  }
+}

--- a/vadl/test/resources/snapshots/aarch64/RegisterInfo.td
+++ b/vadl/test/resources/snapshots/aarch64/RegisterInfo.td
@@ -1,0 +1,861 @@
+
+def NZCV_N : Register<"NZCV_N">
+{
+    let Namespace = "aarch64temp";
+    let AsmName = "NZCV_N";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [ ];
+    let SubRegIndices = [ ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 0 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
+
+
+    let HWEncoding = 0;
+
+    let isArtificial = 0;
+}
+def NZCV_Z : Register<"NZCV_Z">
+{
+    let Namespace = "aarch64temp";
+    let AsmName = "NZCV_Z";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [ ];
+    let SubRegIndices = [ ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 1 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
+
+
+    let HWEncoding = 0;
+
+    let isArtificial = 0;
+}
+def NZCV_C : Register<"NZCV_C">
+{
+    let Namespace = "aarch64temp";
+    let AsmName = "NZCV_C";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [ ];
+    let SubRegIndices = [ ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 2 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
+
+
+    let HWEncoding = 0;
+
+    let isArtificial = 0;
+}
+def NZCV_V : Register<"NZCV_V">
+{
+    let Namespace = "aarch64temp";
+    let AsmName = "NZCV_V";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [ ];
+    let SubRegIndices = [ ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 3 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
+
+
+    let HWEncoding = 0;
+
+    let isArtificial = 0;
+}
+def CurrentEL : Register<"CurrentEL">
+{
+    let Namespace = "aarch64temp";
+    let AsmName = "CurrentEL";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [ ];
+    let SubRegIndices = [ ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 4 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
+
+
+    let HWEncoding = 0;
+
+    let isArtificial = 0;
+}
+def SPSel : Register<"SPSel">
+{
+    let Namespace = "aarch64temp";
+    let AsmName = "SPSel";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [ ];
+    let SubRegIndices = [ ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 5 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
+
+
+    let HWEncoding = 0;
+
+    let isArtificial = 0;
+}
+def SP_EL0 : Register<"SP_EL0">
+{
+    let Namespace = "aarch64temp";
+    let AsmName = "SP_EL0";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [ ];
+    let SubRegIndices = [ ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 6 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
+
+
+    let HWEncoding = 0;
+
+    let isArtificial = 0;
+}
+def SP_EL1 : Register<"SP_EL1">
+{
+    let Namespace = "aarch64temp";
+    let AsmName = "SP_EL1";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [ ];
+    let SubRegIndices = [ ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 7 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
+
+
+    let HWEncoding = 0;
+
+    let isArtificial = 0;
+}
+def ELR_EL1 : Register<"ELR_EL1">
+{
+    let Namespace = "aarch64temp";
+    let AsmName = "ELR_EL1";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [ ];
+    let SubRegIndices = [ ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 8 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
+
+
+    let HWEncoding = 0;
+
+    let isArtificial = 0;
+}
+def VBAR_EL1 : Register<"VBAR_EL1">
+{
+    let Namespace = "aarch64temp";
+    let AsmName = "VBAR_EL1";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [ ];
+    let SubRegIndices = [ ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 9 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
+
+
+    let HWEncoding = 0;
+
+    let isArtificial = 0;
+}
+def ESR_EL1 : Register<"ESR_EL1">
+{
+    let Namespace = "aarch64temp";
+    let AsmName = "ESR_EL1";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [ ];
+    let SubRegIndices = [ ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 10 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
+
+
+    let HWEncoding = 0;
+
+    let isArtificial = 0;
+}
+def SPSR_EL1 : Register<"SPSR_EL1">
+{
+    let Namespace = "aarch64temp";
+    let AsmName = "SPSR_EL1";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [ ];
+    let SubRegIndices = [ ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 11 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
+
+
+    let HWEncoding = 0;
+
+    let isArtificial = 0;
+}
+def PC : Register<"PC">
+{
+    let Namespace = "aarch64temp";
+    let AsmName = "PC";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [ ];
+    let SubRegIndices = [ ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 12 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
+
+
+    let HWEncoding = 0;
+
+    let isArtificial = 0;
+}
+def S0 : Register<"S0">
+{
+    let Namespace = "aarch64temp";
+    let AsmName = "X0";
+    let AltNames = [ "X0"  ];
+    let Aliases = [ ];
+    let SubRegs = [ ];
+    let SubRegIndices = [ ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 15 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
+
+    let HWEncoding{4-0} = 0;
+
+
+    let isArtificial = 0;
+}
+def S1 : Register<"S1">
+{
+    let Namespace = "aarch64temp";
+    let AsmName = "X1";
+    let AltNames = [ "X1"  ];
+    let Aliases = [ ];
+    let SubRegs = [ ];
+    let SubRegIndices = [ ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 16 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
+
+    let HWEncoding{4-0} = 1;
+
+
+    let isArtificial = 0;
+}
+def S2 : Register<"S2">
+{
+    let Namespace = "aarch64temp";
+    let AsmName = "X2";
+    let AltNames = [ "X2"  ];
+    let Aliases = [ ];
+    let SubRegs = [ ];
+    let SubRegIndices = [ ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 17 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
+
+    let HWEncoding{4-0} = 2;
+
+
+    let isArtificial = 0;
+}
+def S3 : Register<"S3">
+{
+    let Namespace = "aarch64temp";
+    let AsmName = "X3";
+    let AltNames = [ "X3"  ];
+    let Aliases = [ ];
+    let SubRegs = [ ];
+    let SubRegIndices = [ ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 18 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
+
+    let HWEncoding{4-0} = 3;
+
+
+    let isArtificial = 0;
+}
+def S4 : Register<"S4">
+{
+    let Namespace = "aarch64temp";
+    let AsmName = "X4";
+    let AltNames = [ "X4"  ];
+    let Aliases = [ ];
+    let SubRegs = [ ];
+    let SubRegIndices = [ ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 19 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
+
+    let HWEncoding{4-0} = 4;
+
+
+    let isArtificial = 0;
+}
+def S5 : Register<"S5">
+{
+    let Namespace = "aarch64temp";
+    let AsmName = "X5";
+    let AltNames = [ "X5"  ];
+    let Aliases = [ ];
+    let SubRegs = [ ];
+    let SubRegIndices = [ ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 20 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
+
+    let HWEncoding{4-0} = 5;
+
+
+    let isArtificial = 0;
+}
+def S6 : Register<"S6">
+{
+    let Namespace = "aarch64temp";
+    let AsmName = "X6";
+    let AltNames = [ "X6"  ];
+    let Aliases = [ ];
+    let SubRegs = [ ];
+    let SubRegIndices = [ ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 21 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
+
+    let HWEncoding{4-0} = 6;
+
+
+    let isArtificial = 0;
+}
+def S7 : Register<"S7">
+{
+    let Namespace = "aarch64temp";
+    let AsmName = "X7";
+    let AltNames = [ "X7"  ];
+    let Aliases = [ ];
+    let SubRegs = [ ];
+    let SubRegIndices = [ ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 22 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
+
+    let HWEncoding{4-0} = 7;
+
+
+    let isArtificial = 0;
+}
+def S8 : Register<"S8">
+{
+    let Namespace = "aarch64temp";
+    let AsmName = "X8";
+    let AltNames = [ "X8"  ];
+    let Aliases = [ ];
+    let SubRegs = [ ];
+    let SubRegIndices = [ ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 23 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
+
+    let HWEncoding{4-0} = 8;
+
+
+    let isArtificial = 0;
+}
+def S9 : Register<"S9">
+{
+    let Namespace = "aarch64temp";
+    let AsmName = "X9";
+    let AltNames = [ "X9"  ];
+    let Aliases = [ ];
+    let SubRegs = [ ];
+    let SubRegIndices = [ ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 24 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
+
+    let HWEncoding{4-0} = 9;
+
+
+    let isArtificial = 0;
+}
+def S10 : Register<"S10">
+{
+    let Namespace = "aarch64temp";
+    let AsmName = "X10";
+    let AltNames = [ "X10"  ];
+    let Aliases = [ ];
+    let SubRegs = [ ];
+    let SubRegIndices = [ ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 25 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
+
+    let HWEncoding{4-0} = 10;
+
+
+    let isArtificial = 0;
+}
+def S11 : Register<"S11">
+{
+    let Namespace = "aarch64temp";
+    let AsmName = "X11";
+    let AltNames = [ "X11"  ];
+    let Aliases = [ ];
+    let SubRegs = [ ];
+    let SubRegIndices = [ ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 26 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
+
+    let HWEncoding{4-0} = 11;
+
+
+    let isArtificial = 0;
+}
+def S12 : Register<"S12">
+{
+    let Namespace = "aarch64temp";
+    let AsmName = "X12";
+    let AltNames = [ "X12"  ];
+    let Aliases = [ ];
+    let SubRegs = [ ];
+    let SubRegIndices = [ ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 27 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
+
+    let HWEncoding{4-0} = 12;
+
+
+    let isArtificial = 0;
+}
+def S13 : Register<"S13">
+{
+    let Namespace = "aarch64temp";
+    let AsmName = "X13";
+    let AltNames = [ "X13"  ];
+    let Aliases = [ ];
+    let SubRegs = [ ];
+    let SubRegIndices = [ ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 28 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
+
+    let HWEncoding{4-0} = 13;
+
+
+    let isArtificial = 0;
+}
+def S14 : Register<"S14">
+{
+    let Namespace = "aarch64temp";
+    let AsmName = "X14";
+    let AltNames = [ "X14"  ];
+    let Aliases = [ ];
+    let SubRegs = [ ];
+    let SubRegIndices = [ ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 29 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
+
+    let HWEncoding{4-0} = 14;
+
+
+    let isArtificial = 0;
+}
+def S15 : Register<"S15">
+{
+    let Namespace = "aarch64temp";
+    let AsmName = "X15";
+    let AltNames = [ "X15"  ];
+    let Aliases = [ ];
+    let SubRegs = [ ];
+    let SubRegIndices = [ ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 30 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
+
+    let HWEncoding{4-0} = 15;
+
+
+    let isArtificial = 0;
+}
+def S16 : Register<"S16">
+{
+    let Namespace = "aarch64temp";
+    let AsmName = "X16";
+    let AltNames = [ "X16"  ];
+    let Aliases = [ ];
+    let SubRegs = [ ];
+    let SubRegIndices = [ ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 31 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
+
+    let HWEncoding{4-0} = 16;
+
+
+    let isArtificial = 0;
+}
+def S17 : Register<"S17">
+{
+    let Namespace = "aarch64temp";
+    let AsmName = "X17";
+    let AltNames = [ "X17"  ];
+    let Aliases = [ ];
+    let SubRegs = [ ];
+    let SubRegIndices = [ ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 32 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
+
+    let HWEncoding{4-0} = 17;
+
+
+    let isArtificial = 0;
+}
+def S18 : Register<"S18">
+{
+    let Namespace = "aarch64temp";
+    let AsmName = "X18";
+    let AltNames = [ "X18"  ];
+    let Aliases = [ ];
+    let SubRegs = [ ];
+    let SubRegIndices = [ ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 33 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
+
+    let HWEncoding{4-0} = 18;
+
+
+    let isArtificial = 0;
+}
+def S19 : Register<"S19">
+{
+    let Namespace = "aarch64temp";
+    let AsmName = "X19";
+    let AltNames = [ "X19"  ];
+    let Aliases = [ ];
+    let SubRegs = [ ];
+    let SubRegIndices = [ ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 34 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
+
+    let HWEncoding{4-0} = 19;
+
+
+    let isArtificial = 0;
+}
+def S20 : Register<"S20">
+{
+    let Namespace = "aarch64temp";
+    let AsmName = "X20";
+    let AltNames = [ "X20"  ];
+    let Aliases = [ ];
+    let SubRegs = [ ];
+    let SubRegIndices = [ ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 35 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
+
+    let HWEncoding{4-0} = 20;
+
+
+    let isArtificial = 0;
+}
+def S21 : Register<"S21">
+{
+    let Namespace = "aarch64temp";
+    let AsmName = "X21";
+    let AltNames = [ "X21"  ];
+    let Aliases = [ ];
+    let SubRegs = [ ];
+    let SubRegIndices = [ ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 36 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
+
+    let HWEncoding{4-0} = 21;
+
+
+    let isArtificial = 0;
+}
+def S22 : Register<"S22">
+{
+    let Namespace = "aarch64temp";
+    let AsmName = "X22";
+    let AltNames = [ "X22"  ];
+    let Aliases = [ ];
+    let SubRegs = [ ];
+    let SubRegIndices = [ ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 37 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
+
+    let HWEncoding{4-0} = 22;
+
+
+    let isArtificial = 0;
+}
+def S23 : Register<"S23">
+{
+    let Namespace = "aarch64temp";
+    let AsmName = "X23";
+    let AltNames = [ "X23"  ];
+    let Aliases = [ ];
+    let SubRegs = [ ];
+    let SubRegIndices = [ ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 38 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
+
+    let HWEncoding{4-0} = 23;
+
+
+    let isArtificial = 0;
+}
+def S24 : Register<"S24">
+{
+    let Namespace = "aarch64temp";
+    let AsmName = "X24";
+    let AltNames = [ "X24"  ];
+    let Aliases = [ ];
+    let SubRegs = [ ];
+    let SubRegIndices = [ ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 39 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
+
+    let HWEncoding{4-0} = 24;
+
+
+    let isArtificial = 0;
+}
+def S25 : Register<"S25">
+{
+    let Namespace = "aarch64temp";
+    let AsmName = "X25";
+    let AltNames = [ "X25"  ];
+    let Aliases = [ ];
+    let SubRegs = [ ];
+    let SubRegIndices = [ ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 40 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
+
+    let HWEncoding{4-0} = 25;
+
+
+    let isArtificial = 0;
+}
+def S26 : Register<"S26">
+{
+    let Namespace = "aarch64temp";
+    let AsmName = "X26";
+    let AltNames = [ "X26"  ];
+    let Aliases = [ ];
+    let SubRegs = [ ];
+    let SubRegIndices = [ ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 41 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
+
+    let HWEncoding{4-0} = 26;
+
+
+    let isArtificial = 0;
+}
+def S27 : Register<"S27">
+{
+    let Namespace = "aarch64temp";
+    let AsmName = "X27";
+    let AltNames = [ "X27"  ];
+    let Aliases = [ ];
+    let SubRegs = [ ];
+    let SubRegIndices = [ ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 42 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
+
+    let HWEncoding{4-0} = 27;
+
+
+    let isArtificial = 0;
+}
+def S28 : Register<"S28">
+{
+    let Namespace = "aarch64temp";
+    let AsmName = "X28";
+    let AltNames = [ "X28"  ];
+    let Aliases = [ ];
+    let SubRegs = [ ];
+    let SubRegIndices = [ ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 43 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
+
+    let HWEncoding{4-0} = 28;
+
+
+    let isArtificial = 0;
+}
+def S29 : Register<"S29">
+{
+    let Namespace = "aarch64temp";
+    let AsmName = "A_FP";
+    let AltNames = [ "A_FP"  ];
+    let Aliases = [ ];
+    let SubRegs = [ ];
+    let SubRegIndices = [ ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 44 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
+
+    let HWEncoding{4-0} = 29;
+
+
+    let isArtificial = 0;
+}
+def S30 : Register<"S30">
+{
+    let Namespace = "aarch64temp";
+    let AsmName = "A_LR";
+    let AltNames = [ "A_LR"  ];
+    let Aliases = [ ];
+    let SubRegs = [ ];
+    let SubRegIndices = [ ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 45 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
+
+    let HWEncoding{4-0} = 30;
+
+
+    let isArtificial = 0;
+}
+def S31 : Register<"S31">
+{
+    let Namespace = "aarch64temp";
+    let AsmName = "A_SP";
+    let AltNames = [ "A_SP"  ];
+    let Aliases = [ ];
+    let SubRegs = [ ];
+    let SubRegIndices = [ ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 46 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
+
+    let HWEncoding{4-0} = 31;
+
+
+    let isArtificial = 0;
+}
+
+
+
+def SP : Register<"SP">
+{
+    let Namespace = "aarch64temp";
+    let AsmName = "SP";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [ ];
+    let SubRegIndices = [ ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 13 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
+    let HWEncoding = 31;
+    let isArtificial = 1;
+}
+def LR : Register<"LR">
+{
+    let Namespace = "aarch64temp";
+    let AsmName = "LR";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [ ];
+    let SubRegIndices = [ ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 14 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
+    let HWEncoding = 30;
+    let isArtificial = 1;
+}
+
+
+defvar aarch64temp = DefaultMode;
+
+def SLenRI : RegInfoByHwMode<
+      [ aarch64temp ],
+      [RegInfo<64,64,64>]>;
+def S : RegisterClass
+< /* namespace = */ "aarch64temp"
+, /* regTypes  = */  [  i64 ]
+, /* alignment = */ 32
+, /* regList   = */
+  ( add S9, S10, S11, S12, S13, S14, S15, S19, S20, S21, S22, S23, S24, S25, S26, S27, S28, S0, S1, S2, S3, S4, S5, S6, S7, S8, S16, S17, S18, S29, S30, S31 )
+> {
+  let RegInfos = SLenRI;
+}
+

--- a/vadl/test/vadl/lcb/aarch64/template/EmitRegisterInfoCppFilePassTest.java
+++ b/vadl/test/vadl/lcb/aarch64/template/EmitRegisterInfoCppFilePassTest.java
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.lcb.aarch64.template;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.shaded.com.google.common.io.Files;
+import vadl.lcb.AbstractLcbTest;
+import vadl.lcb.template.lib.Target.EmitRegisterInfoCppFilePass;
+import vadl.pass.PassKey;
+import vadl.pass.exception.DuplicatedPassKeyException;
+import vadl.template.AbstractTemplateRenderingPass;
+
+public class EmitRegisterInfoCppFilePassTest extends AbstractLcbTest {
+  @Test
+  void testLowering() throws IOException, DuplicatedPassKeyException {
+    // Given
+    var configuration = getConfiguration(false);
+    var testSetup = runLcb(configuration, "sys/aarch64/aarch64-abi.vadl",
+        new PassKey(EmitRegisterInfoCppFilePass.class.getName()));
+
+    // When
+    var passResult =
+        (AbstractTemplateRenderingPass.Result) testSetup.passManager().getPassResults()
+            .lastResultOf(EmitRegisterInfoCppFilePass.class);
+
+    // Then
+    var resultFile = passResult.emittedFile().toFile();
+    var trimmed = Files.asCharSource(resultFile, Charset.defaultCharset()).read().trim();
+    var output = trimmed.lines();
+
+    var fs = new File(
+        "test/resources/snapshots/aarch64/RegisterInfo.td");
+    var expected = FileUtils.readFileToString(fs, "UTF-8");
+
+    Assertions.assertLinesMatch(expected.trim().lines(), output);
+  }
+}

--- a/vadl/test/vadl/lcb/aarch64/template/EmitRegisterInfoTableGenFilePassTest.java
+++ b/vadl/test/vadl/lcb/aarch64/template/EmitRegisterInfoTableGenFilePassTest.java
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.lcb.aarch64.template;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.shaded.com.google.common.io.Files;
+import vadl.gcb.valuetypes.TargetName;
+import vadl.lcb.AbstractLcbTest;
+import vadl.lcb.template.lib.Target.EmitRegisterInfoCppFilePass;
+import vadl.lcb.template.lib.Target.EmitRegisterInfoTableGenFilePass;
+import vadl.pass.PassKey;
+import vadl.pass.exception.DuplicatedPassKeyException;
+import vadl.template.AbstractTemplateRenderingPass;
+
+public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
+  @Test
+  void testLowering() throws IOException, DuplicatedPassKeyException {
+    // Given
+    var configuration = getConfiguration(false);
+    configuration.setTargetName(new TargetName("aarch64temp"));
+    var testSetup = runLcb(configuration, "sys/aarch64/aarch64-abi.vadl",
+        new PassKey(EmitRegisterInfoTableGenFilePass.class.getName()));
+
+    // When
+    var passResult =
+        (AbstractTemplateRenderingPass.Result) testSetup.passManager().getPassResults()
+            .lastResultOf(EmitRegisterInfoTableGenFilePass.class);
+
+    // Then
+    var resultFile = passResult.emittedFile().toFile();
+    var trimmed = Files.asCharSource(resultFile, Charset.defaultCharset()).read().trim();
+    var output = trimmed.lines().map(String::trim);
+
+    var fs = new File(
+        "test/resources/snapshots/aarch64/RegisterInfo.td");
+    var expected = FileUtils.readFileToString(fs, "UTF-8");
+
+    Assertions.assertLinesMatch(expected.trim().lines().map(String::trim), output);
+  }
+}


### PR DESCRIPTION
This PR renders artificial resources which are alias registers as `isArtificial = 1`. Currently, we ignore alias names for register files. I haven't figured out what to do with in TableGen yet.