### PR TITLE
lcb: Cast constants to signed for tablegen

### DIFF
--- a/vadl/main/vadl/lcb/passes/llvmLowering/tablegen/lowering/TableGenPatternPrinterVisitor.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/tablegen/lowering/TableGenPatternPrinterVisitor.java
@@ -41,6 +41,7 @@ import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmTypeCastSD;
 import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmZExtLoad;
 import vadl.lcb.passes.llvmLowering.strategies.LlvmInstructionLoweringStrategy;
 import vadl.lcb.passes.llvmLowering.strategies.visitors.TableGenNodeVisitor;
+import vadl.types.Type;
 import vadl.viam.Constant;
 import vadl.viam.graph.Node;
 import vadl.viam.graph.NodeList;
@@ -94,9 +95,17 @@ public class TableGenPatternPrinterVisitor
         || node.constant() instanceof Constant.Str, "constant must be value or string");
     if (node.constant() instanceof Constant.Value constant) {
       var ty = ValueType.from(constant.type());
-      if (ty.isPresent()) {
+      if (ty.isPresent() && ty.get().isSigned()) {
+        // LLVM only allows signed constants.
         writer.write(String.format("(%s %d)",
             ty.get().getLlvmType(),
+            constant.intValue()));
+      } else if (ty.isPresent()) {
+        // ty is unsigned, so we need to make it signed and hope that it still fits.
+        var bitWidth = ty.get().getBitwidth();
+        var signedType = ValueType.from(Type.signedInt(bitWidth)).get();
+        writer.write(String.format("(%s %d)",
+            signedType.getLlvmType(),
             constant.intValue()));
       } else {
         throw Diagnostic.error(String.format("Constant has no valid LLVM type: '%s'.",

--- a/vadl/test/resources/snapshots/aarch64/InstrInfoTableGen.td
+++ b/vadl/test/resources/snapshots/aarch64/InstrInfoTableGen.td
@@ -53284,7 +53284,7 @@ def : Pat<(i64 (zextloadi8 (add S:$rn, AArch64Base_LDRB_offsetAsInt64:$offset)))
         (LDRB S:$rn, AArch64Base_LDRB_offsetAsInt64:$offset)>;
 
 
-def : Pat<(i64 (zextloadi16 (add S:$rn, (shl AArch64Base_LDRH_offsetAsInt64:$offset, (u64 1))))),
+def : Pat<(i64 (zextloadi16 (add S:$rn, (shl AArch64Base_LDRH_offsetAsInt64:$offset, (i64 1))))),
         (LDRH S:$rn, AArch64Base_LDRH_offsetAsInt64:$offset)>;
 
 
@@ -53626,23 +53626,23 @@ def : Pat<(i64 (sextloadi8 (add S:$rn, AArch64Base_LDRSBX_offsetAsInt64:$offset)
         (LDRSBX S:$rn, AArch64Base_LDRSBX_offsetAsInt64:$offset)>;
 
 
-def : Pat<(i32 (sextloadi16 (add S:$rn, (shl AArch64Base_LDRSHW_offsetAsInt64:$offset, (u64 1))))),
+def : Pat<(i32 (sextloadi16 (add S:$rn, (shl AArch64Base_LDRSHW_offsetAsInt64:$offset, (i64 1))))),
         (LDRSHW S:$rn, AArch64Base_LDRSHW_offsetAsInt64:$offset)>;
 
 
-def : Pat<(i64 (sextloadi16 (add S:$rn, (shl AArch64Base_LDRSHX_offsetAsInt64:$offset, (u64 1))))),
+def : Pat<(i64 (sextloadi16 (add S:$rn, (shl AArch64Base_LDRSHX_offsetAsInt64:$offset, (i64 1))))),
         (LDRSHX S:$rn, AArch64Base_LDRSHX_offsetAsInt64:$offset)>;
 
 
-def : Pat<(i64 (sextloadi32 (add S:$rn, (shl AArch64Base_LDRSWX_offsetAsInt64:$offset, (u64 2))))),
+def : Pat<(i64 (sextloadi32 (add S:$rn, (shl AArch64Base_LDRSWX_offsetAsInt64:$offset, (i64 2))))),
         (LDRSWX S:$rn, AArch64Base_LDRSWX_offsetAsInt64:$offset)>;
 
 
-def : Pat<(i64 (zextloadi32 (add S:$rn, (shl AArch64Base_LDRW_offsetAsInt64:$offset, (u64 2))))),
+def : Pat<(i64 (zextloadi32 (add S:$rn, (shl AArch64Base_LDRW_offsetAsInt64:$offset, (i64 2))))),
         (LDRW S:$rn, AArch64Base_LDRW_offsetAsInt64:$offset)>;
 
 
-def : Pat<(i64 (load (add S:$rn, (shl AArch64Base_LDRX_offsetAsInt64:$offset, (u64 3))))),
+def : Pat<(i64 (load (add S:$rn, (shl AArch64Base_LDRX_offsetAsInt64:$offset, (i64 3))))),
         (LDRX S:$rn, AArch64Base_LDRX_offsetAsInt64:$offset)>;
 
 
@@ -53900,7 +53900,7 @@ def : Pat<(truncstorei8 S:$rt, (add S:$rn, AArch64Base_STRB_offsetAsInt64:$offse
         (STRB S:$rn, S:$rt, AArch64Base_STRB_offsetAsInt64:$offset)>;
 
 
-def : Pat<(truncstorei16 S:$rt, (add S:$rn, (shl AArch64Base_STRH_offsetAsInt64:$offset, (u64 1)))),
+def : Pat<(truncstorei16 S:$rt, (add S:$rn, (shl AArch64Base_STRH_offsetAsInt64:$offset, (i64 1)))),
         (STRH S:$rn, S:$rt, AArch64Base_STRH_offsetAsInt64:$offset)>;
 
 
@@ -54048,11 +54048,11 @@ def : Pat<(store S:$rt, (add S:$rn, S:$rm)),
         (STRRegXUXTXUn S:$rn, S:$rm, S:$rt)>;
 
 
-def : Pat<(truncstorei32 S:$rt, (add S:$rn, (shl AArch64Base_STRW_offsetAsInt64:$offset, (u64 2)))),
+def : Pat<(truncstorei32 S:$rt, (add S:$rn, (shl AArch64Base_STRW_offsetAsInt64:$offset, (i64 2)))),
         (STRW S:$rn, S:$rt, AArch64Base_STRW_offsetAsInt64:$offset)>;
 
 
-def : Pat<(store S:$rt, (add S:$rn, (shl AArch64Base_STRX_offsetAsInt64:$offset, (u64 3)))),
+def : Pat<(store S:$rt, (add S:$rn, (shl AArch64Base_STRX_offsetAsInt64:$offset, (i64 3)))),
         (STRX S:$rn, S:$rt, AArch64Base_STRX_offsetAsInt64:$offset)>;
 
 


### PR DESCRIPTION
LLVM doesn't like that we have unsigned constants. We cast them to signed and hope that it fits.

```
def : Pat<(i64 (zextloadi16 (add S:$rn, (shl AArch64Base_LDRH_offsetAsInt64:$offset, (u64 1))))),
        (LDRH S:$rn, AArch64Base_LDRH_offsetAsInt64:$offset)>;
```

becomes

```
def : Pat<(i64 (zextloadi16 (add S:$rn, (shl AArch64Base_LDRH_offsetAsInt64:$offset, (i64 1))))),
        (LDRH S:$rn, AArch64Base_LDRH_offsetAsInt64:$offset)>;
```