### PR TITLE
ast: Added annotations for status registers

### DIFF
--- a/vadl/main/vadl/ast/AnnotationTable.java
+++ b/vadl/main/vadl/ast/AnnotationTable.java
@@ -36,6 +36,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import vadl.gcb.annotations.SkipPruningAnnotation;
+import vadl.gcb.annotations.StatusRegisterAnnotation;
 import vadl.types.Type;
 import vadl.utils.Pair;
 import vadl.utils.SourceLocation;
@@ -125,7 +126,7 @@ public class AnnotationTable {
     annotationOn(EncodingDefinition.class, "select when", EncodingConstraintAnnotation::new)
         .check((def, annotation, lowering) -> annotation.verifyExprType(Type.bool()))
         .applyViam((def, annotation, lowering) -> {
-          // The actual formular checks are done in the the VdtEncodingConstraintValidationPass.
+          // The actual formular checks are done in the VdtEncodingConstraintValidationPass.
           var encoding = (Encoding) def;
           var graph = new BehaviorLowering(lowering).getFunctionGraph(annotation.expr,
               encoding.simpleName() + " Constraint");
@@ -188,6 +189,34 @@ public class AnnotationTable {
         .applyViam((def, annotation, lowering) -> {
           if (annotation.isEnabled) {
             def.addAnnotation(new SkipPruningAnnotation());
+          }
+        }).build();
+
+    annotationOn(RegisterDefinition.class, "negative status register", EnableAnnotation::new)
+        .applyViam((def, annotation, lowering) -> {
+          if (annotation.isEnabled) {
+            def.addAnnotation(new StatusRegisterAnnotation.NegativeStatusRegisterAnnotation());
+          }
+        }).build();
+
+    annotationOn(RegisterDefinition.class, "zero status register", EnableAnnotation::new)
+        .applyViam((def, annotation, lowering) -> {
+          if (annotation.isEnabled) {
+            def.addAnnotation(new StatusRegisterAnnotation.ZeroStatusRegisterAnnotation());
+          }
+        }).build();
+
+    annotationOn(RegisterDefinition.class, "carry status register", EnableAnnotation::new)
+        .applyViam((def, annotation, lowering) -> {
+          if (annotation.isEnabled) {
+            def.addAnnotation(new StatusRegisterAnnotation.CarryStatusRegisterAnnotation());
+          }
+        }).build();
+
+    annotationOn(RegisterDefinition.class, "overflow status register", EnableAnnotation::new)
+        .applyViam((def, annotation, lowering) -> {
+          if (annotation.isEnabled) {
+            def.addAnnotation(new StatusRegisterAnnotation.OverflowStatusRegisterAnnotation());
           }
         }).build();
   }

--- a/vadl/main/vadl/gcb/annotations/StatusRegisterAnnotation.java
+++ b/vadl/main/vadl/gcb/annotations/StatusRegisterAnnotation.java
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.gcb.annotations;
+
+import vadl.viam.RegisterTensor;
+
+/**
+ * Indicates that the {@link RegisterTensor} is a status register and needs special
+ * treatment in the compiler-generator.
+ */
+public abstract class StatusRegisterAnnotation extends vadl.viam.Annotation<RegisterTensor> {
+
+  /**
+   * Register annotation for the negative status register.
+   */
+  public static class NegativeStatusRegisterAnnotation extends StatusRegisterAnnotation {
+    @Override
+    public Class<RegisterTensor> parentDefinitionClass() {
+      return RegisterTensor.class;
+    }
+  }
+
+  /**
+   * Register annotation for the zero status register.
+   */
+  public static class ZeroStatusRegisterAnnotation extends StatusRegisterAnnotation {
+    @Override
+    public Class<RegisterTensor> parentDefinitionClass() {
+      return RegisterTensor.class;
+    }
+  }
+
+  /**
+   * Register annotation for the carry status register.
+   */
+  public static class CarryStatusRegisterAnnotation extends StatusRegisterAnnotation {
+    @Override
+    public Class<RegisterTensor> parentDefinitionClass() {
+      return RegisterTensor.class;
+    }
+  }
+
+  /**
+   * Register annotation for the overflow status register.
+   */
+  public static class OverflowStatusRegisterAnnotation extends StatusRegisterAnnotation {
+    @Override
+    public Class<RegisterTensor> parentDefinitionClass() {
+      return RegisterTensor.class;
+    }
+  }
+}
+
+
+

--- a/vadl/test/resources/testSource/sys/aarch64/aarch64.vadl
+++ b/vadl/test/resources/testSource/sys/aarch64/aarch64.vadl
@@ -65,9 +65,13 @@ instruction set architecture AArch64Base = {
   alias register SP : Address = S(31) // stack pointer
   alias register LR : Address = S(30) // link register (return address)
 
+  [negative status register]
   register NZCV_N : Bits1             // Negative
+  [zero status register]
   register NZCV_Z : Bits1             // Zero
+  [carry status register]
   register NZCV_C : Bits1             // Carry
+  [overflow status register]
   register NZCV_V : Bits1             // oVerflow
 
   enumeration CondCode : Bits<4> =    // condition code encodings, do not change order


### PR DESCRIPTION
This PR adds new annotations to annotate status registers. This will come in handy when we need figure out the edge cases for non-default-flow pruning. 