### PR TITLE
lcb: Skip inst aliases when field assignment has expression

### DIFF
--- a/vadl/main/vadl/lcb/passes/llvmLowering/LlvmLoweringPass.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/LlvmLoweringPass.java
@@ -592,7 +592,7 @@ public class LlvmLoweringPass extends Pass {
           DeferredDiagnosticStore.add(
               Diagnostic.warning("Cannot create an instruction alias for expressions",
                   argument.location()).build());
-          return Collections.emptyList();
+          return new ArrayList<>();
         }
       }
     }

--- a/vadl/main/vadl/lcb/passes/llvmLowering/LlvmLoweringPass.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/LlvmLoweringPass.java
@@ -31,6 +31,7 @@ import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import vadl.configuration.LcbConfiguration;
+import vadl.error.DeferredDiagnosticStore;
 import vadl.error.Diagnostic;
 import vadl.gcb.passes.DetermineRegisterUsesAndDefsPass;
 import vadl.gcb.passes.IdentifyFieldUsagePass;
@@ -479,6 +480,11 @@ public class LlvmLoweringPass extends Pass {
             "must exist");
     var machineRecord = ensureNonNull(machineRecords.get(instruction.target()), "must exist");
     var args = getArgsForInstAlias(machineRecord, fieldUsages, instruction);
+
+    if (args.isEmpty()) {
+      return Collections.emptyList();
+    }
+
     var graph = new Graph("output");
     graph.addWithInputs(
         new LcbMachineInstructionNode(new NodeList<>(args), instruction.target()));
@@ -582,6 +588,11 @@ public class LlvmLoweringPass extends Pass {
         } else if (argument instanceof ConstantNode constantNode) {
           args.add(new LcbMachineInstructionParameterNode(
               new GcbConstantOperand(constantNode, constantNode.constant())));
+        } else {
+          DeferredDiagnosticStore.add(
+              Diagnostic.warning("Cannot create an instruction alias for expressions",
+                  argument.location()).build());
+          return Collections.emptyList();
         }
       }
     }

--- a/vadl/test/resources/snapshots/aarch64/InstrInfoTableGen.td
+++ b/vadl/test/resources/snapshots/aarch64/InstrInfoTableGen.td
@@ -52141,11 +52141,9 @@ let Defs = [  ];
 
 
 
-def : InstAlias<"wzr$rd, wzr$rn, #$shift", (SBFMW S:$rd, S:$rn, 31, 31)>;
 
-def : InstAlias<"wzr$rd, wzr$rn, #$shift", (UBFMW S:$rd, S:$rn)>;
 
-def : InstAlias<"wzr$rd, wzr$rn, #$shift", (UBFMW S:$rd, S:$rn, 31, 31)>;
+
 
 def : InstAlias<"wzr$rd, wzr$rn, wzr$rm", (ASRW S:$rd, S:$rn, S:$rm)>;
 
@@ -52156,8 +52154,6 @@ def : InstAlias<"wzr$rd, wzr$rn, wzr$rm", (LSRW S:$rd, S:$rn, S:$rm)>;
 def : InstAlias<"wzr$rd, wzr$rn, wzr$rm", (MADDW S:$rd, S31, S:$rn, S:$rm)>;
 
 def : InstAlias<"xzr$rd, xzr$rn, #$shift", (SBFMX S:$rd, S:$rn, 63, AArch64Base_SBFMX_rightXSizeAsInt64:$rightXSize, 63)>;
-
-def : InstAlias<"xzr$rd, xzr$rn, #$shift", (UBFMX S:$rd, S:$rn)>;
 
 def : InstAlias<"xzr$rd, xzr$rn, #$shift", (UBFMX S:$rd, S:$rn, 63, AArch64Base_UBFMX_rightXSizeAsInt64:$rightXSize, 63)>;
 


### PR DESCRIPTION
We cannot create inst alias from arbitrary expressions. At the moment, the operand gets skipped, but this leads to a crash. Now, we are skipping the whole generation of the inst alias.