### PR TITLE
iss: Fix a wrong TCG operation lowering of a signed IssConstExtractNode

### DIFF
--- a/vadl/main/vadl/iss/passes/tcgLowering/TcgOpLoweringPass.java
+++ b/vadl/main/vadl/iss/passes/tcgLowering/TcgOpLoweringPass.java
@@ -464,7 +464,7 @@ class TcgOpLoweringExecutor implements CfgTraverser {
       // extract  dest, t0,  0, toWidth
 
       var t0 = tmp(0);
-      var toWidth = intU(toHandle.fromWidth(), 32).toNode();
+      var toWidth = intU(toHandle.toWidth(), 32).toNode();
       replaceCurrent(
           new TcgExtractNode(t0, src, ofs, len, TcgExtend.SIGN),
           new TcgExtractNode(dest, t0, ofs, toWidth, TcgExtend.ZERO)


### PR DESCRIPTION
There was a typo in the IssConstExtractNode lowering.
Instead of truncating the signed extracted value to the "toWidth", it truncated it to the "fromWidth" which is obviously false, as it essentially undos the sign extract.