### PR TITLE
iss: Added before->instruction->after state-transition to diff-context of the cosimulation-report

### DIFF
--- a/vadl-cosim/Cargo.lock
+++ b/vadl-cosim/Cargo.lock
@@ -644,9 +644,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
 dependencies = [
  "itoa",
  "memchr",
@@ -911,6 +911,7 @@ dependencies = [
  "clap",
  "cosim-lib",
  "figment",
+ "serde_json",
  "tracing",
  "tracing-subscriber",
 ]

--- a/vadl-cosim/broker/Cargo.toml
+++ b/vadl-cosim/broker/Cargo.toml
@@ -13,3 +13,4 @@ figment = { version = "0.10.19", features = ["toml"] }
 
 tracing = { version = "0.1.41", features = ["attributes"] }
 tracing-subscriber = "0.3.19"
+serde_json = "1.0.141"

--- a/vadl-cosim/broker/src/main.rs
+++ b/vadl-cosim/broker/src/main.rs
@@ -12,6 +12,7 @@ use cosim_lib::{
     cli::Cli,
     config::Config,
     cosim::Broker,
+    diff::Report,
     trace::{connect, db::setup_database},
 };
 
@@ -46,13 +47,65 @@ fn main() -> Result<()> {
     }
 
     let mut broker = Broker::create(&config)?;
-    let report = broker.run(&config)?;
+    let report_data = broker.run(&config)?;
 
-    let report_json = serde_json::to_string_pretty(&report)?;
+    let report = match &config.testing.protocol.out.verbosity {
+        cosim_lib::config::OutVerbosity::Full => serde_json::to_string_pretty(&report_data)?,
+        cosim_lib::config::OutVerbosity::Short => {
+            let mut buf = String::new();
+            if report_data.passed {
+                buf.push_str("Cosimulation passed!");
+            } else {
+                add_plain_report_summary(&mut buf, &report_data);
+            }
+            buf
+        }
+    };
 
-    println!("{report_json}");
+    match config.testing.protocol.out.file {
+        Some(ref file) => {
+            std::fs::write(file, report)?;
+        }
+        None => println!("{report}"),
+    }
 
     broker.finish(&config)?;
 
     Ok(())
+}
+
+fn add_plain_report_summary(buf: &mut String, report: &Report) {
+    buf.push_str("Cosimulation failed!\n");
+    let pc = report.diff_context[0].after_state.pc;
+    buf.push_str(&format!("Failure at pc = 0x{pc:02X?} ({pc})\n\n"));
+
+    buf.push_str("The following divergences were found:\n");
+
+    for diff in &report.diffs {
+        let desc = &diff.description;
+        buf.push_str(&format!("- \"{desc}\":\n"));
+        for i in 0..diff.values.len() {
+            let v = &diff.values[i];
+            let ctx = &report.diff_context[i];
+            let name = ctx.client_name.clone().unwrap_or(ctx.client_id.to_string());
+
+            buf.push_str(&format!("\t- In \"{name}\" the value is \"{v}\"\n"));
+        }
+    }
+
+    buf.push_str("\nThe divergence occurred after the following instructions were executed:\n");
+
+    let min_insns = report
+        .diff_context
+        .iter()
+        .map(|ctx| &ctx.error_instruction.0)
+        .min_by_key(|insns| insns.len())
+        .unwrap();
+
+    for insn in min_insns {
+        let pc = insn.pc;
+        let disas = &insn.disas;
+        let insn_data = &insn.insn_data;
+        buf.push_str(&format!("- (pc={pc}): {disas} ({insn_data})\n"));
+    }
 }

--- a/vadl-cosim/broker/src/main.rs
+++ b/vadl-cosim/broker/src/main.rs
@@ -11,9 +11,9 @@ use tracing::{Level, info};
 use cosim_lib::{
     cli::Cli,
     config::Config,
-    cosim::Broker, trace::{connect, db::setup_database},
+    cosim::Broker,
+    trace::{connect, db::setup_database},
 };
