### PR TITLE
lcb: Fixed duplicated immediate records

### DIFF
--- a/vadl/main/vadl/lcb/passes/llvmLowering/immediates/GenerateTableGenImmediateRecordPass.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/immediates/GenerateTableGenImmediateRecordPass.java
@@ -33,6 +33,7 @@ import vadl.pass.PassResults;
 import vadl.viam.Abi;
 import vadl.viam.Specification;
 import vadl.viam.graph.control.InstrCallNode;
+import vadl.viam.passes.NormalizeFieldsToFieldAccessFunctionsPass;
 
 /**
  * This pass extracts the immediates from the TableGen records.
@@ -59,6 +60,18 @@ public class GenerateTableGenImmediateRecordPass extends Pass {
     viam.isa().orElseThrow()
         .ownInstructions().forEach(instruction -> {
           instruction.format().fieldAccesses().forEach(fieldAccess -> {
+            // When a field access is changed to a field access function it is
+            // added the instruction format's field accesses. Therefore,
+            // we will have a lot field accesses which are not part of the instruction's behavior.
+            if (fieldAccess instanceof
+                NormalizeFieldsToFieldAccessFunctionsPass.GeneratedFieldAccess genFieldAccess) {
+              if (!genFieldAccess.instruction().equals(instruction)) {
+                // If we have generated a field access for an instruction then only generate
+                // an immediate record if it's the same instruction.
+                return;
+              }
+            }
+
             var originalType = abi.stackPointer().registerFile().resultType();
             var llvmType = ValueType.from(originalType);
 

--- a/vadl/main/vadl/viam/passes/NormalizeFieldsToFieldAccessFunctionsPass.java
+++ b/vadl/main/vadl/viam/passes/NormalizeFieldsToFieldAccessFunctionsPass.java
@@ -30,6 +30,7 @@ import vadl.pass.PassResults;
 import vadl.types.Type;
 import vadl.viam.Constant;
 import vadl.viam.Format;
+import vadl.viam.Format.FieldAccess;
 import vadl.viam.Function;
 import vadl.viam.Identifier;
 import vadl.viam.Instruction;
@@ -87,10 +88,11 @@ public class NormalizeFieldsToFieldAccessFunctionsPass extends Pass {
                     instruction.format().identifier.append(
                         instruction.identifier().last()
                             .append(fieldRefNode.formatField().identifier.last().parts()).parts());
-                var fieldAccess = new Format.FieldAccess(
+                var fieldAccess = new GeneratedFieldAccess(
                     id,
                     createAccessFunction(id, fieldRefNode),
-                    createPredicateFunction(id, fieldRefNode)
+                    createPredicateFunction(id, fieldRefNode),
+                    instruction
                 );
                 instruction.format().fieldAccesses().add(fieldAccess);
                 var fieldAccessRefNode = new FieldAccessRefNode(
@@ -144,5 +146,37 @@ public class NormalizeFieldsToFieldAccessFunctionsPass extends Pass {
     ControlNode startNode = graph.add(new StartNode(endNode));
     startNode.setSourceLocation(fieldRefNode.location());
     return new Function(id, new Parameter[] {}, Type.bool(), graph);
+  }
+
+  /**
+   * This class extends {@link FieldAccess} and it's intention is to store the {@link Instruction}
+   * which it was generated for. The {@link NormalizeFieldsToFieldAccessFunctionsPass} might
+   * create a lot of field accesses and adds them to the {@link Format}. It's easier for later
+   * passes to generate only the used field access functions when we store a reference to the
+   * {@link Instruction} which generated it.
+   */
+  public static class GeneratedFieldAccess extends FieldAccess {
+    private final Instruction instruction;
+
+    /**
+     * Constructs a new FieldAccess object with the given identifier, accessFunction function,
+     * encoding function, and predicate function.
+     *
+     * @param identifier     The identifier of the Immediate.
+     * @param accessFunction The access function of the FieldAccess.  {@code () -> T}
+     * @param predicate      The predicate function of the Immediate. {@code () -> Bool}
+     * @param instruction    The instruction for which the {@link FieldAccess} was generated for.
+     */
+    public GeneratedFieldAccess(Identifier identifier,
+                                Function accessFunction,
+                                @Nullable Function predicate,
+                                Instruction instruction) {
+      super(identifier, accessFunction, predicate);
+      this.instruction = instruction;
+    }
+
+    public Instruction instruction() {
+      return instruction;
+    }
   }
 }


### PR DESCRIPTION
The problem is that when we generate field accesses from fields then we add the generated field accesses to the format. In `vadl/main/vadl/lcb/passes/llvmLowering/immediates/GenerateTableGenImmediateRecordPass.java`, we then iterate over all the field accesses (including generated ones) and generate the immediate records. Because the field accesses were generated per instruction, the format will include the same field access multiple times if the format's instructions use it.
We could generate the field access once and then replace it in every format's instruction. But instead, we store the instruction which generated the field access and check it when generating the immediate records.