### PR TITLE
lcb: Added lowering for sext and zext

### DIFF
--- a/vadl/main/vadl/lcb/passes/llvmLowering/strategies/LlvmInstructionLoweringStrategy.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/strategies/LlvmInstructionLoweringStrategy.java
@@ -424,6 +424,7 @@ public abstract class LlvmInstructionLoweringStrategy {
         || hasSignExtensionInGraph(instruction, graph)
         || hasMultipleOutputs(graph)
         || rejectWhenReadingFromMemory(graph)
+        || rejectWhenWritingToMemory(graph)
         || hasUnreplacedBuiltins(graph)) {
       return true;
     }
@@ -476,6 +477,13 @@ public abstract class LlvmInstructionLoweringStrategy {
       return true;
     }
     return false;
+  }
+
+  /**
+   * If the {@link Graph} it has nodes which writes to memory then we cannot lower it.
+   */
+  protected boolean rejectWhenWritingToMemory(Graph graph) {
+    return !graph.getNodes(WriteMemNode.class).toList().isEmpty();
   }
 
   /**

--- a/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/LlvmInstructionLoweringMemoryStoreStrategyImpl.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/LlvmInstructionLoweringMemoryStoreStrategyImpl.java
@@ -80,6 +80,14 @@ public class LlvmInstructionLoweringMemoryStoreStrategyImpl
   }
 
   /**
+   * This strategy is ok with it when it has {@link ReadMemNode} or {@link WriteMemNode}.
+   */
+  @Override
+  protected boolean rejectWhenWritingToMemory(Graph graph) {
+    return false;
+  }
+
+  /**
    * LLVM requires a pattern for loading directly from a frame index. But for example in the RISCV
    * specification we only have an instruction which stores from register + immediate. This method
    * will drop the immediate and replace it by {@code 0}.

--- a/vadl/main/vadl/lcb/passes/llvmLowering/tablegen/lowering/TableGenPatternPrinterVisitor.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/tablegen/lowering/TableGenPatternPrinterVisitor.java
@@ -343,12 +343,16 @@ public class TableGenPatternPrinterVisitor
 
   @Override
   public void visit(ZeroExtendNode node) {
-
+    writer.write("(zext ");
+    visit(node.value());
+    writer.write(")");
   }
 
   @Override
   public void visit(SignExtendNode node) {
-
+    writer.write("(sext ");
+    visit(node.value());
+    writer.write(")");
   }
 
   @Override

--- a/vadl/test/resources/snapshots/aarch64/InstrInfoTableGen.td
+++ b/vadl/test/resources/snapshots/aarch64/InstrInfoTableGen.td
@@ -53952,11 +53952,11 @@ def : Pat<(truncstorei16 S:$rt, (add AddrFI:$rn, (shl AArch64Base_STRH_offsetAsI
 
 
 
-def : Pat<(truncstorei8 S:$rt, (add S:$rn, )),
+def : Pat<(truncstorei8 S:$rt, (add S:$rn, (sext S:$rm))),
         (STRRegBSXTWIs S:$rn, S:$rm, S:$rt)>;
 
 
-def : Pat<(truncstorei8 S:$rt, (add S:$rn, )),
+def : Pat<(truncstorei8 S:$rt, (add S:$rn, (sext S:$rm))),
         (STRRegBSXTWUn S:$rn, S:$rm, S:$rt)>;
 
 
@@ -53984,11 +53984,11 @@ def : Pat<(truncstorei8 S:$rt, (add S:$rn, S:$rm)),
         (STRRegBUXTXUn S:$rn, S:$rm, S:$rt)>;
 
 
-def : Pat<(truncstorei16 S:$rt, (add S:$rn, (shl , (i64 1)))),
+def : Pat<(truncstorei16 S:$rt, (add S:$rn, (shl (sext S:$rm), (i64 1)))),
         (STRRegHSXTWIs S:$rn, S:$rm, S:$rt)>;
 
 
-def : Pat<(truncstorei16 S:$rt, (add S:$rn, )),
+def : Pat<(truncstorei16 S:$rt, (add S:$rn, (sext S:$rm))),
         (STRRegHSXTWUn S:$rn, S:$rm, S:$rt)>;
 
 
@@ -54016,11 +54016,11 @@ def : Pat<(truncstorei16 S:$rt, (add S:$rn, S:$rm)),
         (STRRegHUXTXUn S:$rn, S:$rm, S:$rt)>;
 
 
-def : Pat<(truncstorei32 S:$rt, (add S:$rn, (shl , (i64 2)))),
+def : Pat<(truncstorei32 S:$rt, (add S:$rn, (shl (sext S:$rm), (i64 2)))),
         (STRRegWSXTWIs S:$rn, S:$rm, S:$rt)>;
 
 
-def : Pat<(truncstorei32 S:$rt, (add S:$rn, )),
+def : Pat<(truncstorei32 S:$rt, (add S:$rn, (sext S:$rm))),
         (STRRegWSXTWUn S:$rn, S:$rm, S:$rt)>;
 
 
@@ -54048,36 +54048,20 @@ def : Pat<(truncstorei32 S:$rt, (add S:$rn, S:$rm)),
         (STRRegWUXTXUn S:$rn, S:$rm, S:$rt)>;
 
 
-def : Pat<(store S:$rt, (add S:$rn, (shl , (i64 3)))),
-        (STRRegXSXTWIs S:$rn, S:$rm, S:$rt)>;
 
 
-def : Pat<(store S:$rt, (add S:$rn, )),
-        (STRRegXSXTWUn S:$rn, S:$rm, S:$rt)>;
 
 
-def : Pat<(store S:$rt, (add S:$rn, (shl S:$rm, (i64 3)))),
-        (STRRegXSXTXIs S:$rn, S:$rm, S:$rt)>;
 
 
-def : Pat<(store S:$rt, (add S:$rn, S:$rm)),
-        (STRRegXSXTXUn S:$rn, S:$rm, S:$rt)>;
 
 
-def : Pat<(store S:$rt, (add S:$rn, (shl S:$rm, (i64 3)))),
-        (STRRegXUXTWIs S:$rn, S:$rm, S:$rt)>;
 
 
-def : Pat<(store S:$rt, (add S:$rn, S:$rm)),
-        (STRRegXUXTWUn S:$rn, S:$rm, S:$rt)>;
 
 
-def : Pat<(store S:$rt, (add S:$rn, (shl S:$rm, (i64 3)))),
-        (STRRegXUXTXIs S:$rn, S:$rm, S:$rt)>;
 
 
-def : Pat<(store S:$rt, (add S:$rn, S:$rm)),
-        (STRRegXUXTXUn S:$rn, S:$rm, S:$rt)>;
 
 
 def : Pat<(truncstorei32 S:$rt, (add S:$rn, (shl AArch64Base_STRW_offsetAsInt64:$offset, (i64 2)))),


### PR DESCRIPTION
We were missing handlers for `sext` and `zext`.