### PR TITLE
frontend: Add udec/sdec and remove decimal built-in

### DIFF
--- a/vadl/main/vadl/ast/AstUtils.java
+++ b/vadl/main/vadl/ast/AstUtils.java
@@ -45,6 +45,10 @@ class AstUtils {
     if (pseudoRewrites.containsKey(name)) {
       var singed = argTypes.stream().anyMatch(t -> t instanceof SIntType);
       name = pseudoRewrites.get(name).get(singed ? 0 : 1);
+    } else if (name.equals("decimal")) {
+      // TODO: Remove this once all decimal calls were replaced by s/udec in the VADL specs (#409)
+      // set decimal to be an alias of sdec
+      name = "sdec";
     }
 
     String finalBuiltinName = name;

--- a/vadl/main/vadl/ast/SymbolTable.java
+++ b/vadl/main/vadl/ast/SymbolTable.java
@@ -73,6 +73,8 @@ class SymbolTable {
     symbols.put("start", new BuiltInSymbol());
     symbols.put("executable", new BuiltInSymbol());
     symbols.put("halt", new BuiltInSymbol());
+    // TODO: Remove this once migration of decimal to sdec is done for all specs #409
+    symbols.put("decimal", new BuiltInSymbol());
   }
 
   /**

--- a/vadl/main/vadl/lcb/codegen/assembly/AssemblyInstructionPrinterCodeGeneratorVisitor.java
+++ b/vadl/main/vadl/lcb/codegen/assembly/AssemblyInstructionPrinterCodeGeneratorVisitor.java
@@ -145,7 +145,8 @@ public class AssemblyInstructionPrinterCodeGeneratorVisitor
                 argument.location())
             .build();
       }
-    } else if (node.builtIn() == BuiltInTable.DECIMAL) {
+      // TODO: Implement UDEC builtin
+    } else if (node.builtIn() == BuiltInTable.SDEC) {
       ensure(node.arguments().size() == 1, "Expected only one argument");
       writeImmediateWithRadix(node, 10);
     } else if (node.builtIn() == BuiltInTable.HEX) {

--- a/vadl/main/vadl/lcb/codegen/assembly/AssemblyInstructionPrinterImmediateHandler.java
+++ b/vadl/main/vadl/lcb/codegen/assembly/AssemblyInstructionPrinterImmediateHandler.java
@@ -173,7 +173,8 @@ public class AssemblyInstructionPrinterImmediateHandler
                 argument.location())
             .build();
       }
-    } else if (node.builtIn() == BuiltInTable.DECIMAL) {
+      // TODO: Implement UDEC builtin
+    } else if (node.builtIn() == BuiltInTable.SDEC) {
       writeImmediateWithRadix(node, ctx, 10);
     } else if (node.builtIn() == BuiltInTable.HEX) {
       writeImmediateWithRadix(node, ctx, 16);

--- a/vadl/main/vadl/lcb/codegen/assembly/ParserGenerator.java
+++ b/vadl/main/vadl/lcb/codegen/assembly/ParserGenerator.java
@@ -107,7 +107,8 @@ public class ParserGenerator {
   public static String mapToName(ExpressionNode x) {
     if (x instanceof BuiltInCall b && b.builtIn() == BuiltInTable.MNEMONIC) {
       return "mnemonic";
-    } else if (x instanceof BuiltInCall b && b.builtIn() == BuiltInTable.DECIMAL) {
+      // TODO: Implement UDEC builtin
+    } else if (x instanceof BuiltInCall b && b.builtIn() == BuiltInTable.SDEC) {
       if (b.arguments().get(0) instanceof FieldRefNode frn) {
         return mapToName(frn);
       } else if (b.arguments().get(0) instanceof FieldAccessRefNode fac) {

--- a/vadl/main/vadl/lcb/passes/llvmLowering/tablegen/lowering/TableGenInstAliasRenderer.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/tablegen/lowering/TableGenInstAliasRenderer.java
@@ -83,8 +83,9 @@ public class TableGenInstAliasRenderer {
         } else if (to instanceof BuiltInCall builtInCall
             && builtInCall.builtIn() == BuiltInTable.MNEMONIC) {
           result.append(pseudoInstruction.simpleName());
+          // TODO: Implement UDEC builtin
         } else if (to instanceof BuiltInCall builtInCall
-            && builtInCall.builtIn() == BuiltInTable.DECIMAL) {
+            && builtInCall.builtIn() == BuiltInTable.SDEC) {
           to.applyOnInputs(this);
         } else if (to instanceof BuiltInCall builtInCall
             && builtInCall.builtIn() == BuiltInTable.HEX) {

--- a/vadl/main/vadl/types/BuiltInTable.java
+++ b/vadl/main/vadl/types/BuiltInTable.java
@@ -1034,16 +1034,35 @@ public class BuiltInTable {
           .build();
 
   /**
-   * Formats value to decimal string.
+   * Formats value to signed decimal string.
    *
-   * <p>{@code function decimal(Bits<N>) -> String<M>}
+   * <p>{@code function sdec(Bits<N>) -> String<M>}
    */
-  public static final BuiltIn DECIMAL =
-      func("decimal",
+  public static final BuiltIn SDEC =
+      func("sdec",
           Type.relation(BitsType.class, StringType.class))
           .takesDefault()
           .returns(Type.string())
-          .computeUnary(a -> new Constant.Str(a.asVal().decimal()))
+          .computeUnary(a -> new Constant.Str(
+              // cast to signed type and get decimal value
+              a.asVal().castTo(Type.signedInt(a.type().asDataType().bitWidth()))
+                  .decimal()))
+          .build();
+
+  /**
+   * Formats value to unsigned decimal string.
+   *
+   * <p>{@code function udec(Bits<N>) -> String<M>}
+   */
+  public static final BuiltIn UDEC =
+      func("udec",
+          Type.relation(BitsType.class, StringType.class))
+          .takesDefault()
+          .returns(Type.string())
+          .computeUnary(a -> new Constant.Str(
+              // cast to unsigned type and get decimal value
+              a.asVal().castTo(Type.unsignedInt(a.type().asDataType().bitWidth()))
+                  .decimal()))
           .build();
 
   /**
@@ -1295,7 +1314,8 @@ public class BuiltInTable {
       REGISTER,
 
       BINARY,
-      DECIMAL,
+      SDEC,
+      UDEC,
       HEX,
       OCTAL,
 
@@ -1542,7 +1562,7 @@ public class BuiltInTable {
     /**
      * Creates a {@link BuiltInCall} node from this built-in and the given arguments.
      */
-    public BuiltInCall  call(NodeList<ExpressionNode> arguments) {
+    public BuiltInCall call(NodeList<ExpressionNode> arguments) {
       return BuiltInCall.of(this, arguments);
     }
   }

--- a/vadl/test/vadl/ast/ParserTest.java
+++ b/vadl/test/vadl/ast/ParserTest.java
@@ -345,4 +345,14 @@ public class ParserTest {
 
     Assertions.assertDoesNotThrow(() -> VadlParser.parse(prog));
   }
+
+  @Test
+  void parseUdecSdec() {
+    var prog = """
+        function a(bits: Bits<32>) -> String = udec(bits)
+        function b(bits: Bits<32>) -> String = sdec(bits)
+        """;
+
+    Assertions.assertDoesNotThrow(() -> VadlParser.parse(prog));
+  }
 }


### PR DESCRIPTION
This PR closes #408.

It adds the `udec` and `sdec` built-ins. The old `decimal` built-in is removed but the name can stil be used as an alias for `sdec`. 

Once all specification were adapted, to used `udec`/`sdec`, we must also remove this alias (#409).