### PR TITLE
lcb: Fixes for Aarch64

### DIFF
--- a/vadl/main/vadl/gcb/passes/DetermineRegisterUsesAndDefsPass.java
+++ b/vadl/main/vadl/gcb/passes/DetermineRegisterUsesAndDefsPass.java
@@ -31,6 +31,7 @@ import vadl.pass.PassResults;
 import vadl.viam.CompilerInstruction;
 import vadl.viam.Instruction;
 import vadl.viam.PseudoInstruction;
+import vadl.viam.RegisterTensor;
 import vadl.viam.Specification;
 import vadl.viam.graph.Graph;
 import vadl.viam.graph.control.InstrCallNode;
@@ -40,7 +41,9 @@ import vadl.viam.graph.dependency.FieldAccessRefNode;
 import vadl.viam.graph.dependency.FieldRefNode;
 import vadl.viam.graph.dependency.ReadRegTensorNode;
 import vadl.viam.graph.dependency.ReadResourceNode;
+import vadl.viam.graph.dependency.WriteArtificialResNode;
 import vadl.viam.graph.dependency.WriteRegTensorNode;
+import vadl.viam.graph.dependency.WriteResourceNode;
 
 /**
  * Determine the uses and defs of registers.
@@ -168,22 +171,50 @@ public class DetermineRegisterUsesAndDefsPass extends Pass {
    * @param behavior of the {@link Instruction}.
    */
   private static List<RegisterRef> getRegisterDefs(Graph behavior) {
-    return behavior.getNodes(WriteRegTensorNode.class)
-        .filter(writeRegTensorNode -> writeRegTensorNode.indices().stream()
-            .allMatch(ExpressionNode::isConstant))
-        .filter(writeRegTensorNode -> writeRegTensorNode.registerTensor().constraints().length == 0)
-        .filter(readRegTensorNode -> !readRegTensorNode.isPcAccess())
-        .map(node -> {
-          var reg = node.regTensor();
-          reg.ensure(reg.indexDimensions().size() < 2,
-              "Only register and register files supported");
-          if (reg.isSingleRegister()) {
-            return new RegisterRef(reg);
-          } else {
-            return new RegisterRef(reg, ((ConstantNode) node.indices().getFirst()).constant());
-          }
-        })
+    var writeRegCandidates = behavior.getNodes(WriteRegTensorNode.class).toList();
+    var writeArtificialCandidates =
+        behavior.getNodes(WriteArtificialResNode.class)
+            .filter(node -> node.resourceDefinition().innerResourceRef() instanceof RegisterTensor)
+            .toList();
+
+    return Stream.concat(writeRegCandidates.stream()
+                .filter(node -> isRegister(node, node.registerTensor()))
+                .map(DetermineRegisterUsesAndDefsPass::map),
+            writeArtificialCandidates.stream()
+                .filter(node -> isRegister(node,
+                    (RegisterTensor) node.resourceDefinition().innerResourceRef())
+                    && node.resourceDefinition().readFunction().parameters().length == 0)
+                .map(DetermineRegisterUsesAndDefsPass::map)
+        )
         .toList();
+  }
+
+  private static boolean isRegister(WriteResourceNode node, RegisterTensor tensor) {
+    var allAddressesConstant = node.indices().stream()
+        .allMatch(ExpressionNode::isConstant);
+    var noConstraints = tensor.constraints().length == 0;
+    var noPc = true;
+
+    if (node instanceof WriteRegTensorNode tensorNode) {
+      noPc = !tensorNode.isPcAccess();
+    }
+
+    return allAddressesConstant && noConstraints && noPc;
+  }
+
+  private static RegisterRef map(WriteRegTensorNode node) {
+    var reg = node.registerTensor();
+    reg.ensure(reg.indexDimensions().size() < 2,
+        "Only register and register files supported");
+    if (reg.isSingleRegister()) {
+      return new RegisterRef(reg);
+    } else {
+      return new RegisterRef(reg, ((ConstantNode) node.indices().getFirst()).constant());
+    }
+  }
+
+  private static RegisterRef map(WriteArtificialResNode node) {
+    return new RegisterRef(node.resourceDefinition());
   }
 
   /**

--- a/vadl/main/vadl/gcb/passes/DetermineRegisterUsesAndDefsPass.java
+++ b/vadl/main/vadl/gcb/passes/DetermineRegisterUsesAndDefsPass.java
@@ -221,7 +221,7 @@ public class DetermineRegisterUsesAndDefsPass extends Pass {
    * Get a list of {@link RegisterRef} which are read. It is considered a
    * register usage when a {@link ReadRegTensorNode} with a
    * constant address exists. However, the only registers without any constraints on the
-   * register file will be returned. Also program containers are not part of a "Use".
+   * register file will be returned. Also program counters are not part of a "Use".
    *
    * @param behavior of the {@link Instruction}.
    */

--- a/vadl/main/vadl/gcb/passes/IsaMatchingUtils.java
+++ b/vadl/main/vadl/gcb/passes/IsaMatchingUtils.java
@@ -37,6 +37,7 @@ import vadl.viam.Relocation;
 import vadl.viam.Specification;
 import vadl.viam.graph.dependency.BuiltInCall;
 import vadl.viam.graph.dependency.ReadMemNode;
+import vadl.viam.graph.dependency.ReadRegTensorNode;
 import vadl.viam.graph.dependency.WriteMemNode;
 import vadl.viam.graph.dependency.WriteRegTensorNode;
 import vadl.viam.matching.Matcher;
