### PR TITLE
lcb: Removed typecasts before sign and zero extension

### DIFF
--- a/vadl/main/vadl/lcb/passes/isaMatching/IsaMachineInstructionMatchingPass.java
+++ b/vadl/main/vadl/lcb/passes/isaMatching/IsaMachineInstructionMatchingPass.java
@@ -437,6 +437,13 @@ public class IsaMachineInstructionMatchingPass extends Pass implements IsaMatchi
       return false;
     }
 
+    // Only add is allowed as a builtin
+    var builtins = graph.getNodes(BuiltInCall.class).toList();
+    if (builtins.size() != 1 && builtins.stream()
+        .noneMatch(x -> Set.of(ADD).contains(x.builtIn()))) {
+      return false;
+    }
+
     var matched = TreeMatcher.matches(
         graph.getNodes(WriteResourceNode.class).map(x -> x),
         new WriteResourceMatcherForValue(new AnyChildMatcher(new AnyReadMemMatcher())));

--- a/vadl/main/vadl/lcb/passes/llvmLowering/strategies/nodeLowering/LcbNodeReplacementHandler.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/strategies/nodeLowering/LcbNodeReplacementHandler.java
@@ -502,8 +502,7 @@ public class LcbNodeReplacementHandler {
   @SuppressWarnings("MissingJavadocMethod")
   public void handle(ReadMemNode readMemNode) {
     LcbNodeReplacementHandlerDispatcher.dispatch(this, readMemNode.address());
-    readMemNode.replaceAndDelete(
-        new LlvmTypeCastSD(new LlvmLoadSD(readMemNode), readMemNode.type()));
+    readMemNode.replaceAndDelete(new LlvmLoadSD(readMemNode));
   }
 
   @Handler
@@ -572,8 +571,7 @@ public class LcbNodeReplacementHandler {
   public void handle(SignExtendNode signExtendNode) {
     if (signExtendNode.value() instanceof ReadMemNode readMemNode) {
       // Merge SignExtend and ReadMem to LlvmSExtLoad
-      signExtendNode.replaceAndDelete(
-          new LlvmTypeCastSD(new LlvmSExtLoad(readMemNode), makeSigned(signExtendNode.type())));
+      signExtendNode.replaceAndDelete(new LlvmSExtLoad(readMemNode));
       LcbNodeReplacementHandlerDispatcher.dispatch(this, readMemNode.address());
     } else {
       LcbNodeReplacementHandlerDispatcher.dispatch(this, signExtendNode.value());
@@ -744,8 +742,7 @@ public class LcbNodeReplacementHandler {
   @SuppressWarnings("MissingJavadocMethod")
   public void handle(ZeroExtendNode node) {
     if (node.value() instanceof ReadMemNode readMemNode) {
-      node.replaceAndDelete(
-          new LlvmTypeCastSD(new LlvmZExtLoad(readMemNode), makeSigned(node.type())));
+      node.replaceAndDelete(new LlvmZExtLoad(readMemNode));
       LcbNodeReplacementHandlerDispatcher.dispatch(this, readMemNode.address());
     } else {
       // Remove all nodes

--- a/vadl/main/vadl/lcb/passes/llvmLowering/strategies/nodeLowering/LcbNodeReplacementHandler.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/strategies/nodeLowering/LcbNodeReplacementHandler.java
@@ -766,15 +766,4 @@ public class LcbNodeReplacementHandler {
   public void handle(ExpressionNode node) {
     throw Diagnostic.error("not handled", node.location()).build();
   }
-
-
-  private Type makeSigned(DataType type) {
-    if (!type.isSigned()) {
-      if (type instanceof BitsType bitsType) {
-        return SIntType.bits(bitsType.bitWidth());
-      }
-    }
-
-    return type;
-  }
 }

--- a/vadl/test/resources/snapshots/aarch64/InstrInfoTableGen.td
+++ b/vadl/test/resources/snapshots/aarch64/InstrInfoTableGen.td
@@ -52463,243 +52463,243 @@ def : Pat<(xor S:$rn, (srl S:$rm, AArch64Base_EORXLSR_imm6AsInt64:$imm6)),
         (EORXLSR S:$rn, S:$rm, AArch64Base_EORXLSR_imm6AsInt64:$imm6)>;
 
 
-def : Pat<(i64 (zextloadi8 (add S:$rn, AArch64Base_LDRB_offsetAsInt64:$offset))),
+def : Pat<(zextloadi8 (add S:$rn, AArch64Base_LDRB_offsetAsInt64:$offset)),
         (LDRB S:$rn, AArch64Base_LDRB_offsetAsInt64:$offset)>;
 
-def : Pat<(i64 (zextloadi8 (add AddrFI:$rn, AArch64Base_LDRB_offsetAsInt64:$offset))),
+def : Pat<(zextloadi8 (add AddrFI:$rn, AArch64Base_LDRB_offsetAsInt64:$offset)),
         (LDRB AddrFI:$rn, AArch64Base_LDRB_offsetAsInt64:$offset)>;
 
-def : Pat<(i64 (zextloadi8 S:$rn)),
+def : Pat<(zextloadi8 S:$rn),
         (LDRB S:$rn, (i64 0))>;
 
-def : Pat<(i64 (zextloadi8 AddrFI:$rn)),
+def : Pat<(zextloadi8 AddrFI:$rn),
         (LDRB AddrFI:$rn, (i64 0))>;
 
 
-def : Pat<(i64 (zextloadi16 (add S:$rn, (shl AArch64Base_LDRH_offsetAsInt64:$offset, (i64 1))))),
+def : Pat<(zextloadi16 (add S:$rn, (shl AArch64Base_LDRH_offsetAsInt64:$offset, (i64 1)))),
         (LDRH S:$rn, AArch64Base_LDRH_offsetAsInt64:$offset)>;
 
-def : Pat<(i64 (zextloadi16 (add AddrFI:$rn, (shl AArch64Base_LDRH_offsetAsInt64:$offset, (i64 1))))),
+def : Pat<(zextloadi16 (add AddrFI:$rn, (shl AArch64Base_LDRH_offsetAsInt64:$offset, (i64 1)))),
         (LDRH AddrFI:$rn, AArch64Base_LDRH_offsetAsInt64:$offset)>;
 
 
-def : Pat<(i32 (sextloadi8 (add S:$rn, AArch64Base_LDRSBW_offsetAsInt64:$offset))),
+def : Pat<(sextloadi8 (add S:$rn, AArch64Base_LDRSBW_offsetAsInt64:$offset)),
         (LDRSBW S:$rn, AArch64Base_LDRSBW_offsetAsInt64:$offset)>;
 
-def : Pat<(i32 (sextloadi8 (add AddrFI:$rn, AArch64Base_LDRSBW_offsetAsInt64:$offset))),
+def : Pat<(sextloadi8 (add AddrFI:$rn, AArch64Base_LDRSBW_offsetAsInt64:$offset)),
         (LDRSBW AddrFI:$rn, AArch64Base_LDRSBW_offsetAsInt64:$offset)>;
 
-def : Pat<(i32 (sextloadi8 S:$rn)),
+def : Pat<(sextloadi8 S:$rn),
         (LDRSBW S:$rn, (i64 0))>;
 
-def : Pat<(i32 (extloadi8 S:$rn)),
+def : Pat<(extloadi8 S:$rn),
         (LDRSBW S:$rn, (i64 0))>;
 
-def : Pat<(i32 (sextloadi8 AddrFI:$rn)),
+def : Pat<(sextloadi8 AddrFI:$rn),
         (LDRSBW AddrFI:$rn, (i64 0))>;
 
-def : Pat<(i32 (extloadi8 AddrFI:$rn)),
+def : Pat<(extloadi8 AddrFI:$rn),
         (LDRSBW AddrFI:$rn, (i64 0))>;
 
 
-def : Pat<(i64 (sextloadi8 (add S:$rn, AArch64Base_LDRSBX_offsetAsInt64:$offset))),
+def : Pat<(sextloadi8 (add S:$rn, AArch64Base_LDRSBX_offsetAsInt64:$offset)),
         (LDRSBX S:$rn, AArch64Base_LDRSBX_offsetAsInt64:$offset)>;
 
-def : Pat<(i64 (sextloadi8 (add AddrFI:$rn, AArch64Base_LDRSBX_offsetAsInt64:$offset))),
+def : Pat<(sextloadi8 (add AddrFI:$rn, AArch64Base_LDRSBX_offsetAsInt64:$offset)),
         (LDRSBX AddrFI:$rn, AArch64Base_LDRSBX_offsetAsInt64:$offset)>;
 
-def : Pat<(i64 (sextloadi8 S:$rn)),
+def : Pat<(sextloadi8 S:$rn),
         (LDRSBX S:$rn, (i64 0))>;
 
-def : Pat<(i64 (extloadi8 S:$rn)),
+def : Pat<(extloadi8 S:$rn),
         (LDRSBX S:$rn, (i64 0))>;
 
-def : Pat<(i64 (sextloadi8 AddrFI:$rn)),
+def : Pat<(sextloadi8 AddrFI:$rn),
         (LDRSBX AddrFI:$rn, (i64 0))>;
 
-def : Pat<(i64 (extloadi8 AddrFI:$rn)),
+def : Pat<(extloadi8 AddrFI:$rn),
         (LDRSBX AddrFI:$rn, (i64 0))>;
 
 
-def : Pat<(i32 (sextloadi16 (add S:$rn, (shl AArch64Base_LDRSHW_offsetAsInt64:$offset, (i64 1))))),
+def : Pat<(sextloadi16 (add S:$rn, (shl AArch64Base_LDRSHW_offsetAsInt64:$offset, (i64 1)))),
         (LDRSHW S:$rn, AArch64Base_LDRSHW_offsetAsInt64:$offset)>;
 
-def : Pat<(i32 (sextloadi16 (add AddrFI:$rn, (shl AArch64Base_LDRSHW_offsetAsInt64:$offset, (i64 1))))),
+def : Pat<(sextloadi16 (add AddrFI:$rn, (shl AArch64Base_LDRSHW_offsetAsInt64:$offset, (i64 1)))),
         (LDRSHW AddrFI:$rn, AArch64Base_LDRSHW_offsetAsInt64:$offset)>;
 
 
-def : Pat<(i64 (sextloadi16 (add S:$rn, (shl AArch64Base_LDRSHX_offsetAsInt64:$offset, (i64 1))))),
+def : Pat<(sextloadi16 (add S:$rn, (shl AArch64Base_LDRSHX_offsetAsInt64:$offset, (i64 1)))),
         (LDRSHX S:$rn, AArch64Base_LDRSHX_offsetAsInt64:$offset)>;
 
-def : Pat<(i64 (sextloadi16 (add AddrFI:$rn, (shl AArch64Base_LDRSHX_offsetAsInt64:$offset, (i64 1))))),
+def : Pat<(sextloadi16 (add AddrFI:$rn, (shl AArch64Base_LDRSHX_offsetAsInt64:$offset, (i64 1)))),
         (LDRSHX AddrFI:$rn, AArch64Base_LDRSHX_offsetAsInt64:$offset)>;
 
 
-def : Pat<(i64 (sextloadi32 (add S:$rn, (shl AArch64Base_LDRSWX_offsetAsInt64:$offset, (i64 2))))),
+def : Pat<(sextloadi32 (add S:$rn, (shl AArch64Base_LDRSWX_offsetAsInt64:$offset, (i64 2)))),
         (LDRSWX S:$rn, AArch64Base_LDRSWX_offsetAsInt64:$offset)>;
 
-def : Pat<(i64 (sextloadi32 (add AddrFI:$rn, (shl AArch64Base_LDRSWX_offsetAsInt64:$offset, (i64 2))))),
+def : Pat<(sextloadi32 (add AddrFI:$rn, (shl AArch64Base_LDRSWX_offsetAsInt64:$offset, (i64 2)))),
         (LDRSWX AddrFI:$rn, AArch64Base_LDRSWX_offsetAsInt64:$offset)>;
 
 
-def : Pat<(i64 (zextloadi32 (add S:$rn, (shl AArch64Base_LDRW_offsetAsInt64:$offset, (i64 2))))),
+def : Pat<(zextloadi32 (add S:$rn, (shl AArch64Base_LDRW_offsetAsInt64:$offset, (i64 2)))),
         (LDRW S:$rn, AArch64Base_LDRW_offsetAsInt64:$offset)>;
 
-def : Pat<(i64 (zextloadi32 (add AddrFI:$rn, (shl AArch64Base_LDRW_offsetAsInt64:$offset, (i64 2))))),
+def : Pat<(zextloadi32 (add AddrFI:$rn, (shl AArch64Base_LDRW_offsetAsInt64:$offset, (i64 2)))),
         (LDRW AddrFI:$rn, AArch64Base_LDRW_offsetAsInt64:$offset)>;
 
 
-def : Pat<(i64 (load (add S:$rn, (shl AArch64Base_LDRX_offsetAsInt64:$offset, (i64 3))))),
+def : Pat<(load (add S:$rn, (shl AArch64Base_LDRX_offsetAsInt64:$offset, (i64 3)))),
         (LDRX S:$rn, AArch64Base_LDRX_offsetAsInt64:$offset)>;
 
-def : Pat<(i64 (load (add AddrFI:$rn, (shl AArch64Base_LDRX_offsetAsInt64:$offset, (i64 3))))),
+def : Pat<(load (add AddrFI:$rn, (shl AArch64Base_LDRX_offsetAsInt64:$offset, (i64 3)))),
         (LDRX AddrFI:$rn, AArch64Base_LDRX_offsetAsInt64:$offset)>;
 
 
-def : Pat<(i64 (zextloadi8 (add S:$rn, AArch64Base_LDURB_offsetAsInt64:$offset))),
+def : Pat<(zextloadi8 (add S:$rn, AArch64Base_LDURB_offsetAsInt64:$offset)),
         (LDURB S:$rn, AArch64Base_LDURB_offsetAsInt64:$offset)>;
 
-def : Pat<(i64 (zextloadi8 (add AddrFI:$rn, AArch64Base_LDURB_offsetAsInt64:$offset))),
+def : Pat<(zextloadi8 (add AddrFI:$rn, AArch64Base_LDURB_offsetAsInt64:$offset)),
         (LDURB AddrFI:$rn, AArch64Base_LDURB_offsetAsInt64:$offset)>;
 
-def : Pat<(i64 (zextloadi8 S:$rn)),
+def : Pat<(zextloadi8 S:$rn),
         (LDURB S:$rn, (i64 0))>;
 
-def : Pat<(i64 (zextloadi8 AddrFI:$rn)),
+def : Pat<(zextloadi8 AddrFI:$rn),
         (LDURB AddrFI:$rn, (i64 0))>;
 
 
-def : Pat<(i64 (zextloadi16 (add S:$rn, AArch64Base_LDURH_offsetAsInt64:$offset))),
+def : Pat<(zextloadi16 (add S:$rn, AArch64Base_LDURH_offsetAsInt64:$offset)),
         (LDURH S:$rn, AArch64Base_LDURH_offsetAsInt64:$offset)>;
 
-def : Pat<(i64 (zextloadi16 (add AddrFI:$rn, AArch64Base_LDURH_offsetAsInt64:$offset))),
+def : Pat<(zextloadi16 (add AddrFI:$rn, AArch64Base_LDURH_offsetAsInt64:$offset)),
         (LDURH AddrFI:$rn, AArch64Base_LDURH_offsetAsInt64:$offset)>;
 
-def : Pat<(i64 (zextloadi16 S:$rn)),
+def : Pat<(zextloadi16 S:$rn),
         (LDURH S:$rn, (i64 0))>;
 
-def : Pat<(i64 (zextloadi16 AddrFI:$rn)),
+def : Pat<(zextloadi16 AddrFI:$rn),
         (LDURH AddrFI:$rn, (i64 0))>;
 
 
-def : Pat<(i32 (sextloadi8 (add S:$rn, AArch64Base_LDURSBW_offsetAsInt64:$offset))),
+def : Pat<(sextloadi8 (add S:$rn, AArch64Base_LDURSBW_offsetAsInt64:$offset)),
         (LDURSBW S:$rn, AArch64Base_LDURSBW_offsetAsInt64:$offset)>;
 
-def : Pat<(i32 (sextloadi8 (add AddrFI:$rn, AArch64Base_LDURSBW_offsetAsInt64:$offset))),
+def : Pat<(sextloadi8 (add AddrFI:$rn, AArch64Base_LDURSBW_offsetAsInt64:$offset)),
         (LDURSBW AddrFI:$rn, AArch64Base_LDURSBW_offsetAsInt64:$offset)>;
 
-def : Pat<(i32 (sextloadi8 S:$rn)),
+def : Pat<(sextloadi8 S:$rn),
         (LDURSBW S:$rn, (i64 0))>;
 
-def : Pat<(i32 (extloadi8 S:$rn)),
+def : Pat<(extloadi8 S:$rn),
         (LDURSBW S:$rn, (i64 0))>;
 
-def : Pat<(i32 (sextloadi8 AddrFI:$rn)),
+def : Pat<(sextloadi8 AddrFI:$rn),
         (LDURSBW AddrFI:$rn, (i64 0))>;
 
-def : Pat<(i32 (extloadi8 AddrFI:$rn)),
+def : Pat<(extloadi8 AddrFI:$rn),
         (LDURSBW AddrFI:$rn, (i64 0))>;
 
 
-def : Pat<(i64 (sextloadi8 (add S:$rn, AArch64Base_LDURSBX_offsetAsInt64:$offset))),
+def : Pat<(sextloadi8 (add S:$rn, AArch64Base_LDURSBX_offsetAsInt64:$offset)),
         (LDURSBX S:$rn, AArch64Base_LDURSBX_offsetAsInt64:$offset)>;
 
-def : Pat<(i64 (sextloadi8 (add AddrFI:$rn, AArch64Base_LDURSBX_offsetAsInt64:$offset))),
+def : Pat<(sextloadi8 (add AddrFI:$rn, AArch64Base_LDURSBX_offsetAsInt64:$offset)),
         (LDURSBX AddrFI:$rn, AArch64Base_LDURSBX_offsetAsInt64:$offset)>;
 
-def : Pat<(i64 (sextloadi8 S:$rn)),
+def : Pat<(sextloadi8 S:$rn),
         (LDURSBX S:$rn, (i64 0))>;
 
-def : Pat<(i64 (extloadi8 S:$rn)),
+def : Pat<(extloadi8 S:$rn),
         (LDURSBX S:$rn, (i64 0))>;
 
-def : Pat<(i64 (sextloadi8 AddrFI:$rn)),
+def : Pat<(sextloadi8 AddrFI:$rn),
         (LDURSBX AddrFI:$rn, (i64 0))>;
 
-def : Pat<(i64 (extloadi8 AddrFI:$rn)),
+def : Pat<(extloadi8 AddrFI:$rn),
         (LDURSBX AddrFI:$rn, (i64 0))>;
 
 
-def : Pat<(i32 (sextloadi16 (add S:$rn, AArch64Base_LDURSHW_offsetAsInt64:$offset))),
+def : Pat<(sextloadi16 (add S:$rn, AArch64Base_LDURSHW_offsetAsInt64:$offset)),
         (LDURSHW S:$rn, AArch64Base_LDURSHW_offsetAsInt64:$offset)>;
 
-def : Pat<(i32 (sextloadi16 (add AddrFI:$rn, AArch64Base_LDURSHW_offsetAsInt64:$offset))),
+def : Pat<(sextloadi16 (add AddrFI:$rn, AArch64Base_LDURSHW_offsetAsInt64:$offset)),
         (LDURSHW AddrFI:$rn, AArch64Base_LDURSHW_offsetAsInt64:$offset)>;
 
-def : Pat<(i32 (sextloadi16 S:$rn)),
+def : Pat<(sextloadi16 S:$rn),
         (LDURSHW S:$rn, (i64 0))>;
 
-def : Pat<(i32 (extloadi16 S:$rn)),
+def : Pat<(extloadi16 S:$rn),
         (LDURSHW S:$rn, (i64 0))>;
 
-def : Pat<(i32 (sextloadi16 AddrFI:$rn)),
+def : Pat<(sextloadi16 AddrFI:$rn),
         (LDURSHW AddrFI:$rn, (i64 0))>;
 
-def : Pat<(i32 (extloadi16 AddrFI:$rn)),
+def : Pat<(extloadi16 AddrFI:$rn),
         (LDURSHW AddrFI:$rn, (i64 0))>;
 
 
-def : Pat<(i64 (sextloadi16 (add S:$rn, AArch64Base_LDURSHX_offsetAsInt64:$offset))),
+def : Pat<(sextloadi16 (add S:$rn, AArch64Base_LDURSHX_offsetAsInt64:$offset)),
         (LDURSHX S:$rn, AArch64Base_LDURSHX_offsetAsInt64:$offset)>;
 
-def : Pat<(i64 (sextloadi16 (add AddrFI:$rn, AArch64Base_LDURSHX_offsetAsInt64:$offset))),
+def : Pat<(sextloadi16 (add AddrFI:$rn, AArch64Base_LDURSHX_offsetAsInt64:$offset)),
         (LDURSHX AddrFI:$rn, AArch64Base_LDURSHX_offsetAsInt64:$offset)>;
 
-def : Pat<(i64 (sextloadi16 S:$rn)),
+def : Pat<(sextloadi16 S:$rn),
         (LDURSHX S:$rn, (i64 0))>;
 
-def : Pat<(i64 (extloadi16 S:$rn)),
+def : Pat<(extloadi16 S:$rn),
         (LDURSHX S:$rn, (i64 0))>;
 
-def : Pat<(i64 (sextloadi16 AddrFI:$rn)),
+def : Pat<(sextloadi16 AddrFI:$rn),
         (LDURSHX AddrFI:$rn, (i64 0))>;
 
-def : Pat<(i64 (extloadi16 AddrFI:$rn)),
+def : Pat<(extloadi16 AddrFI:$rn),
         (LDURSHX AddrFI:$rn, (i64 0))>;
 
 
-def : Pat<(i64 (sextloadi32 (add S:$rn, AArch64Base_LDURSWX_offsetAsInt64:$offset))),
+def : Pat<(sextloadi32 (add S:$rn, AArch64Base_LDURSWX_offsetAsInt64:$offset)),
         (LDURSWX S:$rn, AArch64Base_LDURSWX_offsetAsInt64:$offset)>;
 
-def : Pat<(i64 (sextloadi32 (add AddrFI:$rn, AArch64Base_LDURSWX_offsetAsInt64:$offset))),
+def : Pat<(sextloadi32 (add AddrFI:$rn, AArch64Base_LDURSWX_offsetAsInt64:$offset)),
         (LDURSWX AddrFI:$rn, AArch64Base_LDURSWX_offsetAsInt64:$offset)>;
 
-def : Pat<(i64 (sextloadi32 S:$rn)),
+def : Pat<(sextloadi32 S:$rn),
         (LDURSWX S:$rn, (i64 0))>;
 
-def : Pat<(i64 (extloadi32 S:$rn)),
+def : Pat<(extloadi32 S:$rn),
         (LDURSWX S:$rn, (i64 0))>;
 
-def : Pat<(i64 (sextloadi32 AddrFI:$rn)),
+def : Pat<(sextloadi32 AddrFI:$rn),
         (LDURSWX AddrFI:$rn, (i64 0))>;
 
-def : Pat<(i64 (extloadi32 AddrFI:$rn)),
+def : Pat<(extloadi32 AddrFI:$rn),
         (LDURSWX AddrFI:$rn, (i64 0))>;
 
 
-def : Pat<(i64 (zextloadi32 (add S:$rn, AArch64Base_LDURW_offsetAsInt64:$offset))),
+def : Pat<(zextloadi32 (add S:$rn, AArch64Base_LDURW_offsetAsInt64:$offset)),
         (LDURW S:$rn, AArch64Base_LDURW_offsetAsInt64:$offset)>;
 
-def : Pat<(i64 (zextloadi32 (add AddrFI:$rn, AArch64Base_LDURW_offsetAsInt64:$offset))),
+def : Pat<(zextloadi32 (add AddrFI:$rn, AArch64Base_LDURW_offsetAsInt64:$offset)),
         (LDURW AddrFI:$rn, AArch64Base_LDURW_offsetAsInt64:$offset)>;
 
-def : Pat<(i64 (zextloadi32 S:$rn)),
+def : Pat<(zextloadi32 S:$rn),
         (LDURW S:$rn, (i64 0))>;
 
-def : Pat<(i64 (zextloadi32 AddrFI:$rn)),
+def : Pat<(zextloadi32 AddrFI:$rn),
         (LDURW AddrFI:$rn, (i64 0))>;
 
 
-def : Pat<(i64 (load (add S:$rn, AArch64Base_LDURX_offsetAsInt64:$offset))),
+def : Pat<(load (add S:$rn, AArch64Base_LDURX_offsetAsInt64:$offset)),
         (LDURX S:$rn, AArch64Base_LDURX_offsetAsInt64:$offset)>;
 
-def : Pat<(i64 (load (add AddrFI:$rn, AArch64Base_LDURX_offsetAsInt64:$offset))),
+def : Pat<(load (add AddrFI:$rn, AArch64Base_LDURX_offsetAsInt64:$offset)),
         (LDURX AddrFI:$rn, AArch64Base_LDURX_offsetAsInt64:$offset)>;
 
-def : Pat<(i64 (load S:$rn)),
+def : Pat<(load S:$rn),
         (LDURX S:$rn, (i64 0))>;
 
-def : Pat<(i64 (load AddrFI:$rn)),
+def : Pat<(load AddrFI:$rn),
         (LDURX AddrFI:$rn, (i64 0))>;
 
 

--- a/vadl/test/resources/snapshots/rv64im/InstrInfoTableGen.td
+++ b/vadl/test/resources/snapshots/rv64im/InstrInfoTableGen.td
@@ -5264,112 +5264,112 @@ def : Pat<(brind (add X:$rs1, RV3264Base_JALR_immSAsInt64:$immS)),
         (PseudoBRIND X:$rs1, RV3264Base_JALR_immSAsInt64:$immS)>;
 
 
-def : Pat<(i64 (sextloadi8 (add X:$rs1, RV3264Base_LB_immSAsInt64:$immS))),
+def : Pat<(sextloadi8 (add X:$rs1, RV3264Base_LB_immSAsInt64:$immS)),
         (LB X:$rs1, RV3264Base_LB_immSAsInt64:$immS)>;
 
-def : Pat<(i64 (sextloadi8 (add AddrFI:$rs1, RV3264Base_LB_immSAsInt64:$immS))),
+def : Pat<(sextloadi8 (add AddrFI:$rs1, RV3264Base_LB_immSAsInt64:$immS)),
         (LB AddrFI:$rs1, RV3264Base_LB_immSAsInt64:$immS)>;
 
-def : Pat<(i64 (sextloadi8 X:$rs1)),
+def : Pat<(sextloadi8 X:$rs1),
         (LB X:$rs1, (i64 0))>;
 
-def : Pat<(i64 (extloadi8 X:$rs1)),
+def : Pat<(extloadi8 X:$rs1),
         (LB X:$rs1, (i64 0))>;
 
-def : Pat<(i64 (sextloadi8 AddrFI:$rs1)),
+def : Pat<(sextloadi8 AddrFI:$rs1),
         (LB AddrFI:$rs1, (i64 0))>;
 
-def : Pat<(i64 (extloadi8 AddrFI:$rs1)),
+def : Pat<(extloadi8 AddrFI:$rs1),
         (LB AddrFI:$rs1, (i64 0))>;
 
 
-def : Pat<(i64 (zextloadi8 (add X:$rs1, RV3264Base_LBU_immSAsInt64:$immS))),
+def : Pat<(zextloadi8 (add X:$rs1, RV3264Base_LBU_immSAsInt64:$immS)),
         (LBU X:$rs1, RV3264Base_LBU_immSAsInt64:$immS)>;
 
-def : Pat<(i64 (zextloadi8 (add AddrFI:$rs1, RV3264Base_LBU_immSAsInt64:$immS))),
+def : Pat<(zextloadi8 (add AddrFI:$rs1, RV3264Base_LBU_immSAsInt64:$immS)),
         (LBU AddrFI:$rs1, RV3264Base_LBU_immSAsInt64:$immS)>;
 
-def : Pat<(i64 (zextloadi8 X:$rs1)),
+def : Pat<(zextloadi8 X:$rs1),
         (LBU X:$rs1, (i64 0))>;
 
-def : Pat<(i64 (zextloadi8 AddrFI:$rs1)),
+def : Pat<(zextloadi8 AddrFI:$rs1),
         (LBU AddrFI:$rs1, (i64 0))>;
 
 
-def : Pat<(i64 (load (add X:$rs1, RV3264Base_LD_immSAsInt64:$immS))),
+def : Pat<(load (add X:$rs1, RV3264Base_LD_immSAsInt64:$immS)),
         (LD X:$rs1, RV3264Base_LD_immSAsInt64:$immS)>;
 
-def : Pat<(i64 (load (add AddrFI:$rs1, RV3264Base_LD_immSAsInt64:$immS))),
+def : Pat<(load (add AddrFI:$rs1, RV3264Base_LD_immSAsInt64:$immS)),
         (LD AddrFI:$rs1, RV3264Base_LD_immSAsInt64:$immS)>;
 
-def : Pat<(i64 (load X:$rs1)),
+def : Pat<(load X:$rs1),
         (LD X:$rs1, (i64 0))>;
 
-def : Pat<(i64 (load AddrFI:$rs1)),
+def : Pat<(load AddrFI:$rs1),
         (LD AddrFI:$rs1, (i64 0))>;
 
 
-def : Pat<(i64 (sextloadi16 (add X:$rs1, RV3264Base_LH_immSAsInt64:$immS))),
+def : Pat<(sextloadi16 (add X:$rs1, RV3264Base_LH_immSAsInt64:$immS)),
         (LH X:$rs1, RV3264Base_LH_immSAsInt64:$immS)>;
 
-def : Pat<(i64 (sextloadi16 (add AddrFI:$rs1, RV3264Base_LH_immSAsInt64:$immS))),
+def : Pat<(sextloadi16 (add AddrFI:$rs1, RV3264Base_LH_immSAsInt64:$immS)),
         (LH AddrFI:$rs1, RV3264Base_LH_immSAsInt64:$immS)>;
 
-def : Pat<(i64 (sextloadi16 X:$rs1)),
+def : Pat<(sextloadi16 X:$rs1),
         (LH X:$rs1, (i64 0))>;
 
-def : Pat<(i64 (extloadi16 X:$rs1)),
+def : Pat<(extloadi16 X:$rs1),
         (LH X:$rs1, (i64 0))>;
 
-def : Pat<(i64 (sextloadi16 AddrFI:$rs1)),
+def : Pat<(sextloadi16 AddrFI:$rs1),
         (LH AddrFI:$rs1, (i64 0))>;
 
-def : Pat<(i64 (extloadi16 AddrFI:$rs1)),
+def : Pat<(extloadi16 AddrFI:$rs1),
         (LH AddrFI:$rs1, (i64 0))>;
 
 
-def : Pat<(i64 (zextloadi16 (add X:$rs1, RV3264Base_LHU_immSAsInt64:$immS))),
+def : Pat<(zextloadi16 (add X:$rs1, RV3264Base_LHU_immSAsInt64:$immS)),
         (LHU X:$rs1, RV3264Base_LHU_immSAsInt64:$immS)>;
 
-def : Pat<(i64 (zextloadi16 (add AddrFI:$rs1, RV3264Base_LHU_immSAsInt64:$immS))),
+def : Pat<(zextloadi16 (add AddrFI:$rs1, RV3264Base_LHU_immSAsInt64:$immS)),
         (LHU AddrFI:$rs1, RV3264Base_LHU_immSAsInt64:$immS)>;
 
-def : Pat<(i64 (zextloadi16 X:$rs1)),
+def : Pat<(zextloadi16 X:$rs1),
         (LHU X:$rs1, (i64 0))>;
 
-def : Pat<(i64 (zextloadi16 AddrFI:$rs1)),
+def : Pat<(zextloadi16 AddrFI:$rs1),
         (LHU AddrFI:$rs1, (i64 0))>;
 
 
-def : Pat<(i64 (sextloadi32 (add X:$rs1, RV3264Base_LW_immSAsInt64:$immS))),
+def : Pat<(sextloadi32 (add X:$rs1, RV3264Base_LW_immSAsInt64:$immS)),
         (LW X:$rs1, RV3264Base_LW_immSAsInt64:$immS)>;
 
-def : Pat<(i64 (sextloadi32 (add AddrFI:$rs1, RV3264Base_LW_immSAsInt64:$immS))),
+def : Pat<(sextloadi32 (add AddrFI:$rs1, RV3264Base_LW_immSAsInt64:$immS)),
         (LW AddrFI:$rs1, RV3264Base_LW_immSAsInt64:$immS)>;
 
-def : Pat<(i64 (sextloadi32 X:$rs1)),
+def : Pat<(sextloadi32 X:$rs1),
         (LW X:$rs1, (i64 0))>;
 
-def : Pat<(i64 (extloadi32 X:$rs1)),
+def : Pat<(extloadi32 X:$rs1),
         (LW X:$rs1, (i64 0))>;
 
-def : Pat<(i64 (sextloadi32 AddrFI:$rs1)),
+def : Pat<(sextloadi32 AddrFI:$rs1),
         (LW AddrFI:$rs1, (i64 0))>;
 
-def : Pat<(i64 (extloadi32 AddrFI:$rs1)),
+def : Pat<(extloadi32 AddrFI:$rs1),
         (LW AddrFI:$rs1, (i64 0))>;
 
 
-def : Pat<(i64 (zextloadi32 (add X:$rs1, RV3264Base_LWU_immSAsInt64:$immS))),
+def : Pat<(zextloadi32 (add X:$rs1, RV3264Base_LWU_immSAsInt64:$immS)),
         (LWU X:$rs1, RV3264Base_LWU_immSAsInt64:$immS)>;
 
-def : Pat<(i64 (zextloadi32 (add AddrFI:$rs1, RV3264Base_LWU_immSAsInt64:$immS))),
+def : Pat<(zextloadi32 (add AddrFI:$rs1, RV3264Base_LWU_immSAsInt64:$immS)),
         (LWU AddrFI:$rs1, RV3264Base_LWU_immSAsInt64:$immS)>;
 
-def : Pat<(i64 (zextloadi32 X:$rs1)),
+def : Pat<(zextloadi32 X:$rs1),
         (LWU X:$rs1, (i64 0))>;
 
-def : Pat<(i64 (zextloadi32 AddrFI:$rs1)),
+def : Pat<(zextloadi32 AddrFI:$rs1),
         (LWU AddrFI:$rs1, (i64 0))>;
 
 


### PR DESCRIPTION
Removed the typecasts because TableGen's typechecker doesn't allow them for AArch64. I don't know why.

```
def : Pat<(i64 (sextloadi32 (add X:$rs1, RV3264Base_LW_immSAsInt64:$immS))),
        (LW X:$rs1, RV3264Base_LW_immSAsInt64:$immS)>;
```