### PR TITLE
asm: Add abbreviated JALR form to rv32im asm grammar

### DIFF
--- a/vadl/test/resources/llvm/riscv/asm/rv32im/parser/IType.s
+++ b/vadl/test/resources/llvm/riscv/asm/rv32im/parser/IType.s
@@ -41,3 +41,15 @@ JALR x14, x15, 45
 # CHECK-NEXT: <MCOperand Reg:16>
 # CHECK-NEXT: <MCOperand Reg:17>
 # CHECK-NEXT: <MCOperand Imm:45>>
+
+JALR x15
+# CHECK: <MCInst #{{[0-9]+}} JALR
+# CHECK-NEXT: <MCOperand Reg:3>
+# CHECK-NEXT: <MCOperand Reg:17>
+# CHECK-NEXT: <MCOperand Imm:0>>
+
+JALR x14, 45(x15)
+# CHECK: <MCInst #{{[0-9]+}} JALR
+# CHECK-NEXT: <MCOperand Reg:16>
+# CHECK-NEXT: <MCOperand Reg:17>
+# CHECK-NEXT: <MCOperand Imm:45>>

--- a/vadl/test/resources/testSource/sys/risc-v/rv32im.vadl
+++ b/vadl/test/resources/testSource/sys/risc-v/rv32im.vadl
@@ -155,19 +155,26 @@ assembly description ASM for ABI = {
         ) @operand
     ;
 
+    // FIXME: Fix constant types in typechecker to allow just '1' instead of '1 as Bits<1>'
     JalrInstruction @instruction:
+      var rdTmp = null @operand
       var rs1Tmp = null @operand
       var immTmp = null @operand
       mnemonic = "JALR" @operand
-      rd = Register@operand ","
-      // FIXME: Fix constant types in typechecker to allow just '1' instead of '1 as Bits<1>'
-      (  ?(laideq(1 as Bits<1>, ","))
-          rs1Tmp = Register@operand ","
-          immTmp = JalrImmediateOperand
-        |
-          immTmp = JalrImmediateOperand
-          "(" rs1Tmp = Register@operand  ")"
+      ( ?(laideq(1 as Bits<1>, ",") )
+          rdTmp = Register@operand ","
+          ( ?(laideq(1 as Bits<1>, ",") )         // jalr rd, rs, imm
+              rs1Tmp = Register@operand ","
+              immTmp = JalrImmediateOperand
+            |
+              immTmp = JalrImmediateOperand       // jalr rd, imm(rs)
+              "(" rs1Tmp = Register@operand  ")"
+          )
+      | rdTmp = (x1_string @register) @operand    // jalr rs
+        rs1Tmp = Register@operand
+        immTmp = zero_const @operand
       )
+      rd = rdTmp
       rs1 = rs1Tmp
       immS = immTmp
     ;
@@ -323,6 +330,9 @@ assembly description ASM for ABI = {
       symbol = ImmediateOperand
     ;
   }
+
+  function x1_string -> String = "x1"
+  function zero_const -> SInt<64> = 0
 
   function lga_32_string -> String = "LGA_32"
 


### PR DESCRIPTION
This PR extends the `rv32im` assembly grammar so that the abbreviated form of  `JALR` can be parsed.
Before these forms could be parsed:
```
jalr x1, x2, 0
jalr x1, 0(x2)
```
Now also this form can be parsed:
```
jalr x2
```