@@ -89,8 +90,14 @@ public interface IsaMatchingUtils {
    */
   default boolean findRegisterRegisterOrRegisterImmediateOrImmediateRegister(
       UninlinedGraph behavior, List<BuiltInTable.BuiltIn> builtins) {
-    return findRR(behavior, builtins)
-        || findRegisterImmediateOrImmediateRegister(behavior, builtins);
+    return (findRR(behavior, builtins)
+        || findRegisterImmediateOrImmediateRegister(behavior, builtins))
+        && noPcAccess(behavior);
+  }
+
+  private boolean noPcAccess(UninlinedGraph behavior) {
+    return behavior.getNodes(WriteRegTensorNode.class).noneMatch(WriteRegTensorNode::isPcAccess)
+        && behavior.getNodes(ReadRegTensorNode.class).noneMatch(ReadRegTensorNode::isPcAccess);
   }
 
   /**
@@ -105,7 +112,7 @@ public interface IsaMatchingUtils {
             new AnyChildMatcher(new AnyReadRegisterFileMatcher())
         )));
 
-    return !matched.isEmpty() && writesExactlyOneRegisterClass(behavior);
+    return !matched.isEmpty() && writesExactlyOneRegisterClass(behavior) && noPcAccess(behavior);
   }
 
   /**
@@ -127,7 +134,7 @@ public interface IsaMatchingUtils {
         matchers
     );
 
-    return !matched.isEmpty() && writesExactlyOneRegisterClass(behavior);
+    return !matched.isEmpty() && writesExactlyOneRegisterClass(behavior) && noPcAccess(behavior);
   }
 
   /**

--- a/vadl/main/vadl/gcb/passes/MachineInstructionLabel.java
+++ b/vadl/main/vadl/gcb/passes/MachineInstructionLabel.java
@@ -85,9 +85,10 @@ public enum MachineInstructionLabel {
   /*
   UNCONDITIONAL JUMPS
    */
-  JALR,
+  JALR, //  unconditional indirect jump without immediate. With linking register.
   JAL, // the difference between JAL and J is that JAL also writes a linking register.
-  J,
+  J, // unconditional jump with no linking register.
+  JR, //  unconditional indirect jump without immediate. No linking register.
   /*
   CONDITIONAL MOVE
    */

--- a/vadl/main/vadl/gcb/passes/RegisterRef.java
+++ b/vadl/main/vadl/gcb/passes/RegisterRef.java
@@ -44,6 +44,7 @@ public class RegisterRef extends Resource {
 
   @Nullable
   private Format refFormat;
+
   @Nullable
   private Constant address;
   private final List<RegisterTensor.Constraint> constraints;
@@ -132,6 +133,11 @@ public class RegisterRef extends Resource {
   @Override
   public void accept(DefinitionVisitor visitor) {
 
+  }
+
+  @Nullable
+  public Constant address() {
+    return address;
   }
 
   public List<RegisterTensor.Constraint> constraints() {

--- a/vadl/main/vadl/gcb/passes/RegisterRef.java
+++ b/vadl/main/vadl/gcb/passes/RegisterRef.java
@@ -23,6 +23,7 @@ import java.util.Objects;
 import javax.annotation.Nullable;
 import vadl.types.ConcreteRelationType;
 import vadl.types.DataType;
+import vadl.viam.ArtificialResource;
 import vadl.viam.Constant;
 import vadl.viam.DefinitionVisitor;
 import vadl.viam.Format;
@@ -55,6 +56,18 @@ public class RegisterRef extends Resource {
     register.ensure(register.isSingleRegister(), "must be single register");
     this.resultType = register.resultType();
     this.relationType = register.relationType();
+    this.address = null;
+    // When constructed over register then they are no constraints.
+    this.constraints = Collections.emptyList();
+  }
+
+  /**
+   * Constructor.
+   */
+  public RegisterRef(ArtificialResource artificialResource) {
+    super(artificialResource.identifier);
+    this.resultType = artificialResource.resultType();
+    this.relationType = artificialResource.relationType();
     this.address = null;
     // When constructed over register then they are no constraints.
     this.constraints = Collections.emptyList();

--- a/vadl/main/vadl/gcb/passes/operands/GenerateInstructionOperandsPass.java
+++ b/vadl/main/vadl/gcb/passes/operands/GenerateInstructionOperandsPass.java
@@ -251,7 +251,7 @@ public class GenerateInstructionOperandsPass extends Pass {
         PseudoNodeOperandCollectorDispatcher.dispatch(handler, writeRegTensorNode.condition());
         PseudoNodeOperandCollectorDispatcher.dispatch(handler, writeRegTensorNode.value());
         // We don't handle the indices because they are considered output operands.
-      } else if(sideEffectNode instanceof WriteArtificialResNode writeArtificialResNode) {
+      } else if (sideEffectNode instanceof WriteArtificialResNode writeArtificialResNode) {
         PseudoNodeOperandCollectorDispatcher.dispatch(handler, writeArtificialResNode.condition());
         PseudoNodeOperandCollectorDispatcher.dispatch(handler, writeArtificialResNode.value());
         // We don't handle the indices because they are considered output operands.
@@ -497,7 +497,8 @@ public class GenerateInstructionOperandsPass extends Pass {
    */
   private List<WriteResourceNode> extractWrites(Graph graph) {
     return Stream.concat(graph.getNodes(WriteRegTensorNode.class)
-                .filter(e -> e.regTensor().isRegisterFile()),
+                .filter(e -> e.regTensor().isRegisterFile())
+                .map(x -> (WriteResourceNode) x),
             graph.getNodes(WriteArtificialResNode.class).filter(
                 e -> e.resourceDefinition().innerResourceRef() instanceof RegisterTensor tensor
                     && tensor.isRegisterFile()))

--- a/vadl/main/vadl/gcb/passes/operands/GenerateInstructionOperandsPass.java
+++ b/vadl/main/vadl/gcb/passes/operands/GenerateInstructionOperandsPass.java
@@ -251,6 +251,10 @@ public class GenerateInstructionOperandsPass extends Pass {
         PseudoNodeOperandCollectorDispatcher.dispatch(handler, writeRegTensorNode.condition());
         PseudoNodeOperandCollectorDispatcher.dispatch(handler, writeRegTensorNode.value());
         // We don't handle the indices because they are considered output operands.
+      } else if(sideEffectNode instanceof WriteArtificialResNode writeArtificialResNode) {
+        PseudoNodeOperandCollectorDispatcher.dispatch(handler, writeArtificialResNode.condition());
+        PseudoNodeOperandCollectorDispatcher.dispatch(handler, writeArtificialResNode.value());
+        // We don't handle the indices because they are considered output operands.
       }
     });
 

--- a/vadl/main/vadl/lcb/passes/isaMatching/IsaMachineInstructionMatchingPass.java
+++ b/vadl/main/vadl/lcb/passes/isaMatching/IsaMachineInstructionMatchingPass.java
@@ -287,6 +287,8 @@ public class IsaMachineInstructionMatchingPass extends Pass implements IsaMatchi
         instruction.attachExtension(new MachineInstructionCtx(MachineInstructionLabel.JAL, ty));
       } else if (findJ(behavior, pc)) {
         instruction.attachExtension(new MachineInstructionCtx(MachineInstructionLabel.J, ty));
+      } else if (findJR(behavior, pc)) {
+        instruction.attachExtension(new MachineInstructionCtx(MachineInstructionLabel.JR, ty));
       }
     });
 
@@ -567,7 +569,25 @@ public class IsaMachineInstructionMatchingPass extends Pass implements IsaMatchi
   }
 
   /**
-   * Match {@link Instruction} which modifies the PC not store the result into a register.
+   * Match {@link Instruction} which modifies the PC without an immediate not store the result into
+   * a register.
+   */
+  private boolean findJR(UninlinedGraph behavior, Counter pcRegister) {
+    var writesPc =
+        behavior.getNodes(WriteRegTensorNode.class)
+            .filter(x -> x.regTensor().equals(pcRegister.registerTensor()))
+            .toList();
+    var writes = behavior.getNodes(WriteResourceNode.class).toList();
+    var immediates = behavior.getNodes(FieldAccessRefNode.class).toList();
+
+    return writesPc.size() == 1
+        && writes.size() == 1
+        && immediates.isEmpty();
+  }
+
+  /**
+   * Match {@link Instruction} which modifies the PC with an immediate not store the result into
+   * a register.
    */
   private boolean findJ(UninlinedGraph behavior, Counter pcRegister) {
     var writesPc =

--- a/vadl/main/vadl/lcb/passes/llvmLowering/LlvmLoweringPass.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/LlvmLoweringPass.java
@@ -54,11 +54,12 @@ import vadl.lcb.passes.llvmLowering.strategies.instruction.LlvmCompilerInstructi
 import vadl.lcb.passes.llvmLowering.strategies.instruction.LlvmInstructionLoweringAddImmediateStrategyImpl;
 import vadl.lcb.passes.llvmLowering.strategies.instruction.LlvmInstructionLoweringConditionalBranchesStrategyImpl;
 import vadl.lcb.passes.llvmLowering.strategies.instruction.LlvmInstructionLoweringDefaultStrategyImpl;
-import vadl.lcb.passes.llvmLowering.strategies.instruction.LlvmInstructionLoweringIndirectJumpStrategyImpl;
+import vadl.lcb.passes.llvmLowering.strategies.instruction.LlvmInstructionLoweringIndirectJumpAndLinkStrategyImpl;
 import vadl.lcb.passes.llvmLowering.strategies.instruction.LlvmInstructionLoweringLoadUpperImmediateStrategyImpl;
 import vadl.lcb.passes.llvmLowering.strategies.instruction.LlvmInstructionLoweringMemoryLoadStrategyImpl;
 import vadl.lcb.passes.llvmLowering.strategies.instruction.LlvmInstructionLoweringMemoryStoreStrategyImpl;
-import vadl.lcb.passes.llvmLowering.strategies.instruction.LlvmInstructionLoweringUnconditionalJumpsStrategyImpl;
+import vadl.lcb.passes.llvmLowering.strategies.instruction.LlvmInstructionLoweringUnconditionalIndirectJumpWithoutLinkRegistersStrategyImpl;
+import vadl.lcb.passes.llvmLowering.strategies.instruction.LlvmInstructionLoweringUnconditionalJumpWithLinkRegistersStrategyImpl;
 import vadl.lcb.passes.llvmLowering.strategies.instruction.LlvmInstructionLoweringXoriAndOriStrategyImpl;
 import vadl.lcb.passes.llvmLowering.strategies.instruction.LlvmPseudoInstructionLoweringDefaultStrategyImpl;
 import vadl.lcb.passes.llvmLowering.strategies.instruction.LlvmPseudoInstructionLoweringLoadGlobalAddressStrategyImpl;
@@ -317,9 +318,12 @@ public class LlvmLoweringPass extends Pass {
             new LlvmInstructionLoweringLessThanUnsignedConditionalsStrategyImpl(architectureType),
             new LlvmInstructionLoweringLessThanImmediateUnsignedConditionalsStrategyImpl(
                 architectureType),
-            new LlvmInstructionLoweringUnconditionalJumpsStrategyImpl(architectureType),
+            new LlvmInstructionLoweringUnconditionalJumpWithLinkRegistersStrategyImpl(
+                architectureType),
+            new LlvmInstructionLoweringUnconditionalIndirectJumpWithoutLinkRegistersStrategyImpl(
+                architectureType),
             new LlvmInstructionLoweringConditionalBranchesStrategyImpl(architectureType),
-            new LlvmInstructionLoweringIndirectJumpStrategyImpl(architectureType),
+            new LlvmInstructionLoweringIndirectJumpAndLinkStrategyImpl(architectureType),
             new LlvmInstructionLoweringMemoryStoreStrategyImpl(architectureType),
             new LlvmInstructionLoweringMemoryLoadStrategyImpl(architectureType),
             new LlvmInstructionLoweringXoriAndOriStrategyImpl(architectureType),

--- a/vadl/main/vadl/lcb/passes/llvmLowering/domain/selectionDag/LlvmReadArtificialResourceNode.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/domain/selectionDag/LlvmReadArtificialResourceNode.java
@@ -1,0 +1,94 @@
+// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.lcb.passes.llvmLowering.domain.selectionDag;
+
+import vadl.gcb.passes.operands.model.GcbDefaultInstructionOperand;
+import vadl.gcb.passes.operands.model.GcbInstructionIndexedRegisterFileOperand;
+import vadl.gcb.passes.operands.model.GcbInstructionOperand;
+import vadl.gcb.passes.operands.model.GcbInstructionRegisterFileOperand;
+import vadl.lcb.passes.llvmLowering.LlvmNodeLowerable;
+import vadl.lcb.passes.llvmLowering.strategies.visitors.TableGenMachineInstructionVisitor;
+import vadl.lcb.passes.llvmLowering.strategies.visitors.TableGenNodeVisitor;
+import vadl.types.DataType;
+import vadl.viam.ArtificialResource;
+import vadl.viam.RegisterTensor;
+import vadl.viam.graph.GraphNodeVisitor;
+import vadl.viam.graph.NodeList;
+import vadl.viam.graph.dependency.ExpressionNode;
+import vadl.viam.graph.dependency.FieldRefNode;
+import vadl.viam.graph.dependency.FuncParamNode;
+import vadl.viam.graph.dependency.ReadRegTensorNode;
+
+/**
+ * LLVM node for the selection dag.
+ */
+public class LlvmReadArtificialResourceNode extends ReadRegTensorNode implements LlvmNodeLowerable,
+    LlvmNodeReplaceable {
+  protected final ArtificialResource artificialResource;
+  protected GcbDefaultInstructionOperand instructionOperand;
+
+  /**
+   * Constructor.
+   */
+  public LlvmReadArtificialResourceNode(ArtificialResource artificialResource,
+                                        ExpressionNode address,
+                                        DataType type) {
+    super((RegisterTensor) artificialResource.innerResourceRef(),
+        new NodeList<>(address),
+        type,
+        null);
+    this.artificialResource = artificialResource;
+    if (artificialResource.readFunction().parameters().length == 0) {
+      // It is a register
+      instructionOperand =
+          new GcbInstructionIndexedRegisterFileOperand(this, (FuncParamNode) address);
+    } else {
+      instructionOperand = new GcbInstructionRegisterFileOperand(this, (FieldRefNode) address);
+    }
+  }
+
+  @Override
+  public GcbInstructionOperand operand() {
+    return instructionOperand;
+  }
+
+  @Override
+  public LlvmReadArtificialResourceNode copy() {
+    return new LlvmReadArtificialResourceNode(artificialResource, address().copy(), type());
+  }
+
+  @Override
+  public LlvmReadArtificialResourceNode shallowCopy() {
+    return new LlvmReadArtificialResourceNode(artificialResource, address(), type());
+  }
+
+  @Override
+  public String lower() {
+    return operand().render();
+  }
+
+  @Override
+  public void accept(GraphNodeVisitor visitor) {
+    if (visitor instanceof TableGenMachineInstructionVisitor v) {
+      v.visit(this);
+    } else if (visitor instanceof TableGenNodeVisitor v) {
+      v.visit(this);
+    } else {
+      visitor.visit(this);
+    }
+  }
+}

--- a/vadl/main/vadl/lcb/passes/llvmLowering/strategies/LlvmInstructionLoweringStrategy.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/strategies/LlvmInstructionLoweringStrategy.java
@@ -237,6 +237,7 @@ public abstract class LlvmInstructionLoweringStrategy {
 
         operands.set(i, new TableGenInstructionLabelOperand(llvmNode));
       } else if (operand instanceof GcbInstructionImmediateOperand immediateOperand
+          && !(operand instanceof TableGenInstructionLabelOperand)
           && !fieldAccesses.containsKey(immediateOperand.fieldAccess())
           && !basicBlocks.containsKey(immediateOperand.fieldAccess())) {
         // This branch is taken when the field access was removed from the instruction's behavior

--- a/vadl/main/vadl/lcb/passes/llvmLowering/strategies/LlvmInstructionLoweringStrategy.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/strategies/LlvmInstructionLoweringStrategy.java
@@ -57,6 +57,7 @@ import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmBrCondSD;
 import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmBrSD;
 import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmFieldAccessRefNode;
 import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmFrameIndexSD;
+import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmReadArtificialResourceNode;
 import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmUnlowerableSD;
 import vadl.lcb.passes.llvmLowering.strategies.nodeLowering.LcbNodeReplacementHandler;
 import vadl.lcb.passes.llvmLowering.strategies.nodeLowering.LcbNodeReplacementHandlerDispatcher;
@@ -235,6 +236,19 @@ public abstract class LlvmInstructionLoweringStrategy {
                 instruction.location().join(immediateOperand.fieldAccess().location())));
 
         operands.set(i, new TableGenInstructionLabelOperand(llvmNode));
+      } else if (operand instanceof GcbInstructionImmediateOperand immediateOperand
+          && !fieldAccesses.containsKey(immediateOperand.fieldAccess())
+          && !basicBlocks.containsKey(immediateOperand.fieldAccess())) {
+        // This branch is taken when the field access was removed from the instruction's behavior
+        // because of optimisations. However, we still need to replace this operand.
+        var fieldAccess = immediateOperand.fieldAccess();
+        var llvmNode =
+            new LlvmFieldAccessRefNode(instruction,
+                fieldAccess,
+                fieldAccess.type(),
+                architectureType,
+                LlvmFieldAccessRefNode.Usage.Immediate);
+        operands.set(i, new TableGenInstructionImmediateOperand(llvmNode));
       } else if (operand instanceof GcbInstructionRegisterFileOperand registerFileOperand
           && registerFileOperand.origin() instanceof ReadRegTensorNode readNode) {
         if (frameIndices.containsKey(readNode)) {
@@ -476,6 +490,8 @@ public abstract class LlvmInstructionLoweringStrategy {
   public static GcbInstructionOperand generateTableGenInputOutput(Node operand) {
     if (operand instanceof LlvmFrameIndexSD node) {
       return generateInstructionOperand(node);
+    } else if (operand instanceof LlvmReadArtificialResourceNode node) {
+      return generateInstructionOperandRegisterFile(node);
     } else if (operand instanceof ReadRegTensorNode node && node.regTensor().isRegisterFile()) {
       return generateInstructionOperandRegisterFile(node);
     } else if (operand instanceof LlvmFieldAccessRefNode node) {

--- a/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/LlvmInstructionLoweringIndirectJumpAndLinkStrategyImpl.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/LlvmInstructionLoweringIndirectJumpAndLinkStrategyImpl.java
@@ -66,9 +66,9 @@ import vadl.viam.graph.dependency.SideEffectNode;
  * Generates the {@link LlvmLoweringRecord} for {@link MachineInstructionLabel#JALR}
  * instruction.
  */
-public class LlvmInstructionLoweringIndirectJumpStrategyImpl
+public class LlvmInstructionLoweringIndirectJumpAndLinkStrategyImpl
     extends LlvmInstructionLoweringStrategy {
-  public LlvmInstructionLoweringIndirectJumpStrategyImpl(
+  public LlvmInstructionLoweringIndirectJumpAndLinkStrategyImpl(
       ValueType architectureType) {
     super(architectureType);
   }

--- a/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/LlvmInstructionLoweringUnconditionalIndirectJumpWithoutLinkRegistersStrategyImpl.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/LlvmInstructionLoweringUnconditionalIndirectJumpWithoutLinkRegistersStrategyImpl.java
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.lcb.passes.llvmLowering.strategies.instruction;
+
+import static vadl.gcb.passes.MachineInstructionLabel.JR;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import vadl.gcb.passes.DetermineRegisterUsesAndDefsPass;
+import vadl.gcb.passes.MachineInstructionLabel;
+import vadl.gcb.passes.operands.model.GcbInstructionOperand;
+import vadl.gcb.valuetypes.ValueType;
+import vadl.lcb.passes.isaMatching.IsaMachineInstructionMatchingPass;
+import vadl.lcb.passes.llvmLowering.LlvmLoweringPass;
+import vadl.lcb.passes.llvmLowering.domain.LlvmLoweringRecord;
+import vadl.lcb.passes.llvmLowering.strategies.LlvmInstructionLoweringStrategy;
+import vadl.lcb.passes.llvmLowering.tablegen.model.TableGenPattern;
+import vadl.viam.Abi;
+import vadl.viam.Instruction;
+import vadl.viam.graph.Graph;
+import vadl.viam.graph.dependency.SideEffectNode;
+import vadl.viam.graph.dependency.WriteResourceNode;
+
+/**
+ * Lowering unconditional indirect jump instructions without linking register into TableGen
+ * patterns.
+ */
+public class LlvmInstructionLoweringUnconditionalIndirectJumpWithoutLinkRegistersStrategyImpl
+    extends LlvmInstructionLoweringStrategy {
+  public LlvmInstructionLoweringUnconditionalIndirectJumpWithoutLinkRegistersStrategyImpl(
+      ValueType architectureType) {
+    super(architectureType);
+  }
+
+  @Override
+  protected Set<MachineInstructionLabel> getSupportedInstructionLabels() {
+    return Set.of(JR);
+  }
+
+  @Override
+  public Optional<LlvmLoweringRecord.Machine> lowerInstruction(
+      IsaMachineInstructionMatchingPass.Result labelledMachineInstructions,
+      Instruction instruction,
+      Graph uninlinedBehavior,
+      Abi abi,
+      DetermineRegisterUsesAndDefsPass.Info registerDefsUses) {
+    var copy = uninlinedBehavior.copy();
+
+    for (var node : copy.getNodes(SideEffectNode.class).toList()) {
+      replaceNode(instruction, node);
+    }
+
+    copy.deinitializeNodes();
+    return Optional.of(
+        createIntermediateResult(instruction, copy, registerDefsUses));
+  }
+
+  private LlvmLoweringRecord.Machine createIntermediateResult(
+      Instruction instruction,
+      Graph uninlinedGraph,
+      DetermineRegisterUsesAndDefsPass.Info registerDefsUses) {
+
+    var info = lowerBaseInfo(instruction, uninlinedGraph, registerDefsUses);
+    var unchangedFlags = getFlags(uninlinedGraph);
+    var flags = LlvmLoweringPass.Flags.withNoTerminator(
+        LlvmLoweringPass.Flags.withNoBranch(unchangedFlags));
+
+    return new LlvmLoweringRecord.Machine(
+        instruction,
+        info.withFlags(flags),
+        Collections.emptyList(),
+        Collections.emptyList());
+  }
+
+
+  @Override
+  protected List<TableGenPattern> generatePatterns(Instruction instruction,
+                                                   List<GcbInstructionOperand> inputOperands,
+                                                   List<WriteResourceNode> sideEffectNodes) {
+    throw new RuntimeException("Must not be called. Use the other method");
+  }
+
+  @Override
+  protected List<TableGenPattern> generatePatternVariations(
+      Instruction instruction,
+      IsaMachineInstructionMatchingPass.Result supportedInstructions,
+      Graph behavior,
+      List<GcbInstructionOperand> inputOperands,
+      List<GcbInstructionOperand> outputOperands,
+      List<TableGenPattern> patterns,
+      Abi abi) {
+    return Collections.emptyList();
+  }
+}

--- a/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/LlvmInstructionLoweringUnconditionalJumpWithLinkRegistersStrategyImpl.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/LlvmInstructionLoweringUnconditionalJumpWithLinkRegistersStrategyImpl.java
@@ -40,9 +40,10 @@ import vadl.viam.graph.dependency.WriteResourceNode;
 /**
  * Lowering unconditional jump instructions into TableGen patterns.
  */
-public class LlvmInstructionLoweringUnconditionalJumpsStrategyImpl
+public class LlvmInstructionLoweringUnconditionalJumpWithLinkRegistersStrategyImpl
     extends LlvmInstructionLoweringStrategy {
-  public LlvmInstructionLoweringUnconditionalJumpsStrategyImpl(ValueType architectureType) {
+  public LlvmInstructionLoweringUnconditionalJumpWithLinkRegistersStrategyImpl(
+      ValueType architectureType) {
     super(architectureType);
   }
 

--- a/vadl/main/vadl/lcb/passes/llvmLowering/strategies/nodeLowering/LcbNodeReplacementHandler.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/strategies/nodeLowering/LcbNodeReplacementHandler.java
@@ -615,6 +615,7 @@ public class LcbNodeReplacementHandler {
   }
 
   @Handler
+  @SuppressWarnings("MissingJavadocMethod")
   public void handle(WriteArtificialResNode writeArtificialResNode) {
     if (writeArtificialResNode.isDeleted()) {
       return;

--- a/vadl/main/vadl/lcb/passes/llvmLowering/strategies/nodeLowering/LcbNodeReplacementHandler.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/strategies/nodeLowering/LcbNodeReplacementHandler.java
@@ -40,6 +40,7 @@ import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmFieldAccessRefNode;
 import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmLoadSD;
 import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmMulSD;
 import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmOrSD;
+import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmReadArtificialResourceNode;
 import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmReadRegFileNode;
 import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmSDivSD;
 import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmSExtLoad;
@@ -105,6 +106,7 @@ import vadl.viam.graph.dependency.SliceNode;
 import vadl.viam.graph.dependency.TensorNode;
 import vadl.viam.graph.dependency.TruncateNode;
 import vadl.viam.graph.dependency.TupleGetFieldNode;
+import vadl.viam.graph.dependency.WriteArtificialResNode;
 import vadl.viam.graph.dependency.WriteMemNode;
 import vadl.viam.graph.dependency.WriteRegTensorNode;
 import vadl.viam.graph.dependency.ZeroExtendNode;
@@ -176,7 +178,10 @@ public class LcbNodeReplacementHandler {
   @Handler
   @SuppressWarnings("MissingJavadocMethod")
   public void handle(ReadArtificialResNode node) {
-    throw Diagnostic.error("not supported", node.location()).build();
+    node.replaceAndDelete(
+        new LlvmReadArtificialResourceNode(node.resourceDefinition(),
+            node.indices().getFirst(),
+            node.type()));
   }
 
   @Handler
@@ -606,6 +611,20 @@ public class LcbNodeReplacementHandler {
     }
 
     LcbNodeReplacementHandlerDispatcher.dispatch(this, writeMemNode.value());
+  }
+
+  @Handler
+  public void handle(WriteArtificialResNode writeArtificialResNode) {
+    if (writeArtificialResNode.isDeleted()) {
+      return;
+    }
+
+    for (var index : writeArtificialResNode.indices()) {
+      LcbNodeReplacementHandlerDispatcher.dispatch(this, index);
+    }
+
+    LcbNodeReplacementHandlerDispatcher.dispatch(this, writeArtificialResNode.condition());
+    LcbNodeReplacementHandlerDispatcher.dispatch(this, writeArtificialResNode.value());
   }
 
   @Handler

--- a/vadl/main/vadl/lcb/passes/llvmLowering/strategies/nodeLowering/LcbNodeReplacementHandler.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/strategies/nodeLowering/LcbNodeReplacementHandler.java
@@ -494,6 +494,7 @@ public class LcbNodeReplacementHandler {
       }
     } else {
       LcbNodeReplacementHandlerDispatcher.dispatch(this, sliceNode.value());
+      Objects.requireNonNull(sliceNode.graph()).add(new LlvmUnlowerableSD());
     }
   }
 

--- a/vadl/main/vadl/lcb/passes/llvmLowering/strategies/visitors/TableGenNodeVisitor.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/strategies/visitors/TableGenNodeVisitor.java
@@ -25,6 +25,7 @@ import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmExtLoad;
 import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmFieldAccessRefNode;
 import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmFrameIndexSD;
 import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmLoadSD;
+import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmReadArtificialResourceNode;
 import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmReadRegFileNode;
 import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmSExtLoad;
 import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmSetccSD;
@@ -118,6 +119,11 @@ public interface TableGenNodeVisitor extends LcbGraphNodeVisitor {
    * Visit {@link LlvmReadRegFileNode}.
    */
   void visit(LlvmReadRegFileNode node);
+
+  /**
+   * Visit {@link LlvmReadArtificialResourceNode}.
+   */
+  void visit(LlvmReadArtificialResourceNode node);
 
   /**
    * Visit {@link LlvmFrameIndexSD}.

--- a/vadl/main/vadl/lcb/passes/llvmLowering/tablegen/lowering/TableGenInstructionRenderer.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/tablegen/lowering/TableGenInstructionRenderer.java
@@ -19,6 +19,7 @@ package vadl.lcb.passes.llvmLowering.tablegen.lowering;
 import static vadl.viam.ViamError.ensure;
 
 import java.util.BitSet;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import javax.annotation.Nullable;
@@ -33,7 +34,6 @@ import vadl.lcb.passes.llvmLowering.tablegen.model.TableGenPseudoInstruction;
 import vadl.lcb.passes.llvmLowering.tablegen.model.TableGenSelectionPattern;
 import vadl.lcb.passes.llvmLowering.tablegen.model.TableGenSelectionWithOutputPattern;
 import vadl.viam.CompilerInstruction;
-import vadl.viam.Definition;
 import vadl.viam.Instruction;
 import vadl.viam.PseudoInstruction;
 
@@ -122,9 +122,19 @@ public final class TableGenInstructionRenderer {
             .map(x -> (TableGenSelectionPattern) x)
             .map(TableGenInstructionRenderer::lower)
             .collect(Collectors.joining(",")),
-        instruction.getUses().stream().map(Definition::simpleName).collect(Collectors.joining(",")),
-        instruction.getDefs().stream().map(Definition::simpleName).collect(Collectors.joining(","))
+        instruction.getUses().stream().map(TableGenInstructionRenderer::renderRegisterRef)
+            .collect(Collectors.joining(",")),
+        instruction.getDefs().stream().map(TableGenInstructionRenderer::renderRegisterRef)
+            .collect(Collectors.joining(","))
     );
+  }
+
+  private static String renderRegisterRef(RegisterRef x) {
+    if (x.hasAddress()) {
+      return x.identifier.simpleName() + Objects.requireNonNull(x.address()).asVal().intValue();
+    } else {
+      return x.identifier.simpleName();
+    }
   }
 
 

--- a/vadl/main/vadl/lcb/passes/llvmLowering/tablegen/lowering/TableGenInstructionRenderer.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/tablegen/lowering/TableGenInstructionRenderer.java
@@ -129,15 +129,6 @@ public final class TableGenInstructionRenderer {
     );
   }
 
-  private static String renderRegisterRef(RegisterRef x) {
-    if (x.hasAddress()) {
-      return x.identifier.simpleName() + Objects.requireNonNull(x.address()).asVal().intValue();
-    } else {
-      return x.identifier.simpleName();
-    }
-  }
-
-
   /**
    * Transforms the given {@link PseudoInstruction} into a string which can be used by LLVM's
    * TableGen.
@@ -339,6 +330,14 @@ public final class TableGenInstructionRenderer {
     return String.format("let Inst{%s} = %s{%s};", inst,
         fieldEncoding.getSourceBitBlockName(),
         source);
+  }
+
+  private static String renderRegisterRef(RegisterRef x) {
+    if (x.hasAddress()) {
+      return x.identifier.simpleName() + Objects.requireNonNull(x.address()).asVal().intValue();
+    } else {
+      return x.identifier.simpleName();
+    }
   }
 
   /**

--- a/vadl/main/vadl/lcb/passes/llvmLowering/tablegen/lowering/TableGenPatternPrinterVisitor.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/tablegen/lowering/TableGenPatternPrinterVisitor.java
@@ -30,6 +30,7 @@ import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmExtLoad;
 import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmFieldAccessRefNode;
 import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmFrameIndexSD;
 import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmLoadSD;
+import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmReadArtificialResourceNode;
 import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmReadRegFileNode;
 import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmSExtLoad;
 import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmSetccSD;
@@ -151,6 +152,12 @@ public class TableGenPatternPrinterVisitor
 
   @Override
   public void visit(LlvmReadRegFileNode readRegFileNode) {
+    var operand = LlvmInstructionLoweringStrategy.generateTableGenInputOutput(readRegFileNode);
+    writer.write(operand.render());
+  }
+
+  @Override
+  public void visit(LlvmReadArtificialResourceNode readRegFileNode) {
     var operand = LlvmInstructionLoweringStrategy.generateTableGenInputOutput(readRegFileNode);
     writer.write(operand.render());
   }

--- a/vadl/main/vadl/lcb/template/lib/Target/EmitRegisterInfoCppFilePass.java
+++ b/vadl/main/vadl/lcb/template/lib/Target/EmitRegisterInfoCppFilePass.java
@@ -16,7 +16,6 @@
 
 package vadl.lcb.template.lib.Target;
 
-import static vadl.viam.ViamError.ensure;
 import static vadl.viam.ViamError.ensureNonNull;
 import static vadl.viam.ViamError.ensurePresent;
 
@@ -27,6 +26,7 @@ import java.util.Comparator;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import javax.annotation.Nullable;
 import vadl.configuration.LcbConfiguration;
 import vadl.error.Diagnostic;
@@ -195,7 +195,8 @@ public class EmitRegisterInfoCppFilePass extends LcbTemplateRenderingPass {
 
     var entries = new ArrayList<FrameIndexElimination>();
     var affected =
-        List.of(MachineInstructionLabel.ADDI_32, MachineInstructionLabel.ADDI_64,
+        List.of(MachineInstructionLabel.ADDI_32,
+            MachineInstructionLabel.ADDI_64,
             MachineInstructionLabel.STORE_MEM,
             MachineInstructionLabel.LOAD_MEM);
 
@@ -210,26 +211,29 @@ public class EmitRegisterInfoCppFilePass extends LcbTemplateRenderingPass {
         var indices =
             extractFrameIndexAndImmIndexFromMachineInstruction(tableGenMachineInstructions,
                 instruction);
-        var isSigned = immediate.fieldAccess().type() instanceof SIntType;
-        var fieldBitWidth = immediate.fieldAccess().fieldRef().bitSlice().bitSize();
-        long minValue = isSigned ? -1 * (long) Math.pow(2, fieldBitWidth - 1) : 0;
-        long maxValue = isSigned ? (long) Math.pow(2, fieldBitWidth - 1) - 1 :
-            (long) Math.pow(2, fieldBitWidth);
-        var entry = new FrameIndexElimination(label, instruction, immediate,
-            TableGenImmediateRecord.createPredicateMethod(instruction, immediate.fieldAccess())
-                .lower(),
-            instruction.behavior().getNodes(ReadRegTensorNode.class)
-                .filter(x -> x.regTensor().isRegisterFile())
-                .findFirst().get()
-                .regTensor(), indices, minValue, maxValue);
-        entries.add(entry);
+
+        indices.ifPresent(ind -> {
+          var isSigned = immediate.fieldAccess().type() instanceof SIntType;
+          var fieldBitWidth = immediate.fieldAccess().fieldRef().bitSlice().bitSize();
+          long minValue = isSigned ? -1 * (long) Math.pow(2, fieldBitWidth - 1) : 0;
+          long maxValue = isSigned ? (long) Math.pow(2, fieldBitWidth - 1) - 1 :
+              (long) Math.pow(2, fieldBitWidth);
+          var entry = new FrameIndexElimination(label, instruction, immediate,
+              TableGenImmediateRecord.createPredicateMethod(instruction, immediate.fieldAccess())
+                  .lower(),
+              instruction.behavior().getNodes(ReadRegTensorNode.class)
+                  .filter(x -> x.regTensor().isRegisterFile())
+                  .findFirst().get()
+                  .regTensor(), ind, minValue, maxValue);
+          entries.add(entry);
+        });
       }
     }
 
     return entries;
   }
 
-  private MachineInstructionIndices extractFrameIndexAndImmIndexFromMachineInstruction(
+  private Optional<MachineInstructionIndices> extractFrameIndexAndImmIndexFromMachineInstruction(
       List<TableGenMachineInstruction> tableGenMachineInstructions, Instruction instruction) {
     var machineInstructionIndices = new ArrayList<MachineInstructionIndices>();
 
@@ -265,7 +269,10 @@ public class EmitRegisterInfoCppFilePass extends LcbTemplateRenderingPass {
       }
     }
 
-    ensure(!machineInstructionIndices.isEmpty(), "Expected at least one FI pattern");
-    return machineInstructionIndices.stream().findFirst().get();
+    if (machineInstructionIndices.isEmpty()) {
+      return Optional.empty();
+    } else {
+      return machineInstructionIndices.stream().findFirst();
+    }
   }
 }

--- a/vadl/main/vadl/pass/PassOrders.java
+++ b/vadl/main/vadl/pass/PassOrders.java
@@ -221,6 +221,9 @@ public class PassOrders {
     // needs to know about those status built-in calls.
     order.skip(StatusBuiltInInlinePass.class);
 
+    // We need to keep the aliases.
+    order.skip(ArtificialResInlinerPass.class);
+
     order.add(new GenerateCompilerRegistersPass(gcbConfiguration));
     // skip inlining of field access
     order.skip(FieldAccessInlinerPass.class);

--- a/vadl/main/vadl/viam/graph/dependency/ReadArtificialResNode.java
+++ b/vadl/main/vadl/viam/graph/dependency/ReadArtificialResNode.java
@@ -20,14 +20,16 @@ import java.util.List;
 import vadl.javaannotations.viam.DataValue;
 import vadl.types.DataType;
 import vadl.viam.ArtificialResource;
+import vadl.viam.RegisterTensor;
 import vadl.viam.graph.GraphNodeVisitor;
+import vadl.viam.graph.HasRegisterTensor;
 import vadl.viam.graph.Node;
 import vadl.viam.graph.NodeList;
 
 /**
  * A read of an {@link ArtificialResource}.
  */
-public class ReadArtificialResNode extends ReadResourceNode {
+public class ReadArtificialResNode extends ReadResourceNode implements HasRegisterTensor {
 
   @DataValue
   private final ArtificialResource resource;
@@ -63,5 +65,17 @@ public class ReadArtificialResNode extends ReadResourceNode {
   @Override
   public <T extends GraphNodeVisitor> void accept(T visitor) {
 
+  }
+
+  @Override
+  public RegisterTensor registerTensor() {
+    return (RegisterTensor) resource.innerResourceRef();
+  }
+
+  @Override
+  public boolean hasRegisterFile() {
+    // If parameter's length is 1 then it is a register file.
+    // If parameter's length is 0 then it is a register.
+    return resource.isRegisterFile() && resource.readFunction().parameters().length == 1;
   }
 }

--- a/vadl/main/vadl/viam/graph/dependency/WriteArtificialResNode.java
+++ b/vadl/main/vadl/viam/graph/dependency/WriteArtificialResNode.java
@@ -20,14 +20,16 @@ import java.util.List;
 import javax.annotation.Nullable;
 import vadl.javaannotations.viam.DataValue;
 import vadl.viam.ArtificialResource;
+import vadl.viam.RegisterTensor;
 import vadl.viam.graph.GraphNodeVisitor;
+import vadl.viam.graph.HasRegisterTensor;
 import vadl.viam.graph.Node;
 import vadl.viam.graph.NodeList;
 
 /**
  * A write to an {@link ArtificialResource}.
  */
-public class WriteArtificialResNode extends WriteResourceNode {
+public class WriteArtificialResNode extends WriteResourceNode implements HasRegisterTensor {
 
   @DataValue
   protected ArtificialResource resource;
@@ -82,5 +84,17 @@ public class WriteArtificialResNode extends WriteResourceNode {
   @Override
   public void accept(GraphNodeVisitor visitor) {
     visitor.visit(this);
+  }
+
+  @Override
+  public RegisterTensor registerTensor() {
+    return (RegisterTensor) resource.innerResourceRef();
+  }
+
+  @Override
+  public boolean hasRegisterFile() {
+    // If parameter's length is 1 then it is a register file.
+    // If parameter's length is 0 then it is a register.
+    return resource.isRegisterFile() && resource.readFunction().parameters().length == 1;
   }
 }

--- a/vadl/test/resources/snapshots/aarch64/RegisterInfo.cpp
+++ b/vadl/test/resources/snapshots/aarch64/RegisterInfo.cpp
@@ -30,2413 +30,2071 @@ using namespace llvm;
 void processornamevalueRegisterInfo::anchor() {}
 
 processornamevalueRegisterInfo::processornamevalueRegisterInfo()
-    : processornamevalueGenRegisterInfo( processornamevalue::S30 )
+: processornamevalueGenRegisterInfo( processornamevalue::S30 )
 {
 }
 
 const uint16_t * processornamevalueRegisterInfo::getCalleeSavedRegs(const MachineFunction * /*MF*/
 ) const
 {
-    // defined in calling convention tablegen
-    return CSR_processornamevalue_SaveList;
+// defined in calling convention tablegen
+return CSR_processornamevalue_SaveList;
 }
 
 BitVector processornamevalueRegisterInfo::getReservedRegs(const MachineFunction &MF) const
 {
-    BitVector Reserved(getNumRegs());
+BitVector Reserved(getNumRegs());
 
-    markSuperRegs(Reserved, processornamevalue::S29); // frame pointer
-    markSuperRegs(Reserved, processornamevalue::S31); // stack pointer
-    markSuperRegs(Reserved, processornamevalue::); // global pointer
-
-
-    markSuperRegs(Reserved, processornamevalue::); // thread pointer
+markSuperRegs(Reserved, processornamevalue::S29); // frame pointer
+markSuperRegs(Reserved, processornamevalue::S31); // stack pointer
+markSuperRegs(Reserved, processornamevalue::); // global pointer
 
 
+markSuperRegs(Reserved, processornamevalue::); // thread pointer
 
 
-    assert(checkAllSuperRegsMarked(Reserved));
 
-    return Reserved;
+
+assert(checkAllSuperRegsMarked(Reserved));
+
+return Reserved;
 }
 
 
 bool eliminateFrameIndexADDXI
-    ( MachineBasicBlock::iterator II
-    , int SPAdj
-    , unsigned FIOperandNum
-    , unsigned FrameReg
-    , StackOffset FrameIndexOffset
-    , RegScavenger *RS
-    )
+( MachineBasicBlock::iterator II
+, int SPAdj
+, unsigned FIOperandNum
+, unsigned FrameReg
+, StackOffset FrameIndexOffset
+, RegScavenger *RS
+)
 {
-    MachineInstr &MI = *II;
-    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+MachineInstr &MI = *II;
+assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
 
-    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
 
-    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-    //
-    // try to inline the offset into the instruction
-    //
+//
+// try to inline the offset into the instruction
+//
 
-    if(Offset >= 0 && Offset <= 4096 && AArch64Base_ADDXI_imm12X_predicate(Offset))
-    {
-        // immediate can be encoded and instruction can be inlined.
-        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-        ImmOp.setImm( Offset );
-        return false; // success
-    }
-
-
-    DebugLoc DL = MI.getDebugLoc();
-    MachineBasicBlock &MBB = *MI.getParent();
-    MachineFunction *MF = MBB.getParent();
-    MachineRegisterInfo &MRI = MF->getRegInfo();
-    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
-
-    //
-    // try to generate a scratch register and adjust frame register with given offset
-    //
-
-    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-    {
-        // the scratch register can properly be manipulated and used as address register.
-        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-        ImmOp.setImm( 0 );
-        return false; // success
-    }
-
-    return true; // failure
+if(Offset >= 0 && Offset <= 4096 && AArch64Base_ADDXI_imm12X_predicate(Offset))
+{
+// immediate can be encoded and instruction can be inlined.
+FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+ImmOp.setImm( Offset );
+return false; // success
 }
-bool eliminateFrameIndexADDXSXSB
-    ( MachineBasicBlock::iterator II
-    , int SPAdj
-    , unsigned FIOperandNum
-    , unsigned FrameReg
-    , StackOffset FrameIndexOffset
-    , RegScavenger *RS
-    )
+
+
+DebugLoc DL = MI.getDebugLoc();
+MachineBasicBlock &MBB = *MI.getParent();
+MachineFunction *MF = MBB.getParent();
+MachineRegisterInfo &MRI = MF->getRegInfo();
+const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+
+//
+// try to generate a scratch register and adjust frame register with given offset
+//
+
+Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
 {
-    MachineInstr &MI = *II;
-    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-    assert(  MI.getOperand(FIOperandNum + 2).isImm() && "Immediate operand position does not match expected position!" );
-
-    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 2);
-
-    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
-
-    //
-    // try to inline the offset into the instruction
-    //
-
-    if(Offset >= 0 && Offset <= 8 && AArch64Base_ADDXSXSB_imm3_predicate(Offset))
-    {
-        // immediate can be encoded and instruction can be inlined.
-        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-        ImmOp.setImm( Offset );
-        return false; // success
-    }
-
-
-    DebugLoc DL = MI.getDebugLoc();
-    MachineBasicBlock &MBB = *MI.getParent();
-    MachineFunction *MF = MBB.getParent();
-    MachineRegisterInfo &MRI = MF->getRegInfo();
-    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
-
-    //
-    // try to generate a scratch register and adjust frame register with given offset
-    //
-
-    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-    {
-        // the scratch register can properly be manipulated and used as address register.
-        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-        ImmOp.setImm( 0 );
-        return false; // success
-    }
-
-    return true; // failure
+// the scratch register can properly be manipulated and used as address register.
+FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+ImmOp.setImm( 0 );
+return false; // success
 }
-bool eliminateFrameIndexADDXSXSH
-    ( MachineBasicBlock::iterator II
-    , int SPAdj
-    , unsigned FIOperandNum
-    , unsigned FrameReg
-    , StackOffset FrameIndexOffset
-    , RegScavenger *RS
-    )
-{
-    MachineInstr &MI = *II;
-    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-    assert(  MI.getOperand(FIOperandNum + 2).isImm() && "Immediate operand position does not match expected position!" );
 
-    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 2);
-
-    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
-
-    //
-    // try to inline the offset into the instruction
-    //
-
-    if(Offset >= 0 && Offset <= 8 && AArch64Base_ADDXSXSH_imm3_predicate(Offset))
-    {
-        // immediate can be encoded and instruction can be inlined.
-        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-        ImmOp.setImm( Offset );
-        return false; // success
-    }
-
-
-    DebugLoc DL = MI.getDebugLoc();
-    MachineBasicBlock &MBB = *MI.getParent();
-    MachineFunction *MF = MBB.getParent();
-    MachineRegisterInfo &MRI = MF->getRegInfo();
-    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
-
-    //
-    // try to generate a scratch register and adjust frame register with given offset
-    //
-
-    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-    {
-        // the scratch register can properly be manipulated and used as address register.
-        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-        ImmOp.setImm( 0 );
-        return false; // success
-    }
-
-    return true; // failure
-}
-bool eliminateFrameIndexADDXSXSW
-    ( MachineBasicBlock::iterator II
-    , int SPAdj
-    , unsigned FIOperandNum
-    , unsigned FrameReg
-    , StackOffset FrameIndexOffset
-    , RegScavenger *RS
-    )
-{
-    MachineInstr &MI = *II;
-    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-    assert(  MI.getOperand(FIOperandNum + 2).isImm() && "Immediate operand position does not match expected position!" );
-
-    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 2);
-
-    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
-
-    //
-    // try to inline the offset into the instruction
-    //
-
-    if(Offset >= 0 && Offset <= 8 && AArch64Base_ADDXSXSW_imm3_predicate(Offset))
-    {
-        // immediate can be encoded and instruction can be inlined.
-        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-        ImmOp.setImm( Offset );
-        return false; // success
-    }
-
-
-    DebugLoc DL = MI.getDebugLoc();
-    MachineBasicBlock &MBB = *MI.getParent();
-    MachineFunction *MF = MBB.getParent();
-    MachineRegisterInfo &MRI = MF->getRegInfo();
-    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
-
-    //
-    // try to generate a scratch register and adjust frame register with given offset
-    //
-
-    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-    {
-        // the scratch register can properly be manipulated and used as address register.
-        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-        ImmOp.setImm( 0 );
-        return false; // success
-    }
-
-    return true; // failure
-}
-bool eliminateFrameIndexADDXUXSB
-    ( MachineBasicBlock::iterator II
-    , int SPAdj
-    , unsigned FIOperandNum
-    , unsigned FrameReg
-    , StackOffset FrameIndexOffset
-    , RegScavenger *RS
-    )
-{
-    MachineInstr &MI = *II;
-    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-    assert(  MI.getOperand(FIOperandNum + 2).isImm() && "Immediate operand position does not match expected position!" );
-
-    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 2);
-
-    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
-
-    //
-    // try to inline the offset into the instruction
-    //
-
-    if(Offset >= 0 && Offset <= 8 && AArch64Base_ADDXUXSB_imm3_predicate(Offset))
-    {
-        // immediate can be encoded and instruction can be inlined.
-        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-        ImmOp.setImm( Offset );
-        return false; // success
-    }
-
-
-    DebugLoc DL = MI.getDebugLoc();
-    MachineBasicBlock &MBB = *MI.getParent();
-    MachineFunction *MF = MBB.getParent();
-    MachineRegisterInfo &MRI = MF->getRegInfo();
-    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
-
-    //
-    // try to generate a scratch register and adjust frame register with given offset
-    //
-
-    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-    {
-        // the scratch register can properly be manipulated and used as address register.
-        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-        ImmOp.setImm( 0 );
-        return false; // success
-    }
-
-    return true; // failure
-}
-bool eliminateFrameIndexADDXUXSH
-    ( MachineBasicBlock::iterator II
-    , int SPAdj
-    , unsigned FIOperandNum
-    , unsigned FrameReg
-    , StackOffset FrameIndexOffset
-    , RegScavenger *RS
-    )
-{
-    MachineInstr &MI = *II;
-    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-    assert(  MI.getOperand(FIOperandNum + 2).isImm() && "Immediate operand position does not match expected position!" );
-
-    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 2);
-
-    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
-
-    //
-    // try to inline the offset into the instruction
-    //
-
-    if(Offset >= 0 && Offset <= 8 && AArch64Base_ADDXUXSH_imm3_predicate(Offset))
-    {
-        // immediate can be encoded and instruction can be inlined.
-        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-        ImmOp.setImm( Offset );
-        return false; // success
-    }
-
-
-    DebugLoc DL = MI.getDebugLoc();
-    MachineBasicBlock &MBB = *MI.getParent();
-    MachineFunction *MF = MBB.getParent();
-    MachineRegisterInfo &MRI = MF->getRegInfo();
-    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
-
-    //
-    // try to generate a scratch register and adjust frame register with given offset
-    //
-
-    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-    {
-        // the scratch register can properly be manipulated and used as address register.
-        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-        ImmOp.setImm( 0 );
-        return false; // success
-    }
-
-    return true; // failure
-}
-bool eliminateFrameIndexADDXUXSW
-    ( MachineBasicBlock::iterator II
-    , int SPAdj
-    , unsigned FIOperandNum
-    , unsigned FrameReg
-    , StackOffset FrameIndexOffset
-    , RegScavenger *RS
-    )
-{
-    MachineInstr &MI = *II;
-    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-    assert(  MI.getOperand(FIOperandNum + 2).isImm() && "Immediate operand position does not match expected position!" );
-
-    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 2);
-
-    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
-
-    //
-    // try to inline the offset into the instruction
-    //
-
-    if(Offset >= 0 && Offset <= 8 && AArch64Base_ADDXUXSW_imm3_predicate(Offset))
-    {
-        // immediate can be encoded and instruction can be inlined.
-        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-        ImmOp.setImm( Offset );
-        return false; // success
-    }
-
-
-    DebugLoc DL = MI.getDebugLoc();
-    MachineBasicBlock &MBB = *MI.getParent();
-    MachineFunction *MF = MBB.getParent();
-    MachineRegisterInfo &MRI = MF->getRegInfo();
-    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
-
-    //
-    // try to generate a scratch register and adjust frame register with given offset
-    //
-
-    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-    {
-        // the scratch register can properly be manipulated and used as address register.
-        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-        ImmOp.setImm( 0 );
-        return false; // success
-    }
-
-    return true; // failure
+return true; // failure
 }
 bool eliminateFrameIndexLDPSPre
-    ( MachineBasicBlock::iterator II
-    , int SPAdj
-    , unsigned FIOperandNum
-    , unsigned FrameReg
-    , StackOffset FrameIndexOffset
-    , RegScavenger *RS
-    )
+( MachineBasicBlock::iterator II
+, int SPAdj
+, unsigned FIOperandNum
+, unsigned FrameReg
+, StackOffset FrameIndexOffset
+, RegScavenger *RS
+)
 {
-    MachineInstr &MI = *II;
-    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+MachineInstr &MI = *II;
+assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
 
-    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
 
-    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-    //
-    // try to inline the offset into the instruction
-    //
+//
+// try to inline the offset into the instruction
+//
 
-    if(Offset >= -64 && Offset <= 63 && AArch64Base_LDPSPre_offWSize_predicate(Offset))
-    {
-        // immediate can be encoded and instruction can be inlined.
-        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-        ImmOp.setImm( Offset );
-        return false; // success
-    }
+if(Offset >= -64 && Offset <= 63 && AArch64Base_LDPSPre_offWSize_predicate(Offset))
+{
+// immediate can be encoded and instruction can be inlined.
+FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+ImmOp.setImm( Offset );
+return false; // success
+}
 
 
-    DebugLoc DL = MI.getDebugLoc();
-    MachineBasicBlock &MBB = *MI.getParent();
-    MachineFunction *MF = MBB.getParent();
-    MachineRegisterInfo &MRI = MF->getRegInfo();
-    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+DebugLoc DL = MI.getDebugLoc();
+MachineBasicBlock &MBB = *MI.getParent();
+MachineFunction *MF = MBB.getParent();
+MachineRegisterInfo &MRI = MF->getRegInfo();
+const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-    //
-    // try to generate a scratch register and adjust frame register with given offset
-    //
+//
+// try to generate a scratch register and adjust frame register with given offset
+//
 
-    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-    {
-        // the scratch register can properly be manipulated and used as address register.
-        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-        ImmOp.setImm( 0 );
-        return false; // success
-    }
+Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+{
+// the scratch register can properly be manipulated and used as address register.
+FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+ImmOp.setImm( 0 );
+return false; // success
+}
 
-    return true; // failure
+return true; // failure
 }
 bool eliminateFrameIndexLDPSPst
-    ( MachineBasicBlock::iterator II
-    , int SPAdj
-    , unsigned FIOperandNum
-    , unsigned FrameReg
-    , StackOffset FrameIndexOffset
-    , RegScavenger *RS
-    )
+( MachineBasicBlock::iterator II
+, int SPAdj
+, unsigned FIOperandNum
+, unsigned FrameReg
+, StackOffset FrameIndexOffset
+, RegScavenger *RS
+)
 {
-    MachineInstr &MI = *II;
-    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+MachineInstr &MI = *II;
+assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
 
-    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
 
-    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-    //
-    // try to inline the offset into the instruction
-    //
+//
+// try to inline the offset into the instruction
+//
 
-    if(Offset >= -64 && Offset <= 63 && AArch64Base_LDPSPst_offWSize_predicate(Offset))
-    {
-        // immediate can be encoded and instruction can be inlined.
-        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-        ImmOp.setImm( Offset );
-        return false; // success
-    }
+if(Offset >= -64 && Offset <= 63 && AArch64Base_LDPSPst_offWSize_predicate(Offset))
+{
+// immediate can be encoded and instruction can be inlined.
+FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+ImmOp.setImm( Offset );
+return false; // success
+}
 
 
-    DebugLoc DL = MI.getDebugLoc();
-    MachineBasicBlock &MBB = *MI.getParent();
-    MachineFunction *MF = MBB.getParent();
-    MachineRegisterInfo &MRI = MF->getRegInfo();
-    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+DebugLoc DL = MI.getDebugLoc();
+MachineBasicBlock &MBB = *MI.getParent();
+MachineFunction *MF = MBB.getParent();
+MachineRegisterInfo &MRI = MF->getRegInfo();
+const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-    //
-    // try to generate a scratch register and adjust frame register with given offset
-    //
+//
+// try to generate a scratch register and adjust frame register with given offset
+//
 
-    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-    {
-        // the scratch register can properly be manipulated and used as address register.
-        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-        ImmOp.setImm( 0 );
-        return false; // success
-    }
+Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+{
+// the scratch register can properly be manipulated and used as address register.
+FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+ImmOp.setImm( 0 );
+return false; // success
+}
 
-    return true; // failure
+return true; // failure
 }
 bool eliminateFrameIndexLDPWPre
-    ( MachineBasicBlock::iterator II
-    , int SPAdj
-    , unsigned FIOperandNum
-    , unsigned FrameReg
-    , StackOffset FrameIndexOffset
-    , RegScavenger *RS
-    )
+( MachineBasicBlock::iterator II
+, int SPAdj
+, unsigned FIOperandNum
+, unsigned FrameReg
+, StackOffset FrameIndexOffset
+, RegScavenger *RS
+)
 {
-    MachineInstr &MI = *II;
-    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+MachineInstr &MI = *II;
+assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
 
-    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
 
-    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-    //
-    // try to inline the offset into the instruction
-    //
+//
+// try to inline the offset into the instruction
+//
 
-    if(Offset >= -64 && Offset <= 63 && AArch64Base_LDPWPre_offWSize_predicate(Offset))
-    {
-        // immediate can be encoded and instruction can be inlined.
-        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-        ImmOp.setImm( Offset );
-        return false; // success
-    }
+if(Offset >= -64 && Offset <= 63 && AArch64Base_LDPWPre_offWSize_predicate(Offset))
+{
+// immediate can be encoded and instruction can be inlined.
+FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+ImmOp.setImm( Offset );
+return false; // success
+}
 
 
-    DebugLoc DL = MI.getDebugLoc();
-    MachineBasicBlock &MBB = *MI.getParent();
-    MachineFunction *MF = MBB.getParent();
-    MachineRegisterInfo &MRI = MF->getRegInfo();
-    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+DebugLoc DL = MI.getDebugLoc();
+MachineBasicBlock &MBB = *MI.getParent();
+MachineFunction *MF = MBB.getParent();
+MachineRegisterInfo &MRI = MF->getRegInfo();
+const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-    //
-    // try to generate a scratch register and adjust frame register with given offset
-    //
+//
+// try to generate a scratch register and adjust frame register with given offset
+//
 
-    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-    {
-        // the scratch register can properly be manipulated and used as address register.
-        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-        ImmOp.setImm( 0 );
-        return false; // success
-    }
+Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+{
+// the scratch register can properly be manipulated and used as address register.
+FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+ImmOp.setImm( 0 );
+return false; // success
+}
 
-    return true; // failure
+return true; // failure
 }
 bool eliminateFrameIndexLDPWPst
-    ( MachineBasicBlock::iterator II
-    , int SPAdj
-    , unsigned FIOperandNum
-    , unsigned FrameReg
-    , StackOffset FrameIndexOffset
-    , RegScavenger *RS
-    )
+( MachineBasicBlock::iterator II
+, int SPAdj
+, unsigned FIOperandNum
+, unsigned FrameReg
+, StackOffset FrameIndexOffset
+, RegScavenger *RS
+)
 {
-    MachineInstr &MI = *II;
-    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+MachineInstr &MI = *II;
+assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
 
-    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
 
-    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-    //
-    // try to inline the offset into the instruction
-    //
+//
+// try to inline the offset into the instruction
+//
 
-    if(Offset >= -64 && Offset <= 63 && AArch64Base_LDPWPst_offWSize_predicate(Offset))
-    {
-        // immediate can be encoded and instruction can be inlined.
-        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-        ImmOp.setImm( Offset );
-        return false; // success
-    }
+if(Offset >= -64 && Offset <= 63 && AArch64Base_LDPWPst_offWSize_predicate(Offset))
+{
+// immediate can be encoded and instruction can be inlined.
+FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+ImmOp.setImm( Offset );
+return false; // success
+}
 
 
-    DebugLoc DL = MI.getDebugLoc();
-    MachineBasicBlock &MBB = *MI.getParent();
-    MachineFunction *MF = MBB.getParent();
-    MachineRegisterInfo &MRI = MF->getRegInfo();
-    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+DebugLoc DL = MI.getDebugLoc();
+MachineBasicBlock &MBB = *MI.getParent();
+MachineFunction *MF = MBB.getParent();
+MachineRegisterInfo &MRI = MF->getRegInfo();
+const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-    //
-    // try to generate a scratch register and adjust frame register with given offset
-    //
+//
+// try to generate a scratch register and adjust frame register with given offset
+//
 
-    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-    {
-        // the scratch register can properly be manipulated and used as address register.
-        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-        ImmOp.setImm( 0 );
-        return false; // success
-    }
+Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+{
+// the scratch register can properly be manipulated and used as address register.
+FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+ImmOp.setImm( 0 );
+return false; // success
+}
 
-    return true; // failure
+return true; // failure
 }
 bool eliminateFrameIndexLDPXPre
-    ( MachineBasicBlock::iterator II
-    , int SPAdj
-    , unsigned FIOperandNum
-    , unsigned FrameReg
-    , StackOffset FrameIndexOffset
-    , RegScavenger *RS
-    )
+( MachineBasicBlock::iterator II
+, int SPAdj
+, unsigned FIOperandNum
+, unsigned FrameReg
+, StackOffset FrameIndexOffset
+, RegScavenger *RS
+)
 {
-    MachineInstr &MI = *II;
-    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+MachineInstr &MI = *II;
+assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
 
-    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
 
-    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-    //
-    // try to inline the offset into the instruction
-    //
+//
+// try to inline the offset into the instruction
+//
 
-    if(Offset >= -64 && Offset <= 63 && AArch64Base_LDPXPre_offXSize_predicate(Offset))
-    {
-        // immediate can be encoded and instruction can be inlined.
-        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-        ImmOp.setImm( Offset );
-        return false; // success
-    }
+if(Offset >= -64 && Offset <= 63 && AArch64Base_LDPXPre_offXSize_predicate(Offset))
+{
+// immediate can be encoded and instruction can be inlined.
+FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+ImmOp.setImm( Offset );
+return false; // success
+}
 
 
-    DebugLoc DL = MI.getDebugLoc();
-    MachineBasicBlock &MBB = *MI.getParent();
-    MachineFunction *MF = MBB.getParent();
-    MachineRegisterInfo &MRI = MF->getRegInfo();
-    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+DebugLoc DL = MI.getDebugLoc();
+MachineBasicBlock &MBB = *MI.getParent();
+MachineFunction *MF = MBB.getParent();
+MachineRegisterInfo &MRI = MF->getRegInfo();
+const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-    //
-    // try to generate a scratch register and adjust frame register with given offset
-    //
+//
+// try to generate a scratch register and adjust frame register with given offset
+//
 
-    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-    {
-        // the scratch register can properly be manipulated and used as address register.
-        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-        ImmOp.setImm( 0 );
-        return false; // success
-    }
+Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+{
+// the scratch register can properly be manipulated and used as address register.
+FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+ImmOp.setImm( 0 );
+return false; // success
+}
 
-    return true; // failure
+return true; // failure
 }
 bool eliminateFrameIndexLDPXPst
-    ( MachineBasicBlock::iterator II
-    , int SPAdj
-    , unsigned FIOperandNum
-    , unsigned FrameReg
-    , StackOffset FrameIndexOffset
-    , RegScavenger *RS
-    )
+( MachineBasicBlock::iterator II
+, int SPAdj
+, unsigned FIOperandNum
+, unsigned FrameReg
+, StackOffset FrameIndexOffset
+, RegScavenger *RS
+)
 {
-    MachineInstr &MI = *II;
-    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+MachineInstr &MI = *II;
+assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
 
-    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
 
-    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-    //
-    // try to inline the offset into the instruction
-    //
+//
+// try to inline the offset into the instruction
+//
 
-    if(Offset >= -64 && Offset <= 63 && AArch64Base_LDPXPst_offXSize_predicate(Offset))
-    {
-        // immediate can be encoded and instruction can be inlined.
-        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-        ImmOp.setImm( Offset );
-        return false; // success
-    }
+if(Offset >= -64 && Offset <= 63 && AArch64Base_LDPXPst_offXSize_predicate(Offset))
+{
+// immediate can be encoded and instruction can be inlined.
+FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+ImmOp.setImm( Offset );
+return false; // success
+}
 
 
-    DebugLoc DL = MI.getDebugLoc();
-    MachineBasicBlock &MBB = *MI.getParent();
-    MachineFunction *MF = MBB.getParent();
-    MachineRegisterInfo &MRI = MF->getRegInfo();
-    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+DebugLoc DL = MI.getDebugLoc();
+MachineBasicBlock &MBB = *MI.getParent();
+MachineFunction *MF = MBB.getParent();
+MachineRegisterInfo &MRI = MF->getRegInfo();
+const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-    //
-    // try to generate a scratch register and adjust frame register with given offset
-    //
+//
+// try to generate a scratch register and adjust frame register with given offset
+//
 
-    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-    {
-        // the scratch register can properly be manipulated and used as address register.
-        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-        ImmOp.setImm( 0 );
-        return false; // success
-    }
+Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+{
+// the scratch register can properly be manipulated and used as address register.
+FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+ImmOp.setImm( 0 );
+return false; // success
+}
 
-    return true; // failure
+return true; // failure
 }
 bool eliminateFrameIndexLDRPreB
-    ( MachineBasicBlock::iterator II
-    , int SPAdj
-    , unsigned FIOperandNum
-    , unsigned FrameReg
-    , StackOffset FrameIndexOffset
-    , RegScavenger *RS
-    )
+( MachineBasicBlock::iterator II
+, int SPAdj
+, unsigned FIOperandNum
+, unsigned FrameReg
+, StackOffset FrameIndexOffset
+, RegScavenger *RS
+)
 {
-    MachineInstr &MI = *II;
-    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+MachineInstr &MI = *II;
+assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
 
-    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
 
-    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-    //
-    // try to inline the offset into the instruction
-    //
+//
+// try to inline the offset into the instruction
+//
 
-    if(Offset >= -256 && Offset <= 255 && AArch64Base_LDRPreB_offset_predicate(Offset))
-    {
-        // immediate can be encoded and instruction can be inlined.
-        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-        ImmOp.setImm( Offset );
-        return false; // success
-    }
+if(Offset >= -256 && Offset <= 255 && AArch64Base_LDRPreB_offset_predicate(Offset))
+{
+// immediate can be encoded and instruction can be inlined.
+FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+ImmOp.setImm( Offset );
+return false; // success
+}
 
 
-    DebugLoc DL = MI.getDebugLoc();
-    MachineBasicBlock &MBB = *MI.getParent();
-    MachineFunction *MF = MBB.getParent();
-    MachineRegisterInfo &MRI = MF->getRegInfo();
-    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+DebugLoc DL = MI.getDebugLoc();
+MachineBasicBlock &MBB = *MI.getParent();
+MachineFunction *MF = MBB.getParent();
+MachineRegisterInfo &MRI = MF->getRegInfo();
+const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-    //
-    // try to generate a scratch register and adjust frame register with given offset
-    //
+//
+// try to generate a scratch register and adjust frame register with given offset
+//
 
-    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-    {
-        // the scratch register can properly be manipulated and used as address register.
-        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-        ImmOp.setImm( 0 );
-        return false; // success
-    }
+Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+{
+// the scratch register can properly be manipulated and used as address register.
+FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+ImmOp.setImm( 0 );
+return false; // success
+}
 
-    return true; // failure
+return true; // failure
 }
 bool eliminateFrameIndexLDRPreH
-    ( MachineBasicBlock::iterator II
-    , int SPAdj
-    , unsigned FIOperandNum
-    , unsigned FrameReg
-    , StackOffset FrameIndexOffset
-    , RegScavenger *RS
-    )
+( MachineBasicBlock::iterator II
+, int SPAdj
+, unsigned FIOperandNum
+, unsigned FrameReg
+, StackOffset FrameIndexOffset
+, RegScavenger *RS
+)
 {
-    MachineInstr &MI = *II;
-    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+MachineInstr &MI = *II;
+assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
 
-    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
 
-    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-    //
-    // try to inline the offset into the instruction
-    //
+//
+// try to inline the offset into the instruction
+//
 
-    if(Offset >= -256 && Offset <= 255 && AArch64Base_LDRPreH_offset_predicate(Offset))
-    {
-        // immediate can be encoded and instruction can be inlined.
-        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-        ImmOp.setImm( Offset );
-        return false; // success
-    }
+if(Offset >= -256 && Offset <= 255 && AArch64Base_LDRPreH_offset_predicate(Offset))
+{
+// immediate can be encoded and instruction can be inlined.
+FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+ImmOp.setImm( Offset );
+return false; // success
+}
 
 
-    DebugLoc DL = MI.getDebugLoc();
-    MachineBasicBlock &MBB = *MI.getParent();
-    MachineFunction *MF = MBB.getParent();
-    MachineRegisterInfo &MRI = MF->getRegInfo();
-    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+DebugLoc DL = MI.getDebugLoc();
+MachineBasicBlock &MBB = *MI.getParent();
+MachineFunction *MF = MBB.getParent();
+MachineRegisterInfo &MRI = MF->getRegInfo();
+const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-    //
-    // try to generate a scratch register and adjust frame register with given offset
-    //
+//
+// try to generate a scratch register and adjust frame register with given offset
+//
 
-    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-    {
-        // the scratch register can properly be manipulated and used as address register.
-        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-        ImmOp.setImm( 0 );
-        return false; // success
-    }
+Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+{
+// the scratch register can properly be manipulated and used as address register.
+FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+ImmOp.setImm( 0 );
+return false; // success
+}
 
-    return true; // failure
+return true; // failure
 }
 bool eliminateFrameIndexLDRPreSBW
-    ( MachineBasicBlock::iterator II
-    , int SPAdj
-    , unsigned FIOperandNum
-    , unsigned FrameReg
-    , StackOffset FrameIndexOffset
-    , RegScavenger *RS
-    )
+( MachineBasicBlock::iterator II
+, int SPAdj
+, unsigned FIOperandNum
+, unsigned FrameReg
+, StackOffset FrameIndexOffset
+, RegScavenger *RS
+)
 {
-    MachineInstr &MI = *II;
-    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+MachineInstr &MI = *II;
+assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
 
-    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
 
-    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-    //
-    // try to inline the offset into the instruction
-    //
+//
+// try to inline the offset into the instruction
+//
 
-    if(Offset >= -256 && Offset <= 255 && AArch64Base_LDRPreSBW_offset_predicate(Offset))
-    {
-        // immediate can be encoded and instruction can be inlined.
-        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-        ImmOp.setImm( Offset );
-        return false; // success
-    }
+if(Offset >= -256 && Offset <= 255 && AArch64Base_LDRPreSBW_offset_predicate(Offset))
+{
+// immediate can be encoded and instruction can be inlined.
+FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+ImmOp.setImm( Offset );
+return false; // success
+}
 
 
-    DebugLoc DL = MI.getDebugLoc();
-    MachineBasicBlock &MBB = *MI.getParent();
-    MachineFunction *MF = MBB.getParent();
-    MachineRegisterInfo &MRI = MF->getRegInfo();
-    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+DebugLoc DL = MI.getDebugLoc();
+MachineBasicBlock &MBB = *MI.getParent();
+MachineFunction *MF = MBB.getParent();
+MachineRegisterInfo &MRI = MF->getRegInfo();
+const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-    //
-    // try to generate a scratch register and adjust frame register with given offset
-    //
+//
+// try to generate a scratch register and adjust frame register with given offset
+//
 
-    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-    {
-        // the scratch register can properly be manipulated and used as address register.
-        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-        ImmOp.setImm( 0 );
-        return false; // success
-    }
+Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+{
+// the scratch register can properly be manipulated and used as address register.
+FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+ImmOp.setImm( 0 );
+return false; // success
+}
 
-    return true; // failure
+return true; // failure
 }
 bool eliminateFrameIndexLDRPreSBX
-    ( MachineBasicBlock::iterator II
-    , int SPAdj
-    , unsigned FIOperandNum
-    , unsigned FrameReg
-    , StackOffset FrameIndexOffset
-    , RegScavenger *RS
-    )
+( MachineBasicBlock::iterator II
+, int SPAdj
+, unsigned FIOperandNum
+, unsigned FrameReg
+, StackOffset FrameIndexOffset
+, RegScavenger *RS
+)
 {
-    MachineInstr &MI = *II;
-    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+MachineInstr &MI = *II;
+assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
 
-    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
 
-    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-    //
-    // try to inline the offset into the instruction
-    //
+//
+// try to inline the offset into the instruction
+//
 
-    if(Offset >= -256 && Offset <= 255 && AArch64Base_LDRPreSBX_offset_predicate(Offset))
-    {
-        // immediate can be encoded and instruction can be inlined.
-        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-        ImmOp.setImm( Offset );
-        return false; // success
-    }
+if(Offset >= -256 && Offset <= 255 && AArch64Base_LDRPreSBX_offset_predicate(Offset))
+{
+// immediate can be encoded and instruction can be inlined.
+FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+ImmOp.setImm( Offset );
+return false; // success
+}
 
 
-    DebugLoc DL = MI.getDebugLoc();
-    MachineBasicBlock &MBB = *MI.getParent();
-    MachineFunction *MF = MBB.getParent();
-    MachineRegisterInfo &MRI = MF->getRegInfo();
-    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+DebugLoc DL = MI.getDebugLoc();
+MachineBasicBlock &MBB = *MI.getParent();
+MachineFunction *MF = MBB.getParent();
+MachineRegisterInfo &MRI = MF->getRegInfo();
+const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-    //
-    // try to generate a scratch register and adjust frame register with given offset
-    //
+//
+// try to generate a scratch register and adjust frame register with given offset
+//
 
-    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-    {
-        // the scratch register can properly be manipulated and used as address register.
-        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-        ImmOp.setImm( 0 );
-        return false; // success
-    }
+Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+{
+// the scratch register can properly be manipulated and used as address register.
+FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+ImmOp.setImm( 0 );
+return false; // success
+}
 
-    return true; // failure
+return true; // failure
 }
 bool eliminateFrameIndexLDRPreSHW
-    ( MachineBasicBlock::iterator II
-    , int SPAdj
-    , unsigned FIOperandNum
-    , unsigned FrameReg
-    , StackOffset FrameIndexOffset
-    , RegScavenger *RS
-    )
+( MachineBasicBlock::iterator II
+, int SPAdj
+, unsigned FIOperandNum
+, unsigned FrameReg
+, StackOffset FrameIndexOffset
+, RegScavenger *RS
+)
 {
-    MachineInstr &MI = *II;
-    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+MachineInstr &MI = *II;
+assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
 
-    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
 
-    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-    //
-    // try to inline the offset into the instruction
-    //
+//
+// try to inline the offset into the instruction
+//
 
-    if(Offset >= -256 && Offset <= 255 && AArch64Base_LDRPreSHW_offset_predicate(Offset))
-    {
-        // immediate can be encoded and instruction can be inlined.
-        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-        ImmOp.setImm( Offset );
-        return false; // success
-    }
+if(Offset >= -256 && Offset <= 255 && AArch64Base_LDRPreSHW_offset_predicate(Offset))
+{
+// immediate can be encoded and instruction can be inlined.
+FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+ImmOp.setImm( Offset );
+return false; // success
+}
 
 
-    DebugLoc DL = MI.getDebugLoc();
-    MachineBasicBlock &MBB = *MI.getParent();
-    MachineFunction *MF = MBB.getParent();
-    MachineRegisterInfo &MRI = MF->getRegInfo();
-    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+DebugLoc DL = MI.getDebugLoc();
+MachineBasicBlock &MBB = *MI.getParent();
+MachineFunction *MF = MBB.getParent();
+MachineRegisterInfo &MRI = MF->getRegInfo();
+const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-    //
-    // try to generate a scratch register and adjust frame register with given offset
-    //
+//
+// try to generate a scratch register and adjust frame register with given offset
+//
 
-    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-    {
-        // the scratch register can properly be manipulated and used as address register.
-        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-        ImmOp.setImm( 0 );
-        return false; // success
-    }
+Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+{
+// the scratch register can properly be manipulated and used as address register.
+FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+ImmOp.setImm( 0 );
+return false; // success
+}
 
-    return true; // failure
+return true; // failure
 }
 bool eliminateFrameIndexLDRPreSHX
-    ( MachineBasicBlock::iterator II
-    , int SPAdj
-    , unsigned FIOperandNum
-    , unsigned FrameReg
-    , StackOffset FrameIndexOffset
-    , RegScavenger *RS
-    )
+( MachineBasicBlock::iterator II
+, int SPAdj
+, unsigned FIOperandNum
+, unsigned FrameReg
+, StackOffset FrameIndexOffset
+, RegScavenger *RS
+)
 {
-    MachineInstr &MI = *II;
-    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+MachineInstr &MI = *II;
+assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
 
-    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
 
-    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-    //
-    // try to inline the offset into the instruction
-    //
+//
+// try to inline the offset into the instruction
+//
 
-    if(Offset >= -256 && Offset <= 255 && AArch64Base_LDRPreSHX_offset_predicate(Offset))
-    {
-        // immediate can be encoded and instruction can be inlined.
-        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-        ImmOp.setImm( Offset );
-        return false; // success
-    }
+if(Offset >= -256 && Offset <= 255 && AArch64Base_LDRPreSHX_offset_predicate(Offset))
+{
+// immediate can be encoded and instruction can be inlined.
+FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+ImmOp.setImm( Offset );
+return false; // success
+}
 
 
-    DebugLoc DL = MI.getDebugLoc();
-    MachineBasicBlock &MBB = *MI.getParent();
-    MachineFunction *MF = MBB.getParent();
-    MachineRegisterInfo &MRI = MF->getRegInfo();
-    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+DebugLoc DL = MI.getDebugLoc();
+MachineBasicBlock &MBB = *MI.getParent();
+MachineFunction *MF = MBB.getParent();
+MachineRegisterInfo &MRI = MF->getRegInfo();
+const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-    //
-    // try to generate a scratch register and adjust frame register with given offset
-    //
+//
+// try to generate a scratch register and adjust frame register with given offset
+//
 
-    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-    {
-        // the scratch register can properly be manipulated and used as address register.
-        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-        ImmOp.setImm( 0 );
-        return false; // success
-    }
+Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+{
+// the scratch register can properly be manipulated and used as address register.
+FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+ImmOp.setImm( 0 );
+return false; // success
+}
 
-    return true; // failure
+return true; // failure
 }
 bool eliminateFrameIndexLDRPreSWX
-    ( MachineBasicBlock::iterator II
-    , int SPAdj
-    , unsigned FIOperandNum
-    , unsigned FrameReg
-    , StackOffset FrameIndexOffset
-    , RegScavenger *RS
-    )
+( MachineBasicBlock::iterator II
+, int SPAdj
+, unsigned FIOperandNum
+, unsigned FrameReg
+, StackOffset FrameIndexOffset
+, RegScavenger *RS
+)
 {
-    MachineInstr &MI = *II;
-    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+MachineInstr &MI = *II;
+assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
 
-    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
 
-    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-    //
-    // try to inline the offset into the instruction
-    //
+//
+// try to inline the offset into the instruction
+//
 
-    if(Offset >= -256 && Offset <= 255 && AArch64Base_LDRPreSWX_offset_predicate(Offset))
-    {
-        // immediate can be encoded and instruction can be inlined.
-        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-        ImmOp.setImm( Offset );
-        return false; // success
-    }
+if(Offset >= -256 && Offset <= 255 && AArch64Base_LDRPreSWX_offset_predicate(Offset))
+{
+// immediate can be encoded and instruction can be inlined.
+FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+ImmOp.setImm( Offset );
+return false; // success
+}
 
 
-    DebugLoc DL = MI.getDebugLoc();
-    MachineBasicBlock &MBB = *MI.getParent();
-    MachineFunction *MF = MBB.getParent();
-    MachineRegisterInfo &MRI = MF->getRegInfo();
-    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+DebugLoc DL = MI.getDebugLoc();
+MachineBasicBlock &MBB = *MI.getParent();
+MachineFunction *MF = MBB.getParent();
+MachineRegisterInfo &MRI = MF->getRegInfo();
+const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-    //
-    // try to generate a scratch register and adjust frame register with given offset
-    //
+//
+// try to generate a scratch register and adjust frame register with given offset
+//
 
-    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-    {
-        // the scratch register can properly be manipulated and used as address register.
-        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-        ImmOp.setImm( 0 );
-        return false; // success
-    }
+Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+{
+// the scratch register can properly be manipulated and used as address register.
+FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+ImmOp.setImm( 0 );
+return false; // success
+}
 
-    return true; // failure
+return true; // failure
 }
 bool eliminateFrameIndexLDRPreW
-    ( MachineBasicBlock::iterator II
-    , int SPAdj
-    , unsigned FIOperandNum
-    , unsigned FrameReg
-    , StackOffset FrameIndexOffset
-    , RegScavenger *RS
-    )
+( MachineBasicBlock::iterator II
+, int SPAdj
+, unsigned FIOperandNum
+, unsigned FrameReg
+, StackOffset FrameIndexOffset
+, RegScavenger *RS
+)
 {
-    MachineInstr &MI = *II;
-    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+MachineInstr &MI = *II;
+assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
 
-    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
 
-    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-    //
-    // try to inline the offset into the instruction
-    //
+//
+// try to inline the offset into the instruction
+//
 
-    if(Offset >= -256 && Offset <= 255 && AArch64Base_LDRPreW_offset_predicate(Offset))
-    {
-        // immediate can be encoded and instruction can be inlined.
-        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-        ImmOp.setImm( Offset );
-        return false; // success
-    }
+if(Offset >= -256 && Offset <= 255 && AArch64Base_LDRPreW_offset_predicate(Offset))
+{
+// immediate can be encoded and instruction can be inlined.
+FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+ImmOp.setImm( Offset );
+return false; // success
+}
 
 
-    DebugLoc DL = MI.getDebugLoc();
-    MachineBasicBlock &MBB = *MI.getParent();
-    MachineFunction *MF = MBB.getParent();
-    MachineRegisterInfo &MRI = MF->getRegInfo();
-    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+DebugLoc DL = MI.getDebugLoc();
+MachineBasicBlock &MBB = *MI.getParent();
+MachineFunction *MF = MBB.getParent();
+MachineRegisterInfo &MRI = MF->getRegInfo();
+const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-    //
-    // try to generate a scratch register and adjust frame register with given offset
-    //
+//
+// try to generate a scratch register and adjust frame register with given offset
+//
 
-    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-    {
-        // the scratch register can properly be manipulated and used as address register.
-        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-        ImmOp.setImm( 0 );
-        return false; // success
-    }
+Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+{
+// the scratch register can properly be manipulated and used as address register.
+FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+ImmOp.setImm( 0 );
+return false; // success
+}
 
-    return true; // failure
+return true; // failure
 }
 bool eliminateFrameIndexLDRPreX
-    ( MachineBasicBlock::iterator II
-    , int SPAdj
-    , unsigned FIOperandNum
-    , unsigned FrameReg
-    , StackOffset FrameIndexOffset
-    , RegScavenger *RS
-    )
+( MachineBasicBlock::iterator II
+, int SPAdj
+, unsigned FIOperandNum
+, unsigned FrameReg
+, StackOffset FrameIndexOffset
+, RegScavenger *RS
+)
 {
-    MachineInstr &MI = *II;
-    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+MachineInstr &MI = *II;
+assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
 
-    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
 
-    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-    //
-    // try to inline the offset into the instruction
-    //
+//
+// try to inline the offset into the instruction
+//
 
-    if(Offset >= -256 && Offset <= 255 && AArch64Base_LDRPreX_offset_predicate(Offset))
-    {
-        // immediate can be encoded and instruction can be inlined.
-        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-        ImmOp.setImm( Offset );
-        return false; // success
-    }
+if(Offset >= -256 && Offset <= 255 && AArch64Base_LDRPreX_offset_predicate(Offset))
+{
+// immediate can be encoded and instruction can be inlined.
+FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+ImmOp.setImm( Offset );
+return false; // success
+}
 
 
-    DebugLoc DL = MI.getDebugLoc();
-    MachineBasicBlock &MBB = *MI.getParent();
-    MachineFunction *MF = MBB.getParent();
-    MachineRegisterInfo &MRI = MF->getRegInfo();
-    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+DebugLoc DL = MI.getDebugLoc();
+MachineBasicBlock &MBB = *MI.getParent();
+MachineFunction *MF = MBB.getParent();
+MachineRegisterInfo &MRI = MF->getRegInfo();
+const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-    //
-    // try to generate a scratch register and adjust frame register with given offset
-    //
+//
+// try to generate a scratch register and adjust frame register with given offset
+//
 
-    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-    {
-        // the scratch register can properly be manipulated and used as address register.
-        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-        ImmOp.setImm( 0 );
-        return false; // success
-    }
+Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+{
+// the scratch register can properly be manipulated and used as address register.
+FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+ImmOp.setImm( 0 );
+return false; // success
+}
 
-    return true; // failure
+return true; // failure
 }
 bool eliminateFrameIndexLDRPstB
-    ( MachineBasicBlock::iterator II
-    , int SPAdj
-    , unsigned FIOperandNum
-    , unsigned FrameReg
-    , StackOffset FrameIndexOffset
-    , RegScavenger *RS
-    )
+( MachineBasicBlock::iterator II
+, int SPAdj
+, unsigned FIOperandNum
+, unsigned FrameReg
+, StackOffset FrameIndexOffset
+, RegScavenger *RS
+)
 {
-    MachineInstr &MI = *II;
-    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+MachineInstr &MI = *II;
+assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
 
-    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
 
-    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-    //
-    // try to inline the offset into the instruction
-    //
+//
+// try to inline the offset into the instruction
+//
 
-    if(Offset >= -256 && Offset <= 255 && AArch64Base_LDRPstB_offset_predicate(Offset))
-    {
-        // immediate can be encoded and instruction can be inlined.
-        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-        ImmOp.setImm( Offset );
-        return false; // success
-    }
+if(Offset >= -256 && Offset <= 255 && AArch64Base_LDRPstB_offset_predicate(Offset))
+{
+// immediate can be encoded and instruction can be inlined.
+FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+ImmOp.setImm( Offset );
+return false; // success
+}
 
 
-    DebugLoc DL = MI.getDebugLoc();
-    MachineBasicBlock &MBB = *MI.getParent();
-    MachineFunction *MF = MBB.getParent();
-    MachineRegisterInfo &MRI = MF->getRegInfo();
-    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+DebugLoc DL = MI.getDebugLoc();
+MachineBasicBlock &MBB = *MI.getParent();
+MachineFunction *MF = MBB.getParent();
+MachineRegisterInfo &MRI = MF->getRegInfo();
+const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-    //
-    // try to generate a scratch register and adjust frame register with given offset
-    //
+//
+// try to generate a scratch register and adjust frame register with given offset
+//
 
-    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-    {
-        // the scratch register can properly be manipulated and used as address register.
-        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-        ImmOp.setImm( 0 );
-        return false; // success
-    }
+Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+{
+// the scratch register can properly be manipulated and used as address register.
+FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+ImmOp.setImm( 0 );
+return false; // success
+}
 
-    return true; // failure
+return true; // failure
 }
 bool eliminateFrameIndexLDRPstH
-    ( MachineBasicBlock::iterator II
-    , int SPAdj
-    , unsigned FIOperandNum
-    , unsigned FrameReg
-    , StackOffset FrameIndexOffset
-    , RegScavenger *RS
-    )
+( MachineBasicBlock::iterator II
+, int SPAdj
+, unsigned FIOperandNum
+, unsigned FrameReg
+, StackOffset FrameIndexOffset
+, RegScavenger *RS
+)
 {
-    MachineInstr &MI = *II;
-    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+MachineInstr &MI = *II;
+assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
 
-    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
 
-    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-    //
-    // try to inline the offset into the instruction
-    //
+//
+// try to inline the offset into the instruction
+//
 
-    if(Offset >= -256 && Offset <= 255 && AArch64Base_LDRPstH_offset_predicate(Offset))
-    {
-        // immediate can be encoded and instruction can be inlined.
-        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-        ImmOp.setImm( Offset );
-        return false; // success
-    }
+if(Offset >= -256 && Offset <= 255 && AArch64Base_LDRPstH_offset_predicate(Offset))
+{
+// immediate can be encoded and instruction can be inlined.
+FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+ImmOp.setImm( Offset );
+return false; // success
+}
 
 
-    DebugLoc DL = MI.getDebugLoc();
-    MachineBasicBlock &MBB = *MI.getParent();
-    MachineFunction *MF = MBB.getParent();
-    MachineRegisterInfo &MRI = MF->getRegInfo();
-    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+DebugLoc DL = MI.getDebugLoc();
+MachineBasicBlock &MBB = *MI.getParent();
+MachineFunction *MF = MBB.getParent();
+MachineRegisterInfo &MRI = MF->getRegInfo();
+const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-    //
-    // try to generate a scratch register and adjust frame register with given offset
-    //
+//
+// try to generate a scratch register and adjust frame register with given offset
+//
 
-    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-    {
-        // the scratch register can properly be manipulated and used as address register.
-        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-        ImmOp.setImm( 0 );
-        return false; // success
-    }
+Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+{
+// the scratch register can properly be manipulated and used as address register.
+FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+ImmOp.setImm( 0 );
+return false; // success
+}
 
-    return true; // failure
+return true; // failure
 }
 bool eliminateFrameIndexLDRPstSBW
-    ( MachineBasicBlock::iterator II
-    , int SPAdj
-    , unsigned FIOperandNum
-    , unsigned FrameReg
-    , StackOffset FrameIndexOffset
-    , RegScavenger *RS
-    )
+( MachineBasicBlock::iterator II
+, int SPAdj
+, unsigned FIOperandNum
+, unsigned FrameReg
+, StackOffset FrameIndexOffset
+, RegScavenger *RS
+)
 {
-    MachineInstr &MI = *II;
-    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+MachineInstr &MI = *II;
+assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
 
-    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
 
-    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-    //
-    // try to inline the offset into the instruction
-    //
+//
+// try to inline the offset into the instruction
+//
 
-    if(Offset >= -256 && Offset <= 255 && AArch64Base_LDRPstSBW_offset_predicate(Offset))
-    {
-        // immediate can be encoded and instruction can be inlined.
-        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-        ImmOp.setImm( Offset );
-        return false; // success
-    }
+if(Offset >= -256 && Offset <= 255 && AArch64Base_LDRPstSBW_offset_predicate(Offset))
+{
+// immediate can be encoded and instruction can be inlined.
+FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+ImmOp.setImm( Offset );
+return false; // success
+}
 
 
-    DebugLoc DL = MI.getDebugLoc();
-    MachineBasicBlock &MBB = *MI.getParent();
-    MachineFunction *MF = MBB.getParent();
-    MachineRegisterInfo &MRI = MF->getRegInfo();
-    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+DebugLoc DL = MI.getDebugLoc();
+MachineBasicBlock &MBB = *MI.getParent();
+MachineFunction *MF = MBB.getParent();
+MachineRegisterInfo &MRI = MF->getRegInfo();
+const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-    //
-    // try to generate a scratch register and adjust frame register with given offset
-    //
+//
+// try to generate a scratch register and adjust frame register with given offset
+//
 
-    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-    {
-        // the scratch register can properly be manipulated and used as address register.
-        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-        ImmOp.setImm( 0 );
-        return false; // success
-    }
+Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+{
+// the scratch register can properly be manipulated and used as address register.
+FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+ImmOp.setImm( 0 );
+return false; // success
+}
 
-    return true; // failure
+return true; // failure
 }
 bool eliminateFrameIndexLDRPstSBX
-    ( MachineBasicBlock::iterator II
-    , int SPAdj
-    , unsigned FIOperandNum
-    , unsigned FrameReg
-    , StackOffset FrameIndexOffset
-    , RegScavenger *RS
-    )
+( MachineBasicBlock::iterator II
+, int SPAdj
+, unsigned FIOperandNum
+, unsigned FrameReg
+, StackOffset FrameIndexOffset
+, RegScavenger *RS
+)
 {
-    MachineInstr &MI = *II;
-    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+MachineInstr &MI = *II;
+assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
 
-    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
 
-    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-    //
-    // try to inline the offset into the instruction
-    //
+//
+// try to inline the offset into the instruction
+//
 
-    if(Offset >= -256 && Offset <= 255 && AArch64Base_LDRPstSBX_offset_predicate(Offset))
-    {
-        // immediate can be encoded and instruction can be inlined.
-        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-        ImmOp.setImm( Offset );
-        return false; // success
-    }
+if(Offset >= -256 && Offset <= 255 && AArch64Base_LDRPstSBX_offset_predicate(Offset))
+{
+// immediate can be encoded and instruction can be inlined.
+FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+ImmOp.setImm( Offset );
+return false; // success
+}
 
 
-    DebugLoc DL = MI.getDebugLoc();
-    MachineBasicBlock &MBB = *MI.getParent();
-    MachineFunction *MF = MBB.getParent();
-    MachineRegisterInfo &MRI = MF->getRegInfo();
-    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+DebugLoc DL = MI.getDebugLoc();
+MachineBasicBlock &MBB = *MI.getParent();
+MachineFunction *MF = MBB.getParent();
+MachineRegisterInfo &MRI = MF->getRegInfo();
+const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-    //
-    // try to generate a scratch register and adjust frame register with given offset
-    //
+//
+// try to generate a scratch register and adjust frame register with given offset
+//
 
-    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-    {
-        // the scratch register can properly be manipulated and used as address register.
-        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-        ImmOp.setImm( 0 );
-        return false; // success
-    }
+Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+{
+// the scratch register can properly be manipulated and used as address register.
+FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+ImmOp.setImm( 0 );
+return false; // success
+}
 
-    return true; // failure
+return true; // failure
 }
 bool eliminateFrameIndexLDRPstSHW
-    ( MachineBasicBlock::iterator II
-    , int SPAdj
-    , unsigned FIOperandNum
-    , unsigned FrameReg
-    , StackOffset FrameIndexOffset
-    , RegScavenger *RS
-    )
+( MachineBasicBlock::iterator II
+, int SPAdj
+, unsigned FIOperandNum
+, unsigned FrameReg
+, StackOffset FrameIndexOffset
+, RegScavenger *RS
+)
 {
-    MachineInstr &MI = *II;
-    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+MachineInstr &MI = *II;
+assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
 
-    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
 
-    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-    //
-    // try to inline the offset into the instruction
-    //
+//
+// try to inline the offset into the instruction
+//
 
-    if(Offset >= -256 && Offset <= 255 && AArch64Base_LDRPstSHW_offset_predicate(Offset))
-    {
-        // immediate can be encoded and instruction can be inlined.
-        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-        ImmOp.setImm( Offset );
-        return false; // success
-    }
+if(Offset >= -256 && Offset <= 255 && AArch64Base_LDRPstSHW_offset_predicate(Offset))
+{
+// immediate can be encoded and instruction can be inlined.
+FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+ImmOp.setImm( Offset );
+return false; // success
+}
 
 
-    DebugLoc DL = MI.getDebugLoc();
-    MachineBasicBlock &MBB = *MI.getParent();
-    MachineFunction *MF = MBB.getParent();
-    MachineRegisterInfo &MRI = MF->getRegInfo();
-    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+DebugLoc DL = MI.getDebugLoc();
+MachineBasicBlock &MBB = *MI.getParent();
+MachineFunction *MF = MBB.getParent();
+MachineRegisterInfo &MRI = MF->getRegInfo();
+const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-    //
-    // try to generate a scratch register and adjust frame register with given offset
-    //
+//
+// try to generate a scratch register and adjust frame register with given offset
+//
 
-    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-    {
-        // the scratch register can properly be manipulated and used as address register.
-        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-        ImmOp.setImm( 0 );
-        return false; // success
-    }
+Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+{
+// the scratch register can properly be manipulated and used as address register.
+FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+ImmOp.setImm( 0 );
+return false; // success
+}
 
-    return true; // failure
+return true; // failure
 }
 bool eliminateFrameIndexLDRPstSHX
-    ( MachineBasicBlock::iterator II
-    , int SPAdj
-    , unsigned FIOperandNum
-    , unsigned FrameReg
-    , StackOffset FrameIndexOffset
-    , RegScavenger *RS
-    )
+( MachineBasicBlock::iterator II
+, int SPAdj
+, unsigned FIOperandNum
+, unsigned FrameReg
+, StackOffset FrameIndexOffset
+, RegScavenger *RS
+)
 {
-    MachineInstr &MI = *II;
-    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+MachineInstr &MI = *II;
+assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
 
-    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
 
-    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-    //
-    // try to inline the offset into the instruction
-    //
+//
+// try to inline the offset into the instruction
+//
 
-    if(Offset >= -256 && Offset <= 255 && AArch64Base_LDRPstSHX_offset_predicate(Offset))
-    {
-        // immediate can be encoded and instruction can be inlined.
-        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-        ImmOp.setImm( Offset );
-        return false; // success
-    }
+if(Offset >= -256 && Offset <= 255 && AArch64Base_LDRPstSHX_offset_predicate(Offset))
+{
+// immediate can be encoded and instruction can be inlined.
+FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+ImmOp.setImm( Offset );
+return false; // success
+}
 
 
-    DebugLoc DL = MI.getDebugLoc();
-    MachineBasicBlock &MBB = *MI.getParent();
-    MachineFunction *MF = MBB.getParent();
-    MachineRegisterInfo &MRI = MF->getRegInfo();
-    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+DebugLoc DL = MI.getDebugLoc();
+MachineBasicBlock &MBB = *MI.getParent();
+MachineFunction *MF = MBB.getParent();
+MachineRegisterInfo &MRI = MF->getRegInfo();
+const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-    //
-    // try to generate a scratch register and adjust frame register with given offset
-    //
+//
+// try to generate a scratch register and adjust frame register with given offset
+//
 
-    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-    {
-        // the scratch register can properly be manipulated and used as address register.
-        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-        ImmOp.setImm( 0 );
-        return false; // success
-    }
+Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+{
+// the scratch register can properly be manipulated and used as address register.
+FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+ImmOp.setImm( 0 );
+return false; // success
+}
 
-    return true; // failure
+return true; // failure
 }
 bool eliminateFrameIndexLDRPstSWX
-    ( MachineBasicBlock::iterator II
-    , int SPAdj
-    , unsigned FIOperandNum
-    , unsigned FrameReg
-    , StackOffset FrameIndexOffset
-    , RegScavenger *RS
-    )
+( MachineBasicBlock::iterator II
+, int SPAdj
+, unsigned FIOperandNum
+, unsigned FrameReg
+, StackOffset FrameIndexOffset
+, RegScavenger *RS
+)
 {
-    MachineInstr &MI = *II;
-    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+MachineInstr &MI = *II;
+assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
 
-    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
 
-    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-    //
-    // try to inline the offset into the instruction
-    //
+//
+// try to inline the offset into the instruction
+//
 
-    if(Offset >= -256 && Offset <= 255 && AArch64Base_LDRPstSWX_offset_predicate(Offset))
-    {
-        // immediate can be encoded and instruction can be inlined.
-        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-        ImmOp.setImm( Offset );
-        return false; // success
-    }
+if(Offset >= -256 && Offset <= 255 && AArch64Base_LDRPstSWX_offset_predicate(Offset))
+{
+// immediate can be encoded and instruction can be inlined.
+FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+ImmOp.setImm( Offset );
+return false; // success
+}
 
 
-    DebugLoc DL = MI.getDebugLoc();
-    MachineBasicBlock &MBB = *MI.getParent();
-    MachineFunction *MF = MBB.getParent();
-    MachineRegisterInfo &MRI = MF->getRegInfo();
-    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+DebugLoc DL = MI.getDebugLoc();
+MachineBasicBlock &MBB = *MI.getParent();
+MachineFunction *MF = MBB.getParent();
+MachineRegisterInfo &MRI = MF->getRegInfo();
+const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-    //
-    // try to generate a scratch register and adjust frame register with given offset
-    //
+//
+// try to generate a scratch register and adjust frame register with given offset
+//
 
-    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-    {
-        // the scratch register can properly be manipulated and used as address register.
-        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-        ImmOp.setImm( 0 );
-        return false; // success
-    }
+Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+{
+// the scratch register can properly be manipulated and used as address register.
+FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+ImmOp.setImm( 0 );
+return false; // success
+}
 
-    return true; // failure
+return true; // failure
 }
 bool eliminateFrameIndexLDRPstW
-    ( MachineBasicBlock::iterator II
-    , int SPAdj
-    , unsigned FIOperandNum
-    , unsigned FrameReg
-    , StackOffset FrameIndexOffset
-    , RegScavenger *RS
-    )
+( MachineBasicBlock::iterator II
+, int SPAdj
+, unsigned FIOperandNum
+, unsigned FrameReg
+, StackOffset FrameIndexOffset
+, RegScavenger *RS
+)
 {
-    MachineInstr &MI = *II;
-    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+MachineInstr &MI = *II;
+assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
 
-    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
 
-    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-    //
-    // try to inline the offset into the instruction
-    //
+//
+// try to inline the offset into the instruction
+//
 
-    if(Offset >= -256 && Offset <= 255 && AArch64Base_LDRPstW_offset_predicate(Offset))
-    {
-        // immediate can be encoded and instruction can be inlined.
-        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-        ImmOp.setImm( Offset );
-        return false; // success
-    }
+if(Offset >= -256 && Offset <= 255 && AArch64Base_LDRPstW_offset_predicate(Offset))
+{
+// immediate can be encoded and instruction can be inlined.
+FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+ImmOp.setImm( Offset );
+return false; // success
+}
 
 
-    DebugLoc DL = MI.getDebugLoc();
-    MachineBasicBlock &MBB = *MI.getParent();
-    MachineFunction *MF = MBB.getParent();
-    MachineRegisterInfo &MRI = MF->getRegInfo();
-    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+DebugLoc DL = MI.getDebugLoc();
+MachineBasicBlock &MBB = *MI.getParent();
+MachineFunction *MF = MBB.getParent();
+MachineRegisterInfo &MRI = MF->getRegInfo();
+const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-    //
-    // try to generate a scratch register and adjust frame register with given offset
-    //
+//
+// try to generate a scratch register and adjust frame register with given offset
+//
 
-    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-    {
-        // the scratch register can properly be manipulated and used as address register.
-        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-        ImmOp.setImm( 0 );
-        return false; // success
-    }
+Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+{
+// the scratch register can properly be manipulated and used as address register.
+FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+ImmOp.setImm( 0 );
+return false; // success
+}
 
-    return true; // failure
+return true; // failure
 }
 bool eliminateFrameIndexLDRPstX
-    ( MachineBasicBlock::iterator II
-    , int SPAdj
-    , unsigned FIOperandNum
-    , unsigned FrameReg
-    , StackOffset FrameIndexOffset
-    , RegScavenger *RS
-    )
+( MachineBasicBlock::iterator II
+, int SPAdj
+, unsigned FIOperandNum
+, unsigned FrameReg
+, StackOffset FrameIndexOffset
+, RegScavenger *RS
+)
 {
-    MachineInstr &MI = *II;
-    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+MachineInstr &MI = *II;
+assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
 
-    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
 
-    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-    //
-    // try to inline the offset into the instruction
-    //
+//
+// try to inline the offset into the instruction
+//
 
-    if(Offset >= -256 && Offset <= 255 && AArch64Base_LDRPstX_offset_predicate(Offset))
-    {
-        // immediate can be encoded and instruction can be inlined.
-        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-        ImmOp.setImm( Offset );
-        return false; // success
-    }
+if(Offset >= -256 && Offset <= 255 && AArch64Base_LDRPstX_offset_predicate(Offset))
+{
+// immediate can be encoded and instruction can be inlined.
+FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+ImmOp.setImm( Offset );
+return false; // success
+}
 
 
-    DebugLoc DL = MI.getDebugLoc();
-    MachineBasicBlock &MBB = *MI.getParent();
-    MachineFunction *MF = MBB.getParent();
-    MachineRegisterInfo &MRI = MF->getRegInfo();
-    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+DebugLoc DL = MI.getDebugLoc();
+MachineBasicBlock &MBB = *MI.getParent();
+MachineFunction *MF = MBB.getParent();
+MachineRegisterInfo &MRI = MF->getRegInfo();
+const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-    //
-    // try to generate a scratch register and adjust frame register with given offset
-    //
+//
+// try to generate a scratch register and adjust frame register with given offset
+//
 
-    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-    {
-        // the scratch register can properly be manipulated and used as address register.
-        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-        ImmOp.setImm( 0 );
-        return false; // success
-    }
+Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+{
+// the scratch register can properly be manipulated and used as address register.
+FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+ImmOp.setImm( 0 );
+return false; // success
+}
 
-    return true; // failure
+return true; // failure
 }
 bool eliminateFrameIndexSTRPreB
-    ( MachineBasicBlock::iterator II
-    , int SPAdj
-    , unsigned FIOperandNum
-    , unsigned FrameReg
-    , StackOffset FrameIndexOffset
-    , RegScavenger *RS
-    )
+( MachineBasicBlock::iterator II
+, int SPAdj
+, unsigned FIOperandNum
+, unsigned FrameReg
+, StackOffset FrameIndexOffset
+, RegScavenger *RS
+)
 {
-    MachineInstr &MI = *II;
-    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-    assert(  MI.getOperand(FIOperandNum + 2).isImm() && "Immediate operand position does not match expected position!" );
+MachineInstr &MI = *II;
+assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+assert(  MI.getOperand(FIOperandNum + 2).isImm() && "Immediate operand position does not match expected position!" );
 
-    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 2);
+MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 2);
 
-    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-    //
-    // try to inline the offset into the instruction
-    //
+//
+// try to inline the offset into the instruction
+//
 
-    if(Offset >= -256 && Offset <= 255 && AArch64Base_STRPreB_offset_predicate(Offset))
-    {
-        // immediate can be encoded and instruction can be inlined.
-        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-        ImmOp.setImm( Offset );
-        return false; // success
-    }
+if(Offset >= -256 && Offset <= 255 && AArch64Base_STRPreB_offset_predicate(Offset))
+{
+// immediate can be encoded and instruction can be inlined.
+FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+ImmOp.setImm( Offset );
+return false; // success
+}
 
 
-    DebugLoc DL = MI.getDebugLoc();
-    MachineBasicBlock &MBB = *MI.getParent();
-    MachineFunction *MF = MBB.getParent();
-    MachineRegisterInfo &MRI = MF->getRegInfo();
-    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+DebugLoc DL = MI.getDebugLoc();
+MachineBasicBlock &MBB = *MI.getParent();
+MachineFunction *MF = MBB.getParent();
+MachineRegisterInfo &MRI = MF->getRegInfo();
+const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-    //
-    // try to generate a scratch register and adjust frame register with given offset
-    //
+//
+// try to generate a scratch register and adjust frame register with given offset
+//
 
-    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-    {
-        // the scratch register can properly be manipulated and used as address register.
-        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-        ImmOp.setImm( 0 );
-        return false; // success
-    }
+Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+{
+// the scratch register can properly be manipulated and used as address register.
+FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+ImmOp.setImm( 0 );
+return false; // success
+}
 
-    return true; // failure
+return true; // failure
 }
 bool eliminateFrameIndexSTRPreH
-    ( MachineBasicBlock::iterator II
-    , int SPAdj
-    , unsigned FIOperandNum
-    , unsigned FrameReg
-    , StackOffset FrameIndexOffset
-    , RegScavenger *RS
-    )
+( MachineBasicBlock::iterator II
+, int SPAdj
+, unsigned FIOperandNum
+, unsigned FrameReg
+, StackOffset FrameIndexOffset
+, RegScavenger *RS
+)
 {
-    MachineInstr &MI = *II;
-    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-    assert(  MI.getOperand(FIOperandNum + 2).isImm() && "Immediate operand position does not match expected position!" );
+MachineInstr &MI = *II;
+assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+assert(  MI.getOperand(FIOperandNum + 2).isImm() && "Immediate operand position does not match expected position!" );
 
-    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 2);
+MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 2);
 
-    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-    //
-    // try to inline the offset into the instruction
-    //
+//
+// try to inline the offset into the instruction
+//
 
-    if(Offset >= -256 && Offset <= 255 && AArch64Base_STRPreH_offset_predicate(Offset))
-    {
-        // immediate can be encoded and instruction can be inlined.
-        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-        ImmOp.setImm( Offset );
-        return false; // success
-    }
+if(Offset >= -256 && Offset <= 255 && AArch64Base_STRPreH_offset_predicate(Offset))
+{
+// immediate can be encoded and instruction can be inlined.
+FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+ImmOp.setImm( Offset );
+return false; // success
+}
 
 
-    DebugLoc DL = MI.getDebugLoc();
-    MachineBasicBlock &MBB = *MI.getParent();
-    MachineFunction *MF = MBB.getParent();
-    MachineRegisterInfo &MRI = MF->getRegInfo();
-    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+DebugLoc DL = MI.getDebugLoc();
+MachineBasicBlock &MBB = *MI.getParent();
+MachineFunction *MF = MBB.getParent();
+MachineRegisterInfo &MRI = MF->getRegInfo();
+const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-    //
-    // try to generate a scratch register and adjust frame register with given offset
-    //
+//
+// try to generate a scratch register and adjust frame register with given offset
+//
 
-    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-    {
-        // the scratch register can properly be manipulated and used as address register.
-        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-        ImmOp.setImm( 0 );
-        return false; // success
-    }
+Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+{
+// the scratch register can properly be manipulated and used as address register.
+FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+ImmOp.setImm( 0 );
+return false; // success
+}
 
-    return true; // failure
+return true; // failure
 }
 bool eliminateFrameIndexSTRPreW
-    ( MachineBasicBlock::iterator II
-    , int SPAdj
-    , unsigned FIOperandNum
-    , unsigned FrameReg
-    , StackOffset FrameIndexOffset
-    , RegScavenger *RS
-    )
+( MachineBasicBlock::iterator II
+, int SPAdj
+, unsigned FIOperandNum
+, unsigned FrameReg
+, StackOffset FrameIndexOffset
+, RegScavenger *RS
+)
 {
-    MachineInstr &MI = *II;
-    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-    assert(  MI.getOperand(FIOperandNum + 2).isImm() && "Immediate operand position does not match expected position!" );
+MachineInstr &MI = *II;
+assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+assert(  MI.getOperand(FIOperandNum + 2).isImm() && "Immediate operand position does not match expected position!" );
 
-    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 2);
+MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 2);
 
-    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-    //
-    // try to inline the offset into the instruction
-    //
+//
+// try to inline the offset into the instruction
+//
 
-    if(Offset >= -256 && Offset <= 255 && AArch64Base_STRPreW_offset_predicate(Offset))
-    {
-        // immediate can be encoded and instruction can be inlined.
-        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-        ImmOp.setImm( Offset );
-        return false; // success
-    }
+if(Offset >= -256 && Offset <= 255 && AArch64Base_STRPreW_offset_predicate(Offset))
+{
+// immediate can be encoded and instruction can be inlined.
+FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+ImmOp.setImm( Offset );
+return false; // success
+}
 
 
-    DebugLoc DL = MI.getDebugLoc();
-    MachineBasicBlock &MBB = *MI.getParent();
-    MachineFunction *MF = MBB.getParent();
-    MachineRegisterInfo &MRI = MF->getRegInfo();
-    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+DebugLoc DL = MI.getDebugLoc();
+MachineBasicBlock &MBB = *MI.getParent();
+MachineFunction *MF = MBB.getParent();
+MachineRegisterInfo &MRI = MF->getRegInfo();
+const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-    //
-    // try to generate a scratch register and adjust frame register with given offset
-    //
+//
+// try to generate a scratch register and adjust frame register with given offset
+//
 
-    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-    {
-        // the scratch register can properly be manipulated and used as address register.
-        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-        ImmOp.setImm( 0 );
-        return false; // success
-    }
+Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+{
+// the scratch register can properly be manipulated and used as address register.
+FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+ImmOp.setImm( 0 );
+return false; // success
+}
 
-    return true; // failure
+return true; // failure
 }
 bool eliminateFrameIndexSTRPreX
-    ( MachineBasicBlock::iterator II
-    , int SPAdj
-    , unsigned FIOperandNum
-    , unsigned FrameReg
-    , StackOffset FrameIndexOffset
-    , RegScavenger *RS
-    )
+( MachineBasicBlock::iterator II
+, int SPAdj
+, unsigned FIOperandNum
+, unsigned FrameReg
+, StackOffset FrameIndexOffset
+, RegScavenger *RS
+)
 {
-    MachineInstr &MI = *II;
-    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-    assert(  MI.getOperand(FIOperandNum + 2).isImm() && "Immediate operand position does not match expected position!" );
+MachineInstr &MI = *II;
+assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+assert(  MI.getOperand(FIOperandNum + 2).isImm() && "Immediate operand position does not match expected position!" );
 
-    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 2);
+MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 2);
 
-    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-    //
-    // try to inline the offset into the instruction
-    //
+//
+// try to inline the offset into the instruction
+//
 
-    if(Offset >= -256 && Offset <= 255 && AArch64Base_STRPreX_offset_predicate(Offset))
-    {
-        // immediate can be encoded and instruction can be inlined.
-        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-        ImmOp.setImm( Offset );
-        return false; // success
-    }
+if(Offset >= -256 && Offset <= 255 && AArch64Base_STRPreX_offset_predicate(Offset))
+{
+// immediate can be encoded and instruction can be inlined.
+FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+ImmOp.setImm( Offset );
+return false; // success
+}
 
 
-    DebugLoc DL = MI.getDebugLoc();
-    MachineBasicBlock &MBB = *MI.getParent();
-    MachineFunction *MF = MBB.getParent();
-    MachineRegisterInfo &MRI = MF->getRegInfo();
-    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+DebugLoc DL = MI.getDebugLoc();
+MachineBasicBlock &MBB = *MI.getParent();
+MachineFunction *MF = MBB.getParent();
+MachineRegisterInfo &MRI = MF->getRegInfo();
+const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-    //
-    // try to generate a scratch register and adjust frame register with given offset
-    //
+//
+// try to generate a scratch register and adjust frame register with given offset
+//
 
-    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-    {
-        // the scratch register can properly be manipulated and used as address register.
-        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-        ImmOp.setImm( 0 );
-        return false; // success
-    }
+Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+{
+// the scratch register can properly be manipulated and used as address register.
+FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+ImmOp.setImm( 0 );
+return false; // success
+}
 
-    return true; // failure
+return true; // failure
 }
 bool eliminateFrameIndexSTRPstB
-    ( MachineBasicBlock::iterator II
-    , int SPAdj
-    , unsigned FIOperandNum
-    , unsigned FrameReg
-    , StackOffset FrameIndexOffset
-    , RegScavenger *RS
-    )
+( MachineBasicBlock::iterator II
+, int SPAdj
+, unsigned FIOperandNum
+, unsigned FrameReg
+, StackOffset FrameIndexOffset
+, RegScavenger *RS
+)
 {
-    MachineInstr &MI = *II;
-    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-    assert(  MI.getOperand(FIOperandNum + 2).isImm() && "Immediate operand position does not match expected position!" );
+MachineInstr &MI = *II;
+assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+assert(  MI.getOperand(FIOperandNum + 2).isImm() && "Immediate operand position does not match expected position!" );
 
-    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 2);
+MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 2);
 
-    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-    //
-    // try to inline the offset into the instruction
-    //
+//
+// try to inline the offset into the instruction
+//
 
-    if(Offset >= -256 && Offset <= 255 && AArch64Base_STRPstB_offset_predicate(Offset))
-    {
-        // immediate can be encoded and instruction can be inlined.
-        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-        ImmOp.setImm( Offset );
-        return false; // success
-    }
+if(Offset >= -256 && Offset <= 255 && AArch64Base_STRPstB_offset_predicate(Offset))
+{
+// immediate can be encoded and instruction can be inlined.
+FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+ImmOp.setImm( Offset );
+return false; // success
+}
 
 
-    DebugLoc DL = MI.getDebugLoc();
-    MachineBasicBlock &MBB = *MI.getParent();
-    MachineFunction *MF = MBB.getParent();
-    MachineRegisterInfo &MRI = MF->getRegInfo();
-    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+DebugLoc DL = MI.getDebugLoc();
+MachineBasicBlock &MBB = *MI.getParent();
+MachineFunction *MF = MBB.getParent();
+MachineRegisterInfo &MRI = MF->getRegInfo();
+const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-    //
-    // try to generate a scratch register and adjust frame register with given offset
-    //
+//
+// try to generate a scratch register and adjust frame register with given offset
+//
 
-    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-    {
-        // the scratch register can properly be manipulated and used as address register.
-        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-        ImmOp.setImm( 0 );
-        return false; // success
-    }
+Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+{
+// the scratch register can properly be manipulated and used as address register.
+FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+ImmOp.setImm( 0 );
+return false; // success
+}
 
-    return true; // failure
+return true; // failure
 }
 bool eliminateFrameIndexSTRPstH
-    ( MachineBasicBlock::iterator II
-    , int SPAdj
-    , unsigned FIOperandNum
-    , unsigned FrameReg
-    , StackOffset FrameIndexOffset
-    , RegScavenger *RS
-    )
+( MachineBasicBlock::iterator II
+, int SPAdj
+, unsigned FIOperandNum
+, unsigned FrameReg
+, StackOffset FrameIndexOffset
+, RegScavenger *RS
+)
 {
-    MachineInstr &MI = *II;
-    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-    assert(  MI.getOperand(FIOperandNum + 2).isImm() && "Immediate operand position does not match expected position!" );
+MachineInstr &MI = *II;
+assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+assert(  MI.getOperand(FIOperandNum + 2).isImm() && "Immediate operand position does not match expected position!" );
 
-    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 2);
+MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 2);
 
-    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-    //
-    // try to inline the offset into the instruction
-    //
+//
+// try to inline the offset into the instruction
+//
 
-    if(Offset >= -256 && Offset <= 255 && AArch64Base_STRPstH_offset_predicate(Offset))
-    {
-        // immediate can be encoded and instruction can be inlined.
-        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-        ImmOp.setImm( Offset );
-        return false; // success
-    }
+if(Offset >= -256 && Offset <= 255 && AArch64Base_STRPstH_offset_predicate(Offset))
+{
+// immediate can be encoded and instruction can be inlined.
+FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+ImmOp.setImm( Offset );
+return false; // success
+}
 
 
-    DebugLoc DL = MI.getDebugLoc();
-    MachineBasicBlock &MBB = *MI.getParent();
-    MachineFunction *MF = MBB.getParent();
-    MachineRegisterInfo &MRI = MF->getRegInfo();
-    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+DebugLoc DL = MI.getDebugLoc();
+MachineBasicBlock &MBB = *MI.getParent();
+MachineFunction *MF = MBB.getParent();
+MachineRegisterInfo &MRI = MF->getRegInfo();
+const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-    //
-    // try to generate a scratch register and adjust frame register with given offset
-    //
+//
+// try to generate a scratch register and adjust frame register with given offset
+//
 
-    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-    {
-        // the scratch register can properly be manipulated and used as address register.
-        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-        ImmOp.setImm( 0 );
-        return false; // success
-    }
+Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+{
+// the scratch register can properly be manipulated and used as address register.
+FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+ImmOp.setImm( 0 );
+return false; // success
+}
 
-    return true; // failure
+return true; // failure
 }
 bool eliminateFrameIndexSTRPstW
-    ( MachineBasicBlock::iterator II
-    , int SPAdj
-    , unsigned FIOperandNum
-    , unsigned FrameReg
-    , StackOffset FrameIndexOffset
-    , RegScavenger *RS
-    )
+( MachineBasicBlock::iterator II
+, int SPAdj
+, unsigned FIOperandNum
+, unsigned FrameReg
+, StackOffset FrameIndexOffset
+, RegScavenger *RS
+)
 {
-    MachineInstr &MI = *II;
-    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-    assert(  MI.getOperand(FIOperandNum + 2).isImm() && "Immediate operand position does not match expected position!" );
+MachineInstr &MI = *II;
+assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+assert(  MI.getOperand(FIOperandNum + 2).isImm() && "Immediate operand position does not match expected position!" );
 
-    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 2);
+MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 2);
 
