### PR TITLE
lcb: Removed gcc reg aliases

### DIFF
--- a/vadl/main/resources/templates/lcb/clang/lib/Basic/Targets/ClangTarget.cpp
+++ b/vadl/main/resources/templates/lcb/clang/lib/Basic/Targets/ClangTarget.cpp
@@ -18,16 +18,8 @@ ArrayRef<const char *> [(${namespace})]TargetInfo::getGCCRegNames() const
 
 ArrayRef<TargetInfo::GCCRegAlias> [(${namespace})]TargetInfo::getGCCRegAliases() const
 {
-    static const TargetInfo::GCCRegAlias GCCRegAliases[] =
-    {
-    [# th:each="register, iterStat : ${registers}" ]
-        {
-            {[# th:each="alias, iterAliasStat : ${registers}" ] "[(${alias.name})]"[# th:if="${!iterAliasStat.last}" ],[/] [/]},
-            "[(${register.name})]"
-        }[# th:if="${!iterStat.last}" ],[/]
-    [/]
-    };
-    return llvm::ArrayRef( GCCRegAliases );
+    std::vector<TargetInfo::GCCRegAlias> aliases; // keep it empty
+    return llvm::ArrayRef(aliases);
 }
 
 void [(${namespace})]TargetInfo::getTargetDefines(const LangOptions &Opts,

--- a/vadl/main/vadl/lcb/template/clang/lib/Basic/Targets/EmitClangTargetCppFilePass.java
+++ b/vadl/main/vadl/lcb/template/clang/lib/Basic/Targets/EmitClangTargetCppFilePass.java
@@ -49,9 +49,10 @@ public class EmitClangTargetCppFilePass extends LcbTemplateRenderingPass {
   @Override
   protected Map<String, Object> createVariables(final PassResults passResults,
                                                 Specification specification) {
+    var registers = extractRegisters(specification);
     return Map.of(CommonVarNames.NAMESPACE,
         lcbConfiguration().targetName().value().toLowerCase(),
-        CommonVarNames.REGISTERS, extractRegisters(specification)
+        CommonVarNames.REGISTERS, registers
     );
   }
 


### PR DESCRIPTION
We would need to extend the VADL lang to be able
to specify them correctly. Meanwhile, they are not really needed at the moment.