### PR TITLE
 iss: Changed cosimulation-tracing to single-threaded implementation 

### DIFF
--- a/vadl-cosim/Cargo.lock
+++ b/vadl-cosim/Cargo.lock
@@ -181,38 +181,12 @@ dependencies = [
  "figment",
  "fnv",
  "libc",
- "rayon",
  "rusqlite",
  "serde",
  "serde_json",
  "tracing",
  "tracing-subscriber",
 ]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
@@ -592,26 +566,6 @@ dependencies = [
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width 0.2.0",
-]
-
-[[package]]
-name = "rayon"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
 ]
 
 [[package]]

--- a/vadl-cosim/broker/src/main.rs
+++ b/vadl-cosim/broker/src/main.rs
@@ -11,7 +11,7 @@ use tracing::{Level, info};
 use cosim_lib::{
     cli::Cli,
     config::Config,
-    cosim::Broker,
+    cosim::Broker, trace::{connect, db::setup_database},
 };
 
 
@@ -37,6 +37,11 @@ fn main() -> Result<()> {
     if config.dev.dry_run {
         info!(?config, "Dry-Run.");
         return Ok(());
+    }
+
+    if config.tracing.clear_on_rerun {
+        let conn = connect(&config)?;
+        setup_database(&conn)?;
     }
 
     let mut broker = Broker::create(&config)?;

--- a/vadl-cosim/broker/src/main.rs
+++ b/vadl-cosim/broker/src/main.rs
@@ -51,7 +51,5 @@ fn main() -> Result<()> {
 
     broker.finish(&config)?;
 
-
     Ok(())
 }
-

--- a/vadl-cosim/config.toml
+++ b/vadl-cosim/config.toml
@@ -193,19 +193,25 @@ file = "cosim.log"
 clear_on_rerun = true
 
 # Tracing means collecting the data from the qemu clients at *every execution step*
-# This slows the cosimulation process.
-# Therefore, four tracing modes are available:
+# This slows the cosimulation process by factor of ~16x. (500ms without tracing, 8s with tracing)
+# Therefore, three tracing modes are available:
 #	- "none" (default): Disables tracing - fastest option but no additional information for debugging.
-#	- "collect": Collects tracing-data but doesn't write it to disk until after cosimulation is done
-#			   This causes a performance impact of roughly 2x but the data is not available during interactive debugging
-#	- "threaded": The tracing-data is writting while the cosimulation process runs by using a threadpool. 
-#				  Marginally slower than the "collect" mode.
-#				  The data is available during interactive debugging but takes some time to sync to the current state.
-#	- "sync": Tracing data is synchronously written to the database. By far the slowest option, "threaded" should usually be preferred.
+#						(+): Much faster cosimulation speed
+#						(-): No tracing data which could be useful for debugging
+#						=> Use this mode when running a large test-suite and only switch to tracing when a test-case is known to fail.
+#	- "sync": The tracing data is writting while the cosimulation process runs. 
+#		      (+): Tracing data is available at every execution step, making a live-view possible.
+#			  (-): Much slower than without tracing.
+#			  => Use this mode when manually debugging.
+#	- "collect": Collects tracing-data but doesn't write it to disk until after cosimulation is done.
+#				 The benefit of this mode is that the cosimulation-result is immediately available.
+#				 (+): Cosimulation-result is available just as quickly as with the "none" option.
+#				 (-): Tracing data is only available at the end of the cosimulation-process.
+#				 => This mode is probably most useful when manually running a test where the test-result is not known beforehand. In most cases using a combination of "none" and "sync" is probably preferred.
 # The data is always "tagged" with a date (when was the cosimulation-run started) and a counter that orders entries inside a cosimulation-run.
 # Therefore even if the data is entered out-of-order in the database it is still possible to order it correctly.
 [tracing]
-mode = "threaded"
+mode = "none"
 # NOTE: If no db-file is found at the given path then one will be automatically created.
 dir = "./cosim-run/trace"
 file = "trace.sqlite3"

--- a/vadl-cosim/config.toml
+++ b/vadl-cosim/config.toml
@@ -205,12 +205,11 @@ clear_on_rerun = true
 # The data is always "tagged" with a date (when was the cosimulation-run started) and a counter that orders entries inside a cosimulation-run.
 # Therefore even if the data is entered out-of-order in the database it is still possible to order it correctly.
 [tracing]
-mode = "none"
-
+mode = "threaded"
+# NOTE: If no db-file is found at the given path then one will be automatically created.
 dir = "./cosim-run/trace"
-
-# NOTE: The cosimulation cli can be used to generate a sqlite3 db-file with the necessary tables created.
 file = "trace.sqlite3"
+clear_on_rerun = true
 
 [dev]
 # Prints the loaded configuration if set to true and exits

--- a/vadl-cosim/cosim-lib/Cargo.toml
+++ b/vadl-cosim/cosim-lib/Cargo.toml
@@ -12,7 +12,6 @@ fnv = "1.0.7"
 
 libc = "0.2.174"
 
-rayon = "1.10.0"
 rusqlite = { version = "0.37.0" }
 
 serde = { version = "1.0.219", features = ["derive"] }

--- a/vadl-cosim/cosim-lib/res/creates.sql
+++ b/vadl-cosim/cosim-lib/res/creates.sql
@@ -1,0 +1,49 @@
+CREATE TABLE shm_register (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    cpu_id INTEGER, 
+    size INTEGER NOT NULL,
+    data BLOB NOT NULL,
+    name TEXT NOT NULL,
+    FOREIGN KEY (cpu_id) REFERENCES shm_cpu(id)
+);
+
+CREATE TABLE shm_cpu (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    parent_id INTEGER,
+    idx INTEGER NOT NULL,
+    registers_size INTEGER NOT NULL
+);
+
+CREATE TABLE tb_insn_info (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    tb_info_id INTEGER,
+    pc INTEGER NOT NULL,
+    size INTEGER NOT NULL,
+    symbol TEXT NOT NULL,
+    hwaddr TEXT NOT NULL,
+    disas TEXT NOT NULL,
+    data_size INTEGER NOT NULL,
+    data BLOB NOT NULL,
+    FOREIGN KEY (tb_info_id) REFERENCES tb_info(id)
+);
+
+CREATE TABLE tb_info (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    pc INTEGER NOT NULL,
+    insns_info_size INTEGER NOT NULL
+);
+
+CREATE TABLE broker_shm_tb (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    init_mask INTEGER NOT NULL,
+    tb_info_id INTEGER NOT NULL,
+    FOREIGN KEY (tb_info_id) REFERENCES tb_info(id)
+);
+
+CREATE TABLE broker_shm_exec (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    init_mask INTEGER NOT NULL,
+    insn_info_id INTEGER NOT NULL,
+    FOREIGN KEY (insn_info_id) REFERENCES tb_insn_info(id)
+);
+

--- a/vadl-cosim/cosim-lib/res/drops.sql
+++ b/vadl-cosim/cosim-lib/res/drops.sql
@@ -1,0 +1,6 @@
+DROP TABLE IF EXISTS broker_shm_exec;
+DROP TABLE IF EXISTS broker_shm_tb;
+DROP TABLE IF EXISTS tb_info;
+DROP TABLE IF EXISTS tb_insn_info;
+DROP TABLE IF EXISTS shm_cpu;
+DROP TABLE IF EXISTS shm_register;

--- a/vadl-cosim/cosim-lib/src/config/mod.rs
+++ b/vadl-cosim/cosim-lib/src/config/mod.rs
@@ -38,7 +38,6 @@ pub enum TracingMode {
     #[default]
     None,
     Collect,
-    Threaded,
     Sync,
 }
 

--- a/vadl-cosim/cosim-lib/src/config/mod.rs
+++ b/vadl-cosim/cosim-lib/src/config/mod.rs
@@ -27,6 +27,9 @@ pub struct Tracing {
 
     #[serde(default = "default_tracing_file")]
     pub file: String,
+
+    #[serde(default = "default_true")]
+    pub clear_on_rerun: bool,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq)]