-    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-    //
-    // try to inline the offset into the instruction
-    //
+//
+// try to inline the offset into the instruction
+//
 
-    if(Offset >= -256 && Offset <= 255 && AArch64Base_STRPstW_offset_predicate(Offset))
-    {
-        // immediate can be encoded and instruction can be inlined.
-        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-        ImmOp.setImm( Offset );
-        return false; // success
-    }
+if(Offset >= -256 && Offset <= 255 && AArch64Base_STRPstW_offset_predicate(Offset))
+{
+// immediate can be encoded and instruction can be inlined.
+FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+ImmOp.setImm( Offset );
+return false; // success
+}
 
 
-    DebugLoc DL = MI.getDebugLoc();
-    MachineBasicBlock &MBB = *MI.getParent();
-    MachineFunction *MF = MBB.getParent();
-    MachineRegisterInfo &MRI = MF->getRegInfo();
-    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+DebugLoc DL = MI.getDebugLoc();
+MachineBasicBlock &MBB = *MI.getParent();
+MachineFunction *MF = MBB.getParent();
+MachineRegisterInfo &MRI = MF->getRegInfo();
+const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-    //
-    // try to generate a scratch register and adjust frame register with given offset
-    //
+//
+// try to generate a scratch register and adjust frame register with given offset
+//
 