-
 
 fn main() -> Result<()> {
     let cli = Cli::parse();

--- a/vadl-cosim/broker/src/main.rs
+++ b/vadl-cosim/broker/src/main.rs
@@ -31,6 +31,7 @@ fn main() -> Result<()> {
         tracing_subscriber::fmt()
             .pretty()
             .with_max_level(level)
+            .with_writer(std::io::stderr)
             .init();
     }
 
@@ -47,7 +48,9 @@ fn main() -> Result<()> {
     let mut broker = Broker::create(&config)?;
     let report = broker.run(&config)?;
 
-    dbg!(report);
+    let report_json = serde_json::to_string_pretty(&report)?;
+
+    println!("{report_json}");
 
     broker.finish(&config)?;
 

--- a/vadl-cosim/config.toml
+++ b/vadl-cosim/config.toml
@@ -208,8 +208,6 @@ clear_on_rerun = true
 #				 (+): Cosimulation-result is available just as quickly as with the "none" option.
 #				 (-): Tracing data is only available at the end of the cosimulation-process.
 #				 => This mode is probably most useful when manually running a test where the test-result is not known beforehand. In most cases using a combination of "none" and "sync" is probably preferred.
-# The data is always "tagged" with a date (when was the cosimulation-run started) and a counter that orders entries inside a cosimulation-run.
-# Therefore even if the data is entered out-of-order in the database it is still possible to order it correctly.
 [tracing]
 mode = "none"
 # NOTE: If no db-file is found at the given path then one will be automatically created.

--- a/vadl-cosim/config.toml
+++ b/vadl-cosim/config.toml
@@ -175,10 +175,10 @@ stop_after_n_instructions = 10000
 
 # Where the test result should be saved and in which format
 [testing.protocol.out]
-dir = "./cosim-run/result"
+file = "./cosim-run/result/result.json"
 
-# Supported formats: "json"
-format = "json"
+# "short" | "full"
+verbosity = "short"
 
 [logging]
 enable = true 

--- a/vadl-cosim/cosim-lib/src/cli/mod.rs
+++ b/vadl-cosim/cosim-lib/src/cli/mod.rs
@@ -3,19 +3,17 @@ use clap::Parser;
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 pub struct Cli {
-
     /// Path to the (toml) config file
     #[arg(short, long, value_name="FILE", default_value_t = default_config_file())]
     pub config: String,
 
     /// Defines where the test-executable is passed to when starting the QEMU-client
-    #[arg(short, long, value_name="FILE")]
+    #[arg(short, long, value_name = "FILE")]
     pub test_exec: Option<String>,
 
     #[arg(long)]
     pub tui: bool,
 }
-
 
 fn default_config_file() -> String {
     "./config.toml".into()

--- a/vadl-cosim/cosim-lib/src/config/mod.rs
+++ b/vadl-cosim/cosim-lib/src/config/mod.rs
@@ -84,22 +84,18 @@ fn default_false() -> bool {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct Out {
-    #[serde(default = "default_out_dir")]
-    pub dir: String,
+    #[serde(default = "OutVerbosity::default")]
+    pub verbosity: OutVerbosity,
 
-    #[serde(default = "OutFormat::default")]
-    pub format: OutFormat,
-}
-
-fn default_out_dir() -> String {
-    "./result".into()
+    pub file: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Default)]
 #[serde(rename_all = "lowercase")]
-pub enum OutFormat {
+pub enum OutVerbosity {
     #[default]
-    Json,
+    Full,
+    Short,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/vadl-cosim/cosim-lib/src/cosim/mod.rs
+++ b/vadl-cosim/cosim-lib/src/cosim/mod.rs
@@ -5,10 +5,12 @@ use tracing::debug;
 use crate::{
     config::{Config, TracingMode},
     diff::{
-        diff::diff_cpus, get_all_clients_contexts, clone_client_shms, get_all_clients_instructions, get_client_context_from_wrapper, BrokerSHMWrapper, DiffContext, DiffContextClient, DiffEntry, Report
+        DiffContext, DiffContextClient, DiffEntry, Report, diff::diff_cpus,
+        get_all_clients_contexts_before, get_all_clients_contexts_current,
+        get_all_clients_instructions,
     },
     ipc::qemu::Client,
-    trace::{connect, get_client_trace, store_trace, trace_collect, TraceStore},
+    trace::{TraceStore, connect, get_client_trace, store_trace, trace_collect},
 };
 
 #[derive(Debug)]
@@ -91,8 +93,6 @@ impl Broker {
         self.check_clients_are_initially_synchronized(config)?;
 
         while self.any_client_open() {
-            let before_states = clone_client_shms(&self.clients, config);
-
             match config.testing.protocol.layer {
                 crate::config::ProtocolLayer::Insn | crate::config::ProtocolLayer::TBStrict => {
                     for client in &mut self.clients {
@@ -104,7 +104,7 @@ impl Broker {
                 crate::config::ProtocolLayer::TB => {
                     if let TBSyncResult::Diverged(diff_entry) = self.tb_sync_clients(config) {
                         debug!("client diverged during tb synchronization");
-                        let diff_context = self.build_diff_context(before_states, config);
+                        let diff_context = self.build_diff_context(config);
                         diffs.push(diff_entry);
                         return Ok(Report::failed(diffs, diff_context));
                     }
@@ -123,7 +123,7 @@ impl Broker {
             diffs.append(&mut self.diff_clients(config));
 
             if !diffs.is_empty() {
-                let diff_context = self.build_diff_context(before_states, config);
+                let diff_context = self.build_diff_context(config);
                 return Ok(Report::failed(diffs, diff_context));
             }
         }
@@ -140,9 +140,9 @@ impl Broker {
             .clients
             .iter()
             .map(|c| match config.testing.protocol.layer {
-                crate::config::ProtocolLayer::Insn => c.shm.get_exec().insn_info.pc,
+                crate::config::ProtocolLayer::Insn => c.shms.current().get_exec().insn_info.pc,
                 crate::config::ProtocolLayer::TB | crate::config::ProtocolLayer::TBStrict => {
-                    c.shm.get_tb().tb_info.pc
+                    c.shms.current().get_tb().tb_info.pc
                 }
             })
             .collect::<Vec<_>>();
@@ -160,7 +160,7 @@ impl Broker {
 
         for (idx, client) in &mut self.clients.iter_mut().enumerate() {
             while client.is_open {
-                let shm = client.shm.get_tb();
+                let shm = client.shms.current().get_tb();
                 let start_pc = shm.tb_info.pc;
                 let insn_sizes = shm
                     .tb_info
@@ -171,7 +171,7 @@ impl Broker {
                 insns_executed_per_client[idx] = insn_sizes.len();
 
                 if client.run(config) {
-                    let shm = client.shm.get_tb();
+                    let shm = client.shms.current().get_tb();
                     let end_pc = shm.tb_info.pc;
                     let sync_info = ClientSyncInfo {
                         start_pc,
@@ -235,8 +235,8 @@ impl Broker {
 
                 match config.testing.protocol.layer {
                     crate::config::ProtocolLayer::Insn => {
-                        let c1insn = c1.shm.get_exec();
-                        let c2insn = c2.shm.get_exec();
+                        let c1insn = c1.shms.current().get_exec();
+                        let c2insn = c2.shms.current().get_exec();
 
                         return diff_cpus(
                             &c1insn.cpus,
@@ -247,8 +247,8 @@ impl Broker {
                         );
                     }
                     crate::config::ProtocolLayer::TB | crate::config::ProtocolLayer::TBStrict => {
-                        let c1insn = c1.shm.get_tb();
-                        let c2insn = c2.shm.get_tb();
+                        let c1insn = c1.shms.current().get_tb();
+                        let c2insn = c2.shms.current().get_tb();
 
                         return diff_cpus(
                             &c1insn.cpus,
@@ -293,14 +293,14 @@ impl Broker {
         }
     }
 
-    fn build_diff_context(&self, mut before_states: Vec<BrokerSHMWrapper>, config: &Config) -> DiffContext {
-        let mut after_states = get_all_clients_contexts(&self.clients, config);
+    fn build_diff_context(&self, config: &Config) -> DiffContext {
+        let mut before_states = get_all_clients_contexts_before(&self.clients, config);
+        let mut after_states = get_all_clients_contexts_current(&self.clients, config);
         let mut error_instructions = get_all_clients_instructions(&self.clients, config);
         let mut diff_context = vec![];
 
         for client in &self.clients {
             let before_state = before_states.pop().unwrap();
-            let before_state = get_client_context_from_wrapper(before_state, config);
             let error_instruction = error_instructions.pop().unwrap();
             let after_state = after_states.pop().unwrap();
 

--- a/vadl-cosim/cosim-lib/src/cosim/mod.rs
+++ b/vadl-cosim/cosim-lib/src/cosim/mod.rs
@@ -1,18 +1,12 @@
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use rusqlite::Connection;
 use tracing::debug;
 
 use crate::{
     config::{Config, TracingMode},
-    diff::{diff::diff_cpus, DiffContextClient, DiffEntry, Report},
+    diff::{DiffContextClient, DiffEntry, Report, diff::diff_cpus},
     ipc::qemu::Client,
-    trace::{
-        connect, 
-        get_client_trace, 
-        store_trace, 
-        trace_collect, 
-        TraceStore
-    },
+    trace::{TraceStore, connect, get_client_trace, store_trace, trace_collect},
 };
 
 #[derive(Debug)]
@@ -32,7 +26,7 @@ impl ClientSyncInfo {
 
 pub struct Broker {
     clients: Vec<Client>,
-    trace_store: TraceStore, 
+    trace_store: TraceStore,
     trace_connection: Connection,
 }
 
@@ -142,11 +136,10 @@ impl Broker {
         let start_pcs = self
             .clients
             .iter()
-            .map(|c| {
-                match config.testing.protocol.layer {
-                    crate::config::ProtocolLayer::Insn => unsafe { &c.shm.get().data.shm_exec }.insn_info.pc,
-                    crate::config::ProtocolLayer::TB |
-                    crate::config::ProtocolLayer::TBStrict => unsafe { &c.shm.get().data.shm_tb }.tb_info.pc,
+            .map(|c| match config.testing.protocol.layer {
+                crate::config::ProtocolLayer::Insn => c.shm.get_exec().insn_info.pc,
+                crate::config::ProtocolLayer::TB | crate::config::ProtocolLayer::TBStrict => {
+                    c.shm.get_tb().tb_info.pc
                 }
             })
             .collect::<Vec<_>>();
@@ -163,9 +156,8 @@ impl Broker {
         let mut insns_executed_per_client = vec![0; self.clients.len()];
 
         for (idx, client) in &mut self.clients.iter_mut().enumerate() {
-            let client_shm = client.shm.clone();
             while client.is_open {
-                let shm = unsafe { &client_shm.get().data.shm_tb };
+                let shm = client.shm.get_tb();
                 let start_pc = shm.tb_info.pc;
                 let insn_sizes = shm
                     .tb_info
@@ -176,6 +168,7 @@ impl Broker {
                 insns_executed_per_client[idx] = insn_sizes.len();
 
                 if client.run(config) {
+                    let shm = client.shm.get_tb();
                     let end_pc = shm.tb_info.pc;
                     let sync_info = ClientSyncInfo {
                         start_pc,
@@ -260,8 +253,8 @@ impl Broker {
 
                 match config.testing.protocol.layer {
                     crate::config::ProtocolLayer::Insn => {
-                        let c1insn = unsafe { &c1.shm.get().data.shm_exec };
-                        let c2insn = unsafe { &c2.shm.get().data.shm_exec };
+                        let c1insn = c1.shm.get_exec();
+                        let c2insn = c2.shm.get_exec();
 
                         let ctx1 = DiffContextClient::from_insn(c1, c1insn);
                         let ctx2 = DiffContextClient::from_insn(c2, c2insn);
@@ -276,8 +269,8 @@ impl Broker {
                         );
                     }
                     crate::config::ProtocolLayer::TB | crate::config::ProtocolLayer::TBStrict => {
-                        let c1insn = unsafe { &c1.shm.get().data.shm_tb };
-                        let c2insn = unsafe { &c2.shm.get().data.shm_tb };
+                        let c1insn = c1.shm.get_tb();
+                        let c2insn = c2.shm.get_tb();
 
                         let ctx1 = DiffContextClient::from_tb(c1, c1insn);
                         let ctx2 = DiffContextClient::from_tb(c2, c2insn);
@@ -318,11 +311,11 @@ impl Broker {
             }
             TracingMode::Sync => {
                 for client in &self.clients {
-                    let trace = get_client_trace(client, config); 
+                    let trace = get_client_trace(client, config);
                     store_trace(trace, &self.trace_connection)?;
                 }
                 Ok(())
-            },
+            }
         }
     }
 }

--- a/vadl-cosim/cosim-lib/src/cosim/mod.rs
+++ b/vadl-cosim/cosim-lib/src/cosim/mod.rs
@@ -4,9 +4,11 @@ use tracing::debug;
 
 use crate::{
     config::{Config, TracingMode},
-    diff::{DiffContextClient, DiffEntry, Report, diff::diff_cpus},
+    diff::{
+        diff::diff_cpus, get_all_clients_contexts, clone_client_shms, get_all_clients_instructions, get_client_context_from_wrapper, BrokerSHMWrapper, DiffContext, DiffContextClient, DiffEntry, Report
+    },
     ipc::qemu::Client,
-    trace::{TraceStore, connect, get_client_trace, store_trace, trace_collect},
+    trace::{connect, get_client_trace, store_trace, trace_collect, TraceStore},
 };
 
 #[derive(Debug)]
@@ -14,7 +16,6 @@ struct ClientSyncInfo {
     start_pc: u64,
     end_pc: u64,
     insn_sizes: Vec<u64>,
-    client_id: usize,
 }
 
 impl ClientSyncInfo {
@@ -59,11 +60,9 @@ impl Broker {
     pub fn run(&mut self, config: &Config) -> Result<Report> {
         debug!(?config, "running broker");
 
-        let diffs = match config.testing.protocol.mode {
+        match config.testing.protocol.mode {
             crate::config::ProtocolMode::Lockstep => self.run_lockstep(config),
-        }?;
-
-        Ok(diffs.into())
+        }
     }
 
     pub fn finish(mut self, config: &Config) -> Result<()> {
@@ -80,7 +79,7 @@ impl Broker {
         Ok(())
     }
 
-    fn run_lockstep(&mut self, config: &Config) -> Result<Vec<DiffEntry>> {
+    fn run_lockstep(&mut self, config: &Config) -> Result<Report> {
         for (idx, client) in self.clients.iter_mut().enumerate() {
             let client_cfg = config.for_client(idx);
             client.run_n_times(client_cfg.skip_n_instructions, config);
@@ -92,6 +91,8 @@ impl Broker {
         self.check_clients_are_initially_synchronized(config)?;
 
         while self.any_client_open() {
+            let before_states = clone_client_shms(&self.clients, config);
+
             match config.testing.protocol.layer {
                 crate::config::ProtocolLayer::Insn | crate::config::ProtocolLayer::TBStrict => {
                     for client in &mut self.clients {
@@ -103,8 +104,9 @@ impl Broker {
                 crate::config::ProtocolLayer::TB => {
                     if let TBSyncResult::Diverged(diff_entry) = self.tb_sync_clients(config) {
                         debug!("client diverged during tb synchronization");
+                        let diff_context = self.build_diff_context(before_states, config);
                         diffs.push(diff_entry);
-                        return Ok(diffs);
+                        return Ok(Report::failed(diffs, diff_context));
                     }
                 }
             };
@@ -113,7 +115,7 @@ impl Broker {
                 if stop_after > 0 {
                     stop_after -= 1;
                 } else {
-                    return Ok(diffs);
+                    return Ok(Report::passed());
                 }
             }
 
@@ -121,11 +123,12 @@ impl Broker {
             diffs.append(&mut self.diff_clients(config));
 
             if !diffs.is_empty() {
-                return Ok(diffs);
+                let diff_context = self.build_diff_context(before_states, config);
+                return Ok(Report::failed(diffs, diff_context));
             }
         }
 
-        Ok(diffs)
+        Ok(Report::passed())
     }
 
     fn any_client_open(&self) -> bool {
@@ -174,7 +177,6 @@ impl Broker {
                         start_pc,
                         end_pc,
                         insn_sizes,
-                        client_id: client.id,
                     };
 
                     if sync_info.is_jump() {
@@ -198,21 +200,11 @@ impl Broker {
                 .map(|i| i.end_pc.to_string())
                 .collect();
 
-            let diff_contexts = client_sync_infos
-                .iter()
-                .map(|i| (&self.clients[i.client_id], i.end_pc))
-                .map(|(c, end_pc)| {
-                    DiffContextClient::new(c.id, c.name.clone(), c.run_count, end_pc)
-                })
-                .collect();
-
-            let diff = DiffEntry::new(
+            return TBSyncResult::Diverged(DiffEntry::new(
                 "tb_info",
                 end_pcs,
                 "clients reached a different end-pc at the end of tb-synchronization",
-                diff_contexts,
-            );
-            return TBSyncResult::Diverged(diff);
+            ));
         }
 
         let insns_executed_diverged = insns_executed_per_client
@@ -225,21 +217,11 @@ impl Broker {
                 .map(|i| i.to_string())
                 .collect();
 
-            let diff_contexts = client_sync_infos
-                .iter()
-                .map(|i| (&self.clients[i.client_id], i.end_pc))
-                .map(|(c, end_pc)| {
-                    DiffContextClient::new(c.id, c.name.clone(), c.run_count, end_pc)
-                })
-                .collect();
-
-            let diff = DiffEntry::new(
+            return TBSyncResult::Diverged(DiffEntry::new(
                 "tb_info.insns_info_size",
                 instr_counts,
                 "clients reached the same end-pc, but executed a different number of instructions",
-                diff_contexts,
-            );
-            return TBSyncResult::Diverged(diff);
+            ));
         }
 
         TBSyncResult::Success
@@ -256,32 +238,24 @@ impl Broker {
                         let c1insn = c1.shm.get_exec();
                         let c2insn = c2.shm.get_exec();
 
-                        let ctx1 = DiffContextClient::from_insn(c1, c1insn);
-                        let ctx2 = DiffContextClient::from_insn(c2, c2insn);
-
                         return diff_cpus(
                             &c1insn.cpus,
                             c1insn.init_mask,
                             &c2insn.cpus,
                             c2insn.init_mask,
                             config,
-                            vec![ctx1, ctx2],
                         );
                     }
                     crate::config::ProtocolLayer::TB | crate::config::ProtocolLayer::TBStrict => {
                         let c1insn = c1.shm.get_tb();
                         let c2insn = c2.shm.get_tb();
 
-                        let ctx1 = DiffContextClient::from_tb(c1, c1insn);
-                        let ctx2 = DiffContextClient::from_tb(c2, c2insn);
-
                         return diff_cpus(
                             &c1insn.cpus,
                             c1insn.init_mask,
                             &c2insn.cpus,
                             c2insn.init_mask,
                             config,
-                            vec![ctx1, ctx2],
                         );
                     }
                 }
@@ -317,5 +291,33 @@ impl Broker {
                 Ok(())
             }
         }
+    }
+
+    fn build_diff_context(&self, mut before_states: Vec<BrokerSHMWrapper>, config: &Config) -> DiffContext {
+        let mut after_states = get_all_clients_contexts(&self.clients, config);
+        let mut error_instructions = get_all_clients_instructions(&self.clients, config);
+        let mut diff_context = vec![];
+
+        for client in &self.clients {
+            let before_state = before_states.pop().unwrap();
+            let before_state = get_client_context_from_wrapper(before_state, config);
+            let error_instruction = error_instructions.pop().unwrap();
+            let after_state = after_states.pop().unwrap();
+
+            let client_id = client.id;
+            let client_name = client.name.clone();
+            let client_run_count = client.run_count;
+
+            diff_context.push(DiffContextClient::new(
+                client_id,
+                client_name,
+                client_run_count,
+                before_state,
+                error_instruction,
+                after_state,
+            ));
+        }
+
+        diff_context
     }
 }

--- a/vadl-cosim/cosim-lib/src/diff/diff.rs
+++ b/vadl-cosim/cosim-lib/src/diff/diff.rs
@@ -3,7 +3,7 @@ use std::cell::RefCell;
 use crate::{
     config::Config,
     diff::{DiffContext, DiffEntry},
-    ipc::cstructs::{SHMRegister, MAX_CPU_COUNT, MAX_CPU_REGISTERS, SHMCPU},
+    ipc::cstructs::{MAX_CPU_COUNT, MAX_CPU_REGISTERS, SHMCPU, SHMRegister},
 };
 
 // NOTE: Technically it is more performant to pass in the memo-vec as an argument to not have
@@ -77,11 +77,7 @@ pub fn diff_cpu(
         let csub_reg = &sub_cpu.registers_slice()[reg_index];
         let rsub_name = csub_reg.mapped_name(config);
 
-        if config
-            .qemu
-            .ignore_registers
-            .contains(rsub_name)
-        {
+        if config.qemu.ignore_registers.contains(rsub_name) {
             continue;
         }
 
@@ -91,7 +87,12 @@ pub fn diff_cpu(
             continue;
         }
 
-        let csuper_reg_idx = reg_idx_by_name_memoed(super_cpu.registers_slice(), csub_reg.name.as_str(), config, reg_index);
+        let csuper_reg_idx = reg_idx_by_name_memoed(
+            super_cpu.registers_slice(),
+            csub_reg.name.as_str(),
+            config,
+            reg_index,
+        );
         let csuper_reg = &super_cpu.registers_slice()[csuper_reg_idx];
 
         diff_register(
@@ -146,8 +147,13 @@ pub fn diff_register(
     }
 }
 
-fn reg_idx_by_name_memoed(registers: &[SHMRegister], name: &str, config: &Config, reg_index: usize) -> usize {
-    REG_MAP_MEMO.with_borrow_mut(|memo | {
+fn reg_idx_by_name_memoed(
+    registers: &[SHMRegister],
+    name: &str,
+    config: &Config,
+    reg_index: usize,
+) -> usize {
+    REG_MAP_MEMO.with_borrow_mut(|memo| {
         assert!(reg_index < memo.len(), "invalid memo length");
         if let Some(memo_reg) = memo[reg_index] {
             return memo_reg;
@@ -157,7 +163,6 @@ fn reg_idx_by_name_memoed(registers: &[SHMRegister], name: &str, config: &Config
         memo[reg_index] = Some(reg);
         reg
     })
-
 }
 
 fn reg_idx_by_name(registers: &[SHMRegister], name: &str, config: &Config) -> usize {

--- a/vadl-cosim/cosim-lib/src/diff/diff.rs
+++ b/vadl-cosim/cosim-lib/src/diff/diff.rs
@@ -2,7 +2,7 @@ use std::cell::RefCell;
 
 use crate::{
     config::Config,
-    diff::{DiffContext, DiffEntry},
+    diff::DiffEntry,
     ipc::cstructs::{MAX_CPU_COUNT, MAX_CPU_REGISTERS, SHMCPU, SHMRegister},
 };
 
@@ -20,7 +20,6 @@ pub fn diff_cpus(
     cpus2: &[SHMCPU; MAX_CPU_COUNT],
     init_mask2: i32,
     config: &Config,
-    context: DiffContext,
 ) -> Vec<DiffEntry> {
     let mut diffs = vec![];
 
@@ -29,7 +28,6 @@ pub fn diff_cpus(
             "cpu.init_mask",
             vec![init_mask1.to_string(), init_mask2.to_string()],
             "The init masks of the cpu differ - meaning different CPUs were used during execution",
-            context,
         ));
 
         return diffs;
@@ -40,7 +38,7 @@ pub fn diff_cpus(
         if flag == 1 {
             let cpu1 = &cpus1[idx];
             let cpu2 = &cpus2[idx];
-            diff_cpu(cpu1, cpu2, idx, config, context.clone(), &mut diffs);
+            diff_cpu(cpu1, cpu2, idx, config, &mut diffs);
         }
     }
 
@@ -52,7 +50,6 @@ pub fn diff_cpu(
     cpu2: &SHMCPU,
     cpu_index: usize,
     config: &Config,
-    context: DiffContext,
     diffs: &mut Vec<DiffEntry>,
 ) {
     if !config.qemu.ignore_unset_registers && cpu1.registers_size != cpu2.registers_size {
@@ -63,7 +60,6 @@ pub fn diff_cpu(
                 cpu2.registers_size.to_string(),
             ],
             "different number of CPU registers",
-            context,
         ));
 
         return;
@@ -101,7 +97,6 @@ pub fn diff_cpu(
             cpu_index,
             reg_index,
             config,
-            context.clone(),
             diffs,
         );
     }
@@ -113,7 +108,6 @@ pub fn diff_register(
     cpu_index: usize,
     reg_index: usize,
     config: &Config,
-    context: DiffContext,
     diffs: &mut Vec<DiffEntry>,
 ) {
     let r1name = reg1.mapped_name(config);
@@ -124,7 +118,6 @@ pub fn diff_register(
             format!("cpu[{cpu_index}].registers[{reg_index}].size"),
             vec![reg1.size.to_string(), reg2.size.to_string()],
             format!("different register sizes for {r1name}"),
-            context.clone(),
         ));
     }
 
@@ -133,7 +126,6 @@ pub fn diff_register(
             format!("cpu[{cpu_index}].registers[{reg_index}].name"),
             vec![r1name.to_string(), r2name.to_string()],
             "different register names",
-            context.clone(),
         ));
     }
 
@@ -142,7 +134,6 @@ pub fn diff_register(
             format!("cpu[{cpu_index}].registers[{reg_index}].data"),
             vec![reg1.data_slice_fmt(), reg2.data_slice_fmt()],
             format!("different register data for {r1name}"),
-            context.clone(),
         ));
     }
 }

--- a/vadl-cosim/cosim-lib/src/diff/diff.rs
+++ b/vadl-cosim/cosim-lib/src/diff/diff.rs
@@ -91,14 +91,7 @@ pub fn diff_cpu(
         );
         let csuper_reg = &super_cpu.registers_slice()[csuper_reg_idx];
 
-        diff_register(
-            csub_reg,
-            csuper_reg,
-            cpu_index,
-            reg_index,
-            config,
-            diffs,
-        );
+        diff_register(csub_reg, csuper_reg, cpu_index, reg_index, config, diffs);
     }
 }
 

--- a/vadl-cosim/cosim-lib/src/diff/mod.rs
+++ b/vadl-cosim/cosim-lib/src/diff/mod.rs
@@ -15,9 +15,9 @@ pub mod diff;
 
 #[derive(Debug, Serialize)]
 pub struct Report {
-    passed: bool,
-    diffs: Vec<DiffEntry>,
-    diff_context: DiffContext,
+    pub passed: bool,
+    pub diffs: Vec<DiffEntry>,
+    pub diff_context: DiffContext,
 }
 
 impl Report {
@@ -36,53 +36,61 @@ impl Report {
             diff_context,
         }
     }
+
+    pub fn without_context(self) -> Self {
+        Report {
+            passed: self.passed,
+            diffs: self.diffs,
+            diff_context: vec![],
+        }
+    }
 }
 
 #[derive(Debug, Serialize)]
 pub struct DiffEntry {
-    key: String,
-    values: Vec<String>,
-    description: String,
+    pub key: String,
+    pub values: Vec<String>,
+    pub description: String,
 }
 
 pub type DiffContext = Vec<DiffContextClient>;
 
 #[derive(Debug, Serialize, Clone)]
 pub struct DiffContextClient {
-    client_id: usize,
-    client_name: Option<String>,
-    client_run_count: u64,
-    before_state: DiffContextClientState,
-    error_instruction: DiffContextClientInstructions,
-    after_state: DiffContextClientState,
+    pub client_id: usize,
+    pub client_name: Option<String>,
+    pub client_run_count: u64,
+    pub before_state: DiffContextClientState,
+    pub error_instruction: DiffContextClientInstructions,
+    pub after_state: DiffContextClientState,
 }
 
 #[derive(Debug, Serialize, Clone)]
 pub struct DiffContextClientState {
-    pc: u64,
-    cpus: Vec<DiffContextClientStateCPU>,
+    pub pc: u64,
+    pub cpus: Vec<DiffContextClientStateCPU>,
 }
 
 #[derive(Debug, Serialize, Clone)]
 pub struct DiffContextClientStateCPU {
-    registers: Vec<DiffContextClientStateRegister>,
+    pub registers: Vec<DiffContextClientStateRegister>,
 }
 
 #[derive(Debug, Serialize, Clone)]
 pub struct DiffContextClientStateRegister {
-    name: String,
-    value: String,
+    pub name: String,
+    pub value: String,
 }
 
 #[derive(Debug, Serialize, Clone)]
-pub struct DiffContextClientInstructions(Vec<DiffContextClientInstruction>);
+pub struct DiffContextClientInstructions(pub Vec<DiffContextClientInstruction>);
 
 #[derive(Debug, Serialize, Clone)]
 pub struct DiffContextClientInstruction {
-    pc: u64,
-    hwaddr: String,
-    disas: String,
-    insn_data: String,
+    pub pc: u64,
+    pub hwaddr: String,
+    pub disas: String,
+    pub insn_data: String,
 }
 
 pub enum DiffValue {

--- a/vadl-cosim/cosim-lib/src/diff/mod.rs
+++ b/vadl-cosim/cosim-lib/src/diff/mod.rs
@@ -137,12 +137,12 @@ pub fn get_all_clients_instructions(
 pub fn get_client_instructions(client: &Client, config: &Config) -> DiffContextClientInstructions {
     match config.testing.protocol.layer {
         crate::config::ProtocolLayer::Insn => {
-            let exec = &client.shm.get_exec().insn_info;
+            let exec = &client.shms.current().get_exec().insn_info;
             let insn = exec.into();
             DiffContextClientInstructions(vec![insn])
         }
         crate::config::ProtocolLayer::TB | crate::config::ProtocolLayer::TBStrict => {
-            let tb = client.shm.get_tb();
+            let tb = client.shms.current().get_tb();
             let insns = tb
                 .tb_info
                 .insns_info_slice()
@@ -165,60 +165,40 @@ impl From<&TBInsnInfo> for DiffContextClientInstruction {
     }
 }
 
-/// A wrapper around the SHM-Data. This is primarily used during the diff-context collection.
-/// Why: The before-state needs to be saved (cloned) since the data changes when a client is run.
-///      While it is possible to directly save the DiffContextClientState, this involves a lot of
-///      string-formatting operations which is significantly slower than just copying the data.
-///      Therefore the data is first cloned and then later (when a diff is actually found)
-///      converted.
-/// NOTE: While this is already much better performance-wise, another (more performant) solution
-/// might be:
-///     1. Use two shared-memory objects instead of one
-///     2. Alternate between them both from the broker and the qemu-client side
-///     3. The currenlty used object contains the "after" state, while the previous one still
-///        contains the "before" state.
-///     This way no cloning has to be done and the memory is allocated once at program-start.
-///     With the only "downside" being that this would obviously allocated double the amount of
-///     memory for the SHM-Data during the whole cosimulation process.
-#[allow(clippy::large_enum_variant)]
-pub enum BrokerSHMWrapper {
-    TB(BrokerSHMTB),
-    Exec(BrokerSHMExec),
-}
-
-pub fn clone_client_shms(clients: &[Client], config: &Config) -> Vec<BrokerSHMWrapper> {
-    clients
-        .iter()
-        .map(|client| match config.testing.protocol.layer {
-            crate::config::ProtocolLayer::Insn => BrokerSHMWrapper::Exec(client.shm.get_exec().clone()),
-            crate::config::ProtocolLayer::TB |
-            crate::config::ProtocolLayer::TBStrict => BrokerSHMWrapper::TB(client.shm.get_tb().clone()),
-        })
-        .collect()
-}
-
-pub fn get_all_clients_contexts(
+pub fn get_all_clients_contexts_before(
     clients: &[Client],
     config: &Config,
 ) -> Vec<DiffContextClientState> {
     clients
         .iter()
-        .map(|client| get_client_context(client, config))
+        .map(|client| get_client_context_before(client, config))
         .collect()
 }
 
-pub fn get_client_context_from_wrapper(wrapper: BrokerSHMWrapper, config: &Config) -> DiffContextClientState {
-    match wrapper {
-        BrokerSHMWrapper::TB(broker_shmtb) => (&broker_shmtb, config).into(),
-        BrokerSHMWrapper::Exec(broker_shmexec) => (&broker_shmexec, config).into(),
+pub fn get_client_context_before(client: &Client, config: &Config) -> DiffContextClientState {
+    match config.testing.protocol.layer {
+        crate::config::ProtocolLayer::Insn => (client.shms.previous().get_exec(), config).into(),
+        crate::config::ProtocolLayer::TB | crate::config::ProtocolLayer::TBStrict => {
+            (client.shms.previous().get_tb(), config).into()
+        }
     }
 }
 
-pub fn get_client_context(client: &Client, config: &Config) -> DiffContextClientState {
+pub fn get_all_clients_contexts_current(
+    clients: &[Client],
+    config: &Config,
+) -> Vec<DiffContextClientState> {
+    clients
+        .iter()
+        .map(|client| get_client_context_current(client, config))
+        .collect()
+}
+
+pub fn get_client_context_current(client: &Client, config: &Config) -> DiffContextClientState {
     match config.testing.protocol.layer {
-        crate::config::ProtocolLayer::Insn => (client.shm.get_exec(), config).into(),
+        crate::config::ProtocolLayer::Insn => (client.shms.current().get_exec(), config).into(),
         crate::config::ProtocolLayer::TB | crate::config::ProtocolLayer::TBStrict => {
-            (client.shm.get_tb(), config).into()
+            (client.shms.current().get_tb(), config).into()
         }
     }
 }

--- a/vadl-cosim/cosim-lib/src/diff/mod.rs
+++ b/vadl-cosim/cosim-lib/src/diff/mod.rs
@@ -2,9 +2,12 @@ use std::fmt::Debug;
 
 use serde::Serialize;
 
-use crate::ipc::{
-    cstructs::{BrokerSHMExec, BrokerSHMTB},
-    qemu::Client,
+use crate::{
+    config::Config,
+    ipc::{
+        cstructs::{BrokerSHMExec, BrokerSHMTB, SHMCPU, SHMRegister, TBInsnInfo},
+        qemu::Client,
+    },
 };
 
 #[allow(clippy::module_inception)]
@@ -14,6 +17,7 @@ pub mod diff;
 pub struct Report {
     passed: bool,
     diffs: Vec<DiffEntry>,
+    diff_context: DiffContext,
 }
 
 impl Report {
@@ -21,23 +25,15 @@ impl Report {
         Report {
             passed: true,
             diffs: Vec::new(),
+            diff_context: Vec::new(),
         }
     }
 
-    pub fn failed(diffs: Vec<DiffEntry>) -> Self {
+    pub fn failed(diffs: Vec<DiffEntry>, diff_context: DiffContext) -> Self {
         Report {
             passed: false,
             diffs,
-        }
-    }
-}
-
-impl From<Vec<DiffEntry>> for Report {
-    fn from(diffs: Vec<DiffEntry>) -> Self {
-        if diffs.is_empty() {
-            Self::passed()
-        } else {
-            Self::failed(diffs)
+            diff_context,
         }
     }
 }
@@ -47,7 +43,6 @@ pub struct DiffEntry {
     key: String,
     values: Vec<String>,
     description: String,
-    context: DiffContext,
 }
 
 pub type DiffContext = Vec<DiffContextClient>;
@@ -57,7 +52,37 @@ pub struct DiffContextClient {
     client_id: usize,
     client_name: Option<String>,
     client_run_count: u64,
+    before_state: DiffContextClientState,
+    error_instruction: DiffContextClientInstructions,
+    after_state: DiffContextClientState,
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct DiffContextClientState {
     pc: u64,
+    cpus: Vec<DiffContextClientStateCPU>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct DiffContextClientStateCPU {
+    registers: Vec<DiffContextClientStateRegister>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct DiffContextClientStateRegister {
+    name: String,
+    value: String,
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct DiffContextClientInstructions(Vec<DiffContextClientInstruction>);
+
+#[derive(Debug, Serialize, Clone)]
+pub struct DiffContextClientInstruction {
+    pc: u64,
+    hwaddr: String,
+    disas: String,
+    insn_data: String,
 }
 
 pub enum DiffValue {
@@ -70,47 +95,173 @@ impl DiffEntry {
         key: impl Into<String>,
         values: Vec<String>,
         description: impl Into<String>,
-        context: DiffContext,
     ) -> Self {
         Self {
             key: key.into(),
             values,
             description: description.into(),
-            context,
         }
     }
 }
 
 impl DiffContextClient {
-    pub fn new(
+    pub fn new<T: Into<DiffContextClientState>>(
         client_id: usize,
         client_name: Option<String>,
         client_run_count: u64,
-        pc: u64,
+        before_state: T,
+        error_instruction: DiffContextClientInstructions,
+        after_state: T,
     ) -> Self {
         Self {
             client_id,
             client_name,
             client_run_count,
-            pc,
+            before_state: before_state.into(),
+            error_instruction,
+            after_state: after_state.into(),
         }
     }
+}
 
-    pub fn from_tb(client: &Client, shm: &BrokerSHMTB) -> Self {
-        Self::new(
-            client.id,
-            client.name.clone(),
-            client.run_count,
-            shm.tb_info.pc,
-        )
+pub fn get_all_clients_instructions(
+    clients: &[Client],
+    config: &Config,
+) -> Vec<DiffContextClientInstructions> {
+    clients
+        .iter()
+        .map(|client| get_client_instructions(client, config))
+        .collect()
+}
+
+pub fn get_client_instructions(client: &Client, config: &Config) -> DiffContextClientInstructions {
+    match config.testing.protocol.layer {
+        crate::config::ProtocolLayer::Insn => {
+            let exec = &client.shm.get_exec().insn_info;
+            let insn = exec.into();
+            DiffContextClientInstructions(vec![insn])
+        }
+        crate::config::ProtocolLayer::TB | crate::config::ProtocolLayer::TBStrict => {
+            let tb = client.shm.get_tb();
+            let insns = tb
+                .tb_info
+                .insns_info_slice()
+                .iter()
+                .map(|insn| insn.into())
+                .collect();
+            DiffContextClientInstructions(insns)
+        }
     }
+}
 
-    pub fn from_insn(client: &Client, shm: &BrokerSHMExec) -> Self {
-        Self::new(
-            client.id,
-            client.name.clone(),
-            client.run_count,
-            shm.insn_info.pc,
-        )
+impl From<&TBInsnInfo> for DiffContextClientInstruction {
+    fn from(value: &TBInsnInfo) -> Self {
+        DiffContextClientInstruction {
+            pc: value.pc,
+            hwaddr: value.hwaddr.as_str().to_owned(),
+            disas: value.disas.as_str().to_owned(),
+            insn_data: value.data.buffer_slice_fmt(),
+        }
+    }
+}
+
+/// A wrapper around the SHM-Data. This is primarily used during the diff-context collection.
+/// Why: The before-state needs to be saved (cloned) since the data changes when a client is run.
+///      While it is possible to directly save the DiffContextClientState, this involves a lot of
+///      string-formatting operations which is significantly slower than just copying the data.
+///      Therefore the data is first cloned and then later (when a diff is actually found)
+///      converted.
+/// NOTE: While this is already much better performance-wise, another (more performant) solution
+/// might be:
+///     1. Use two shared-memory objects instead of one
+///     2. Alternate between them both from the broker and the qemu-client side
+///     3. The currenlty used object contains the "after" state, while the previous one still
+///        contains the "before" state.
+///     This way no cloning has to be done and the memory is allocated once at program-start.
+///     With the only "downside" being that this would obviously allocated double the amount of
+///     memory for the SHM-Data during the whole cosimulation process.
+#[allow(clippy::large_enum_variant)]
+pub enum BrokerSHMWrapper {
+    TB(BrokerSHMTB),
+    Exec(BrokerSHMExec),
+}
+
+pub fn clone_client_shms(clients: &[Client], config: &Config) -> Vec<BrokerSHMWrapper> {
+    clients
+        .iter()
+        .map(|client| match config.testing.protocol.layer {
+            crate::config::ProtocolLayer::Insn => BrokerSHMWrapper::Exec(client.shm.get_exec().clone()),
+            crate::config::ProtocolLayer::TB |
+            crate::config::ProtocolLayer::TBStrict => BrokerSHMWrapper::TB(client.shm.get_tb().clone()),
+        })
+        .collect()
+}
+
+pub fn get_all_clients_contexts(
+    clients: &[Client],
+    config: &Config,
+) -> Vec<DiffContextClientState> {
+    clients
+        .iter()
+        .map(|client| get_client_context(client, config))
+        .collect()
+}
+
+pub fn get_client_context_from_wrapper(wrapper: BrokerSHMWrapper, config: &Config) -> DiffContextClientState {
+    match wrapper {
+        BrokerSHMWrapper::TB(broker_shmtb) => (&broker_shmtb, config).into(),
+        BrokerSHMWrapper::Exec(broker_shmexec) => (&broker_shmexec, config).into(),
+    }
+}
+
+pub fn get_client_context(client: &Client, config: &Config) -> DiffContextClientState {
+    match config.testing.protocol.layer {
+        crate::config::ProtocolLayer::Insn => (client.shm.get_exec(), config).into(),
+        crate::config::ProtocolLayer::TB | crate::config::ProtocolLayer::TBStrict => {
+            (client.shm.get_tb(), config).into()
+        }
+    }
+}
+
+impl From<(&BrokerSHMTB, &Config)> for DiffContextClientState {
+    fn from((value, config): (&BrokerSHMTB, &Config)) -> Self {
+        let cpus = value.cpus.iter().map(|cpu| (cpu, config).into()).collect();
+
+        DiffContextClientState {
+            pc: value.tb_info.pc,
+            cpus,
+        }
+    }
+}
+
+impl From<(&BrokerSHMExec, &Config)> for DiffContextClientState {
+    fn from((value, config): (&BrokerSHMExec, &Config)) -> Self {
+        let cpus = value.cpus.iter().map(|cpu| (cpu, config).into()).collect();
+
+        DiffContextClientState {
+            pc: value.insn_info.pc,
+            cpus,
+        }
+    }
+}
+
+impl From<(&SHMCPU, &Config)> for DiffContextClientStateCPU {
+    fn from((value, config): (&SHMCPU, &Config)) -> Self {
+        let registers = value
+            .registers_slice()
+            .iter()
+            .map(|r| (r, config).into())
+            .collect();
+
+        DiffContextClientStateCPU { registers }
+    }
+}
+
+impl From<(&SHMRegister, &Config)> for DiffContextClientStateRegister {
+    fn from((value, config): (&SHMRegister, &Config)) -> Self {
+        DiffContextClientStateRegister {
+            name: value.mapped_name(config).to_owned(),
+            value: value.data_slice_fmt(),
+        }
     }
 }

--- a/vadl-cosim/cosim-lib/src/diff/mod.rs
+++ b/vadl-cosim/cosim-lib/src/diff/mod.rs
@@ -2,7 +2,10 @@ use std::fmt::Debug;
 
 use serde::Serialize;
 
-use crate::ipc::{cstructs::{BrokerSHMExec, BrokerSHMTB}, qemu::Client};
+use crate::ipc::{
+    cstructs::{BrokerSHMExec, BrokerSHMTB},
+    qemu::Client,
+};
 
 #[allow(clippy::module_inception)]
 pub mod diff;
@@ -45,7 +48,7 @@ pub struct DiffEntry {
     values: Vec<String>,
     description: String,
     context: DiffContext,
-} 
+}
 
 pub type DiffContext = Vec<DiffContextClient>;
 
@@ -79,15 +82,35 @@ impl DiffEntry {
 }
 
 impl DiffContextClient {
-    pub fn new(client_id: usize, client_name: Option<String>, client_run_count: u64, pc: u64) -> Self {
-        Self { client_id, client_name, client_run_count, pc }
+    pub fn new(
+        client_id: usize,
+        client_name: Option<String>,
+        client_run_count: u64,
+        pc: u64,
+    ) -> Self {
+        Self {
+            client_id,
+            client_name,
+            client_run_count,
+            pc,
+        }
     }
 
     pub fn from_tb(client: &Client, shm: &BrokerSHMTB) -> Self {
-        Self::new(client.id, client.name.clone(), client.run_count, shm.tb_info.pc)
+        Self::new(
+            client.id,
+            client.name.clone(),
+            client.run_count,
+            shm.tb_info.pc,
+        )
     }
 
     pub fn from_insn(client: &Client, shm: &BrokerSHMExec) -> Self {
-        Self::new(client.id, client.name.clone(), client.run_count, shm.insn_info.pc)
+        Self::new(
+            client.id,
+            client.name.clone(),
+            client.run_count,
+            shm.insn_info.pc,
+        )
     }
 }

--- a/vadl-cosim/cosim-lib/src/ipc/cstructs.rs
+++ b/vadl-cosim/cosim-lib/src/ipc/cstructs.rs
@@ -46,7 +46,8 @@ impl SHMRegister {
     }
 
     pub fn data_slice_fmt(&self) -> String {
-        let s = self.data_slice()
+        let s = self
+            .data_slice()
             .iter()
             .map(|b| format!("{b:02X?}"))
             .collect::<String>();
@@ -117,7 +118,8 @@ impl InsnData {
     }
 
     pub fn buffer_slice_fmt(&self) -> String {
-        let s = self.buffer_slice()
+        let s = self
+            .buffer_slice()
             .iter()
             .map(|b| format!("{b:02X?}"))
             .collect::<String>();
@@ -247,5 +249,9 @@ pub union BrokerSHMData {
 #[repr(C)]
 pub struct BrokerSHM {
     pub data: BrokerSHMData,
+}
+
+#[repr(C)]
+pub struct BrokerSem {
     pub sync: Semaphore,
 }

--- a/vadl-cosim/cosim-lib/src/ipc/cstructs.rs
+++ b/vadl-cosim/cosim-lib/src/ipc/cstructs.rs
@@ -1,5 +1,4 @@
-use libc::{pthread_cond_t, pthread_mutex_t};
-use serde::{ser::SerializeStruct, Serialize};
+use serde::{Serialize, ser::SerializeStruct};
 
 use crate::{config::Config, ipc::sem::Semaphore};
 
@@ -21,7 +20,8 @@ pub struct SHMString {
 impl Serialize for SHMString {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer {
+        S: serde::Serializer,
+    {
         serializer.serialize_str(self.as_str())
     }
 }
@@ -62,7 +62,8 @@ impl SHMRegister {
 impl Serialize for SHMRegister {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer {
+        S: serde::Serializer,
+    {
         let mut s = serializer.serialize_struct("register", 3)?;
         s.serialize_field("size", &self.size)?;
         s.serialize_field("data", &self.data_slice_fmt())?;
@@ -88,7 +89,8 @@ impl SHMCPU {
 impl Serialize for SHMCPU {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer {
+        S: serde::Serializer,
+    {
         let mut s = serializer.serialize_struct("cpu", 3)?;
         s.serialize_field("idx", &self.idx)?;
         s.serialize_field("registers_size", &self.registers_size)?;
@@ -113,7 +115,8 @@ impl InsnData {
 impl Serialize for InsnData {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer {
+        S: serde::Serializer,
+    {
         let mut s = serializer.serialize_struct("insn-data", 2)?;
         s.serialize_field("size", &self.size)?;
         s.serialize_field("buffer", &self.buffer_slice())?;
@@ -149,7 +152,8 @@ impl TBInfo {
 impl Serialize for TBInfo {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer {
+        S: serde::Serializer,
+    {
         let mut s = serializer.serialize_struct("tb-info", 3)?;
         s.serialize_field("pc", &self.pc)?;
         s.serialize_field("insns_info_size", &self.insns_info_size)?;
@@ -170,7 +174,8 @@ pub struct BrokerSHMTB {
 impl Serialize for BrokerSHMTB {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer {
+        S: serde::Serializer,
+    {
         let mut s = serializer.serialize_struct("shm-tb", 3)?;
         s.serialize_field("init_mask", &self.init_mask)?;
 
@@ -200,7 +205,8 @@ pub struct BrokerSHMExec {
 impl Serialize for BrokerSHMExec {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer {
+        S: serde::Serializer,
+    {
         let mut s = serializer.serialize_struct("shm-tb", 3)?;
         s.serialize_field("init_mask", &self.init_mask)?;
 

--- a/vadl-cosim/cosim-lib/src/ipc/cstructs.rs
+++ b/vadl-cosim/cosim-lib/src/ipc/cstructs.rs
@@ -46,7 +46,12 @@ impl SHMRegister {
     }
 
     pub fn data_slice_fmt(&self) -> String {
-        format!("{:02X?}", self.data_slice())
+        let s = self.data_slice()
+            .iter()
+            .map(|b| format!("{b:02X?}"))
+            .collect::<String>();
+
+        format!("0x{s}")
     }
 
     pub fn mapped_name<'a>(&'a self, config: &'a Config) -> &'a str {
@@ -109,6 +114,15 @@ pub struct InsnData {
 impl InsnData {
     pub fn buffer_slice(&self) -> &[u8] {
         &self.buffer[..self.size]
+    }
+
+    pub fn buffer_slice_fmt(&self) -> String {
+        let s = self.buffer_slice()
+            .iter()
+            .map(|b| format!("{b:02X?}"))
+            .collect::<String>();
+
+        format!("0x{s}")
     }
 }
 

--- a/vadl-cosim/cosim-lib/src/ipc/mod.rs
+++ b/vadl-cosim/cosim-lib/src/ipc/mod.rs
@@ -2,26 +2,21 @@ use std::ffi::CStr;
 
 use libc::strerror;
 
-pub mod sem;
-pub mod shm;
 pub mod cstructs;
 pub mod qemu;
+pub mod sem;
+pub mod shm;
 
 const PERMISSONS: u32 = 0o600;
 
 #[cfg(target_os = "macos")]
 fn get_errno() -> i32 {
-    unsafe {
-        *libc::__error()
-    }
+    unsafe { *libc::__error() }
 }
-
 
 #[cfg(target_os = "linux")]
 fn get_errno() -> i32 {
-    unsafe {
-        *libc::__errno_location()
-    }
+    unsafe { *libc::__errno_location() }
 }
 
 /// Retrieves and formats an error message from `errno`.
@@ -36,4 +31,40 @@ fn get_last_error(context: &str) -> String {
             err
         )
     }
+}
+
+#[macro_export]
+macro_rules! bail_on_libc_err {
+    ($expr:expr) => {{
+        let res = $expr;
+        if res != 0 {
+            let s = stringify!($expr);
+            bail!(get_last_error(&format!("{s} failed")))
+        }
+        res
+    }};
+    ($expr:expr, $errcode:expr) => {{
+        let res = $expr;
+        if res == $errcode {
+            let s = stringify!($expr);
+            bail!(get_last_error(&format!("{s} failed")))
+        }
+        res
+    }};
+}
+
+#[macro_export]
+macro_rules! eprintln_on_libc_err {
+    ($expr:expr) => {
+        if $expr != 0 {
+            let s = stringify!($expr);
+            eprintln!("{}", get_last_error(&format!("{s} failed")))
+        }
+    };
+    ($expr:expr, $errcode:expr) => {
+        if $expr == $errcode {
+            let s = stringify!($expr);
+            eprintln!("{}", get_last_error(&format!("{s} failed")))
+        }
+    };
 }

--- a/vadl-cosim/cosim-lib/src/ipc/qemu.rs
+++ b/vadl-cosim/cosim-lib/src/ipc/qemu.rs
@@ -1,5 +1,8 @@
 use std::{
-    fs::File, path::Path, process::{Child, Command}, sync::Arc, time::Duration
+    fs::File,
+    path::Path,
+    process::{Child, Command},
+    time::Duration,
 };
 
 use anyhow::{Context, Result};
@@ -8,7 +11,7 @@ use tracing::{debug, error, info};
 use crate::{
     config::Config,
     ipc::{
-        cstructs::{BrokerSHM, BrokerSHMData},
+        cstructs::BrokerSHM,
         sem::{Semaphore, TimedWaitState},
         shm::SharedMemory,
     },
@@ -16,7 +19,7 @@ use crate::{
 
 pub struct Client {
     pub id: usize,
-    pub shm: Arc<SharedMemory<BrokerSHM>>,
+    pub shm: SharedMemory<BrokerSHM>,
     pub is_open: bool,
     pub process: Child,
     pub name: Option<String>,
@@ -59,7 +62,7 @@ impl Client {
                         Ok(None) => {
                             error!(
                                 client_id = self.id,
-                                is_server = self.shm.get().sync.is_server,
+                                is_server = self.shm.get_sync().is_server,
                                 "client is still running but unresponive"
                             );
                         }
@@ -97,9 +100,9 @@ impl Client {
     pub fn create(config: &Config, client_idx: usize) -> Result<Self> {
         let client_cfg = config.for_client(client_idx);
 
-        let shm: SharedMemory<BrokerSHM> =
+        let mut shm: SharedMemory<BrokerSHM> =
             SharedMemory::create(&format!("/cosimulation-shm-{client_idx}"))?;
-        shm.get_mut().sync = Semaphore::create();
+        shm.get_mut().sync = Semaphore::create()?;
 
         info!(
             client_id = client_idx,
@@ -181,7 +184,7 @@ impl Client {
 
         Ok(Self {
             id: client_idx,
-            shm: shm.into(),
+            shm,
             is_open: true,
             process: client_process,
             name: client_cfg.name.clone(),

--- a/vadl-cosim/cosim-lib/src/ipc/qemu.rs
+++ b/vadl-cosim/cosim-lib/src/ipc/qemu.rs
@@ -11,15 +11,51 @@ use tracing::{debug, error, info};
 use crate::{
     config::Config,
     ipc::{
-        cstructs::BrokerSHM,
+        cstructs::{BrokerSHM, BrokerSem},
         sem::{Semaphore, TimedWaitState},
         shm::SharedMemory,
     },
 };
 
+const SHMQUEUE_LEN: usize = 2;
+
+pub struct SHMQueue {
+    data: [SharedMemory<BrokerSHM>; SHMQUEUE_LEN],
+    idx: usize,
+}
+
+impl SHMQueue {
+    pub fn new(data: [SharedMemory<BrokerSHM>; SHMQUEUE_LEN]) -> Self {
+        Self { data, idx: 0 }
+    }
+
+    pub fn current(&self) -> &SharedMemory<BrokerSHM> {
+        &self.data[self.idx]
+    }
+
+    pub fn previous(&self) -> &SharedMemory<BrokerSHM> {
+        if self.idx == 0 {
+            &self.data[SHMQUEUE_LEN - 1]
+        } else {
+            &self.data[self.idx - 1]
+        }
+    }
+
+    pub fn next(&mut self) {
+        self.idx += 1;
+        self.idx %= SHMQUEUE_LEN;
+    }
+
+    pub fn get_next(&mut self) -> &SharedMemory<BrokerSHM> {
+        self.next();
+        self.current()
+    }
+}
+
 pub struct Client {
     pub id: usize,
-    pub shm: SharedMemory<BrokerSHM>,
+    pub shms: SHMQueue,
+    pub sem: SharedMemory<BrokerSem>,
     pub is_open: bool,
     pub process: Child,
     pub name: Option<String>,
@@ -62,7 +98,7 @@ impl Client {
                         Ok(None) => {
                             error!(
                                 client_id = self.id,
-                                is_server = self.shm.get_sync().is_server,
+                                is_server = self.sem.get_sync().is_server,
                                 "client is still running but unresponive"
                             );
                         }
@@ -83,14 +119,15 @@ impl Client {
     }
 
     fn run_inner(&mut self, config: &Config) -> Result<bool> {
-        self.shm.release_client()?;
+        self.shms.next();
+        self.sem.release_client()?;
 
         if config.for_client(self.id).gdb.enable {
-            self.shm.wait_client()?;
+            self.sem.wait_client()?;
             return Ok(true);
         }
 
-        let wait_res = self.shm.timedwait_client(Duration::from_secs(1))?;
+        let wait_res = self.sem.timedwait_client(Duration::from_secs(1))?;
         match wait_res {
             TimedWaitState::Timeout => Ok(false),
             TimedWaitState::Success => Ok(true),
@@ -100,9 +137,16 @@ impl Client {
     pub fn create(config: &Config, client_idx: usize) -> Result<Self> {
         let client_cfg = config.for_client(client_idx);
 
-        let mut shm: SharedMemory<BrokerSHM> =
-            SharedMemory::create(&format!("/cosimulation-shm-{client_idx}"))?;
-        shm.get_mut().sync = Semaphore::create()?;
+        let shm0: SharedMemory<BrokerSHM> =
+            SharedMemory::create(&format!("/cosimulation-shm-{client_idx}-0"))?;
+        let shm1: SharedMemory<BrokerSHM> =
+            SharedMemory::create(&format!("/cosimulation-shm-{client_idx}-1"))?;
+
+        let shms_queue = SHMQueue::new([shm0, shm1]);
+
+        let mut sem: SharedMemory<BrokerSem> =
+            SharedMemory::create(&format!("/cosimulation-sem-{client_idx}"))?;
+        sem.get_mut().sync = Semaphore::create()?;
 
         info!(
             client_id = client_idx,
@@ -184,7 +228,8 @@ impl Client {
 
         Ok(Self {
             id: client_idx,
-            shm,
+            shms: shms_queue,
+            sem,
             is_open: true,
             process: client_process,
             name: client_cfg.name.clone(),

--- a/vadl-cosim/cosim-lib/src/ipc/sem.rs
+++ b/vadl-cosim/cosim-lib/src/ipc/sem.rs
@@ -1,9 +1,14 @@
-use crate::ipc::get_errno;
+use crate::{bail_on_libc_err, eprintln_on_libc_err};
 use anyhow::{Result, bail};
 use libc::{
-    clock_gettime, pthread_cond_broadcast, pthread_cond_destroy, pthread_cond_init, pthread_cond_t, pthread_cond_timedwait, pthread_cond_wait, pthread_condattr_init, pthread_condattr_setpshared, pthread_condattr_t, pthread_mutex_destroy, pthread_mutex_init, pthread_mutex_lock, pthread_mutex_t, pthread_mutex_unlock, pthread_mutexattr_init, pthread_mutexattr_setpshared, pthread_mutexattr_t, timespec, CLOCK_REALTIME, ETIMEDOUT, PTHREAD_PROCESS_SHARED
+    CLOCK_REALTIME, ETIMEDOUT, PTHREAD_PROCESS_SHARED, clock_gettime, pthread_cond_broadcast,
+    pthread_cond_destroy, pthread_cond_init, pthread_cond_t, pthread_cond_timedwait,
+    pthread_cond_wait, pthread_condattr_init, pthread_condattr_setpshared, pthread_condattr_t,
+    pthread_mutex_destroy, pthread_mutex_init, pthread_mutex_lock, pthread_mutex_t,
+    pthread_mutex_unlock, pthread_mutexattr_init, pthread_mutexattr_setpshared,
+    pthread_mutexattr_t, timespec,
 };
-use std::{mem::MaybeUninit, time::Duration};
+use std::time::Duration;
 
 use crate::ipc::get_last_error;
 
@@ -22,65 +27,67 @@ pub enum TimedWaitState {
 }
 
 impl Semaphore {
-    /// Creates a new named semaphore with the given initial value.
-    ///
-    /// # Arguments
-    /// * `name` - The name of the semaphore.
-    /// * `initial_value` - The initial count of the semaphore.
-    ///
-    /// # Returns
-    /// * `Ok(Self)` if the semaphore is created successfully.
-    /// * `Err(String)` if the creation fails.
-    pub fn create() -> Self {
-        let mut mutex_attr: pthread_mutexattr_t = unsafe { MaybeUninit::zeroed().assume_init() };
+    pub fn create() -> Result<Self> {
+        let mut mutex_attr: pthread_mutexattr_t = unsafe { std::mem::zeroed() };
         let mutex_attr_ptr = &mut mutex_attr as *mut _;
-        unsafe { 
-            pthread_mutexattr_init(mutex_attr_ptr);
-            pthread_mutexattr_setpshared(mutex_attr_ptr, PTHREAD_PROCESS_SHARED) 
-        };
 
-        let mut mutex: pthread_mutex_t = unsafe { MaybeUninit::zeroed().assume_init() };
+        unsafe {
+            bail_on_libc_err!(pthread_mutexattr_init(mutex_attr_ptr));
+            bail_on_libc_err!(pthread_mutexattr_setpshared(
+                mutex_attr_ptr,
+                PTHREAD_PROCESS_SHARED
+            ));
+        }
+
+        let mut mutex: pthread_mutex_t = unsafe { std::mem::zeroed() };
         let mutex_ptr = &mut mutex as *mut _;
-        unsafe { pthread_mutex_init(mutex_ptr, mutex_attr_ptr) };
 
-        let mut cond_attr: pthread_condattr_t = unsafe { MaybeUninit::zeroed().assume_init() };
+        unsafe {
+            bail_on_libc_err!(pthread_mutex_init(mutex_ptr, mutex_attr_ptr));
+        }
+
+        let mut cond_attr: pthread_condattr_t = unsafe { std::mem::zeroed() };
         let cond_attr_ptr = &mut cond_attr as *mut _;
-        unsafe { 
-            pthread_condattr_init(cond_attr_ptr);
-            pthread_condattr_setpshared(cond_attr_ptr, PTHREAD_PROCESS_SHARED);
-        };
 
-        let mut cond_server: pthread_cond_t = unsafe { MaybeUninit::zeroed().assume_init() };
-        let mut cond_client: pthread_cond_t = unsafe { MaybeUninit::zeroed().assume_init() };
+        unsafe {
+            bail_on_libc_err!(pthread_condattr_init(cond_attr_ptr));
+            bail_on_libc_err!(pthread_condattr_setpshared(
+                cond_attr_ptr,
+                PTHREAD_PROCESS_SHARED
+            ));
+        }
+
+        let mut cond_server: pthread_cond_t = unsafe { std::mem::zeroed() };
+        let mut cond_client: pthread_cond_t = unsafe { std::mem::zeroed() };
 
         let cond_server_ptr = &mut cond_server as *mut _;
         let cond_client_ptr = &mut cond_client as *mut _;
 
-        unsafe { 
-            pthread_cond_init(cond_server_ptr, cond_attr_ptr);
-            pthread_cond_init(cond_client_ptr, cond_attr_ptr);
-        };
+        unsafe {
+            bail_on_libc_err!(pthread_cond_init(cond_server_ptr, cond_attr_ptr));
+            bail_on_libc_err!(pthread_cond_init(cond_client_ptr, cond_attr_ptr));
+        }
 
-        let is_server = true;
-        Self {
+        Ok(Self {
             mutex,
             cond_server,
             cond_client,
-            is_server,
-        }
+            // Initial value is `true` to indicate that the server has the initial mutex lock
+            is_server: true,
+        })
     }
 
     pub fn wait(&mut self) -> Result<()> {
         let mutex_ptr = &mut self.mutex as *mut _;
         let cond_ptr = &mut self.cond_server as *mut _;
-        if unsafe { pthread_mutex_lock(mutex_ptr) } == -1 {
-            bail!(get_last_error(&format!("Failed to lock semaphore",)));
+        unsafe {
+            bail_on_libc_err!(pthread_mutex_lock(mutex_ptr));
         }
 
         #[allow(clippy::while_immutable_condition)]
         while !self.is_server {
-            if unsafe { pthread_cond_wait(cond_ptr, mutex_ptr) } == -1 {
-                bail!(get_last_error(&format!("Failed to lock semaphore",)));
+            unsafe {
+                bail_on_libc_err!(pthread_cond_wait(cond_ptr, mutex_ptr));
             }
         }
 
@@ -95,16 +102,11 @@ impl Semaphore {
 
         let ts_ptr = &mut ts as *mut _;
         let mutex_ptr = &mut self.mutex as *mut _;
-        let cond_ptr= &mut self.cond_server as *mut _;
+        let cond_ptr = &mut self.cond_server as *mut _;
 
-        if unsafe { pthread_mutex_lock(mutex_ptr) } != 0 {
-            bail!(get_last_error("fail"));
-        }
-
-        if unsafe { clock_gettime(CLOCK_REALTIME, ts_ptr) } == -1 {
-            bail!(get_last_error(&format!(
-                "clock_gettime failed in semaphore timedwait"
-            )));
+        unsafe {
+            bail_on_libc_err!(pthread_mutex_lock(mutex_ptr));
+            bail_on_libc_err!(clock_gettime(CLOCK_REALTIME, ts_ptr));
         }
 
         ts.tv_sec += duration.as_secs() as i64;
@@ -120,23 +122,17 @@ impl Semaphore {
 
         let mut rc: i32 = 0;
         while !self.is_server && rc == 0 {
-            rc = unsafe {
-                pthread_cond_timedwait(cond_ptr, mutex_ptr, ts_ptr)
-            };
+            rc = unsafe { pthread_cond_timedwait(cond_ptr, mutex_ptr, ts_ptr) };
         }
 
         match rc {
             0 => Ok(TimedWaitState::Success),
-            ETIMEDOUT =>  {
-                if unsafe { pthread_mutex_unlock(mutex_ptr) } != 0 {
-                    bail!(get_last_error("fail"));
-                }
-                Ok(TimedWaitState::Timeout) 
-            },
+            ETIMEDOUT => {
+                unsafe { bail_on_libc_err!(pthread_mutex_unlock(mutex_ptr)) };
+                Ok(TimedWaitState::Timeout)
+            }
             _ => {
-                if unsafe { pthread_mutex_unlock(mutex_ptr) } != 0 {
-                    bail!(get_last_error("fail"));
-                }
+                unsafe { bail_on_libc_err!(pthread_mutex_unlock(mutex_ptr)) };
                 bail!("failed to timedwait")
             }
         }
@@ -145,13 +141,12 @@ impl Semaphore {
     pub fn post(&mut self) -> Result<()> {
         let mutex_ptr = &mut self.mutex as *mut _;
         let cond_ptr = &mut self.cond_client as *mut _;
-        
+
         self.is_server = false;
 
-        unsafe { pthread_cond_broadcast(cond_ptr) };
-
-        if unsafe { pthread_mutex_unlock(mutex_ptr) } == -1 {
-            bail!(get_last_error(&format!("Failed to unlock semaphore",)));
+        unsafe {
+            bail_on_libc_err!(pthread_cond_broadcast(cond_ptr));
+            bail_on_libc_err!(pthread_mutex_unlock(mutex_ptr), -1);
         }
 
         Ok(())
@@ -165,20 +160,9 @@ impl Drop for Semaphore {
         let cond_server_ptr = &mut self.cond_server as *mut _;
         let cond_client_ptr = &mut self.cond_client as *mut _;
         unsafe {
-            if pthread_mutex_destroy(mutex_ptr) == -1 {
-                let err = get_errno();
-                eprintln!("Warning: sem_close failed: {}", err);
-            }
-
-            if pthread_cond_destroy(cond_server_ptr) == -1 {
-                let err = get_errno();
-                eprintln!("Waringin: pthread_cond_destroy on cond_server failed: {}", err);
-            }
-
-            if pthread_cond_destroy(cond_client_ptr) == -1 {
-                let err = get_errno();
-                eprintln!("Waringin: pthread_cond_destroy on cond_client failed: {}", err);
-            }
+            eprintln_on_libc_err!(pthread_mutex_destroy(mutex_ptr));
+            eprintln_on_libc_err!(pthread_cond_destroy(cond_server_ptr));
+            eprintln_on_libc_err!(pthread_cond_destroy(cond_client_ptr));
         }
     }
 }

--- a/vadl-cosim/cosim-lib/src/ipc/shm.rs
+++ b/vadl-cosim/cosim-lib/src/ipc/shm.rs
@@ -1,4 +1,4 @@
-use std::{ffi::CString, marker::PhantomData, mem::ManuallyDrop, ptr, time::Duration};
+use std::{ffi::CString, marker::PhantomData, ptr, time::Duration};
 
 use anyhow::{Context, Result, bail};
 use libc::{
@@ -37,11 +37,11 @@ impl SharedMemory<BrokerSHM> {
         self.get_mut().sync.timedwait(duration)
     }
 
-    pub fn get_exec(&self) -> &ManuallyDrop<BrokerSHMExec> {
+    pub fn get_exec(&self) -> &BrokerSHMExec {
         unsafe { &self.get().data.shm_exec }
     }
 
-    pub fn get_tb(&self) -> &ManuallyDrop<BrokerSHMTB> {
+    pub fn get_tb(&self) -> &BrokerSHMTB {
         unsafe { &self.get().data.shm_tb }
     }
 
@@ -67,7 +67,7 @@ impl<T: Sized> SharedMemory<T> {
             CString::new(mmap_path).with_context(|| format!("Invalid mmap_path: {mmap_path}"))?;
 
         let fd = unsafe {
-            bail_on_libc_err!(shm_open(mmap_path_c.as_ptr(), O_CREAT | O_RDWR, PERMISSONS))
+            bail_on_libc_err!(shm_open(mmap_path_c.as_ptr(), O_CREAT | O_RDWR, PERMISSONS), -1)
         };
 
         unsafe { bail_on_libc_err!(ftruncate(fd, size as i64)) };

--- a/vadl-cosim/cosim-lib/src/ipc/shm.rs
+++ b/vadl-cosim/cosim-lib/src/ipc/shm.rs
@@ -1,17 +1,23 @@
-use std::{ffi::CString, marker::PhantomData, ptr, time::Duration};
+use std::{ffi::CString, marker::PhantomData, mem::ManuallyDrop, ptr, time::Duration};
 
 use anyhow::{Context, Result, bail};
 use libc::{
     MAP_FAILED, MAP_SHARED, O_CREAT, O_RDWR, PROT_READ, PROT_WRITE, close, ftruncate, mmap, munmap,
     shm_open, shm_unlink,
 };
-use tracing::debug;
 
-use crate::ipc::{cstructs::BrokerSHM, get_errno, get_last_error, sem::TimedWaitState, PERMISSONS};
+use crate::{
+    bail_on_libc_err, eprintln_on_libc_err,
+    ipc::{
+        PERMISSONS,
+        cstructs::{BrokerSHM, BrokerSHMExec, BrokerSHMTB},
+        get_last_error,
+        sem::{Semaphore, TimedWaitState},
+    },
+};
 
 pub struct SharedMemory<T: Sized> {
     mmap_ptr: *mut u8,
-    mmap_path: String,
     mmap_path_c: CString,
     size: usize,
     fd: i32,
@@ -19,19 +25,28 @@ pub struct SharedMemory<T: Sized> {
 }
 
 impl SharedMemory<BrokerSHM> {
-    pub fn release_client(&self) -> Result<()> {
-        debug!("releasing client: {}", self.fd);
+    pub fn release_client(&mut self) -> Result<()> {
         self.get_mut().sync.post()
     }
 
-    pub fn wait_client(&self) -> Result<()> {
-        debug!("waiting client: {}", self.fd);
+    pub fn wait_client(&mut self) -> Result<()> {
         self.get_mut().sync.wait()
     }
 
-    pub fn timedwait_client(&self, duration: Duration) -> Result<TimedWaitState> {
-        debug!("waiting client timed: {}, {:?}", self.fd, duration);
+    pub fn timedwait_client(&mut self, duration: Duration) -> Result<TimedWaitState> {
         self.get_mut().sync.timedwait(duration)
+    }
+
+    pub fn get_exec(&self) -> &ManuallyDrop<BrokerSHMExec> {
+        unsafe { &self.get().data.shm_exec }
+    }
+
+    pub fn get_tb(&self) -> &ManuallyDrop<BrokerSHMTB> {
+        unsafe { &self.get().data.shm_tb }
+    }
+
+    pub fn get_sync(&self) -> &Semaphore {
+        &self.get().sync
     }
 }
 
@@ -47,40 +62,37 @@ impl<T: Sized> SharedMemory<T> {
     /// * `Err(String)` on failure.
     pub fn create(mmap_path: &str) -> Result<Self> {
         let size = size_of::<T>();
+
         let mmap_path_c =
             CString::new(mmap_path).with_context(|| format!("Invalid mmap_path: {mmap_path}"))?;
-        unsafe {
-            let fd = shm_open(mmap_path_c.as_ptr(), O_CREAT | O_RDWR, PERMISSONS);
-            if fd == -1 {
-                bail!(get_last_error("Failed to open shared memory"));
-            }
 
-            if ftruncate(fd, size as i64) == -1 {
-                bail!(get_last_error("Failed to truncate shared memory"));
-            }
+        let fd = unsafe {
+            bail_on_libc_err!(shm_open(mmap_path_c.as_ptr(), O_CREAT | O_RDWR, PERMISSONS))
+        };
 
-            let addr = mmap(
-                ptr::null_mut(),
-                size,
-                PROT_READ | PROT_WRITE,
-                MAP_SHARED,
-                fd,
-                0,
-            );
+        unsafe { bail_on_libc_err!(ftruncate(fd, size as i64)) };
 
-            if addr == MAP_FAILED {
-                bail!(get_last_error(&format!("Failed to map memory {mmap_path}")));
-            }
+        let addr = unsafe {
+            bail_on_libc_err!(
+                mmap(
+                    ptr::null_mut(),
+                    size,
+                    PROT_READ | PROT_WRITE,
+                    MAP_SHARED,
+                    fd,
+                    0,
+                ),
+                MAP_FAILED
+            )
+        };
 
-            Ok(Self {
-                mmap_ptr: addr as *mut u8,
-                mmap_path: mmap_path.to_string(),
-                mmap_path_c,
-                size,
-                fd,
-                _phantom: PhantomData,
-            })
-        }
+        Ok(Self {
+            mmap_ptr: addr as *mut u8,
+            mmap_path_c,
+            size,
+            fd,
+            _phantom: PhantomData,
+        })
     }
 
     /// Reads and deserializes data from shared memory.
@@ -92,7 +104,7 @@ impl<T: Sized> SharedMemory<T> {
     }
 
     #[allow(clippy::mut_from_ref)]
-    pub fn get_mut(&self) -> &mut T {
+    pub fn get_mut(&mut self) -> &mut T {
         let data_ptr = self.mmap_ptr as *mut T;
         let shared: &mut T = unsafe { &mut *data_ptr };
         shared
@@ -102,26 +114,9 @@ impl<T: Sized> SharedMemory<T> {
 impl<T: Sized> Drop for SharedMemory<T> {
     fn drop(&mut self) {
         unsafe {
-            if munmap(self.mmap_ptr as *mut _, self.size) == -1 {
-                let err = get_errno();
-                eprintln!("Warning: munmap failed on {}: {}", self.mmap_path, err);
-            }
-
-            if close(self.fd) == -1 {
-                let err = get_errno();
-                eprintln!(
-                    "Warning: close failed on {} (fd={}): {}",
-                    self.mmap_path, self.fd, err
-                );
-            }
-
-            if shm_unlink(self.mmap_path_c.as_ptr()) == -1 {
-                let err = get_errno();
-                eprintln!(
-                    "Warning: shm_unlink failed on {} (fd={}): {}",
-                    self.mmap_path, self.fd, err
-                );
-            }
+            eprintln_on_libc_err!(munmap(self.mmap_ptr as *mut _, self.size));
+            eprintln_on_libc_err!(close(self.fd));
+            eprintln_on_libc_err!(shm_unlink(self.mmap_path_c.as_ptr()));
         }
     }
 }

--- a/vadl-cosim/cosim-lib/src/ipc/shm.rs
+++ b/vadl-cosim/cosim-lib/src/ipc/shm.rs
@@ -10,7 +10,7 @@ use crate::{
     bail_on_libc_err, eprintln_on_libc_err,
     ipc::{
         PERMISSONS,
-        cstructs::{BrokerSHM, BrokerSHMExec, BrokerSHMTB},
+        cstructs::{BrokerSHM, BrokerSHMExec, BrokerSHMTB, BrokerSem},
         get_last_error,
         sem::{Semaphore, TimedWaitState},
     },
@@ -24,7 +24,7 @@ pub struct SharedMemory<T: Sized> {
     _phantom: PhantomData<T>,
 }
 
-impl SharedMemory<BrokerSHM> {
+impl SharedMemory<BrokerSem> {
     pub fn release_client(&mut self) -> Result<()> {
         self.get_mut().sync.post()
     }
@@ -37,16 +37,18 @@ impl SharedMemory<BrokerSHM> {
         self.get_mut().sync.timedwait(duration)
     }
 
+    pub fn get_sync(&self) -> &Semaphore {
+        &self.get().sync
+    }
+}
+
+impl SharedMemory<BrokerSHM> {
     pub fn get_exec(&self) -> &BrokerSHMExec {
         unsafe { &self.get().data.shm_exec }
     }
 
     pub fn get_tb(&self) -> &BrokerSHMTB {
         unsafe { &self.get().data.shm_tb }
-    }
-
-    pub fn get_sync(&self) -> &Semaphore {
-        &self.get().sync
     }
 }
 
@@ -67,7 +69,10 @@ impl<T: Sized> SharedMemory<T> {
             CString::new(mmap_path).with_context(|| format!("Invalid mmap_path: {mmap_path}"))?;
 
         let fd = unsafe {
-            bail_on_libc_err!(shm_open(mmap_path_c.as_ptr(), O_CREAT | O_RDWR, PERMISSONS), -1)
+            bail_on_libc_err!(
+                shm_open(mmap_path_c.as_ptr(), O_CREAT | O_RDWR, PERMISSONS),
+                -1
+            )
         };
 
         unsafe { bail_on_libc_err!(ftruncate(fd, size as i64)) };

--- a/vadl-cosim/cosim-lib/src/lib.rs
+++ b/vadl-cosim/cosim-lib/src/lib.rs
@@ -1,6 +1,6 @@
 pub mod cli;
-pub mod ipc;
-pub mod diff;
-pub mod cosim;
-pub mod trace;
 pub mod config;
+pub mod cosim;
+pub mod diff;
+pub mod ipc;
+pub mod trace;

--- a/vadl-cosim/cosim-lib/src/trace/db.rs
+++ b/vadl-cosim/cosim-lib/src/trace/db.rs
@@ -4,7 +4,7 @@ const CREATES_SQL: &str = include_str!("../../res/creates.sql");
 const DROPS_SQL: &str = include_str!("../../res/drops.sql");
 
 pub fn setup_database(pool: &DBConnection) -> Result<(), rusqlite::Error> {
-    let tx = pool.unchecked_transaction()?;  
+    let tx = pool.unchecked_transaction()?;
     tx.execute_batch(&format!("{DROPS_SQL}; {CREATES_SQL}"))?;
     tx.commit()?;
     Ok(())

--- a/vadl-cosim/cosim-lib/src/trace/mod.rs
+++ b/vadl-cosim/cosim-lib/src/trace/mod.rs
@@ -45,11 +45,11 @@ pub fn store_trace(trace: TraceData, connection: &Connection) -> Result<()> {
 pub fn get_client_trace(client: &crate::ipc::qemu::Client, config: &Config) -> TraceData {
     match config.testing.protocol.layer {
         crate::config::ProtocolLayer::Insn => {
-            let exec = Box::new(client.shm.get_exec().clone());
+            let exec = Box::new(client.shms.current().get_exec().clone());
             TraceData::Exec(exec)
         }
         crate::config::ProtocolLayer::TB | crate::config::ProtocolLayer::TBStrict => {
-            let tb = Box::new(client.shm.get_tb().clone());
+            let tb = Box::new(client.shms.current().get_tb().clone());
             TraceData::TB(tb)
         }
     }

--- a/vadl-cosim/cosim-lib/src/trace/mod.rs
+++ b/vadl-cosim/cosim-lib/src/trace/mod.rs
@@ -1,7 +1,4 @@
-use std::{
-    mem::ManuallyDrop,
-    path::Path,
-};
+use std::{mem::ManuallyDrop, path::Path};
 
 use anyhow::{Context, Result};
 use serde::Serialize;
@@ -32,17 +29,14 @@ pub fn connect(config: &Config) -> Result<Connection> {
         .context("failed to open sqlite connection for tracing")
 }
 
-pub fn store_trace(
-    trace: TraceData,
-    connection: &Connection,
-) -> Result<()> {
+pub fn store_trace(trace: TraceData, connection: &Connection) -> Result<()> {
     match trace {
         TraceData::TB(broker_shmtb) => {
             insert_broker_shm_tb(connection, &broker_shmtb)?;
-        },
+        }
         TraceData::Exec(broker_shmexec) => {
             insert_broker_shm_exec(connection, &broker_shmexec)?;
-        },
+        }
     };
 
     Ok(())
@@ -51,20 +45,17 @@ pub fn store_trace(
 pub fn get_client_trace(client: &crate::ipc::qemu::Client, config: &Config) -> TraceData {
     match config.testing.protocol.layer {
         crate::config::ProtocolLayer::Insn => {
-            let exec = unsafe { &client.shm.read().shm_exec };
-            let exec = exec.clone();
+            let exec = client.shm.get_exec().clone();
             let exec = ManuallyDrop::into_inner(exec);
             let exec = Box::new(exec);
             TraceData::Exec(exec)
         }
-        crate::config::ProtocolLayer::TB |
-        crate::config::ProtocolLayer::TBStrict => {
-            let tb = unsafe { &client.shm.read().shm_tb };
-            let tb = tb.clone();
+        crate::config::ProtocolLayer::TB | crate::config::ProtocolLayer::TBStrict => {
+            let tb = client.shm.get_tb().clone();
             let tb = ManuallyDrop::into_inner(tb);
             let tb = Box::new(tb);
             TraceData::TB(tb)
-        },
+        }
     }
 }
 
@@ -74,7 +65,8 @@ pub fn trace_collect(
     config: &crate::config::Config,
     store: &mut TraceStore,
 ) {
-    clients.iter()
+    clients
+        .iter()
         .map(|c| get_client_trace(c, config))
         .for_each(|t| store.push(t));
 }

--- a/vadl-cosim/cosim-lib/src/trace/mod.rs
+++ b/vadl-cosim/cosim-lib/src/trace/mod.rs
@@ -1,4 +1,4 @@
-use std::{mem::ManuallyDrop, path::Path};
+use std::path::Path;
 
 use anyhow::{Context, Result};
 use serde::Serialize;
@@ -45,15 +45,11 @@ pub fn store_trace(trace: TraceData, connection: &Connection) -> Result<()> {
 pub fn get_client_trace(client: &crate::ipc::qemu::Client, config: &Config) -> TraceData {
     match config.testing.protocol.layer {
         crate::config::ProtocolLayer::Insn => {
-            let exec = client.shm.get_exec().clone();
-            let exec = ManuallyDrop::into_inner(exec);
-            let exec = Box::new(exec);
+            let exec = Box::new(client.shm.get_exec().clone());
             TraceData::Exec(exec)
         }
         crate::config::ProtocolLayer::TB | crate::config::ProtocolLayer::TBStrict => {
-            let tb = client.shm.get_tb().clone();
-            let tb = ManuallyDrop::into_inner(tb);
-            let tb = Box::new(tb);
+            let tb = Box::new(client.shm.get_tb().clone());
             TraceData::TB(tb)
         }
     }

--- a/vadl/main/resources/templates/iss/contrib/plugins/cosimulation.c
+++ b/vadl/main/resources/templates/iss/contrib/plugins/cosimulation.c
@@ -334,11 +334,8 @@ static TBInfo get_tb_info(struct qemu_plugin_tb *tb) {
 static void vcpu_insn_exec(unsigned int cpu_index, void *udata) {
   pthread_mutex_lock(&shm->sync.mutex);
   while(shm->sync.is_server) {
-    PLUGIN_PRINTLN("waiting... %d", shm->sync.is_server);
     pthread_cond_wait(&shm->sync.cond_client, &shm->sync.mutex);
   }
-
-  PLUGIN_PRINTLN("got it!");
 
   TBInsnInfo *tbinsn_info = udata;
 
@@ -354,7 +351,6 @@ static void vcpu_insn_exec(unsigned int cpu_index, void *udata) {
   shm->sync.is_server = true;
   pthread_cond_broadcast(&shm->sync.cond_server);
   pthread_mutex_unlock(&shm->sync.mutex);
-  PLUGIN_PRINTLN("unlocked! %d", shm->sync.is_server);
 }
 
 static void vcpu_tb_exec(unsigned int cpu_index, void *udata) {

--- a/vadl/main/resources/templates/iss/contrib/plugins/cosimulation.c
+++ b/vadl/main/resources/templates/iss/contrib/plugins/cosimulation.c
@@ -24,6 +24,7 @@
 #include <glib.h>
 #include <qemu-plugin.h>
 #include <semaphore.h>
+#include <stddef.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/mman.h>
@@ -156,8 +157,11 @@ typedef struct {
 
 typedef struct {
   BrokerSHMData data;
-  Semaphore sync;
 } BrokerSHM;
+
+typedef struct {
+  Semaphore sync;
+} BrokerSem;
 
 typedef enum {
   INVALID_MODE = 0,
@@ -175,7 +179,27 @@ typedef struct {
 static GArray *cpus;
 
 static Arguments args;
-static BrokerSHM *shm;
+
+static BrokerSem *sem;
+
+#define SHM_QUEUE_SIZE 2
+
+static BrokerSHM *shm[SHM_QUEUE_SIZE];
+static size_t shm_idx = 0;
+
+static BrokerSHM *get_shm(void) {
+  return shm[shm_idx];
+}
+
+static void rotate_shm(void) {
+  shm_idx++;
+  shm_idx %= SHM_QUEUE_SIZE;
+}
+
+static BrokerSHM *next_shm(void) {
+  rotate_shm();
+  return get_shm();
+}
 
 static CPU *get_cpu(int vcpu_index) {
   CPU *c;
@@ -243,10 +267,39 @@ static void plugin_exit(qemu_plugin_id_t id, void *p) {
   PLUGIN_PRINTLN("plugin_exit");
 }
 
+static BrokerSem *connect_to_broker_sem(void) {
+  gchar *sem_name = g_strdup_printf("/cosimulation-sem-%s", args.client_id);
+  int sem_fd = shm_open(sem_name, O_RDWR, 0600);
+  if (sem_fd == -1) {
+    char *err = strerror(errno);
+    g_error("failed to open shared memory for client: %s -> %s", args.client_id,
+            err);
+    return NULL;
+  }
+
+  if (ftruncate(sem_fd, sizeof(BrokerSem)) == -1) {
+    char *err = strerror(errno);
+    g_error("failed to truncate shared memory for client: %s -> %s",
+            args.client_id, err);
+    return NULL;
+  }
+
+  BrokerSem *sem = mmap(NULL, sizeof(BrokerSem), PROT_READ | PROT_WRITE,
+                        MAP_SHARED, sem_fd, 0);
+  if (sem == MAP_FAILED) {
+    char *err = strerror(errno);
+    g_error("failed to mmap shared memory for client: %s -> %s", args.client_id,
+            err);
+    return NULL;
+  }
+
+  return sem;
+}
+
 // Connects to the broker by accessing the assigned shared memory
 // The shared memory is located under /cosimulation/shm-{client_id}
-static BrokerSHM *connect_to_broker(void) {
-  gchar *shm_name = g_strdup_printf("/cosimulation-shm-%s", args.client_id);
+static BrokerSHM *connect_to_broker_data(size_t shm_idx) {
+  gchar *shm_name = g_strdup_printf("/cosimulation-shm-%s-%lu", args.client_id, shm_idx);
   int shm_fd = shm_open(shm_name, O_RDWR, 0600);
   if (shm_fd == -1) {
     char *err = strerror(errno);
@@ -332,10 +385,12 @@ static TBInfo get_tb_info(struct qemu_plugin_tb *tb) {
 }
 
 static void vcpu_insn_exec(unsigned int cpu_index, void *udata) {
-  pthread_mutex_lock(&shm->sync.mutex);
-  while(shm->sync.is_server) {
-    pthread_cond_wait(&shm->sync.cond_client, &shm->sync.mutex);
+  pthread_mutex_lock(&sem->sync.mutex);
+  while(sem->sync.is_server) {
+    pthread_cond_wait(&sem->sync.cond_client, &sem->sync.mutex);
   }
+
+  BrokerSHM *shm = next_shm();
 
   TBInsnInfo *tbinsn_info = udata;
 
@@ -348,16 +403,18 @@ static void vcpu_insn_exec(unsigned int cpu_index, void *udata) {
   // TODO: we cannot free here because the same callback might be used multiple times when a tb gets reused
   // g_free(tbinsn_info);
 
-  shm->sync.is_server = true;
-  pthread_cond_broadcast(&shm->sync.cond_server);
-  pthread_mutex_unlock(&shm->sync.mutex);
+  sem->sync.is_server = true;
+  pthread_cond_broadcast(&sem->sync.cond_server);
+  pthread_mutex_unlock(&sem->sync.mutex);
 }
 
 static void vcpu_tb_exec(unsigned int cpu_index, void *udata) {
-  pthread_mutex_lock(&shm->sync.mutex);
-  while(shm->sync.is_server) {
-    pthread_cond_wait(&shm->sync.cond_client, &shm->sync.mutex);
+  pthread_mutex_lock(&sem->sync.mutex);
+  while(sem->sync.is_server) {
+    pthread_cond_wait(&sem->sync.cond_client, &sem->sync.mutex);
   }
+
+  BrokerSHM *shm = next_shm();
 
   SHMCPU cpu = get_cpu_state(cpu_index);
 
@@ -370,9 +427,9 @@ static void vcpu_tb_exec(unsigned int cpu_index, void *udata) {
   // TODO: we cannot free here because the same callback might be used multiple times when a tb gets reused
   // g_free(tb_info);
 
-  shm->sync.is_server = true;
-  pthread_cond_broadcast(&shm->sync.cond_server);
-  pthread_mutex_unlock(&shm->sync.mutex);
+  sem->sync.is_server = true;
+  pthread_cond_broadcast(&sem->sync.cond_server);
+  pthread_mutex_unlock(&sem->sync.mutex);
 }
 
 static void vcpu_tb_trans(qemu_plugin_id_t id, struct qemu_plugin_tb *tb) {
@@ -463,13 +520,16 @@ QEMU_PLUGIN_EXPORT int qemu_plugin_install(qemu_plugin_id_t id,
 
   PLUGIN_PRINTLN("::qemu_plugin_install");
 
-  shm = connect_to_broker();
-  if (shm == NULL) {
+  sem = connect_to_broker_sem();
+  if (sem == NULL) {
     return EXIT_FAILURE;
   }
 
-  if (args.mode == INSN_MODE) {
-    shm->data.shm_exec.init_mask = 0;
+  for (int i = 0; i < SHM_QUEUE_SIZE; i++) {
+    shm[i] = connect_to_broker_data(i);
+    if (shm[i] == NULL) {
+      return EXIT_FAILURE;
+    }
   }
 
   plugin_id = id;


### PR DESCRIPTION
This PR more data to the cosimulation-report and also now prints the report in a json-format.

Specifically, the report now additionally contains:
- a "before" state of all the registers before a diff occurred
- the instruction that was executed which caused the diverging state
- the "after" state of all the registers when the diff occurred
for each client.

This feature initially slowed the cosimulator by a large amount - with the issue being that the whole before-state needed to be cloned / pre-computed before every iteration "just in case" a divergence occurred. This resulted in a lot of unnecessary cloning / data-transformations.

The final solution can be seen in the last commit (e5fd5c207bce832fcba7b9e49ebff9a85ee5753f): I introduce a second shared-memory object for each client and switch between them, meaning the "before"-state can now be read from the unused shm-object of the given iteration. 