--- a/vadl-cosim/cosim-lib/src/cosim/mod.rs
+++ b/vadl-cosim/cosim-lib/src/cosim/mod.rs
@@ -7,7 +7,11 @@ use crate::{
     diff::{diff::diff_cpus, DiffContextClient, DiffEntry, Report},
     ipc::qemu::Client,
     trace::{
-        connect, db::{insert_broker_shm_exec, insert_broker_shm_tb}, trace_collect, trace_sync, trace_threaded, TraceStore
+        connect, 
+        get_client_trace, 
+        store_trace, 
+        trace_collect, 
+        TraceStore
     },
 };
 
@@ -28,7 +32,8 @@ impl ClientSyncInfo {
 
 pub struct Broker {
     clients: Vec<Client>,
-    pub trace_store: TraceStore,
+    trace_store: TraceStore, 
+    trace_connection: Connection,
 }
 
 enum TBSyncResult {
@@ -48,9 +53,12 @@ impl Broker {
             .map(|(idx, _)| Client::create(config, idx))
             .collect::<Result<Vec<_>>>()?;
 
+        let trace_connection = connect(config)?;
+
         Ok(Self {
             clients,
             trace_store: TraceStore::new(),
+            trace_connection,
         })
     }
 
@@ -67,18 +75,7 @@ impl Broker {
     pub fn finish(mut self, config: &Config) -> Result<()> {
         if config.tracing.mode == crate::config::TracingMode::Collect {
             for entry in self.trace_store {
-                let c = config.clone();
-                rayon::spawn(move || {
-                    let conn = connect(&c).unwrap();
-                    match entry {
-                        crate::trace::TraceData::TB(broker_shmtb) => {
-                            let _ = insert_broker_shm_tb(&conn, &broker_shmtb);
-                        }
-                        crate::trace::TraceData::Exec(broker_shmexec) => {
-                            let _ = insert_broker_shm_exec(&conn, &broker_shmexec);
-                        }
-                    }
-                });
+                store_trace(entry, &self.trace_connection)?;
             }
         }
 
@@ -319,8 +316,13 @@ impl Broker {
                 trace_collect(&self.clients, config, &mut self.trace_store);
                 Ok(())
             }
-            TracingMode::Threaded => trace_threaded(&self.clients, config),
-            TracingMode::Sync => trace_sync(&self.clients, config),
+            TracingMode::Sync => {
+                for client in &self.clients {
+                    let trace = get_client_trace(client, config); 
+                    store_trace(trace, &self.trace_connection)?;
+                }
+                Ok(())
+            },
         }
     }
 }

--- a/vadl-cosim/cosim-lib/src/trace/db.rs
+++ b/vadl-cosim/cosim-lib/src/trace/db.rs
@@ -1,5 +1,15 @@
 use crate::{cosim::DBConnection, ipc::cstructs::*};
 
+const CREATES_SQL: &str = include_str!("../../res/creates.sql");
+const DROPS_SQL: &str = include_str!("../../res/drops.sql");
+
+pub fn setup_database(pool: &DBConnection) -> Result<(), rusqlite::Error> {
+    let tx = pool.unchecked_transaction()?;  
+    tx.execute_batch(&format!("{DROPS_SQL}; {CREATES_SQL}"))?;
+    tx.commit()?;
+    Ok(())
+}
+
 pub fn insert_broker_shm_tb(
     pool: &DBConnection,
     broker: &BrokerSHMTB,
@@ -149,4 +159,3 @@ fn insert_shm_registers(
     }
     Ok(())
 }
-

--- a/vadl-cosim/cosim-lib/src/trace/mod.rs
+++ b/vadl-cosim/cosim-lib/src/trace/mod.rs
@@ -20,7 +20,7 @@ pub enum TraceData {
 }
 
 pub fn connect(config: &Config) -> Result<Connection> {
-    let connect_flags = OpenFlags::SQLITE_OPEN_READ_WRITE | OpenFlags::SQLITE_OPEN_NOFOLLOW;
+    let connect_flags = OpenFlags::SQLITE_OPEN_READ_WRITE | OpenFlags::SQLITE_OPEN_NOFOLLOW | OpenFlags::SQLITE_OPEN_CREATE;
     let path = Path::new(&config.tracing.dir).join(&config.tracing.file);
     Connection::open_with_flags(path, connect_flags)
         .context("failed to open sqlite connection for tracing")

--- a/vadl-cosim/cosim-lib/src/trace/mod.rs
+++ b/vadl-cosim/cosim-lib/src/trace/mod.rs
@@ -1,4 +1,7 @@
-use std::{mem::ManuallyDrop, path::Path};
+use std::{
+    mem::ManuallyDrop,
+    path::Path,
+};
 
 use anyhow::{Context, Result};
 use serde::Serialize;
@@ -20,90 +23,58 @@ pub enum TraceData {
 }
 
 pub fn connect(config: &Config) -> Result<Connection> {
-    let connect_flags = OpenFlags::SQLITE_OPEN_READ_WRITE | OpenFlags::SQLITE_OPEN_NOFOLLOW | OpenFlags::SQLITE_OPEN_CREATE;
+    let connect_flags = OpenFlags::SQLITE_OPEN_READ_WRITE
+        | OpenFlags::SQLITE_OPEN_NOFOLLOW
+        | OpenFlags::SQLITE_OPEN_CREATE
+        | OpenFlags::SQLITE_OPEN_NO_MUTEX;
     let path = Path::new(&config.tracing.dir).join(&config.tracing.file);
     Connection::open_with_flags(path, connect_flags)
         .context("failed to open sqlite connection for tracing")
 }
 
-pub fn trace_threaded(clients: &Vec<crate::ipc::qemu::Client>, config: &crate::config::Config) -> Result<()> {
-    match config.testing.protocol.layer {
-        crate::config::ProtocolLayer::Insn => {
-            for c in clients {
-                let exec = unsafe { &c.shm.read().shm_exec };
-                let exec = exec.clone();
-                let c = config.clone();
-                rayon::spawn(move || {
-                    let conn = connect(&c).unwrap();
-                    let _ = insert_broker_shm_exec(&conn, &exec);
-                });
-            }
-        }
-        crate::config::ProtocolLayer::TB | crate::config::ProtocolLayer::TBStrict => {
-            for c in clients {
-                let tb = unsafe { &c.shm.read().shm_tb };
-                let tb = tb.clone();
-                let c = config.clone();
-                rayon::spawn(move || {
-                    let conn = connect(&c).unwrap();
-                    let _ = insert_broker_shm_tb(&conn, &tb);
-                });
-            }
-        }
+pub fn store_trace(
+    trace: TraceData,
+    connection: &Connection,
+) -> Result<()> {
+    match trace {
+        TraceData::TB(broker_shmtb) => {
+            insert_broker_shm_tb(connection, &broker_shmtb)?;
+        },
+        TraceData::Exec(broker_shmexec) => {
+            insert_broker_shm_exec(connection, &broker_shmexec)?;
+        },
     };
 
     Ok(())
 }
 
-pub fn trace_sync(
-    clients: &Vec<crate::ipc::qemu::Client>,
-    config: &crate::config::Config,
-) -> Result<()> {
-    let conn = connect(config)?;
+pub fn get_client_trace(client: &crate::ipc::qemu::Client, config: &Config) -> TraceData {
     match config.testing.protocol.layer {
         crate::config::ProtocolLayer::Insn => {
-            for c in clients {
-                let exec = unsafe { &c.shm.read().shm_exec };
-                let exec = exec.clone();
-                insert_broker_shm_exec(&conn, &exec)?;
-            }
+            let exec = unsafe { &client.shm.read().shm_exec };
+            let exec = exec.clone();
+            let exec = ManuallyDrop::into_inner(exec);
+            let exec = Box::new(exec);
+            TraceData::Exec(exec)
         }
-        crate::config::ProtocolLayer::TB | crate::config::ProtocolLayer::TBStrict => {
-            for c in clients {
-                let tb = unsafe { &c.shm.read().shm_tb };
-                let tb = tb.clone();
-                insert_broker_shm_tb(&conn, &tb)?;
-            }
-        }
-    };
-
-    Ok(())
+        crate::config::ProtocolLayer::TB |
+        crate::config::ProtocolLayer::TBStrict => {
+            let tb = unsafe { &client.shm.read().shm_tb };
+            let tb = tb.clone();
+            let tb = ManuallyDrop::into_inner(tb);
+            let tb = Box::new(tb);
+            TraceData::TB(tb)
+        },
+    }
 }
 
 pub type TraceStore = Vec<TraceData>;
 pub fn trace_collect(
-    clients: &Vec<crate::ipc::qemu::Client>,
+    clients: &[crate::ipc::qemu::Client],
     config: &crate::config::Config,
     store: &mut TraceStore,
 ) {
-    match config.testing.protocol.layer {
-        crate::config::ProtocolLayer::Insn => {
-            for c in clients {
-                let exec = unsafe { &c.shm.read().shm_exec };
-                let exec = exec.clone();
-                let exec = ManuallyDrop::into_inner(exec);
-                let exec = Box::new(exec);
-                store.push(TraceData::Exec(exec));
-            }
-        }
-        crate::config::ProtocolLayer::TB | crate::config::ProtocolLayer::TBStrict => {
-            for c in clients {
-                let tb = unsafe { &c.shm.read().shm_tb };
-                let tb = tb.clone();
-                let tb = ManuallyDrop::into_inner(tb);
-                let tb = Box::new(tb);
-                store.push(TraceData::TB(tb));
-            }
-        }
-    };
+    clients.iter()
+        .map(|c| get_client_trace(c, config))
+        .for_each(|t| store.push(t));
 }


### PR DESCRIPTION
The multi-threaded implementation of the cosim-tracing contained a bug that not all tracing-entries were actually saved. With the necessary fix implemented, I realized that a single-threaded implementation using a single sqlite-connection is practically just as fast (and much easier to read).

The PR also contains a new feature to automatically create and recreate the db-file at program start.