-    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-    {
-        // the scratch register can properly be manipulated and used as address register.
-        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-        ImmOp.setImm( 0 );
-        return false; // success
-    }
+Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+{
+// the scratch register can properly be manipulated and used as address register.
+FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+ImmOp.setImm( 0 );
+return false; // success
+}
 
-    return true; // failure
+return true; // failure
 }
 bool eliminateFrameIndexSTRPstX
-    ( MachineBasicBlock::iterator II
-    , int SPAdj
-    , unsigned FIOperandNum
-    , unsigned FrameReg
-    , StackOffset FrameIndexOffset
-    , RegScavenger *RS
-    )
+( MachineBasicBlock::iterator II
+, int SPAdj
+, unsigned FIOperandNum
+, unsigned FrameReg
+, StackOffset FrameIndexOffset
+, RegScavenger *RS
+)
 {
-    MachineInstr &MI = *II;
-    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-    assert(  MI.getOperand(FIOperandNum + 2).isImm() && "Immediate operand position does not match expected position!" );
+MachineInstr &MI = *II;
+assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+assert(  MI.getOperand(FIOperandNum + 2).isImm() && "Immediate operand position does not match expected position!" );
 
-    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 2);
+MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 2);
 
-    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-    //
-    // try to inline the offset into the instruction
-    //
+//
+// try to inline the offset into the instruction
+//
 
