### PR TITLE
iss: Using pthread_mutex and pthread_cond instead of named semaphores to support cosimulation on darwin

### DIFF
--- a/vadl-cosim/cosim-lib/src/cosim/mod.rs
+++ b/vadl-cosim/cosim-lib/src/cosim/mod.rs
@@ -147,9 +147,9 @@ impl Broker {
             .iter()
             .map(|c| {
                 match config.testing.protocol.layer {
-                    crate::config::ProtocolLayer::Insn => unsafe { &c.shm.read().shm_exec }.insn_info.pc,
+                    crate::config::ProtocolLayer::Insn => unsafe { &c.shm.get().data.shm_exec }.insn_info.pc,
                     crate::config::ProtocolLayer::TB |
-                    crate::config::ProtocolLayer::TBStrict => unsafe { &c.shm.read().shm_tb }.tb_info.pc,
+                    crate::config::ProtocolLayer::TBStrict => unsafe { &c.shm.get().data.shm_tb }.tb_info.pc,
                 }
             })
             .collect::<Vec<_>>();
@@ -168,7 +168,7 @@ impl Broker {
         for (idx, client) in &mut self.clients.iter_mut().enumerate() {
             let client_shm = client.shm.clone();
             while client.is_open {
-                let shm = unsafe { &client_shm.read().shm_tb };
+                let shm = unsafe { &client_shm.get().data.shm_tb };
                 let start_pc = shm.tb_info.pc;
                 let insn_sizes = shm
                     .tb_info
@@ -263,8 +263,8 @@ impl Broker {
 
                 match config.testing.protocol.layer {
                     crate::config::ProtocolLayer::Insn => {
-                        let c1insn = unsafe { &c1.shm.read().shm_exec };
-                        let c2insn = unsafe { &c2.shm.read().shm_exec };
+                        let c1insn = unsafe { &c1.shm.get().data.shm_exec };
+                        let c2insn = unsafe { &c2.shm.get().data.shm_exec };
 
                         let ctx1 = DiffContextClient::from_insn(c1, c1insn);
                         let ctx2 = DiffContextClient::from_insn(c2, c2insn);
@@ -279,8 +279,8 @@ impl Broker {
                         );
                     }
                     crate::config::ProtocolLayer::TB | crate::config::ProtocolLayer::TBStrict => {
-                        let c1insn = unsafe { &c1.shm.read().shm_tb };
-                        let c2insn = unsafe { &c2.shm.read().shm_tb };
+                        let c1insn = unsafe { &c1.shm.get().data.shm_tb };
+                        let c2insn = unsafe { &c2.shm.get().data.shm_tb };
 
                         let ctx1 = DiffContextClient::from_tb(c1, c1insn);
                         let ctx2 = DiffContextClient::from_tb(c2, c2insn);

--- a/vadl-cosim/cosim-lib/src/ipc/cstructs.rs
+++ b/vadl-cosim/cosim-lib/src/ipc/cstructs.rs
@@ -1,6 +1,7 @@
+use libc::{pthread_cond_t, pthread_mutex_t};
 use serde::{ser::SerializeStruct, Serialize};
 
-use crate::config::Config;
+use crate::{config::Config, ipc::sem::Semaphore};
 
 pub const SHMSTRING_MAX_LEN: usize = 256;
 pub const TBINSNINFO_ENTRIES: usize = 64;
@@ -218,7 +219,13 @@ impl Serialize for BrokerSHMExec {
 }
 
 #[repr(C)]
-pub union BrokerSHM {
+pub union BrokerSHMData {
     pub shm_tb: std::mem::ManuallyDrop<BrokerSHMTB>,
     pub shm_exec: std::mem::ManuallyDrop<BrokerSHMExec>,
+}
+
+#[repr(C)]
+pub struct BrokerSHM {
+    pub data: BrokerSHMData,
+    pub sync: Semaphore,
 }

--- a/vadl-cosim/cosim-lib/src/ipc/qemu.rs
+++ b/vadl-cosim/cosim-lib/src/ipc/qemu.rs
@@ -8,7 +8,7 @@ use tracing::{debug, error, info};
 use crate::{
     config::Config,
     ipc::{
-        cstructs::BrokerSHM,
+        cstructs::{BrokerSHM, BrokerSHMData},
         sem::{Semaphore, TimedWaitState},
         shm::SharedMemory,
     },
@@ -17,8 +17,6 @@ use crate::{
 pub struct Client {
     pub id: usize,
     pub shm: Arc<SharedMemory<BrokerSHM>>,
-    pub sem_server: Semaphore,
-    pub sem_client: Semaphore,
     pub is_open: bool,
     pub process: Child,
     pub name: Option<String>,
@@ -61,6 +59,7 @@ impl Client {
                         Ok(None) => {
                             error!(
                                 client_id = self.id,
+                                is_server = self.shm.get().sync.is_server,
                                 "client is still running but unresponive"
                             );
                         }
@@ -81,14 +80,14 @@ impl Client {
     }
 
     fn run_inner(&mut self, config: &Config) -> Result<bool> {
-        self.sem_client.post()?;
+        self.shm.release_client()?;
 
         if config.for_client(self.id).gdb.enable {
-            self.sem_server.wait()?;
+            self.shm.wait_client()?;
             return Ok(true);
         }
 
-        let wait_res = self.sem_server.timedwait(Duration::from_secs(1))?;
+        let wait_res = self.shm.timedwait_client(Duration::from_secs(1))?;
         match wait_res {
             TimedWaitState::Timeout => Ok(false),
             TimedWaitState::Success => Ok(true),
@@ -100,8 +99,7 @@ impl Client {
 
         let shm: SharedMemory<BrokerSHM> =
             SharedMemory::create(&format!("/cosimulation-shm-{client_idx}"))?;
-        let sem_server = Semaphore::create(&format!("/cosimulation-sem-server-{client_idx}"), 0)?;
-        let sem_client = Semaphore::create(&format!("/cosimulation-sem-client-{client_idx}"), 0)?;
+        shm.get_mut().sync = Semaphore::create();
 
         info!(
             client_id = client_idx,
@@ -184,8 +182,6 @@ impl Client {
         Ok(Self {
             id: client_idx,
             shm: shm.into(),
-            sem_server,
-            sem_client,
             is_open: true,
             process: client_process,
             name: client_cfg.name.clone(),

--- a/vadl-cosim/cosim-lib/src/ipc/sem.rs
+++ b/vadl-cosim/cosim-lib/src/ipc/sem.rs
@@ -1,16 +1,19 @@
-use crate::ipc::{PERMISSONS, get_errno};
-use anyhow::{Context, Result, bail};
+use crate::ipc::get_errno;
+use anyhow::{Result, bail};
 use libc::{
-    c_uint, clock_gettime, sem_close, sem_open, sem_post, sem_timedwait, sem_unlink, sem_wait, timespec, CLOCK_REALTIME, EINTR, ETIMEDOUT, O_CREAT, O_EXCL, O_RDWR, SEM_FAILED
+    clock_gettime, pthread_cond_broadcast, pthread_cond_destroy, pthread_cond_init, pthread_cond_t, pthread_cond_timedwait, pthread_cond_wait, pthread_condattr_init, pthread_condattr_setpshared, pthread_condattr_t, pthread_mutex_destroy, pthread_mutex_init, pthread_mutex_lock, pthread_mutex_t, pthread_mutex_unlock, pthread_mutexattr_init, pthread_mutexattr_setpshared, pthread_mutexattr_t, timespec, CLOCK_REALTIME, ETIMEDOUT, PTHREAD_PROCESS_SHARED
 };
-use std::{ffi::CString, time::Duration};
+use std::{mem::MaybeUninit, time::Duration};
 
 use crate::ipc::get_last_error;
 
 /// A semaphore implementation for inter-process synchronization.
+#[repr(C)]
 pub struct Semaphore {
-    id: *mut libc::sem_t,
-    name: String,
+    pub mutex: pthread_mutex_t,
+    pub cond_server: pthread_cond_t,
+    pub cond_client: pthread_cond_t,
+    pub is_server: bool,
 }
 
 pub enum TimedWaitState {
@@ -28,52 +31,79 @@ impl Semaphore {
     /// # Returns
     /// * `Ok(Self)` if the semaphore is created successfully.
     /// * `Err(String)` if the creation fails.
-    pub fn create(name: &str, initial_value: u32) -> Result<Self> {
-        let name_cstr = CString::new(name).context("Invalid semaphore name")?;
-        unsafe { sem_unlink(name_cstr.as_ptr()) }; // Remove existing semaphore
-        let id = unsafe {
-            sem_open(
-                name_cstr.as_ptr(),
-                O_CREAT | O_EXCL | O_RDWR,
-                PERMISSONS,
-                initial_value as c_uint,
-            )
+    pub fn create() -> Self {
+        let mut mutex_attr: pthread_mutexattr_t = unsafe { MaybeUninit::zeroed().assume_init() };
+        let mutex_attr_ptr = &mut mutex_attr as *mut _;
+        unsafe { 
+            pthread_mutexattr_init(mutex_attr_ptr);
+            pthread_mutexattr_setpshared(mutex_attr_ptr, PTHREAD_PROCESS_SHARED) 
         };
 
-        if id == SEM_FAILED {
-            bail!(get_last_error(&format!(
-                "Failed to create semaphore: {name}"
-            )))
-        }
+        let mut mutex: pthread_mutex_t = unsafe { MaybeUninit::zeroed().assume_init() };
+        let mutex_ptr = &mut mutex as *mut _;
+        unsafe { pthread_mutex_init(mutex_ptr, mutex_attr_ptr) };
 
-        Ok(Self {
-            id,
-            name: name.to_string(),
-        })
+        let mut cond_attr: pthread_condattr_t = unsafe { MaybeUninit::zeroed().assume_init() };
+        let cond_attr_ptr = &mut cond_attr as *mut _;
+        unsafe { 
+            pthread_condattr_init(cond_attr_ptr);
+            pthread_condattr_setpshared(cond_attr_ptr, PTHREAD_PROCESS_SHARED);
+        };
+
+        let mut cond_server: pthread_cond_t = unsafe { MaybeUninit::zeroed().assume_init() };
+        let mut cond_client: pthread_cond_t = unsafe { MaybeUninit::zeroed().assume_init() };
+
+        let cond_server_ptr = &mut cond_server as *mut _;
+        let cond_client_ptr = &mut cond_client as *mut _;
+
+        unsafe { 
+            pthread_cond_init(cond_server_ptr, cond_attr_ptr);
+            pthread_cond_init(cond_client_ptr, cond_attr_ptr);
+        };
+
+        let is_server = true;
+        Self {
+            mutex,
+            cond_server,
+            cond_client,
+            is_server,
+        }
     }
 
-    pub fn wait(&self) -> Result<()> {
-        if unsafe { sem_wait(self.id) } == -1 {
-            bail!(get_last_error(&format!(
-                "Failed to lock semaphore: {}",
-                self.name
-            )));
+    pub fn wait(&mut self) -> Result<()> {
+        let mutex_ptr = &mut self.mutex as *mut _;
+        let cond_ptr = &mut self.cond_server as *mut _;
+        if unsafe { pthread_mutex_lock(mutex_ptr) } == -1 {
+            bail!(get_last_error(&format!("Failed to lock semaphore",)));
         }
+
+        #[allow(clippy::while_immutable_condition)]
+        while !self.is_server {
+            if unsafe { pthread_cond_wait(cond_ptr, mutex_ptr) } == -1 {
+                bail!(get_last_error(&format!("Failed to lock semaphore",)));
+            }
+        }
+
         Ok(())
     }
 
-    pub fn timedwait(&self, duration: Duration) -> Result<TimedWaitState> {
+    pub fn timedwait(&mut self, duration: Duration) -> Result<TimedWaitState> {
         let mut ts = timespec {
             tv_sec: 0,
             tv_nsec: 0,
         };
 
-        let ts_ptr = &mut ts as *mut timespec;
+        let ts_ptr = &mut ts as *mut _;
+        let mutex_ptr = &mut self.mutex as *mut _;
+        let cond_ptr= &mut self.cond_server as *mut _;
+
+        if unsafe { pthread_mutex_lock(mutex_ptr) } != 0 {
+            bail!(get_last_error("fail"));
+        }
 
         if unsafe { clock_gettime(CLOCK_REALTIME, ts_ptr) } == -1 {
             bail!(get_last_error(&format!(
-                "clock_gettime failed in semaphore timedwait: {}",
-                self.name
+                "clock_gettime failed in semaphore timedwait"
             )));
         }
 
@@ -85,39 +115,45 @@ impl Semaphore {
         const TV_NSEC_MAX: i64 = 1_000_000_000;
         if ts.tv_nsec >= TV_NSEC_MAX {
             ts.tv_sec += 1;
-            ts.tv_nsec -= TV_NSEC_MAX; 
+            ts.tv_nsec -= TV_NSEC_MAX;
         }
 
-        let mut s: i32;
-        loop {
-            s = unsafe { sem_timedwait(self.id, ts_ptr) };
-            if s == -1 && get_errno() == EINTR {
-                continue;
-            }
-            break;
+        let mut rc: i32 = 0;
+        while !self.is_server && rc == 0 {
+            rc = unsafe {
+                pthread_cond_timedwait(cond_ptr, mutex_ptr, ts_ptr)
+            };
         }
 
-        if s == -1 {
-            if get_errno() == ETIMEDOUT {
-                Ok(TimedWaitState::Timeout)
-            } else {
-                bail!(get_last_error(&format!(
-                    "Failed to timedwait semaphore: {}",
-                    self.name
-                )))
+        match rc {
+            0 => Ok(TimedWaitState::Success),
+            ETIMEDOUT =>  {
+                if unsafe { pthread_mutex_unlock(mutex_ptr) } != 0 {
+                    bail!(get_last_error("fail"));
+                }
+                Ok(TimedWaitState::Timeout) 
+            },
+            _ => {
+                if unsafe { pthread_mutex_unlock(mutex_ptr) } != 0 {
+                    bail!(get_last_error("fail"));
+                }
+                bail!("failed to timedwait")
             }
-        } else {
-            Ok(TimedWaitState::Success)
         }
     }
 
-    pub fn post(&self) -> Result<()> {
-        if unsafe { sem_post(self.id) } == -1 {
-            bail!(get_last_error(&format!(
-                "Failed to unlock semaphore: {}",
-                self.name
-            )));
+    pub fn post(&mut self) -> Result<()> {
+        let mutex_ptr = &mut self.mutex as *mut _;
+        let cond_ptr = &mut self.cond_client as *mut _;
+        
+        self.is_server = false;
+
+        unsafe { pthread_cond_broadcast(cond_ptr) };
+
+        if unsafe { pthread_mutex_unlock(mutex_ptr) } == -1 {
+            bail!(get_last_error(&format!("Failed to unlock semaphore",)));
         }
+
         Ok(())
     }
 }
@@ -125,16 +161,23 @@ impl Semaphore {
 impl Drop for Semaphore {
     /// Closes and optionally removes the semaphore when dropped.
     fn drop(&mut self) {
+        let mutex_ptr = &mut self.mutex as *mut _;
+        let cond_server_ptr = &mut self.cond_server as *mut _;
+        let cond_client_ptr = &mut self.cond_client as *mut _;
         unsafe {
-            if sem_close(self.id) == -1 {
+            if pthread_mutex_destroy(mutex_ptr) == -1 {
                 let err = get_errno();
-                eprintln!("Warning: sem_close failed {}: {}", self.name, err);
+                eprintln!("Warning: sem_close failed: {}", err);
             }
 
-            let name_cstr = CString::new(self.name.clone()).expect("Failed to create CString");
-            if sem_unlink(name_cstr.as_ptr()) == -1 {
+            if pthread_cond_destroy(cond_server_ptr) == -1 {
                 let err = get_errno();
-                eprintln!("Warning: sem_unlink failed {}: {}", self.name, err);
+                eprintln!("Waringin: pthread_cond_destroy on cond_server failed: {}", err);
+            }
+
+            if pthread_cond_destroy(cond_client_ptr) == -1 {
+                let err = get_errno();
+                eprintln!("Waringin: pthread_cond_destroy on cond_client failed: {}", err);
             }
         }
     }

--- a/vadl-cosim/cosim-lib/src/ipc/shm.rs
+++ b/vadl-cosim/cosim-lib/src/ipc/shm.rs
@@ -1,12 +1,13 @@
-use std::{ffi::CString, marker::PhantomData, ptr};
+use std::{ffi::CString, marker::PhantomData, ptr, time::Duration};
 
 use anyhow::{Context, Result, bail};
 use libc::{
     MAP_FAILED, MAP_SHARED, O_CREAT, O_RDWR, PROT_READ, PROT_WRITE, close, ftruncate, mmap, munmap,
     shm_open, shm_unlink,
 };
+use tracing::debug;
 
-use crate::ipc::{PERMISSONS, get_errno, get_last_error};
+use crate::ipc::{cstructs::BrokerSHM, get_errno, get_last_error, sem::TimedWaitState, PERMISSONS};
 
 pub struct SharedMemory<T: Sized> {
     mmap_ptr: *mut u8,
@@ -15,6 +16,23 @@ pub struct SharedMemory<T: Sized> {
     size: usize,
     fd: i32,
     _phantom: PhantomData<T>,
+}
+
+impl SharedMemory<BrokerSHM> {
+    pub fn release_client(&self) -> Result<()> {
+        debug!("releasing client: {}", self.fd);
+        self.get_mut().sync.post()
+    }
+
+    pub fn wait_client(&self) -> Result<()> {
+        debug!("waiting client: {}", self.fd);
+        self.get_mut().sync.wait()
+    }
+
+    pub fn timedwait_client(&self, duration: Duration) -> Result<TimedWaitState> {
+        debug!("waiting client timed: {}, {:?}", self.fd, duration);
+        self.get_mut().sync.timedwait(duration)
+    }
 }
 
 impl<T: Sized> SharedMemory<T> {
@@ -67,9 +85,16 @@ impl<T: Sized> SharedMemory<T> {
 
     /// Reads and deserializes data from shared memory.
     /// Assumes that the shared memory contains valid data.
-    pub fn read(&self) -> &T {
+    pub fn get(&self) -> &T {
         let data_ptr = self.mmap_ptr as *const T;
         let shared: &T = unsafe { &*data_ptr };
+        shared
+    }
+
+    #[allow(clippy::mut_from_ref)]
+    pub fn get_mut(&self) -> &mut T {
+        let data_ptr = self.mmap_ptr as *mut T;
+        let shared: &mut T = unsafe { &mut *data_ptr };
         shared
     }
 }

--- a/vadl-cosim/cosim-lib/src/trace/mod.rs
+++ b/vadl-cosim/cosim-lib/src/trace/mod.rs
@@ -30,7 +30,7 @@ pub fn trace_threaded(clients: &Vec<crate::ipc::qemu::Client>, config: &crate::c
     match config.testing.protocol.layer {
         crate::config::ProtocolLayer::Insn => {
             for c in clients {
-                let exec = unsafe { &c.shm.read().shm_exec };
+                let exec = unsafe { &c.shm.get().data.shm_exec };
                 let exec = exec.clone();
                 let c = config.clone();
                 rayon::spawn(move || {
@@ -41,7 +41,7 @@ pub fn trace_threaded(clients: &Vec<crate::ipc::qemu::Client>, config: &crate::c
         }
         crate::config::ProtocolLayer::TB | crate::config::ProtocolLayer::TBStrict => {
             for c in clients {
-                let tb = unsafe { &c.shm.read().shm_tb };
+                let tb = unsafe { &c.shm.get().data.shm_tb };
                 let tb = tb.clone();
                 let c = config.clone();
                 rayon::spawn(move || {
@@ -63,14 +63,14 @@ pub fn trace_sync(
     match config.testing.protocol.layer {
         crate::config::ProtocolLayer::Insn => {
             for c in clients {
-                let exec = unsafe { &c.shm.read().shm_exec };
+                let exec = unsafe { &c.shm.get().data.shm_exec };
                 let exec = exec.clone();
                 insert_broker_shm_exec(&conn, &exec)?;
             }
         }
         crate::config::ProtocolLayer::TB | crate::config::ProtocolLayer::TBStrict => {
             for c in clients {
-                let tb = unsafe { &c.shm.read().shm_tb };
+                let tb = unsafe { &c.shm.get().data.shm_tb };
                 let tb = tb.clone();
                 insert_broker_shm_tb(&conn, &tb)?;
             }
@@ -89,7 +89,7 @@ pub fn trace_collect(
     match config.testing.protocol.layer {
         crate::config::ProtocolLayer::Insn => {
             for c in clients {
-                let exec = unsafe { &c.shm.read().shm_exec };
+                let exec = unsafe { &c.shm.get().data.shm_exec };
                 let exec = exec.clone();
                 let exec = ManuallyDrop::into_inner(exec);
                 let exec = Box::new(exec);
@@ -98,7 +98,7 @@ pub fn trace_collect(
         }
         crate::config::ProtocolLayer::TB | crate::config::ProtocolLayer::TBStrict => {
             for c in clients {
-                let tb = unsafe { &c.shm.read().shm_tb };
+                let tb = unsafe { &c.shm.get().data.shm_tb };
                 let tb = tb.clone();
                 let tb = ManuallyDrop::into_inner(tb);
                 let tb = Box::new(tb);

--- a/vadl/main/resources/templates/iss/contrib/plugins/cosimulation.c
+++ b/vadl/main/resources/templates/iss/contrib/plugins/cosimulation.c
@@ -30,6 +30,7 @@
 #include <sys/socket.h>
 #include <time.h>
 #include <unistd.h>
+#include <pthread.h>
 
 QEMU_PLUGIN_EXPORT int qemu_plugin_version = QEMU_PLUGIN_VERSION;
 
@@ -143,6 +144,19 @@ typedef struct {
 typedef union {
   BrokerSHM_TB shm_tb;
   BrokerSHM_Exec shm_exec;
+} BrokerSHMData;
+
+typedef struct {
+  pthread_mutex_t mutex;
+  pthread_cond_t cond_server;
+  pthread_cond_t cond_client;
+  bool is_server;
+} Semaphore;
+
+
+typedef struct {
+  BrokerSHMData data;
+  Semaphore sync;
 } BrokerSHM;
 
 typedef enum {
@@ -162,7 +176,6 @@ static GArray *cpus;
 
 static Arguments args;
 static BrokerSHM *shm;
-static sem_t *sem_client, *sem_server;
 
 static CPU *get_cpu(int vcpu_index) {
   CPU *c;
@@ -225,28 +238,6 @@ static SHMCPU get_cpu_state(unsigned int cpu_index) {
 
   return shm_cpu;
 };
-
-static void open_sems(void) {
-  gchar *sem_client_name =
-      g_strdup_printf("cosimulation-sem-client-%s", args.client_id);
-  sem_client = sem_open(sem_client_name, O_RDWR);
-  if (sem_client == SEM_FAILED) {
-    char *err = strerror(errno);
-    g_error("failed to open sem_client for client: %s -> %s", args.client_id,
-            err);
-    return;
-  }
-
-  gchar *sem_server_name =
-      g_strdup_printf("cosimulation-sem-server-%s", args.client_id);
-  sem_server = sem_open(sem_server_name, O_RDWR);
-  if (sem_server == SEM_FAILED) {
-    char *err = strerror(errno);
-    g_error("failed to open sem_server for client: %s -> %s", args.client_id,
-            err);
-    return;
-  }
-}
 
 static void plugin_exit(qemu_plugin_id_t id, void *p) {
   PLUGIN_PRINTLN("plugin_exit");
@@ -341,36 +332,51 @@ static TBInfo get_tb_info(struct qemu_plugin_tb *tb) {
 }
 
 static void vcpu_insn_exec(unsigned int cpu_index, void *udata) {
+  pthread_mutex_lock(&shm->sync.mutex);
+  while(shm->sync.is_server) {
+    PLUGIN_PRINTLN("waiting... %d", shm->sync.is_server);
+    pthread_cond_wait(&shm->sync.cond_client, &shm->sync.mutex);
+  }
+
+  PLUGIN_PRINTLN("got it!");
+
   TBInsnInfo *tbinsn_info = udata;
-  sem_wait(sem_client);
 
   SHMCPU cpu = get_cpu_state(cpu_index);
 
-  shm->shm_exec.cpus[cpu_index] = cpu;
-  shm->shm_exec.init_mask |= (1 << cpu_index);
-  shm->shm_exec.insn_info = *tbinsn_info;
+  shm->data.shm_exec.cpus[cpu_index] = cpu;
+  shm->data.shm_exec.init_mask |= (1 << cpu_index);
+  shm->data.shm_exec.insn_info = *tbinsn_info;
 
   // TODO: we cannot free here because the same callback might be used multiple times when a tb gets reused
   // g_free(tbinsn_info);
 
-  sem_post(sem_server);
+  shm->sync.is_server = true;
+  pthread_cond_broadcast(&shm->sync.cond_server);
+  pthread_mutex_unlock(&shm->sync.mutex);
+  PLUGIN_PRINTLN("unlocked! %d", shm->sync.is_server);
 }
 
 static void vcpu_tb_exec(unsigned int cpu_index, void *udata) {
-  sem_wait(sem_client);
+  pthread_mutex_lock(&shm->sync.mutex);
+  while(shm->sync.is_server) {
+    pthread_cond_wait(&shm->sync.cond_client, &shm->sync.mutex);
+  }
 
   SHMCPU cpu = get_cpu_state(cpu_index);
 
-  shm->shm_tb.cpus[cpu_index] = cpu;
-  shm->shm_tb.init_mask |= (1 << cpu_index);
+  shm->data.shm_tb.cpus[cpu_index] = cpu;
+  shm->data.shm_tb.init_mask |= (1 << cpu_index);
 
   TBInfo *tb_info = udata;
-  shm->shm_tb.tb_info = *tb_info;
+  shm->data.shm_tb.tb_info = *tb_info;
 
   // TODO: we cannot free here because the same callback might be used multiple times when a tb gets reused
   // g_free(tb_info);
 
-  sem_post(sem_server);
+  shm->sync.is_server = true;
+  pthread_cond_broadcast(&shm->sync.cond_server);
+  pthread_mutex_unlock(&shm->sync.mutex);
 }
 
 static void vcpu_tb_trans(qemu_plugin_id_t id, struct qemu_plugin_tb *tb) {
@@ -466,13 +472,8 @@ QEMU_PLUGIN_EXPORT int qemu_plugin_install(qemu_plugin_id_t id,
     return EXIT_FAILURE;
   }
 
-  open_sems();
-  if (sem_client == NULL || sem_server == NULL) {
-    return EXIT_FAILURE;
-  }
-
   if (args.mode == INSN_MODE) {
-    shm->shm_exec.init_mask = 0;
+    shm->data.shm_exec.init_mask = 0;
   }
 
   plugin_id = id;


### PR DESCRIPTION
`libc::sem_timedwait` is not supported under darwin. While busy-waiting using `libc::sem_trywait` is possible, a cleaner solution is to migrate to `libc::pthread_mutex_t` and `libc::pthread_cond_t` which also have a `timedwait` implementation which is supported by darwin. The current implementation is only marginally slower compared to the original named-semaphore code  (460ms $\to$ 500ms).