-    if(Offset >= -256 && Offset <= 255 && AArch64Base_STRPstX_offset_predicate(Offset))
-    {
-        // immediate can be encoded and instruction can be inlined.
-        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-        ImmOp.setImm( Offset );
-        return false; // success
-    }
+if(Offset >= -256 && Offset <= 255 && AArch64Base_STRPstX_offset_predicate(Offset))
+{
+// immediate can be encoded and instruction can be inlined.
+FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+ImmOp.setImm( Offset );
+return false; // success
+}
 
 
-    DebugLoc DL = MI.getDebugLoc();
-    MachineBasicBlock &MBB = *MI.getParent();
-    MachineFunction *MF = MBB.getParent();
-    MachineRegisterInfo &MRI = MF->getRegInfo();
-    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+DebugLoc DL = MI.getDebugLoc();
+MachineBasicBlock &MBB = *MI.getParent();
+MachineFunction *MF = MBB.getParent();
+MachineRegisterInfo &MRI = MF->getRegInfo();
+const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-    //
-    // try to generate a scratch register and adjust frame register with given offset
-    //
+//
+// try to generate a scratch register and adjust frame register with given offset
+//
 
-    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-    {
-        // the scratch register can properly be manipulated and used as address register.
-        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-        ImmOp.setImm( 0 );
-        return false; // success
-    }
+Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+{
+// the scratch register can properly be manipulated and used as address register.
+FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+ImmOp.setImm( 0 );
+return false; // success
+}
 
-    return true; // failure
+return true; // failure
 }
 
 
 /**
- * This method calls its own replacement class for each allowed instruction.
- * Inside the special instruction the following steps or tries to remove the FI are done.
- *
- *     1. try to inline the frame index calculation into the current instruction.
- *     2. check if we can move the immediate materialization and frame index addition
- *        into a separate instruction with scratch register. The scratch register must be
- *        useable with our current instruction.
- *     3. replace the current instruction with
- *        3.1 a more specific instruction that can load the offset
- *        3.2 a very general instruction that uses a scratch register for computing the
- *            desired frame index.
- *
- * If an instruction is not supported, an llvm_fatal_error is emitted as it should be impossible
- * for a frame index to be an operand.
- */
+* This method calls its own replacement class for each allowed instruction.
+* Inside the special instruction the following steps or tries to remove the FI are done.
+*
+*     1. try to inline the frame index calculation into the current instruction.
+*     2. check if we can move the immediate materialization and frame index addition
+*        into a separate instruction with scratch register. The scratch register must be
+*        useable with our current instruction.
+*     3. replace the current instruction with
+*        3.1 a more specific instruction that can load the offset
+*        3.2 a very general instruction that uses a scratch register for computing the
+*            desired frame index.
+*
+* If an instruction is not supported, an llvm_fatal_error is emitted as it should be impossible
+* for a frame index to be an operand.
+*/
 bool processornamevalueRegisterInfo::eliminateFrameIndex(MachineBasicBlock::iterator II, int SPAdj, unsigned FIOperandNum, RegScavenger *RS) const
 {
-    MachineInstr &MI = *II;
-    const MachineFunction &MF = *MI.getParent()->getParent();
+MachineInstr &MI = *II;
+const MachineFunction &MF = *MI.getParent()->getParent();
 
-    const TargetInstrInfo *TII = MF.getSubtarget().getInstrInfo();
-    const std::string mnemonic = TII->getName(MI.getOpcode()).str(); // for debug purposes
+const TargetInstrInfo *TII = MF.getSubtarget().getInstrInfo();
+const std::string mnemonic = TII->getName(MI.getOpcode()).str(); // for debug purposes
 
-    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-    unsigned FI = FIOp.getIndex();
-    Register FrameReg;
-    StackOffset FrameIndexOffset = getFrameLowering(MF)->getFrameIndexReference(MF, FI, FrameReg);
+MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+unsigned FI = FIOp.getIndex();
+Register FrameReg;
+StackOffset FrameIndexOffset = getFrameLowering(MF)->getFrameIndexReference(MF, FI, FrameReg);
 
-    bool error = true;
-    switch (MI.getOpcode())
-    {
+bool error = true;
+switch (MI.getOpcode())
+{
 
-        case processornamevalue::ADDXI:
-        {
-          error = eliminateFrameIndexADDXI(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-          break;
-        }
-        case processornamevalue::ADDXSXSB:
-        {
-          error = eliminateFrameIndexADDXSXSB(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-          break;
-        }
-        case processornamevalue::ADDXSXSH:
-        {
-          error = eliminateFrameIndexADDXSXSH(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-          break;
-        }
-        case processornamevalue::ADDXSXSW:
-        {
-          error = eliminateFrameIndexADDXSXSW(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-          break;
-        }
-        case processornamevalue::ADDXUXSB:
-        {
-          error = eliminateFrameIndexADDXUXSB(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-          break;
-        }
-        case processornamevalue::ADDXUXSH:
-        {
-          error = eliminateFrameIndexADDXUXSH(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-          break;
-        }
-        case processornamevalue::ADDXUXSW:
-        {
-          error = eliminateFrameIndexADDXUXSW(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-          break;
-        }
-        case processornamevalue::LDPSPre:
-        {
-          error = eliminateFrameIndexLDPSPre(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-          break;
-        }
-        case processornamevalue::LDPSPst:
-        {
-          error = eliminateFrameIndexLDPSPst(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-          break;
-        }
-        case processornamevalue::LDPWPre:
-        {
-          error = eliminateFrameIndexLDPWPre(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-          break;
-        }
-        case processornamevalue::LDPWPst:
-        {
-          error = eliminateFrameIndexLDPWPst(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-          break;
-        }
-        case processornamevalue::LDPXPre:
-        {
-          error = eliminateFrameIndexLDPXPre(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-          break;
-        }
-        case processornamevalue::LDPXPst:
-        {
-          error = eliminateFrameIndexLDPXPst(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-          break;
-        }
-        case processornamevalue::LDRPreB:
-        {
-          error = eliminateFrameIndexLDRPreB(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-          break;
-        }
-        case processornamevalue::LDRPreH:
-        {
-          error = eliminateFrameIndexLDRPreH(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-          break;
-        }
-        case processornamevalue::LDRPreSBW:
-        {
-          error = eliminateFrameIndexLDRPreSBW(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-          break;
-        }
-        case processornamevalue::LDRPreSBX:
-        {
-          error = eliminateFrameIndexLDRPreSBX(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-          break;
-        }
-        case processornamevalue::LDRPreSHW:
-        {
-          error = eliminateFrameIndexLDRPreSHW(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-          break;
-        }
-        case processornamevalue::LDRPreSHX:
-        {
-          error = eliminateFrameIndexLDRPreSHX(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-          break;
-        }
-        case processornamevalue::LDRPreSWX:
-        {
-          error = eliminateFrameIndexLDRPreSWX(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-          break;
-        }
-        case processornamevalue::LDRPreW:
-        {
-          error = eliminateFrameIndexLDRPreW(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-          break;
-        }
-        case processornamevalue::LDRPreX:
-        {
-          error = eliminateFrameIndexLDRPreX(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-          break;
-        }
-        case processornamevalue::LDRPstB:
-        {
-          error = eliminateFrameIndexLDRPstB(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-          break;
-        }
-        case processornamevalue::LDRPstH:
-        {
-          error = eliminateFrameIndexLDRPstH(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-          break;
-        }
-        case processornamevalue::LDRPstSBW:
-        {
-          error = eliminateFrameIndexLDRPstSBW(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-          break;
-        }
-        case processornamevalue::LDRPstSBX:
-        {
-          error = eliminateFrameIndexLDRPstSBX(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-          break;
-        }
-        case processornamevalue::LDRPstSHW:
-        {
-          error = eliminateFrameIndexLDRPstSHW(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-          break;
-        }
-        case processornamevalue::LDRPstSHX:
-        {
-          error = eliminateFrameIndexLDRPstSHX(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-          break;
-        }
-        case processornamevalue::LDRPstSWX:
-        {
-          error = eliminateFrameIndexLDRPstSWX(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-          break;
-        }
-        case processornamevalue::LDRPstW:
-        {
-          error = eliminateFrameIndexLDRPstW(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-          break;
-        }
-        case processornamevalue::LDRPstX:
-        {
-          error = eliminateFrameIndexLDRPstX(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-          break;
-        }
-        case processornamevalue::STRPreB:
-        {
-          error = eliminateFrameIndexSTRPreB(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-          break;
-        }
-        case processornamevalue::STRPreH:
-        {
-          error = eliminateFrameIndexSTRPreH(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-          break;
-        }
-        case processornamevalue::STRPreW:
-        {
-          error = eliminateFrameIndexSTRPreW(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-          break;
-        }
-        case processornamevalue::STRPreX:
-        {
-          error = eliminateFrameIndexSTRPreX(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-          break;
-        }
-        case processornamevalue::STRPstB:
-        {
-          error = eliminateFrameIndexSTRPstB(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-          break;
-        }
-        case processornamevalue::STRPstH:
-        {
-          error = eliminateFrameIndexSTRPstH(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-          break;
-        }
-        case processornamevalue::STRPstW:
-        {
-          error = eliminateFrameIndexSTRPstW(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-          break;
-        }
-        case processornamevalue::STRPstX:
-        {
-          error = eliminateFrameIndexSTRPstX(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-          break;
-        }
+case processornamevalue::ADDXI:
+{
+error = eliminateFrameIndexADDXI(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+break;
+}
+case processornamevalue::LDPSPre:
+{
+error = eliminateFrameIndexLDPSPre(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+break;
+}
+case processornamevalue::LDPSPst:
+{
+error = eliminateFrameIndexLDPSPst(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+break;
+}
+case processornamevalue::LDPWPre:
+{
+error = eliminateFrameIndexLDPWPre(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+break;
+}
+case processornamevalue::LDPWPst:
+{
+error = eliminateFrameIndexLDPWPst(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+break;
+}
+case processornamevalue::LDPXPre:
+{
+error = eliminateFrameIndexLDPXPre(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+break;
+}
+case processornamevalue::LDPXPst:
+{
+error = eliminateFrameIndexLDPXPst(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+break;
+}
+case processornamevalue::LDRPreB:
+{
+error = eliminateFrameIndexLDRPreB(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+break;
+}
+case processornamevalue::LDRPreH:
+{
+error = eliminateFrameIndexLDRPreH(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+break;
+}
+case processornamevalue::LDRPreSBW:
+{
+error = eliminateFrameIndexLDRPreSBW(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+break;
+}
+case processornamevalue::LDRPreSBX:
+{
+error = eliminateFrameIndexLDRPreSBX(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+break;
+}
+case processornamevalue::LDRPreSHW:
+{
+error = eliminateFrameIndexLDRPreSHW(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+break;
+}
+case processornamevalue::LDRPreSHX:
+{
+error = eliminateFrameIndexLDRPreSHX(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+break;
+}
+case processornamevalue::LDRPreSWX:
+{
+error = eliminateFrameIndexLDRPreSWX(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+break;
+}
+case processornamevalue::LDRPreW:
+{
+error = eliminateFrameIndexLDRPreW(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+break;
+}
+case processornamevalue::LDRPreX:
+{
+error = eliminateFrameIndexLDRPreX(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+break;
+}
+case processornamevalue::LDRPstB:
+{
+error = eliminateFrameIndexLDRPstB(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+break;
+}
+case processornamevalue::LDRPstH:
+{
+error = eliminateFrameIndexLDRPstH(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+break;
+}
+case processornamevalue::LDRPstSBW:
+{
+error = eliminateFrameIndexLDRPstSBW(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+break;
+}
+case processornamevalue::LDRPstSBX:
+{
+error = eliminateFrameIndexLDRPstSBX(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+break;
+}
+case processornamevalue::LDRPstSHW:
+{
+error = eliminateFrameIndexLDRPstSHW(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+break;
+}
+case processornamevalue::LDRPstSHX:
+{
+error = eliminateFrameIndexLDRPstSHX(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+break;
+}
+case processornamevalue::LDRPstSWX:
+{
+error = eliminateFrameIndexLDRPstSWX(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+break;
+}
+case processornamevalue::LDRPstW:
+{
+error = eliminateFrameIndexLDRPstW(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+break;
+}
+case processornamevalue::LDRPstX:
+{
+error = eliminateFrameIndexLDRPstX(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+break;
+}
+case processornamevalue::STRPreB:
+{
+error = eliminateFrameIndexSTRPreB(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+break;
+}
+case processornamevalue::STRPreH:
+{
+error = eliminateFrameIndexSTRPreH(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+break;
+}
+case processornamevalue::STRPreW:
+{
+error = eliminateFrameIndexSTRPreW(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+break;
+}
+case processornamevalue::STRPreX:
+{
+error = eliminateFrameIndexSTRPreX(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+break;
+}
+case processornamevalue::STRPstB:
+{
+error = eliminateFrameIndexSTRPstB(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+break;
+}
+case processornamevalue::STRPstH:
+{
+error = eliminateFrameIndexSTRPstH(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+break;
+}
+case processornamevalue::STRPstW:
+{
+error = eliminateFrameIndexSTRPstW(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+break;
+}
+case processornamevalue::STRPstX:
+{
+error = eliminateFrameIndexSTRPstX(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+break;
+}
 
-        default:
-        {
-            /* This should be unreachable! */
-            std::string errMsg;
-            std::stringstream errMsgStream;
-            errMsgStream << "Unexpected frame index for instruction '" << mnemonic << "'";
-            errMsg = errMsgStream.str();
-            llvm_unreachable(errMsg.c_str());
-        }
-    }
+default:
+{
+/* This should be unreachable! */
+std::string errMsg;
+std::stringstream errMsgStream;
+errMsgStream << "Unexpected frame index for instruction '" << mnemonic << "'";
+errMsg = errMsgStream.str();
+llvm_unreachable(errMsg.c_str());
+}
+}
 
-    if (error) // something went wrong
-    {
-        std::string errMsg;
-        std::stringstream errMsgStream;
-        errMsgStream << "Unable to eliminate frame index ('FrameIndex<" << FrameIndexOffset.getFixed() << ">')";
-        errMsgStream << " for instruction '" << mnemonic << "'";
-        errMsg = errMsgStream.str();
-        report_fatal_error(errMsg.c_str()); // if we cannot eliminate the frame index abort!
-    }
+if (error) // something went wrong
+{
+std::string errMsg;
+std::stringstream errMsgStream;
+errMsgStream << "Unable to eliminate frame index ('FrameIndex<" << FrameIndexOffset.getFixed() << ">')";
+errMsgStream << " for instruction '" << mnemonic << "'";
+errMsg = errMsgStream.str();
+report_fatal_error(errMsg.c_str()); // if we cannot eliminate the frame index abort!
+}
 
-    return true;
+return true;
 }
 
 Register processornamevalueRegisterInfo::getFrameRegister(const MachineFunction &MF) const
 {
-    const TargetFrameLowering *TFI = getFrameLowering(MF);
-    return TFI->hasFP(MF) ? processornamevalue::S29 /* FP */ : processornamevalue::S31 /* SP */;
+const TargetFrameLowering *TFI = getFrameLowering(MF);
+return TFI->hasFP(MF) ? processornamevalue::S29 /* FP */ : processornamevalue::S31 /* SP */;
 }
 
 const uint32_t * processornamevalueRegisterInfo::getCallPreservedMask(const MachineFunction & /*MF*/
-                                                                   , CallingConv::ID /*CC*/
+, CallingConv::ID /*CC*/
 ) const
 {
-    // defined in calling convention tablegen
-    return CSR_processornamevalue_RegMask;
+// defined in calling convention tablegen
+return CSR_processornamevalue_RegMask;
 }
 
 
 /*static*/ unsigned processornamevalueRegisterInfo::S(unsigned index)
 {
-  switch (index)
-  {
+switch (index)
+{
 
-    case 0:
-        return processornamevalue::S0;
-    case 1:
-        return processornamevalue::S1;
-    case 2:
-        return processornamevalue::S2;
-    case 3:
-        return processornamevalue::S3;
-    case 4:
-        return processornamevalue::S4;
-    case 5:
-        return processornamevalue::S5;
-    case 6:
-        return processornamevalue::S6;
-    case 7:
-        return processornamevalue::S7;
-    case 8:
-        return processornamevalue::S8;
-    case 9:
-        return processornamevalue::S9;
-    case 10:
-        return processornamevalue::S10;
-    case 11:
-        return processornamevalue::S11;
-    case 12:
-        return processornamevalue::S12;
-    case 13:
-        return processornamevalue::S13;
-    case 14:
-        return processornamevalue::S14;
-    case 15:
-        return processornamevalue::S15;
-    case 16:
-        return processornamevalue::S16;
-    case 17:
-        return processornamevalue::S17;
-    case 18:
-        return processornamevalue::S18;
-    case 19:
-        return processornamevalue::S19;
-    case 20:
-        return processornamevalue::S20;
-    case 21:
-        return processornamevalue::S21;
-    case 22:
-        return processornamevalue::S22;
-    case 23:
-        return processornamevalue::S23;
-    case 24:
-        return processornamevalue::S24;
-    case 25:
-        return processornamevalue::S25;
-    case 26:
-        return processornamevalue::S26;
-    case 27:
-        return processornamevalue::S27;
-    case 28:
-        return processornamevalue::S28;
-    case 29:
-        return processornamevalue::S29;
-    case 30:
-        return processornamevalue::S30;
-    case 31:
-        return processornamevalue::S31;
+case 0:
+return processornamevalue::S0;
+case 1:
+return processornamevalue::S1;
+case 2:
+return processornamevalue::S2;
+case 3:
+return processornamevalue::S3;
+case 4:
+return processornamevalue::S4;
+case 5:
+return processornamevalue::S5;
+case 6:
+return processornamevalue::S6;
+case 7:
+return processornamevalue::S7;
+case 8:
+return processornamevalue::S8;
+case 9:
+return processornamevalue::S9;
+case 10:
+return processornamevalue::S10;
+case 11:
+return processornamevalue::S11;
+case 12:
+return processornamevalue::S12;
+case 13:
+return processornamevalue::S13;
+case 14:
+return processornamevalue::S14;
+case 15:
+return processornamevalue::S15;
+case 16:
+return processornamevalue::S16;
+case 17:
+return processornamevalue::S17;
+case 18:
+return processornamevalue::S18;
+case 19:
+return processornamevalue::S19;
+case 20:
+return processornamevalue::S20;
+case 21:
+return processornamevalue::S21;
+case 22:
+return processornamevalue::S22;
+case 23:
+return processornamevalue::S23;
+case 24:
+return processornamevalue::S24;
+case 25:
+return processornamevalue::S25;
+case 26:
+return processornamevalue::S26;
+case 27:
+return processornamevalue::S27;
+case 28:
+return processornamevalue::S28;
+case 29:
+return processornamevalue::S29;
+case 30:
+return processornamevalue::S30;
+case 31:
+return processornamevalue::S31;
 
-    default:
-    {
-        std::string errMsg;
-        std::stringstream errMsgStream;
-        errMsgStream << "Unable to find index " << "'" << index << "'";
-        errMsgStream << " with name '«registerClass.simpleName»' !\n";
-        errMsg = errMsgStream.str();
-        report_fatal_error(errMsg.c_str());
-    }
-  }
+default:
+{
+std::string errMsg;
+std::stringstream errMsgStream;
+errMsgStream << "Unable to find index " << "'" << index << "'";
+errMsgStream << " with name '«registerClass.simpleName»' !\n";
+errMsg = errMsgStream.str();
+report_fatal_error(errMsg.c_str());
+}
+}
 }


### PR DESCRIPTION
- Fixed register names in instruction's uses and defs
- Fixed missing field accesses when they were optimised
- Make SliceNodes unlowerable
- At the moment, there was a set of instruction labels which all require a Frame-Index pattern. This is, however, not required in AArch64 since multiple instructions exist. So, we need only one pattern per instruction label.