### PR TITLE
sys: Use W register in aarch64 specification

### DIFF
--- a/sys/aarch64/aarch64.vadl
+++ b/sys/aarch64/aarch64.vadl
@@ -60,8 +60,10 @@ instruction set architecture AArch64Base = {
   memory        MEM : Address -> Byte // byte addressed memory
  
   register        S : Index -> BitsX  // general purpose register file with stack pointer
+  alias register R(i) = S(i)(31..0)   // lower half of general purpose register file with stack pointer
   [zero : X(31)]                      // X(31) is the zero register
   alias register  X = S               // general purpose register file with zero register
+  alias register W(i) = X(i)(31..0)   // lower half of general purpose register file with zero register
   alias register SP : Address = S(31) // stack pointer
   alias register LR : Address = S(30) // link register (return address)
 
@@ -217,6 +219,16 @@ instruction set architecture AArch64Base = {
   model-type MemoryModel = (InstrNoFunct, Memory) -> IsaDefs
 
 
+// models for selecting W or X register ****************************************
+
+  model WXReg (index: Id, size: Id): CallEx = {
+    match: Id ($size = WSize => W ; _ => X)($index)
+  }
+
+  model RSReg (index: Id, size: Id): CallEx = {
+    match: Id ($size = WSize => R ; _ => S)($index)
+  }
+
 // models for setting flags ****************************************************
 
   // set no flags
@@ -277,7 +289,7 @@ instruction set architecture AArch64Base = {
   model AddSubExtInstrBase (i: InstrWithFunct, extId: Id, size: Id, f: Flags, extEx: Ex, optId: Id, enc: Encs, asm: Ex): IsaDefs = {
     [undefined when : imm3(2) = 1 && imm3(1..0) != 0]
     instruction AsId ($i.id, $extId): AddSubExtFormat =
-      let result, flags = VADL::$i.funct (S(rn) as Bits<Size::$size>, ($extEx) as Bits<Size::$size>) in {
+      let result, flags = VADL::$i.funct ($RSReg(rn; $size), ($extEx) as Bits<Size::$size>) in {
         $f.resModel (match: Id ($f.ff = OffFlags => S ; _ => X)(rd) ; result )
         }
     encoding AsId ($i.id, $extId) = { op = $i.opcode, sf = SF::$size, ff = FF::$f.ff, option = ExtendType::$optId, $enc }
@@ -322,7 +334,7 @@ instruction set architecture AArch64Base = {
 
   model AddSubImmInstrShft (i: InstrWithFunct, size: Id, f: Flags, immEx: Ex, sh: Lit, asm: Str): IsaDefs = {
     instruction $i.id: AddSubImmFormat =
-      let result, flags = VADL::$i.funct (S(rn) as Bits<Size::$size>, ($immEx) as Bits<Size::$size>) in {
+      let result, flags = VADL::$i.funct ($RSReg(rn; $size), ($immEx) as Bits<Size::$size>) in {
         $f.resModel (match: Id ($f.ff = OffFlags => S ; _ => X)(rd) ; result )
         }
     encoding $i.id = { op = $i.opcode, sf = SF::$size, ff = FF::$f.ff, sh = $sh }
@@ -357,7 +369,7 @@ instruction set architecture AArch64Base = {
     // shift is set explicitely, therefore no undefined check for a shift of 0b11 is required
     [undefined when : sf = 0 && imm6(5) = 1]
     instruction $i.id: AddSubSftFormat =
-      let result, flags = VADL::$i.funct (X(rn) as Bits<Size::$size>, ($sftex) as Bits<Size::$size>) in {
+      let result, flags = VADL::$i.funct ($WXReg(rn; $size), ($sftex) as Bits<Size::$size>) in {
         $f.resModel (X(rd) ; result )
       }
     encoding $i.id = { op = $i.opcode, sf = SF::$size, ff = FF::$f.ff, $enc }
@@ -392,14 +404,14 @@ instruction set architecture AArch64Base = {
 
   model AddSubCarryInstr (i: InstrWithFunct, size: Id): IsaDefs = {
     instruction $i.id: ThreeRegOpFormat =
-      let result, flags = VADL::$i.funct(X(rn) as Bits<Size::$size>, X(rm) as Bits<Size::$size>, NZCV_C) in
+      let result, flags = VADL::$i.funct($WXReg(rn; $size), $WXReg(rm; $size), NZCV_C) in
         X(rd) := result as Bits<Size::$size> as BitsX
     $ThreeRegOpEncAsm ($i; $size)
     }
 
   model AddSubCarryFlagInstr (i: InstrWithFunct, size: Id): IsaDefs = {
     instruction $i.id: ThreeRegOpFormat =
-      let result, flags = VADL::$i.funct(X(rn) as Bits<Size::$size>, X(rm) as Bits<Size::$size>, NZCV_C) in {
+      let result, flags = VADL::$i.funct($WXReg(rn; $size), $WXReg(rm; $size), NZCV_C) in {
         X(rd) := result as Bits<Size::$size> as BitsX
         $SetFlags()
         }
@@ -445,7 +457,7 @@ instruction set architecture AArch64Base = {
 
   model MulAddSubInstr (i: InstrWithFunct, size: Id): IsaDefs = {
     instruction $i.id: MulAddSubFormat =
-      let result = VADL::$i.funct (X(ra) as Bits<Size::$size>, (X(rn) as Bits<Size::$size> * X(rm) as Bits<Size::$size>)) in
+      let result = VADL::$i.funct ($WXReg(ra; $size), $WXReg(rn; $size) * $WXReg(rm; $size)) in
         X(rd) := result as Bits<Size::$size> as BitsX
     encoding $i.id = { op = $i.opcode, sf = SF::$size }
     assembly $i.id = ($i.mnemo, ' ', $size(rd), ', ', $size(rn), ', ', $size(rm), ', ', $size(ra))
@@ -453,7 +465,7 @@ instruction set architecture AArch64Base = {
 
   model MulAddSubLongInstr (i: InstrWithFunct, type: Id): IsaDefs = {
     instruction $i.id: MulAddSubFormat =
-      X(rd) := VADL::$i.funct (X(ra), (X(rn) as $type<Size::WSize> *# X(rm) as $type<Size::WSize>))
+      X(rd) := VADL::$i.funct (X(ra), $WXReg(rn; WSize) *# $WXReg(rm; WSize))
     encoding $i.id = { op = $i.opcode, sf = SF::XSize }
     assembly $i.id = ($i.mnemo, ' ', XSize(rd), ', ', WSize(rn), ', ', WSize(rm), ', ', XSize(ra))
     }
@@ -475,8 +487,8 @@ instruction set architecture AArch64Base = {
 
   model DivInstr (i: InstrWithFunct, size: Id): IsaDefs = {
     instruction $i.id: ThreeRegOpFormat =
-      let dividend = X(rn) as $i.funct<Size::$size> in
-      let divisor  = X(rm) as $i.funct<Size::$size> in
+      let dividend = $WXReg(rn; $size) as $i.funct in
+      let divisor  = $WXReg(rm; $size) as $i.funct in
         let result =
           if divisor = 0
             then 0
@@ -615,7 +627,7 @@ instruction set architecture AArch64Base = {
   model LogicImmFlagInstr (i: InstrWithFunct, size: Id): IsaDefs = {
     [undefined when : imm13Decode (imm13) = 0 || sf = 0 && imm13(12) = 1]
     instruction $i.id: LogicImmFormat =
-      let result, flags = VADL::$i.funct (X(rn) as Bits<Size::$size>, AsId(imm, $size)) in {
+      let result, flags = VADL::$i.funct ($WXReg(rn; $size), AsId(imm, $size)) in {
         X(rd) := result as Bits<Size::$size> as BitsX
         $SetNZClearCVFlags ()
         }
@@ -625,7 +637,7 @@ instruction set architecture AArch64Base = {
   model LogicImmInstr (i: InstrWithFunct, size: Id): IsaDefs = {
     [undefined when : imm13Decode (imm13) = 0 || sf = 0 && imm13(12) = 1]
     instruction $i.id: LogicImmFormat =
-      let result = VADL::$i.funct (X(rn) as Bits<Size::$size>, AsId(imm, $size)) in
+      let result = VADL::$i.funct ($WXReg(rn; $size), AsId(imm, $size)) in
         S(rd) := result as Bits<Size::$size> as BitsX
     $LogicImmEncAsm ($i; $size; "SP")
     }
@@ -646,7 +658,7 @@ instruction set architecture AArch64Base = {
   model LogicRegGeneralInstr (i: InstrWithFunct, size: Id, s: RegShift, f: NoSetFlags): IsaDefs = {
     [undefined when : sf = 0 && imm6(5) = 1]
     instruction $i.id: LogicRegShiftFormat =
-      let result, flags = VADL::$i.funct (X(rn) as Bits<Size::$size>, $s.ex) in {
+      let result, flags = VADL::$i.funct ($WXReg(rn; $size), $s.ex) in {
         X(rd) := result as Bits<Size::$size> as BitsX
         $f ()
         }
@@ -675,11 +687,11 @@ instruction set architecture AArch64Base = {
     }
 
   model LogicRegShiftInstr (modelid: InstrWithFunctSizeRegShift, i: InstrWithFunct, size: Id): IsaDefs = {
-    $LogicRegShiftExtInstr ($modelid; $i; ""   ; $size; (X(rm) as Bits<Size::$size>; imm6 = 0, shift = ShiftType::LSL;  $size(rm))) // TODO pseudo instruction
-    $LogicRegShiftExtInstr ($modelid; $i; "LSL"; $size; (X(rm) as Bits<Size::$size>  << imm6;  shift = ShiftType::LSL; ($size(rm), ", lsl #", decimal(imm6))))
-    $LogicRegShiftExtInstr ($modelid; $i; "LSR"; $size; (X(rm) as UInt<Size::$size>  >> imm6;  shift = ShiftType::LSR; ($size(rm), ", lsr #", decimal(imm6))))
-    $LogicRegShiftExtInstr ($modelid; $i; "ASR"; $size; (X(rm) as SInt<Size::$size>  >> imm6;  shift = ShiftType::ASR; ($size(rm), ", asr #", decimal(imm6))))
-    $LogicRegShiftExtInstr ($modelid; $i; "ROR"; $size; (X(rm) as Bits<Size::$size> <>> imm6;  shift = ShiftType::ROR; ($size(rm), ", ror #", decimal(imm6))))
+    $LogicRegShiftExtInstr ($modelid; $i; ""   ; $size; ($WXReg(rm; $size) as Bits; imm6 = 0, shift = ShiftType::LSL;  $size(rm))) // TODO pseudo instruction
+    $LogicRegShiftExtInstr ($modelid; $i; "LSL"; $size; ($WXReg(rm; $size) as Bits  << imm6;  shift = ShiftType::LSL; ($size(rm), ", lsl #", decimal(imm6))))
+    $LogicRegShiftExtInstr ($modelid; $i; "LSR"; $size; ($WXReg(rm; $size) as UInt  >> imm6;  shift = ShiftType::LSR; ($size(rm), ", lsr #", decimal(imm6))))
+    $LogicRegShiftExtInstr ($modelid; $i; "ASR"; $size; ($WXReg(rm; $size) as SInt  >> imm6;  shift = ShiftType::ASR; ($size(rm), ", asr #", decimal(imm6))))
+    $LogicRegShiftExtInstr ($modelid; $i; "ROR"; $size; ($WXReg(rm; $size) as Bits <>> imm6;  shift = ShiftType::ROR; ($size(rm), ", ror #", decimal(imm6))))
     }
 
 
@@ -696,7 +708,7 @@ instruction set architecture AArch64Base = {
 
   model ShiftRegInstr (i: InstrWithFunct, size: Id): IsaDefs = {
     instruction $i.id: ShiftRegFormat =
-      X(rd) :=  VADL::$i.funct (X(rn) as Bits<Size::$size>, X(rm) as Bits<Size::$size>) as Bits as BitsX
+      X(rd) :=  VADL::$i.funct ($WXReg(rn; $size), $WXReg(rm; $size)) as Bits as BitsX
     encoding $i.id = { op = 0b0011'0101'1000'10, sf = SF::$size, shift = ShiftType::$i.opcode }
     assembly $i.id = ($i.mnemo, ' ', $size(rd), ', ', $size(rn), ', ', $size(rm))
     }
@@ -775,7 +787,7 @@ instruction set architecture AArch64Base = {
     // N is set explicitely, therefore no undefined check for sf != N is required
     [undefined when : sf = 0 && imms(5)]
     instruction $i.id: ExtractRegFormat =
-      let pair = (X(rn) as Bits<Size::$size>, X(rm) as Bits<Size::$size>) in
+      let pair = ($WXReg(rn; $size), $WXReg(rm; $size)) in
         X(rd) :=  (pair >> AsId (shift, $size)) as Bits<Size::$size> as BitsX
     encoding $i.id = { op = $i.opcode, sf = SF::$size, N = SF::$size }
     assembly $i.id = ($i.mnemo, ' ', $size(rd), ', ', $size(rn), ', ', $size(rm), ', #', decimal(imms))
@@ -838,7 +850,7 @@ instruction set architecture AArch64Base = {
     instruction $i.id: BitFieldMoveFormat =
       let left = AsId (left, $size) in
         let right = AsId (right, $size) in
-          let xrn = X(rn) as $i.funct<Size::$size> << left >> right in
+          let xrn = $WXReg(rn; $size) as $i.funct << left >> right in
             let result = match: Ex ($i.mnemo = "bfm" =>
               let mask = ~(~(0 as Bits<Size::$size>) << left >> right) in
                 X(rd) as Bits<Size::$size> & mask | xrn
@@ -866,7 +878,7 @@ instruction set architecture AArch64Base = {
 
   model CountBitsInstr (i: InstrWithFunct, size: Id): IsaDefs = {
     instruction $i.id: TwoRegOpFormat =
-      let result = VADL::$i.funct (X(rn) as Bits<Size::$size>) in
+      let result = VADL::$i.funct ($WXReg(rn; $size)) in
         X(rd) := result as Bits<Size::$size> as BitsX
     $TwoRegOpEncAsm ($i; $size)
     }
@@ -886,7 +898,7 @@ instruction set architecture AArch64Base = {
 
   model ReverseBitsInstr (i: InstrWithFunct, size: Id): IsaDefs = {
     instruction $i.id: TwoRegOpFormat =
-      let result = AsId (revBits, $size) (X(rn) as Bits<Size::$size>) in
+      let result = AsId (revBits, $size) ($WXReg(rn; $size)) in
         X(rd) := result as Bits<Size::$size> as BitsX
     $TwoRegOpEncAsm ($i; $size)
     }
@@ -934,7 +946,7 @@ instruction set architecture AArch64Base = {
   model CondCompareBaseInstr (i: InstrWithFunct, c: Cond, size: Id, ex: Ex, asm: Ex): IsaDefs = {
     instruction $i.id: CondCompareFormat =
       if $c.ex
-        then let result, flags = VADL::$i.funct(X(rn) as Bits<Size::$size>, $ex) in {
+        then let result, flags = VADL::$i.funct($WXReg(rn; $size), $ex) in {
           $SetFlags()
           }
         else {
@@ -953,7 +965,7 @@ instruction set architecture AArch64Base = {
     }
 
   model CondCompareRegInstr (i: InstrWithFunct, c: Cond): IsaDefs = {
-    $CondCompareBaseInstr ($ExtInstrStr ($i; "W"); $c; WSize; X(rm) as BitsW; (', ', WSize(rm)))
+    $CondCompareBaseInstr ($ExtInstrStr ($i; "W"); $c; WSize; W(rm)         ; (', ', WSize(rm)))
     $CondCompareBaseInstr ($ExtInstrStr ($i; "X"); $c; XSize; X(rm)         ; (', ', XSize(rm)))
     }
 
@@ -1091,7 +1103,7 @@ instruction set architecture AArch64Base = {
 
   model CompareBranchInstr (i: InstrWithFunct, size: Id): IsaDefs = {
     instruction $i.id: CompareBranchFormat =
-      if VADL::$i.funct (X(rt) as Bits<Size::$size>, 0) then
+      if VADL::$i.funct ($WXReg(rt; $size), 0) then
         PC := PC + offset
     encoding $i.id = { op = $i.opcode, sf = SF::$size }
     assembly $i.id = ($i.mnemo, ' ', $size(rt), ', ', decimal(imm19))

--- a/sys/aarch64/aarch64.vadl
+++ b/sys/aarch64/aarch64.vadl
@@ -63,6 +63,7 @@ instruction set architecture AArch64Base = {
   alias register R(i) = S(i)(31..0)   // lower half of general purpose register file with stack pointer
   [zero : X(31)]                      // X(31) is the zero register
   alias register  X = S               // general purpose register file with zero register
+  [zero : W(31)]                      // X(31) is the zero register
   alias register W(i) = X(i)(31..0)   // lower half of general purpose register file with zero register
   alias register SP : Address = S(31) // stack pointer
   alias register LR : Address = S(30) // link register (return address)

--- a/vadl/test/resources/embench/build_virt-iss-a64.sh
+++ b/vadl/test/resources/embench/build_virt-iss-a64.sh
@@ -5,4 +5,5 @@ cd $(realpath $(dirname "$0"))
 CFLAGS="-march=armv8-a -g -mstrict-align"
 # benchmarks that use floating point types must be excluded
 FLOATEXCL="cubic,nbody,minver,st,statemate,ud,wikisort"
-./build_all.py --cc aarch64-none-elf-gcc --arch aarch64 --chip generic --board virt-iss --clean --cflags "$CFLAGS" --exclude "$FLOATEXCL$UPFAILING" "$@"
+NOTWORKING=",edn"
+./build_all.py --cc aarch64-none-elf-gcc --arch aarch64 --chip generic --board virt-iss --clean --cflags "$CFLAGS" --exclude "$FLOATEXCL$NOTWORKING" "$@"

--- a/vadl/test/resources/snapshots/aarch64/InstrInfoTableGen.td
+++ b/vadl/test/resources/snapshots/aarch64/InstrInfoTableGen.td
@@ -9014,7 +9014,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_ADDXASR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDXASR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -9185,7 +9185,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_ADDXLSL_imm6AsInt8:$imm6 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDXLSL_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -9244,7 +9244,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_ADDXLSR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDXLSR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -9362,7 +9362,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_ADDXSASR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDXSASR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -9533,7 +9533,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_ADDXSLSL_imm6AsInt8:$imm6 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDXSLSL_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -9592,7 +9592,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_ADDXSLSR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDXSLSR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -9651,7 +9651,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_ADDXSSXSB_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDXSSXSB_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -9709,7 +9709,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_ADDXSSXSH_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDXSSXSH_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -9767,7 +9767,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_ADDXSSXSW_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDXSSXSW_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -9825,7 +9825,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_ADDXSSXSX_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDXSSXSX_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -9883,7 +9883,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -9941,7 +9941,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -9999,7 +9999,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -10057,7 +10057,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -10115,7 +10115,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_ADDXSUXSB_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDXSUXSB_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -10173,7 +10173,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_ADDXSUXSH_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDXSUXSH_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -10231,7 +10231,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_ADDXSUXSW_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDXSUXSW_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -10289,7 +10289,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_ADDXSUXSX_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDXSUXSX_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -10347,7 +10347,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -10405,7 +10405,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -10463,7 +10463,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -10521,7 +10521,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -10579,7 +10579,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_ADDXSXSB_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDXSXSB_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -10637,7 +10637,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_ADDXSXSH_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDXSXSH_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -10695,7 +10695,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_ADDXSXSW_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDXSXSW_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -10753,7 +10753,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_ADDXSXSX_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDXSXSX_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -10811,7 +10811,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -10869,7 +10869,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -10927,7 +10927,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -10985,7 +10985,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -11043,7 +11043,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_ADDXUXSB_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDXUXSB_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -11101,7 +11101,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_ADDXUXSH_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDXUXSH_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -11159,7 +11159,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_ADDXUXSW_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDXUXSW_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -11217,7 +11217,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_ADDXUXSX_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDXUXSX_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -11275,7 +11275,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -11333,7 +11333,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -11391,7 +11391,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -11449,7 +11449,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -12145,7 +12145,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_ANDSXASR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ANDSXASR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -12201,7 +12201,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_ANDSXLSL_imm6AsInt8:$imm6 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ANDSXLSL_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -12257,7 +12257,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_ANDSXLSR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ANDSXLSR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -12313,7 +12313,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_ANDSXROR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ANDSXROR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -12705,7 +12705,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_ANDXASR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ANDXASR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -12761,7 +12761,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_ANDXLSL_imm6AsInt8:$imm6 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ANDXLSL_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -12817,7 +12817,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_ANDXLSR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ANDXLSR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -12873,7 +12873,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_ANDXROR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ANDXROR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -13472,7 +13472,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -13528,7 +13528,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_BICSXASR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_BICSXASR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -13584,7 +13584,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_BICSXLSL_imm6AsInt8:$imm6 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_BICSXLSL_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -13640,7 +13640,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_BICSXLSR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_BICSXLSR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -13696,7 +13696,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_BICSXROR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_BICSXROR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -14032,7 +14032,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -14088,7 +14088,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_BICXASR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_BICXASR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -14144,7 +14144,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_BICXLSL_imm6AsInt8:$imm6 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_BICXLSL_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -14200,7 +14200,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_BICXLSR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_BICXLSR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -14256,7 +14256,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_BICXROR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_BICXROR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -24377,7 +24377,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -24431,7 +24431,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -24485,7 +24485,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -24539,7 +24539,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -24593,7 +24593,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -24647,7 +24647,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -24701,7 +24701,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -24755,7 +24755,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -24809,7 +24809,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -24863,7 +24863,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -24917,7 +24917,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -24971,7 +24971,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -25025,7 +25025,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -25079,7 +25079,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -25133,7 +25133,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -25187,7 +25187,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -25241,7 +25241,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -25295,7 +25295,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -25349,7 +25349,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -25403,7 +25403,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -25457,7 +25457,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -25511,7 +25511,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -25565,7 +25565,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -25619,7 +25619,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -25673,7 +25673,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -25727,7 +25727,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -25781,7 +25781,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -25835,7 +25835,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -25889,7 +25889,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -25943,7 +25943,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -25997,7 +25997,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -26051,7 +26051,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -26105,7 +26105,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -26159,7 +26159,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -26213,7 +26213,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -26267,7 +26267,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -26321,7 +26321,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -26375,7 +26375,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -26429,7 +26429,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -26483,7 +26483,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -26537,7 +26537,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -26591,7 +26591,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -26645,7 +26645,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -26699,7 +26699,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -26753,7 +26753,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -26807,7 +26807,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -26861,7 +26861,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -26915,7 +26915,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -26969,7 +26969,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -27023,7 +27023,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -27077,7 +27077,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -27131,7 +27131,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -27185,7 +27185,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -27239,7 +27239,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -27293,7 +27293,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -27347,7 +27347,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -27401,7 +27401,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -27455,7 +27455,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -27509,7 +27509,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -27563,7 +27563,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -27617,7 +27617,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -27671,7 +27671,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -27725,7 +27725,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -27779,7 +27779,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -27833,7 +27833,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -27887,7 +27887,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -27941,7 +27941,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -27995,7 +27995,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -28049,7 +28049,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -28103,7 +28103,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -28157,7 +28157,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -28211,7 +28211,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -28265,7 +28265,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -28319,7 +28319,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -28373,7 +28373,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -28427,7 +28427,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -28481,7 +28481,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -28535,7 +28535,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -28589,7 +28589,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -28643,7 +28643,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -28697,7 +28697,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -28751,7 +28751,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -28805,7 +28805,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -28859,7 +28859,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -28913,7 +28913,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -28967,7 +28967,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -29021,7 +29021,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -29075,7 +29075,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -29129,7 +29129,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -29183,7 +29183,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -29237,7 +29237,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -29291,7 +29291,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -29345,7 +29345,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -29399,7 +29399,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -29453,7 +29453,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -29507,7 +29507,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -29841,7 +29841,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -29897,7 +29897,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_EONXASR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_EONXASR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -29953,7 +29953,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_EONXLSL_imm6AsInt8:$imm6 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_EONXLSL_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -30009,7 +30009,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_EONXLSR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_EONXLSR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -30065,7 +30065,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_EONXROR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_EONXROR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -30559,7 +30559,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_EORXASR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_EORXASR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -30615,7 +30615,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_EORXLSL_imm6AsInt8:$imm6 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_EORXLSL_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -30671,7 +30671,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_EORXLSR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_EORXLSR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -30727,7 +30727,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_EORXROR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_EORXROR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -32642,7 +32642,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -32701,7 +32701,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -32760,7 +32760,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -32878,7 +32878,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -32937,7 +32937,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -32996,7 +32996,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -33114,7 +33114,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -33173,7 +33173,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -33232,7 +33232,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -33350,7 +33350,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -33409,7 +33409,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -33468,7 +33468,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -33586,7 +33586,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -33645,7 +33645,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -33704,7 +33704,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -33822,7 +33822,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -33881,7 +33881,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -33940,7 +33940,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -34058,7 +34058,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -34117,7 +34117,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -34176,7 +34176,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -34294,7 +34294,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -34353,7 +34353,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -34412,7 +34412,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -34530,7 +34530,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -34589,7 +34589,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -34648,7 +34648,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -34766,7 +34766,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -34825,7 +34825,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -34884,7 +34884,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -35002,7 +35002,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -35061,7 +35061,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -35120,7 +35120,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -35238,7 +35238,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -35297,7 +35297,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -35356,7 +35356,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -35474,7 +35474,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -35533,7 +35533,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -35592,7 +35592,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -35710,7 +35710,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -35769,7 +35769,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -35828,7 +35828,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -35946,7 +35946,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -36005,7 +36005,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -36064,7 +36064,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -36182,7 +36182,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -36241,7 +36241,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -36300,7 +36300,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -36418,7 +36418,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -36477,7 +36477,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -36536,7 +36536,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -36654,7 +36654,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -36713,7 +36713,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -36772,7 +36772,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -38026,7 +38026,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, S:$ra );
+let InOperandList = ( ins S:$ra, S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -39033,7 +39033,7 @@ let AddedComplexity = 0;
 
 let Pattern = [];
 
-let Uses = [  ];
+let Uses = [ S31 ];
 let Defs = [ SP_EL1 ];
 }
 
@@ -39146,7 +39146,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, S:$ra );
+let InOperandList = ( ins S:$ra, S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -39525,7 +39525,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -39581,7 +39581,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_ORNXASR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ORNXASR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -39637,7 +39637,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_ORNXLSL_imm6AsInt8:$imm6 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ORNXLSL_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -39693,7 +39693,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_ORNXLSR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ORNXLSR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -39749,7 +39749,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_ORNXROR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ORNXROR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -40243,7 +40243,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_ORRXASR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ORRXASR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -40299,7 +40299,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_ORRXLSL_imm6AsInt8:$imm6 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ORRXLSL_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -40355,7 +40355,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_ORRXLSR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ORRXLSR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -40411,7 +40411,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_ORRXROR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ORRXROR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -41386,7 +41386,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, S:$ra );
+let InOperandList = ( ins S:$ra, S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -41440,7 +41440,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, S:$ra );
+let InOperandList = ( ins S:$ra, S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -42428,7 +42428,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rm, S:$rn, S:$rt );
+let InOperandList = ( ins S:$rn, S:$rm, S:$rt );
 
 field bits<32> Inst;
 
@@ -42487,7 +42487,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rm, S:$rn, S:$rt );
+let InOperandList = ( ins S:$rn, S:$rm, S:$rt );
 
 field bits<32> Inst;
 
@@ -42546,7 +42546,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rm, S:$rn, S:$rt );
+let InOperandList = ( ins S:$rn, S:$rm, S:$rt );
 
 field bits<32> Inst;
 
@@ -42664,7 +42664,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rm, S:$rn, S:$rt );
+let InOperandList = ( ins S:$rn, S:$rm, S:$rt );
 
 field bits<32> Inst;
 
@@ -42723,7 +42723,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rm, S:$rn, S:$rt );
+let InOperandList = ( ins S:$rn, S:$rm, S:$rt );
 
 field bits<32> Inst;
 
@@ -42782,7 +42782,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rm, S:$rn, S:$rt );
+let InOperandList = ( ins S:$rn, S:$rm, S:$rt );
 
 field bits<32> Inst;
 
@@ -42900,7 +42900,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rm, S:$rn, S:$rt );
+let InOperandList = ( ins S:$rn, S:$rm, S:$rt );
 
 field bits<32> Inst;
 
@@ -42959,7 +42959,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rm, S:$rn, S:$rt );
+let InOperandList = ( ins S:$rn, S:$rm, S:$rt );
 
 field bits<32> Inst;
 
@@ -43018,7 +43018,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rm, S:$rn, S:$rt );
+let InOperandList = ( ins S:$rn, S:$rm, S:$rt );
 
 field bits<32> Inst;
 
@@ -43136,7 +43136,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rm, S:$rn, S:$rt );
+let InOperandList = ( ins S:$rn, S:$rm, S:$rt );
 
 field bits<32> Inst;
 
@@ -43195,7 +43195,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rm, S:$rn, S:$rt );
+let InOperandList = ( ins S:$rn, S:$rm, S:$rt );
 
 field bits<32> Inst;
 
@@ -43254,7 +43254,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rm, S:$rn, S:$rt );
+let InOperandList = ( ins S:$rn, S:$rm, S:$rt );
 
 field bits<32> Inst;
 
@@ -43372,7 +43372,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rm, S:$rn, S:$rt );
+let InOperandList = ( ins S:$rn, S:$rm, S:$rt );
 
 field bits<32> Inst;
 
@@ -43431,7 +43431,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rm, S:$rn, S:$rt );
+let InOperandList = ( ins S:$rn, S:$rm, S:$rt );
 
 field bits<32> Inst;
 
@@ -43490,7 +43490,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rm, S:$rn, S:$rt );
+let InOperandList = ( ins S:$rn, S:$rm, S:$rt );
 
 field bits<32> Inst;
 
@@ -43608,7 +43608,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rm, S:$rn, S:$rt );
+let InOperandList = ( ins S:$rn, S:$rm, S:$rt );
 
 field bits<32> Inst;
 
@@ -43667,7 +43667,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rm, S:$rn, S:$rt );
+let InOperandList = ( ins S:$rn, S:$rm, S:$rt );
 
 field bits<32> Inst;
 
@@ -43726,7 +43726,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rm, S:$rn, S:$rt );
+let InOperandList = ( ins S:$rn, S:$rm, S:$rt );
 
 field bits<32> Inst;
 
@@ -43844,7 +43844,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rm, S:$rn, S:$rt );
+let InOperandList = ( ins S:$rn, S:$rm, S:$rt );
 
 field bits<32> Inst;
 
@@ -43903,7 +43903,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rm, S:$rn, S:$rt );
+let InOperandList = ( ins S:$rn, S:$rm, S:$rt );
 
 field bits<32> Inst;
 
@@ -43962,7 +43962,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rm, S:$rn, S:$rt );
+let InOperandList = ( ins S:$rn, S:$rm, S:$rt );
 
 field bits<32> Inst;
 
@@ -44080,7 +44080,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rm, S:$rn, S:$rt );
+let InOperandList = ( ins S:$rn, S:$rm, S:$rt );
 
 field bits<32> Inst;
 
@@ -44139,7 +44139,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rm, S:$rn, S:$rt );
+let InOperandList = ( ins S:$rn, S:$rm, S:$rt );
 
 field bits<32> Inst;
 
@@ -44198,7 +44198,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rm, S:$rn, S:$rt );
+let InOperandList = ( ins S:$rn, S:$rm, S:$rt );
 
 field bits<32> Inst;
 
@@ -47253,7 +47253,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_SUBXASR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBXASR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -47424,7 +47424,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_SUBXLSL_imm6AsInt8:$imm6 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBXLSL_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -47483,7 +47483,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_SUBXLSR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBXLSR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -47601,7 +47601,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_SUBXSASR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBXSASR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -47772,7 +47772,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_SUBXSLSL_imm6AsInt8:$imm6 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBXSLSL_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -47831,7 +47831,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_SUBXSLSR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBXSLSR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -47890,7 +47890,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_SUBXSSXSB_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBXSSXSB_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -47948,7 +47948,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_SUBXSSXSH_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBXSSXSH_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -48006,7 +48006,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_SUBXSSXSW_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBXSSXSW_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -48064,7 +48064,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_SUBXSSXSX_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBXSSXSX_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -48122,7 +48122,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -48180,7 +48180,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -48238,7 +48238,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -48296,7 +48296,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -48354,7 +48354,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_SUBXSUXSB_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBXSUXSB_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -48412,7 +48412,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_SUBXSUXSH_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBXSUXSH_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -48470,7 +48470,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_SUBXSUXSW_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBXSUXSW_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -48528,7 +48528,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_SUBXSUXSX_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBXSUXSX_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -48586,7 +48586,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -48644,7 +48644,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -48702,7 +48702,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -48760,7 +48760,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -48818,7 +48818,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_SUBXSXSB_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBXSXSB_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -48876,7 +48876,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_SUBXSXSH_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBXSXSH_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -48934,7 +48934,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_SUBXSXSW_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBXSXSW_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -48992,7 +48992,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_SUBXSXSX_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBXSXSX_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -49050,7 +49050,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -49108,7 +49108,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -49166,7 +49166,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -49224,7 +49224,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -49282,7 +49282,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_SUBXUXSB_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBXUXSB_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -49340,7 +49340,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_SUBXUXSH_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBXUXSH_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -49398,7 +49398,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_SUBXUXSW_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBXUXSW_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -49456,7 +49456,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn, AArch64Base_SUBXUXSX_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBXUXSX_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -49514,7 +49514,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -49572,7 +49572,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -49630,7 +49630,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -49688,7 +49688,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -50060,7 +50060,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, S:$ra );
+let InOperandList = ( ins S:$ra, S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -50114,7 +50114,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, S:$ra );
+let InOperandList = ( ins S:$ra, S:$rn, S:$rm );
 
 field bits<32> Inst;
 
@@ -50786,24 +50786,12 @@ def : Pat<(add S:$rn, (srl S:$rm, AArch64Base_ADDWSLSR_imm6AsInt8:$imm6)),
         (ADDWSLSR S:$rn, S:$rm, AArch64Base_ADDWSLSR_imm6AsInt8:$imm6)>;
 
 
-def : Pat<(add S:$rn, (shl S:$rm, AArch64Base_ADDWSSXSW_imm3AsInt8:$imm3)),
-        (ADDWSSXSW S:$rn, S:$rm, AArch64Base_ADDWSSXSW_imm3AsInt8:$imm3)>;
-
-
 def : Pat<(add S:$rn, (shl S:$rm, AArch64Base_ADDWSSXSX_imm3AsInt8:$imm3)),
         (ADDWSSXSX S:$rn, S:$rm, AArch64Base_ADDWSSXSX_imm3AsInt8:$imm3)>;
 
 
 def : Pat<(add S:$rn, S:$rm),
-        (ADDWSSXTW S:$rn, S:$rm)>;
-
-
-def : Pat<(add S:$rn, S:$rm),
         (ADDWSSXTX S:$rn, S:$rm)>;
-
-
-def : Pat<(add S:$rn, (shl S:$rm, AArch64Base_ADDWSUXSW_imm3AsInt8:$imm3)),
-        (ADDWSUXSW S:$rn, S:$rm, AArch64Base_ADDWSUXSW_imm3AsInt8:$imm3)>;
 
 
 def : Pat<(add S:$rn, (shl S:$rm, AArch64Base_ADDWSUXSX_imm3AsInt8:$imm3)),
@@ -50811,15 +50799,7 @@ def : Pat<(add S:$rn, (shl S:$rm, AArch64Base_ADDWSUXSX_imm3AsInt8:$imm3)),
 
 
 def : Pat<(add S:$rn, S:$rm),
-        (ADDWSUXTW S:$rn, S:$rm)>;
-
-
-def : Pat<(add S:$rn, S:$rm),
         (ADDWSUXTX S:$rn, S:$rm)>;
-
-
-def : Pat<(add S:$rn, (shl S:$rm, AArch64Base_ADDWSXSW_imm3AsInt8:$imm3)),
-        (ADDWSXSW S:$rn, S:$rm, AArch64Base_ADDWSXSW_imm3AsInt8:$imm3)>;
 
 
 def : Pat<(add S:$rn, (shl S:$rm, AArch64Base_ADDWSXSX_imm3AsInt8:$imm3)),
@@ -50827,23 +50807,11 @@ def : Pat<(add S:$rn, (shl S:$rm, AArch64Base_ADDWSXSX_imm3AsInt8:$imm3)),
 
 
 def : Pat<(add S:$rn, S:$rm),
-        (ADDWSXTW S:$rn, S:$rm)>;
-
-
-def : Pat<(add S:$rn, S:$rm),
         (ADDWSXTX S:$rn, S:$rm)>;
-
-
-def : Pat<(add S:$rn, (shl S:$rm, AArch64Base_ADDWUXSW_imm3AsInt8:$imm3)),
-        (ADDWUXSW S:$rn, S:$rm, AArch64Base_ADDWUXSW_imm3AsInt8:$imm3)>;
 
 
 def : Pat<(add S:$rn, (shl S:$rm, AArch64Base_ADDWUXSX_imm3AsInt8:$imm3)),
         (ADDWUXSX S:$rn, S:$rm, AArch64Base_ADDWUXSX_imm3AsInt8:$imm3)>;
-
-
-def : Pat<(add S:$rn, S:$rm),
-        (ADDWUXTW S:$rn, S:$rm)>;
 
 
 def : Pat<(add S:$rn, S:$rm),
@@ -50855,7 +50823,7 @@ def : Pat<(add S:$rn, S:$rm),
 
 
 def : Pat<(add S:$rn, (sra S:$rm, AArch64Base_ADDXASR_imm6AsInt8:$imm6)),
-        (ADDXASR S:$rm, S:$rn, AArch64Base_ADDXASR_imm6AsInt8:$imm6)>;
+        (ADDXASR S:$rn, S:$rm, AArch64Base_ADDXASR_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(add S:$rn, AArch64Base_ADDXI_imm12XAsInt64:$imm12X),
@@ -50870,11 +50838,11 @@ def : Pat<(add S:$rn, AArch64Base_ADDXI12_imm12SAsInt64:$imm12S),
 
 
 def : Pat<(add S:$rn, (shl S:$rm, AArch64Base_ADDXLSL_imm6AsInt8:$imm6)),
-        (ADDXLSL S:$rm, S:$rn, AArch64Base_ADDXLSL_imm6AsInt8:$imm6)>;
+        (ADDXLSL S:$rn, S:$rm, AArch64Base_ADDXLSL_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(add S:$rn, (srl S:$rm, AArch64Base_ADDXLSR_imm6AsInt8:$imm6)),
-        (ADDXLSR S:$rm, S:$rn, AArch64Base_ADDXLSR_imm6AsInt8:$imm6)>;
+        (ADDXLSR S:$rn, S:$rm, AArch64Base_ADDXLSR_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(add S:$rn, S:$rm),
@@ -50882,7 +50850,7 @@ def : Pat<(add S:$rn, S:$rm),
 
 
 def : Pat<(add S:$rn, (sra S:$rm, AArch64Base_ADDXSASR_imm6AsInt8:$imm6)),
-        (ADDXSASR S:$rm, S:$rn, AArch64Base_ADDXSASR_imm6AsInt8:$imm6)>;
+        (ADDXSASR S:$rn, S:$rm, AArch64Base_ADDXSASR_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(add S:$rn, AArch64Base_ADDXSI_imm12XAsInt64:$imm12X),
@@ -50894,75 +50862,43 @@ def : Pat<(add S:$rn, AArch64Base_ADDXSI12_imm12SAsInt64:$imm12S),
 
 
 def : Pat<(add S:$rn, (shl S:$rm, AArch64Base_ADDXSLSL_imm6AsInt8:$imm6)),
-        (ADDXSLSL S:$rm, S:$rn, AArch64Base_ADDXSLSL_imm6AsInt8:$imm6)>;
+        (ADDXSLSL S:$rn, S:$rm, AArch64Base_ADDXSLSL_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(add S:$rn, (srl S:$rm, AArch64Base_ADDXSLSR_imm6AsInt8:$imm6)),
-        (ADDXSLSR S:$rm, S:$rn, AArch64Base_ADDXSLSR_imm6AsInt8:$imm6)>;
-
-
-def : Pat<(add S:$rn, (shl S:$rm, AArch64Base_ADDXSSXSW_imm3AsInt8:$imm3)),
-        (ADDXSSXSW S:$rm, S:$rn, AArch64Base_ADDXSSXSW_imm3AsInt8:$imm3)>;
+        (ADDXSLSR S:$rn, S:$rm, AArch64Base_ADDXSLSR_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(add S:$rn, (shl S:$rm, AArch64Base_ADDXSSXSX_imm3AsInt8:$imm3)),
-        (ADDXSSXSX S:$rm, S:$rn, AArch64Base_ADDXSSXSX_imm3AsInt8:$imm3)>;
+        (ADDXSSXSX S:$rn, S:$rm, AArch64Base_ADDXSSXSX_imm3AsInt8:$imm3)>;
 
 
 def : Pat<(add S:$rn, S:$rm),
-        (ADDXSSXTW S:$rm, S:$rn)>;
-
-
-def : Pat<(add S:$rn, S:$rm),
-        (ADDXSSXTX S:$rm, S:$rn)>;
-
-
-def : Pat<(add S:$rn, (shl S:$rm, AArch64Base_ADDXSUXSW_imm3AsInt8:$imm3)),
-        (ADDXSUXSW S:$rm, S:$rn, AArch64Base_ADDXSUXSW_imm3AsInt8:$imm3)>;
+        (ADDXSSXTX S:$rn, S:$rm)>;
 
 
 def : Pat<(add S:$rn, (shl S:$rm, AArch64Base_ADDXSUXSX_imm3AsInt8:$imm3)),
-        (ADDXSUXSX S:$rm, S:$rn, AArch64Base_ADDXSUXSX_imm3AsInt8:$imm3)>;
+        (ADDXSUXSX S:$rn, S:$rm, AArch64Base_ADDXSUXSX_imm3AsInt8:$imm3)>;
 
 
 def : Pat<(add S:$rn, S:$rm),
-        (ADDXSUXTW S:$rm, S:$rn)>;
-
-
-def : Pat<(add S:$rn, S:$rm),
-        (ADDXSUXTX S:$rm, S:$rn)>;
-
-
-def : Pat<(add S:$rn, (shl S:$rm, AArch64Base_ADDXSXSW_imm3AsInt8:$imm3)),
-        (ADDXSXSW S:$rm, S:$rn, AArch64Base_ADDXSXSW_imm3AsInt8:$imm3)>;
+        (ADDXSUXTX S:$rn, S:$rm)>;
 
 
 def : Pat<(add S:$rn, (shl S:$rm, AArch64Base_ADDXSXSX_imm3AsInt8:$imm3)),
-        (ADDXSXSX S:$rm, S:$rn, AArch64Base_ADDXSXSX_imm3AsInt8:$imm3)>;
+        (ADDXSXSX S:$rn, S:$rm, AArch64Base_ADDXSXSX_imm3AsInt8:$imm3)>;
 
 
 def : Pat<(add S:$rn, S:$rm),
-        (ADDXSXTW S:$rm, S:$rn)>;
-
-
-def : Pat<(add S:$rn, S:$rm),
-        (ADDXSXTX S:$rm, S:$rn)>;
-
-
-def : Pat<(add S:$rn, (shl S:$rm, AArch64Base_ADDXUXSW_imm3AsInt8:$imm3)),
-        (ADDXUXSW S:$rm, S:$rn, AArch64Base_ADDXUXSW_imm3AsInt8:$imm3)>;
+        (ADDXSXTX S:$rn, S:$rm)>;
 
 
 def : Pat<(add S:$rn, (shl S:$rm, AArch64Base_ADDXUXSX_imm3AsInt8:$imm3)),
-        (ADDXUXSX S:$rm, S:$rn, AArch64Base_ADDXUXSX_imm3AsInt8:$imm3)>;
+        (ADDXUXSX S:$rn, S:$rm, AArch64Base_ADDXUXSX_imm3AsInt8:$imm3)>;
 
 
 def : Pat<(add S:$rn, S:$rm),
-        (ADDXUXTW S:$rm, S:$rn)>;
-
-
-def : Pat<(add S:$rn, S:$rm),
-        (ADDXUXTX S:$rm, S:$rn)>;
+        (ADDXUXTX S:$rn, S:$rm)>;
 
 
 def : Pat<(and S:$rn, AArch64Base_ANDIW_immWSizeAsInt32:$immWSize),
@@ -51002,15 +50938,15 @@ def : Pat<(and S:$rn, S:$rm),
 
 
 def : Pat<(and S:$rn, (sra S:$rm, AArch64Base_ANDSXASR_imm6AsInt8:$imm6)),
-        (ANDSXASR S:$rm, S:$rn, AArch64Base_ANDSXASR_imm6AsInt8:$imm6)>;
+        (ANDSXASR S:$rn, S:$rm, AArch64Base_ANDSXASR_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(and S:$rn, (shl S:$rm, AArch64Base_ANDSXLSL_imm6AsInt8:$imm6)),
-        (ANDSXLSL S:$rm, S:$rn, AArch64Base_ANDSXLSL_imm6AsInt8:$imm6)>;
+        (ANDSXLSL S:$rn, S:$rm, AArch64Base_ANDSXLSL_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(and S:$rn, (srl S:$rm, AArch64Base_ANDSXLSR_imm6AsInt8:$imm6)),
-        (ANDSXLSR S:$rm, S:$rn, AArch64Base_ANDSXLSR_imm6AsInt8:$imm6)>;
+        (ANDSXLSR S:$rn, S:$rm, AArch64Base_ANDSXLSR_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(and S:$rn, S:$rm),
@@ -51034,15 +50970,15 @@ def : Pat<(and S:$rn, S:$rm),
 
 
 def : Pat<(and S:$rn, (sra S:$rm, AArch64Base_ANDXASR_imm6AsInt8:$imm6)),
-        (ANDXASR S:$rm, S:$rn, AArch64Base_ANDXASR_imm6AsInt8:$imm6)>;
+        (ANDXASR S:$rn, S:$rm, AArch64Base_ANDXASR_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(and S:$rn, (shl S:$rm, AArch64Base_ANDXLSL_imm6AsInt8:$imm6)),
-        (ANDXLSL S:$rm, S:$rn, AArch64Base_ANDXLSL_imm6AsInt8:$imm6)>;
+        (ANDXLSL S:$rn, S:$rm, AArch64Base_ANDXLSL_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(and S:$rn, (srl S:$rm, AArch64Base_ANDXLSR_imm6AsInt8:$imm6)),
-        (ANDXLSR S:$rm, S:$rn, AArch64Base_ANDXLSR_imm6AsInt8:$imm6)>;
+        (ANDXLSR S:$rn, S:$rm, AArch64Base_ANDXLSR_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(sra S:$rn, S:$rm),
@@ -51051,6 +50987,94 @@ def : Pat<(sra S:$rn, S:$rm),
 
 def : Pat<(sra S:$rn, S:$rm),
         (ASRX S:$rn, S:$rm)>;
+
+
+def : Pat<(add S:$rm, (i64 1)),
+        (CSINCCCW S:$rn, S:$rm)>;
+
+
+def : Pat<(add S:$rm, (i64 1)),
+        (CSINCCCX S:$rn, S:$rm)>;
+
+
+def : Pat<(add S:$rm, (i64 1)),
+        (CSINCCSW S:$rn, S:$rm)>;
+
+
+def : Pat<(add S:$rm, (i64 1)),
+        (CSINCCSX S:$rn, S:$rm)>;
+
+
+def : Pat<(add S:$rm, (i64 1)),
+        (CSINCEQW S:$rn, S:$rm)>;
+
+
+def : Pat<(add S:$rm, (i64 1)),
+        (CSINCEQX S:$rn, S:$rm)>;
+
+
+def : Pat<(add S:$rm, (i64 1)),
+        (CSINCGEW S:$rn, S:$rm)>;
+
+
+def : Pat<(add S:$rm, (i64 1)),
+        (CSINCGEX S:$rn, S:$rm)>;
+
+
+def : Pat<(add S:$rm, (i64 1)),
+        (CSINCGTW S:$rn, S:$rm)>;
+
+
+def : Pat<(add S:$rm, (i64 1)),
+        (CSINCGTX S:$rn, S:$rm)>;
+
+
+def : Pat<(add S:$rm, (i64 1)),
+        (CSINCHIW S:$rn, S:$rm)>;
+
+
+def : Pat<(add S:$rm, (i64 1)),
+        (CSINCHIX S:$rn, S:$rm)>;
+
+
+def : Pat<(add S:$rm, (i64 1)),
+        (CSINCMIW S:$rn, S:$rm)>;
+
+
+def : Pat<(add S:$rm, (i64 1)),
+        (CSINCMIX S:$rn, S:$rm)>;
+
+
+def : Pat<(add S:$rm, (i64 1)),
+        (CSINCNEW S:$rn, S:$rm)>;
+
+
+def : Pat<(add S:$rm, (i64 1)),
+        (CSINCNEX S:$rn, S:$rm)>;
+
+
+def : Pat<(add S:$rm, (i64 1)),
+        (CSINCPLW S:$rn, S:$rm)>;
+
+
+def : Pat<(add S:$rm, (i64 1)),
+        (CSINCPLX S:$rn, S:$rm)>;
+
+
+def : Pat<(add S:$rm, (i64 1)),
+        (CSINCVCW S:$rn, S:$rm)>;
+
+
+def : Pat<(add S:$rm, (i64 1)),
+        (CSINCVCX S:$rn, S:$rm)>;
+
+
+def : Pat<(add S:$rm, (i64 1)),
+        (CSINCVSW S:$rn, S:$rm)>;
+
+
+def : Pat<(add S:$rm, (i64 1)),
+        (CSINCVSX S:$rn, S:$rm)>;
 
 
 def : Pat<(xor S:$rn, AArch64Base_EORIW_immWSizeAsInt32:$immWSize),
@@ -51082,15 +51106,15 @@ def : Pat<(xor S:$rn, S:$rm),
 
 
 def : Pat<(xor S:$rn, (sra S:$rm, AArch64Base_EORXASR_imm6AsInt8:$imm6)),
-        (EORXASR S:$rm, S:$rn, AArch64Base_EORXASR_imm6AsInt8:$imm6)>;
+        (EORXASR S:$rn, S:$rm, AArch64Base_EORXASR_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(xor S:$rn, (shl S:$rm, AArch64Base_EORXLSL_imm6AsInt8:$imm6)),
-        (EORXLSL S:$rm, S:$rn, AArch64Base_EORXLSL_imm6AsInt8:$imm6)>;
+        (EORXLSL S:$rn, S:$rm, AArch64Base_EORXLSL_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(xor S:$rn, (srl S:$rm, AArch64Base_EORXLSR_imm6AsInt8:$imm6)),
-        (EORXLSR S:$rm, S:$rn, AArch64Base_EORXLSR_imm6AsInt8:$imm6)>;
+        (EORXLSR S:$rn, S:$rm, AArch64Base_EORXLSR_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(zextloadi8 (add S:$rn, AArch64Base_LDRB_offsetAsInt64:$offset)),
@@ -51354,7 +51378,7 @@ def : Pat<(add S:$ra, (mul S:$rn, S:$rm)),
 
 
 def : Pat<(add S:$ra, (mul S:$rn, S:$rm)),
-        (MADDX S:$rn, S:$rm, S:$ra)>;
+        (MADDX S:$ra, S:$rn, S:$rm)>;
 
 
 def : Pat<(shl AArch64Base_MOVZWPos16_imm16AsInt16:$imm16, (i32 16)),
@@ -51378,7 +51402,7 @@ def : Pat<(sub S:$ra, (mul S:$rn, S:$rm)),
 
 
 def : Pat<(sub S:$ra, (mul S:$rn, S:$rm)),
-        (MSUBX S:$rn, S:$rm, S:$ra)>;
+        (MSUBX S:$ra, S:$rn, S:$rm)>;
 
 
 def : Pat<(or S:$rn, AArch64Base_ORRIW_immWSizeAsInt32:$immWSize),
@@ -51410,15 +51434,15 @@ def : Pat<(or S:$rn, S:$rm),
 
 
 def : Pat<(or S:$rn, (sra S:$rm, AArch64Base_ORRXASR_imm6AsInt8:$imm6)),
-        (ORRXASR S:$rm, S:$rn, AArch64Base_ORRXASR_imm6AsInt8:$imm6)>;
+        (ORRXASR S:$rn, S:$rm, AArch64Base_ORRXASR_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(or S:$rn, (shl S:$rm, AArch64Base_ORRXLSL_imm6AsInt8:$imm6)),
-        (ORRXLSL S:$rm, S:$rn, AArch64Base_ORRXLSL_imm6AsInt8:$imm6)>;
+        (ORRXLSL S:$rn, S:$rm, AArch64Base_ORRXLSL_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(or S:$rn, (srl S:$rm, AArch64Base_ORRXLSR_imm6AsInt8:$imm6)),
-        (ORRXLSR S:$rm, S:$rn, AArch64Base_ORRXLSR_imm6AsInt8:$imm6)>;
+        (ORRXLSR S:$rn, S:$rm, AArch64Base_ORRXLSR_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(sra (shl S:$rn, AArch64Base_SBFMW_leftWSizeAsInt8:$leftWSize), AArch64Base_SBFMW_rightWSizeAsInt8:$rightWSize),
@@ -51575,24 +51599,12 @@ def : Pat<(sub S:$rn, (srl S:$rm, AArch64Base_SUBWSLSR_imm6AsInt8:$imm6)),
         (SUBWSLSR S:$rn, S:$rm, AArch64Base_SUBWSLSR_imm6AsInt8:$imm6)>;
 
 
-def : Pat<(sub S:$rn, (shl S:$rm, AArch64Base_SUBWSSXSW_imm3AsInt8:$imm3)),
-        (SUBWSSXSW S:$rn, S:$rm, AArch64Base_SUBWSSXSW_imm3AsInt8:$imm3)>;
-
-
 def : Pat<(sub S:$rn, (shl S:$rm, AArch64Base_SUBWSSXSX_imm3AsInt8:$imm3)),
         (SUBWSSXSX S:$rn, S:$rm, AArch64Base_SUBWSSXSX_imm3AsInt8:$imm3)>;
 
 
 def : Pat<(sub S:$rn, S:$rm),
-        (SUBWSSXTW S:$rn, S:$rm)>;
-
-
-def : Pat<(sub S:$rn, S:$rm),
         (SUBWSSXTX S:$rn, S:$rm)>;
-
-
-def : Pat<(sub S:$rn, (shl S:$rm, AArch64Base_SUBWSUXSW_imm3AsInt8:$imm3)),
-        (SUBWSUXSW S:$rn, S:$rm, AArch64Base_SUBWSUXSW_imm3AsInt8:$imm3)>;
 
 
 def : Pat<(sub S:$rn, (shl S:$rm, AArch64Base_SUBWSUXSX_imm3AsInt8:$imm3)),
@@ -51600,15 +51612,7 @@ def : Pat<(sub S:$rn, (shl S:$rm, AArch64Base_SUBWSUXSX_imm3AsInt8:$imm3)),
 
 
 def : Pat<(sub S:$rn, S:$rm),
-        (SUBWSUXTW S:$rn, S:$rm)>;
-
-
-def : Pat<(sub S:$rn, S:$rm),
         (SUBWSUXTX S:$rn, S:$rm)>;
-
-
-def : Pat<(sub S:$rn, (shl S:$rm, AArch64Base_SUBWSXSW_imm3AsInt8:$imm3)),
-        (SUBWSXSW S:$rn, S:$rm, AArch64Base_SUBWSXSW_imm3AsInt8:$imm3)>;
 
 
 def : Pat<(sub S:$rn, (shl S:$rm, AArch64Base_SUBWSXSX_imm3AsInt8:$imm3)),
@@ -51616,23 +51620,11 @@ def : Pat<(sub S:$rn, (shl S:$rm, AArch64Base_SUBWSXSX_imm3AsInt8:$imm3)),
 
 
 def : Pat<(sub S:$rn, S:$rm),
-        (SUBWSXTW S:$rn, S:$rm)>;
-
-
-def : Pat<(sub S:$rn, S:$rm),
         (SUBWSXTX S:$rn, S:$rm)>;
-
-
-def : Pat<(sub S:$rn, (shl S:$rm, AArch64Base_SUBWUXSW_imm3AsInt8:$imm3)),
-        (SUBWUXSW S:$rn, S:$rm, AArch64Base_SUBWUXSW_imm3AsInt8:$imm3)>;
 
 
 def : Pat<(sub S:$rn, (shl S:$rm, AArch64Base_SUBWUXSX_imm3AsInt8:$imm3)),
         (SUBWUXSX S:$rn, S:$rm, AArch64Base_SUBWUXSX_imm3AsInt8:$imm3)>;
-
-
-def : Pat<(sub S:$rn, S:$rm),
-        (SUBWUXTW S:$rn, S:$rm)>;
 
 
 def : Pat<(sub S:$rn, S:$rm),
@@ -51644,7 +51636,7 @@ def : Pat<(sub S:$rn, S:$rm),
 
 
 def : Pat<(sub S:$rn, (sra S:$rm, AArch64Base_SUBXASR_imm6AsInt8:$imm6)),
-        (SUBXASR S:$rm, S:$rn, AArch64Base_SUBXASR_imm6AsInt8:$imm6)>;
+        (SUBXASR S:$rn, S:$rm, AArch64Base_SUBXASR_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(sub S:$rn, AArch64Base_SUBXI_imm12XAsInt64:$imm12X),
@@ -51656,11 +51648,11 @@ def : Pat<(sub S:$rn, AArch64Base_SUBXI12_imm12SAsInt64:$imm12S),
 
 
 def : Pat<(sub S:$rn, (shl S:$rm, AArch64Base_SUBXLSL_imm6AsInt8:$imm6)),
-        (SUBXLSL S:$rm, S:$rn, AArch64Base_SUBXLSL_imm6AsInt8:$imm6)>;
+        (SUBXLSL S:$rn, S:$rm, AArch64Base_SUBXLSL_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(sub S:$rn, (srl S:$rm, AArch64Base_SUBXLSR_imm6AsInt8:$imm6)),
-        (SUBXLSR S:$rm, S:$rn, AArch64Base_SUBXLSR_imm6AsInt8:$imm6)>;
+        (SUBXLSR S:$rn, S:$rm, AArch64Base_SUBXLSR_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(sub S:$rn, S:$rm),
@@ -51668,7 +51660,7 @@ def : Pat<(sub S:$rn, S:$rm),
 
 
 def : Pat<(sub S:$rn, (sra S:$rm, AArch64Base_SUBXSASR_imm6AsInt8:$imm6)),
-        (SUBXSASR S:$rm, S:$rn, AArch64Base_SUBXSASR_imm6AsInt8:$imm6)>;
+        (SUBXSASR S:$rn, S:$rm, AArch64Base_SUBXSASR_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(sub S:$rn, AArch64Base_SUBXSI_imm12XAsInt64:$imm12X),
@@ -51680,75 +51672,43 @@ def : Pat<(sub S:$rn, AArch64Base_SUBXSI12_imm12SAsInt64:$imm12S),
 
 
 def : Pat<(sub S:$rn, (shl S:$rm, AArch64Base_SUBXSLSL_imm6AsInt8:$imm6)),
-        (SUBXSLSL S:$rm, S:$rn, AArch64Base_SUBXSLSL_imm6AsInt8:$imm6)>;
+        (SUBXSLSL S:$rn, S:$rm, AArch64Base_SUBXSLSL_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(sub S:$rn, (srl S:$rm, AArch64Base_SUBXSLSR_imm6AsInt8:$imm6)),
-        (SUBXSLSR S:$rm, S:$rn, AArch64Base_SUBXSLSR_imm6AsInt8:$imm6)>;
-
-
-def : Pat<(sub S:$rn, (shl S:$rm, AArch64Base_SUBXSSXSW_imm3AsInt8:$imm3)),
-        (SUBXSSXSW S:$rm, S:$rn, AArch64Base_SUBXSSXSW_imm3AsInt8:$imm3)>;
+        (SUBXSLSR S:$rn, S:$rm, AArch64Base_SUBXSLSR_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(sub S:$rn, (shl S:$rm, AArch64Base_SUBXSSXSX_imm3AsInt8:$imm3)),
-        (SUBXSSXSX S:$rm, S:$rn, AArch64Base_SUBXSSXSX_imm3AsInt8:$imm3)>;
+        (SUBXSSXSX S:$rn, S:$rm, AArch64Base_SUBXSSXSX_imm3AsInt8:$imm3)>;
 
 
 def : Pat<(sub S:$rn, S:$rm),
-        (SUBXSSXTW S:$rm, S:$rn)>;
-
-
-def : Pat<(sub S:$rn, S:$rm),
-        (SUBXSSXTX S:$rm, S:$rn)>;
-
-
-def : Pat<(sub S:$rn, (shl S:$rm, AArch64Base_SUBXSUXSW_imm3AsInt8:$imm3)),
-        (SUBXSUXSW S:$rm, S:$rn, AArch64Base_SUBXSUXSW_imm3AsInt8:$imm3)>;
+        (SUBXSSXTX S:$rn, S:$rm)>;
 
 
 def : Pat<(sub S:$rn, (shl S:$rm, AArch64Base_SUBXSUXSX_imm3AsInt8:$imm3)),
-        (SUBXSUXSX S:$rm, S:$rn, AArch64Base_SUBXSUXSX_imm3AsInt8:$imm3)>;
+        (SUBXSUXSX S:$rn, S:$rm, AArch64Base_SUBXSUXSX_imm3AsInt8:$imm3)>;
 
 
 def : Pat<(sub S:$rn, S:$rm),
-        (SUBXSUXTW S:$rm, S:$rn)>;
-
-
-def : Pat<(sub S:$rn, S:$rm),
-        (SUBXSUXTX S:$rm, S:$rn)>;
-
-
-def : Pat<(sub S:$rn, (shl S:$rm, AArch64Base_SUBXSXSW_imm3AsInt8:$imm3)),
-        (SUBXSXSW S:$rm, S:$rn, AArch64Base_SUBXSXSW_imm3AsInt8:$imm3)>;
+        (SUBXSUXTX S:$rn, S:$rm)>;
 
 
 def : Pat<(sub S:$rn, (shl S:$rm, AArch64Base_SUBXSXSX_imm3AsInt8:$imm3)),
-        (SUBXSXSX S:$rm, S:$rn, AArch64Base_SUBXSXSX_imm3AsInt8:$imm3)>;
+        (SUBXSXSX S:$rn, S:$rm, AArch64Base_SUBXSXSX_imm3AsInt8:$imm3)>;
 
 
 def : Pat<(sub S:$rn, S:$rm),
-        (SUBXSXTW S:$rm, S:$rn)>;
-
-
-def : Pat<(sub S:$rn, S:$rm),
-        (SUBXSXTX S:$rm, S:$rn)>;
-
-
-def : Pat<(sub S:$rn, (shl S:$rm, AArch64Base_SUBXUXSW_imm3AsInt8:$imm3)),
-        (SUBXUXSW S:$rm, S:$rn, AArch64Base_SUBXUXSW_imm3AsInt8:$imm3)>;
+        (SUBXSXTX S:$rn, S:$rm)>;
 
 
 def : Pat<(sub S:$rn, (shl S:$rm, AArch64Base_SUBXUXSX_imm3AsInt8:$imm3)),
-        (SUBXUXSX S:$rm, S:$rn, AArch64Base_SUBXUXSX_imm3AsInt8:$imm3)>;
+        (SUBXUXSX S:$rn, S:$rm, AArch64Base_SUBXUXSX_imm3AsInt8:$imm3)>;
 
 
 def : Pat<(sub S:$rn, S:$rm),
-        (SUBXUXTW S:$rm, S:$rn)>;
-
-
-def : Pat<(sub S:$rn, S:$rm),
-        (SUBXUXTX S:$rm, S:$rn)>;
+        (SUBXUXTX S:$rn, S:$rm)>;
 
 
 def : Pat<(srl (shl S:$rn, AArch64Base_UBFMW_leftWSizeAsInt8:$leftWSize), AArch64Base_UBFMW_rightWSizeAsInt8:$rightWSize),

--- a/vadl/test/resources/snapshots/aarch64/RegisterInfo.td
+++ b/vadl/test/resources/snapshots/aarch64/RegisterInfo.td
@@ -279,8 +279,8 @@ let Namespace = "aarch64temp";
 let AsmName = "X0";
 let AltNames = [ "X0"  ];
 let Aliases = [ ];
-let SubRegs = [ X0, W0 ];
-let SubRegIndices = [ FULL_64, FULL_64 ];
+let SubRegs = [ R0, X0, W0 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 15 ];
 list<int> CostPerUse = [0];
@@ -297,8 +297,8 @@ let Namespace = "aarch64temp";
 let AsmName = "X1";
 let AltNames = [ "X1"  ];
 let Aliases = [ ];
-let SubRegs = [ X1, W1 ];
-let SubRegIndices = [ FULL_64, FULL_64 ];
+let SubRegs = [ R1, X1, W1 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 16 ];
 list<int> CostPerUse = [0];
@@ -315,8 +315,8 @@ let Namespace = "aarch64temp";
 let AsmName = "X2";
 let AltNames = [ "X2"  ];
 let Aliases = [ ];
-let SubRegs = [ X2, W2 ];
-let SubRegIndices = [ FULL_64, FULL_64 ];
+let SubRegs = [ R2, X2, W2 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 17 ];
 list<int> CostPerUse = [0];
@@ -333,8 +333,8 @@ let Namespace = "aarch64temp";
 let AsmName = "X3";
 let AltNames = [ "X3"  ];
 let Aliases = [ ];
-let SubRegs = [ X3, W3 ];
-let SubRegIndices = [ FULL_64, FULL_64 ];
+let SubRegs = [ R3, X3, W3 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 18 ];
 list<int> CostPerUse = [0];
@@ -351,8 +351,8 @@ let Namespace = "aarch64temp";
 let AsmName = "X4";
 let AltNames = [ "X4"  ];
 let Aliases = [ ];
-let SubRegs = [ X4, W4 ];
-let SubRegIndices = [ FULL_64, FULL_64 ];
+let SubRegs = [ R4, X4, W4 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 19 ];
 list<int> CostPerUse = [0];
@@ -369,8 +369,8 @@ let Namespace = "aarch64temp";
 let AsmName = "X5";
 let AltNames = [ "X5"  ];
 let Aliases = [ ];
-let SubRegs = [ X5, W5 ];
-let SubRegIndices = [ FULL_64, FULL_64 ];
+let SubRegs = [ R5, X5, W5 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 20 ];
 list<int> CostPerUse = [0];
@@ -387,8 +387,8 @@ let Namespace = "aarch64temp";
 let AsmName = "X6";
 let AltNames = [ "X6"  ];
 let Aliases = [ ];
-let SubRegs = [ X6, W6 ];
-let SubRegIndices = [ FULL_64, FULL_64 ];
+let SubRegs = [ R6, X6, W6 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 21 ];
 list<int> CostPerUse = [0];
@@ -405,8 +405,8 @@ let Namespace = "aarch64temp";
 let AsmName = "X7";
 let AltNames = [ "X7"  ];
 let Aliases = [ ];
-let SubRegs = [ X7, W7 ];
-let SubRegIndices = [ FULL_64, FULL_64 ];
+let SubRegs = [ R7, X7, W7 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 22 ];
 list<int> CostPerUse = [0];
@@ -423,8 +423,8 @@ let Namespace = "aarch64temp";
 let AsmName = "X8";
 let AltNames = [ "X8"  ];
 let Aliases = [ ];
-let SubRegs = [ X8, W8 ];
-let SubRegIndices = [ FULL_64, FULL_64 ];
+let SubRegs = [ R8, X8, W8 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 23 ];
 list<int> CostPerUse = [0];
@@ -441,8 +441,8 @@ let Namespace = "aarch64temp";
 let AsmName = "X9";
 let AltNames = [ "X9"  ];
 let Aliases = [ ];
-let SubRegs = [ X9, W9 ];
-let SubRegIndices = [ FULL_64, FULL_64 ];
+let SubRegs = [ R9, X9, W9 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 24 ];
 list<int> CostPerUse = [0];
@@ -459,8 +459,8 @@ let Namespace = "aarch64temp";
 let AsmName = "X10";
 let AltNames = [ "X10"  ];
 let Aliases = [ ];
-let SubRegs = [ X10, W10 ];
-let SubRegIndices = [ FULL_64, FULL_64 ];
+let SubRegs = [ R10, X10, W10 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 25 ];
 list<int> CostPerUse = [0];
@@ -477,8 +477,8 @@ let Namespace = "aarch64temp";
 let AsmName = "X11";
 let AltNames = [ "X11"  ];
 let Aliases = [ ];
-let SubRegs = [ X11, W11 ];
-let SubRegIndices = [ FULL_64, FULL_64 ];
+let SubRegs = [ R11, X11, W11 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 26 ];
 list<int> CostPerUse = [0];
@@ -495,8 +495,8 @@ let Namespace = "aarch64temp";
 let AsmName = "X12";
 let AltNames = [ "X12"  ];
 let Aliases = [ ];
-let SubRegs = [ X12, W12 ];
-let SubRegIndices = [ FULL_64, FULL_64 ];
+let SubRegs = [ R12, X12, W12 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 27 ];
 list<int> CostPerUse = [0];
@@ -513,8 +513,8 @@ let Namespace = "aarch64temp";
 let AsmName = "X13";
 let AltNames = [ "X13"  ];
 let Aliases = [ ];
-let SubRegs = [ X13, W13 ];
-let SubRegIndices = [ FULL_64, FULL_64 ];
+let SubRegs = [ R13, X13, W13 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 28 ];
 list<int> CostPerUse = [0];
@@ -531,8 +531,8 @@ let Namespace = "aarch64temp";
 let AsmName = "X14";
 let AltNames = [ "X14"  ];
 let Aliases = [ ];
-let SubRegs = [ X14, W14 ];
-let SubRegIndices = [ FULL_64, FULL_64 ];
+let SubRegs = [ R14, X14, W14 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 29 ];
 list<int> CostPerUse = [0];
@@ -549,8 +549,8 @@ let Namespace = "aarch64temp";
 let AsmName = "X15";
 let AltNames = [ "X15"  ];
 let Aliases = [ ];
-let SubRegs = [ X15, W15 ];
-let SubRegIndices = [ FULL_64, FULL_64 ];
+let SubRegs = [ R15, X15, W15 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 30 ];
 list<int> CostPerUse = [0];
@@ -567,8 +567,8 @@ let Namespace = "aarch64temp";
 let AsmName = "X16";
 let AltNames = [ "X16"  ];
 let Aliases = [ ];
-let SubRegs = [ X16, W16 ];
-let SubRegIndices = [ FULL_64, FULL_64 ];
+let SubRegs = [ R16, X16, W16 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 31 ];
 list<int> CostPerUse = [0];
@@ -585,8 +585,8 @@ let Namespace = "aarch64temp";
 let AsmName = "X17";
 let AltNames = [ "X17"  ];
 let Aliases = [ ];
-let SubRegs = [ X17, W17 ];
-let SubRegIndices = [ FULL_64, FULL_64 ];
+let SubRegs = [ R17, X17, W17 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 32 ];
 list<int> CostPerUse = [0];
@@ -603,8 +603,8 @@ let Namespace = "aarch64temp";
 let AsmName = "X18";
 let AltNames = [ "X18"  ];
 let Aliases = [ ];
-let SubRegs = [ X18, W18 ];
-let SubRegIndices = [ FULL_64, FULL_64 ];
+let SubRegs = [ R18, X18, W18 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 33 ];
 list<int> CostPerUse = [0];
@@ -621,8 +621,8 @@ let Namespace = "aarch64temp";
 let AsmName = "X19";
 let AltNames = [ "X19"  ];
 let Aliases = [ ];
-let SubRegs = [ X19, W19 ];
-let SubRegIndices = [ FULL_64, FULL_64 ];
+let SubRegs = [ R19, X19, W19 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 34 ];
 list<int> CostPerUse = [0];
@@ -639,8 +639,8 @@ let Namespace = "aarch64temp";
 let AsmName = "X20";
 let AltNames = [ "X20"  ];
 let Aliases = [ ];
-let SubRegs = [ X20, W20 ];
-let SubRegIndices = [ FULL_64, FULL_64 ];
+let SubRegs = [ R20, X20, W20 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 35 ];
 list<int> CostPerUse = [0];
@@ -657,8 +657,8 @@ let Namespace = "aarch64temp";
 let AsmName = "X21";
 let AltNames = [ "X21"  ];
 let Aliases = [ ];
-let SubRegs = [ X21, W21 ];
-let SubRegIndices = [ FULL_64, FULL_64 ];
+let SubRegs = [ R21, X21, W21 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 36 ];
 list<int> CostPerUse = [0];
@@ -675,8 +675,8 @@ let Namespace = "aarch64temp";
 let AsmName = "X22";
 let AltNames = [ "X22"  ];
 let Aliases = [ ];
-let SubRegs = [ X22, W22 ];
-let SubRegIndices = [ FULL_64, FULL_64 ];
+let SubRegs = [ R22, X22, W22 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 37 ];
 list<int> CostPerUse = [0];
@@ -693,8 +693,8 @@ let Namespace = "aarch64temp";
 let AsmName = "X23";
 let AltNames = [ "X23"  ];
 let Aliases = [ ];
-let SubRegs = [ X23, W23 ];
-let SubRegIndices = [ FULL_64, FULL_64 ];
+let SubRegs = [ R23, X23, W23 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 38 ];
 list<int> CostPerUse = [0];
@@ -711,8 +711,8 @@ let Namespace = "aarch64temp";
 let AsmName = "X24";
 let AltNames = [ "X24"  ];
 let Aliases = [ ];
-let SubRegs = [ X24, W24 ];
-let SubRegIndices = [ FULL_64, FULL_64 ];
+let SubRegs = [ R24, X24, W24 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 39 ];
 list<int> CostPerUse = [0];
@@ -729,8 +729,8 @@ let Namespace = "aarch64temp";
 let AsmName = "X25";
 let AltNames = [ "X25"  ];
 let Aliases = [ ];
-let SubRegs = [ X25, W25 ];
-let SubRegIndices = [ FULL_64, FULL_64 ];
+let SubRegs = [ R25, X25, W25 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 40 ];
 list<int> CostPerUse = [0];
@@ -747,8 +747,8 @@ let Namespace = "aarch64temp";
 let AsmName = "X26";
 let AltNames = [ "X26"  ];
 let Aliases = [ ];
-let SubRegs = [ X26, W26 ];
-let SubRegIndices = [ FULL_64, FULL_64 ];
+let SubRegs = [ R26, X26, W26 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 41 ];
 list<int> CostPerUse = [0];
@@ -765,8 +765,8 @@ let Namespace = "aarch64temp";
 let AsmName = "X27";
 let AltNames = [ "X27"  ];
 let Aliases = [ ];
-let SubRegs = [ X27, W27 ];
-let SubRegIndices = [ FULL_64, FULL_64 ];
+let SubRegs = [ R27, X27, W27 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 42 ];
 list<int> CostPerUse = [0];
@@ -783,8 +783,8 @@ let Namespace = "aarch64temp";
 let AsmName = "X28";
 let AltNames = [ "X28"  ];
 let Aliases = [ ];
-let SubRegs = [ X28, W28 ];
-let SubRegIndices = [ FULL_64, FULL_64 ];
+let SubRegs = [ R28, X28, W28 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 43 ];
 list<int> CostPerUse = [0];
@@ -801,8 +801,8 @@ let Namespace = "aarch64temp";
 let AsmName = "A_FP";
 let AltNames = [ "A_FP"  ];
 let Aliases = [ ];
-let SubRegs = [ X29, W29 ];
-let SubRegIndices = [ FULL_64, FULL_64 ];
+let SubRegs = [ R29, X29, W29 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 44 ];
 list<int> CostPerUse = [0];
@@ -819,8 +819,8 @@ let Namespace = "aarch64temp";
 let AsmName = "A_LR";
 let AltNames = [ "A_LR"  ];
 let Aliases = [ ];
-let SubRegs = [ X30, W30 ];
-let SubRegIndices = [ FULL_64, FULL_64 ];
+let SubRegs = [ R30, X30, W30 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 45 ];
 list<int> CostPerUse = [0];
@@ -837,10 +837,586 @@ let Namespace = "aarch64temp";
 let AsmName = "A_SP";
 let AltNames = [ "A_SP"  ];
 let Aliases = [ ];
-let SubRegs = [ X31, W31 ];
-let SubRegIndices = [ FULL_64, FULL_64 ];
+let SubRegs = [ R31, X31, W31 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 46 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 31;
+
+
+let isArtificial = false;
+}
+def R0 : Register<"R0">
+{
+let Namespace = "aarch64temp";
+let AsmName = "R0";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 47 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 0;
+
+
+let isArtificial = false;
+}
+def R1 : Register<"R1">
+{
+let Namespace = "aarch64temp";
+let AsmName = "R1";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 48 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 1;
+
+
+let isArtificial = false;
+}
+def R2 : Register<"R2">
+{
+let Namespace = "aarch64temp";
+let AsmName = "R2";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 49 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 2;
+
+
+let isArtificial = false;
+}
+def R3 : Register<"R3">
+{
+let Namespace = "aarch64temp";
+let AsmName = "R3";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 50 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 3;
+
+
+let isArtificial = false;
+}
+def R4 : Register<"R4">
+{
+let Namespace = "aarch64temp";
+let AsmName = "R4";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 51 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 4;
+
+
+let isArtificial = false;
+}
+def R5 : Register<"R5">
+{
+let Namespace = "aarch64temp";
+let AsmName = "R5";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 52 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 5;
+
+
+let isArtificial = false;
+}
+def R6 : Register<"R6">
+{
+let Namespace = "aarch64temp";
+let AsmName = "R6";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 53 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 6;
+
+
+let isArtificial = false;
+}
+def R7 : Register<"R7">
+{
+let Namespace = "aarch64temp";
+let AsmName = "R7";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 54 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 7;
+
+
+let isArtificial = false;
+}
+def R8 : Register<"R8">
+{
+let Namespace = "aarch64temp";
+let AsmName = "R8";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 55 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 8;
+
+
+let isArtificial = false;
+}
+def R9 : Register<"R9">
+{
+let Namespace = "aarch64temp";
+let AsmName = "R9";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 56 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 9;
+
+
+let isArtificial = false;
+}
+def R10 : Register<"R10">
+{
+let Namespace = "aarch64temp";
+let AsmName = "R10";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 57 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 10;
+
+
+let isArtificial = false;
+}
+def R11 : Register<"R11">
+{
+let Namespace = "aarch64temp";
+let AsmName = "R11";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 58 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 11;
+
+
+let isArtificial = false;
+}
+def R12 : Register<"R12">
+{
+let Namespace = "aarch64temp";
+let AsmName = "R12";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 59 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 12;
+
+
+let isArtificial = false;
+}
+def R13 : Register<"R13">
+{
+let Namespace = "aarch64temp";
+let AsmName = "R13";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 60 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 13;
+
+
+let isArtificial = false;
+}
+def R14 : Register<"R14">
+{
+let Namespace = "aarch64temp";
+let AsmName = "R14";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 61 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 14;
+
+
+let isArtificial = false;
+}
+def R15 : Register<"R15">
+{
+let Namespace = "aarch64temp";
+let AsmName = "R15";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 62 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 15;
+
+
+let isArtificial = false;
+}
+def R16 : Register<"R16">
+{
+let Namespace = "aarch64temp";
+let AsmName = "R16";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 63 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 16;
+
+
+let isArtificial = false;
+}
+def R17 : Register<"R17">
+{
+let Namespace = "aarch64temp";
+let AsmName = "R17";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 64 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 17;
+
+
+let isArtificial = false;
+}
+def R18 : Register<"R18">
+{
+let Namespace = "aarch64temp";
+let AsmName = "R18";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 65 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 18;
+
+
+let isArtificial = false;
+}
+def R19 : Register<"R19">
+{
+let Namespace = "aarch64temp";
+let AsmName = "R19";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 66 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 19;
+
+
+let isArtificial = false;
+}
+def R20 : Register<"R20">
+{
+let Namespace = "aarch64temp";
+let AsmName = "R20";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 67 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 20;
+
+
+let isArtificial = false;
+}
+def R21 : Register<"R21">
+{
+let Namespace = "aarch64temp";
+let AsmName = "R21";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 68 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 21;
+
+
+let isArtificial = false;
+}
+def R22 : Register<"R22">
+{
+let Namespace = "aarch64temp";
+let AsmName = "R22";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 69 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 22;
+
+
+let isArtificial = false;
+}
+def R23 : Register<"R23">
+{
+let Namespace = "aarch64temp";
+let AsmName = "R23";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 70 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 23;
+
+
+let isArtificial = false;
+}
+def R24 : Register<"R24">
+{
+let Namespace = "aarch64temp";
+let AsmName = "R24";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 71 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 24;
+
+
+let isArtificial = false;
+}
+def R25 : Register<"R25">
+{
+let Namespace = "aarch64temp";
+let AsmName = "R25";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 72 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 25;
+
+
+let isArtificial = false;
+}
+def R26 : Register<"R26">
+{
+let Namespace = "aarch64temp";
+let AsmName = "R26";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 73 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 26;
+
+
+let isArtificial = false;
+}
+def R27 : Register<"R27">
+{
+let Namespace = "aarch64temp";
+let AsmName = "R27";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 74 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 27;
+
+
+let isArtificial = false;
+}
+def R28 : Register<"R28">
+{
+let Namespace = "aarch64temp";
+let AsmName = "R28";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 75 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 28;
+
+
+let isArtificial = false;
+}
+def R29 : Register<"R29">
+{
+let Namespace = "aarch64temp";
+let AsmName = "R29";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 76 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 29;
+
+
+let isArtificial = false;
+}
+def R30 : Register<"R30">
+{
+let Namespace = "aarch64temp";
+let AsmName = "R30";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 77 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 30;
+
+
+let isArtificial = false;
+}
+def R31 : Register<"R31">
+{
+let Namespace = "aarch64temp";
+let AsmName = "R31";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 78 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -858,7 +1434,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 47 ];
+let DwarfNumbers = [ 79 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -876,7 +1452,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 48 ];
+let DwarfNumbers = [ 80 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -894,7 +1470,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 49 ];
+let DwarfNumbers = [ 81 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -912,7 +1488,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 50 ];
+let DwarfNumbers = [ 82 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -930,7 +1506,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 51 ];
+let DwarfNumbers = [ 83 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -948,7 +1524,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 52 ];
+let DwarfNumbers = [ 84 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -966,7 +1542,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 53 ];
+let DwarfNumbers = [ 85 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -984,7 +1560,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 54 ];
+let DwarfNumbers = [ 86 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -1002,7 +1578,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 55 ];
+let DwarfNumbers = [ 87 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -1020,7 +1596,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 56 ];
+let DwarfNumbers = [ 88 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -1038,7 +1614,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 57 ];
+let DwarfNumbers = [ 89 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -1056,7 +1632,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 58 ];
+let DwarfNumbers = [ 90 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -1074,7 +1650,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 59 ];
+let DwarfNumbers = [ 91 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -1092,7 +1668,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 60 ];
+let DwarfNumbers = [ 92 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -1110,7 +1686,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 61 ];
+let DwarfNumbers = [ 93 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -1128,7 +1704,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 62 ];
+let DwarfNumbers = [ 94 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -1146,7 +1722,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 63 ];
+let DwarfNumbers = [ 95 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -1164,7 +1740,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 64 ];
+let DwarfNumbers = [ 96 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -1182,7 +1758,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 65 ];
+let DwarfNumbers = [ 97 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -1200,7 +1776,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 66 ];
+let DwarfNumbers = [ 98 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -1218,7 +1794,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 67 ];
+let DwarfNumbers = [ 99 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -1236,7 +1812,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 68 ];
+let DwarfNumbers = [ 100 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -1254,7 +1830,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 69 ];
+let DwarfNumbers = [ 101 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -1272,7 +1848,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 70 ];
+let DwarfNumbers = [ 102 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -1290,7 +1866,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 71 ];
+let DwarfNumbers = [ 103 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -1308,7 +1884,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 72 ];
+let DwarfNumbers = [ 104 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -1326,7 +1902,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 73 ];
+let DwarfNumbers = [ 105 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -1344,7 +1920,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 74 ];
+let DwarfNumbers = [ 106 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -1362,7 +1938,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 75 ];
+let DwarfNumbers = [ 107 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -1380,7 +1956,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 76 ];
+let DwarfNumbers = [ 108 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -1398,7 +1974,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 77 ];
+let DwarfNumbers = [ 109 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -1416,7 +1992,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 78 ];
+let DwarfNumbers = [ 110 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -1434,7 +2010,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 79 ];
+let DwarfNumbers = [ 111 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -1452,7 +2028,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 80 ];
+let DwarfNumbers = [ 112 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -1470,7 +2046,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 81 ];
+let DwarfNumbers = [ 113 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -1488,7 +2064,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 82 ];
+let DwarfNumbers = [ 114 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -1506,7 +2082,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 83 ];
+let DwarfNumbers = [ 115 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -1524,7 +2100,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 84 ];
+let DwarfNumbers = [ 116 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -1542,7 +2118,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 85 ];
+let DwarfNumbers = [ 117 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -1560,7 +2136,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 86 ];
+let DwarfNumbers = [ 118 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -1578,7 +2154,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 87 ];
+let DwarfNumbers = [ 119 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -1596,7 +2172,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 88 ];
+let DwarfNumbers = [ 120 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -1614,7 +2190,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 89 ];
+let DwarfNumbers = [ 121 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -1632,7 +2208,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 90 ];
+let DwarfNumbers = [ 122 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -1650,7 +2226,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 91 ];
+let DwarfNumbers = [ 123 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -1668,7 +2244,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 92 ];
+let DwarfNumbers = [ 124 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -1686,7 +2262,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 93 ];
+let DwarfNumbers = [ 125 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -1704,7 +2280,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 94 ];
+let DwarfNumbers = [ 126 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -1722,7 +2298,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 95 ];
+let DwarfNumbers = [ 127 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -1740,7 +2316,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 96 ];
+let DwarfNumbers = [ 128 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -1758,7 +2334,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 97 ];
+let DwarfNumbers = [ 129 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -1776,7 +2352,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 98 ];
+let DwarfNumbers = [ 130 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -1794,7 +2370,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 99 ];
+let DwarfNumbers = [ 131 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -1812,7 +2388,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 100 ];
+let DwarfNumbers = [ 132 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -1830,7 +2406,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 101 ];
+let DwarfNumbers = [ 133 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -1848,7 +2424,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 102 ];
+let DwarfNumbers = [ 134 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -1866,7 +2442,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 103 ];
+let DwarfNumbers = [ 135 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -1884,7 +2460,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 104 ];
+let DwarfNumbers = [ 136 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -1902,7 +2478,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 105 ];
+let DwarfNumbers = [ 137 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -1920,7 +2496,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 106 ];
+let DwarfNumbers = [ 138 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -1938,7 +2514,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 107 ];
+let DwarfNumbers = [ 139 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -1956,7 +2532,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 108 ];
+let DwarfNumbers = [ 140 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -1974,7 +2550,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 109 ];
+let DwarfNumbers = [ 141 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -1992,7 +2568,7 @@ let Aliases = [ ];
 let SubRegs = [  ];
 let SubRegIndices = [  ];
 let RegAltNameIndices = [];
-let DwarfNumbers = [ 110 ];
+let DwarfNumbers = [ 142 ];
 list<int> CostPerUse = [0];
 let CoveredBySubRegs = 0;
 
@@ -2020,6 +2596,14 @@ let RegInfos = SLenRI;
 
 
 
+def R : RegisterClass
+< /* namespace = */ "aarch64temp"
+, /* regTypes  = */  [  i32 ]
+, /* alignment = */ 32
+, /* regList   = */
+( add R0, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17, R18, R19, R20, R21, R22, R23, R24, R25, R26, R27, R28, R29, R30, R31 )
+> {
+}
 def X : RegisterClass
 < /* namespace = */ "aarch64temp"
 , /* regTypes  = */  [  i64 ]
@@ -2030,7 +2614,7 @@ def X : RegisterClass
 }
 def W : RegisterClass
 < /* namespace = */ "aarch64temp"
-, /* regTypes  = */  [  i64 ]
+, /* regTypes  = */  [  i32 ]
 , /* alignment = */ 32
 , /* regList   = */
 ( add W0, W1, W2, W3, W4, W5, W6, W7, W8, W9, W10, W11, W12, W13, W14, W15, W16, W17, W18, W19, W20, W21, W22, W23, W24, W25, W26, W27, W28, W29, W30, W31 )

--- a/vadl/test/resources/testSource/sys/aarch64/aarch64.vadl
+++ b/vadl/test/resources/testSource/sys/aarch64/aarch64.vadl
@@ -60,22 +60,16 @@ instruction set architecture AArch64Base = {
   memory        MEM : Address -> Byte // byte addressed memory
 
   register        S : Index -> BitsX  // general purpose register file with stack pointer
+  alias register R(i) = S(i)(31..0)   // lower half of general purpose register file with stack pointer
   [zero : X(31)]                      // X(31) is the zero register
-  [regfile renaming]
   alias register  X = S               // general purpose register file with zero register
-  [regfile renaming]
-  [half width of : X]
-  alias register  W = S
+  alias register W(i) = X(i)(31..0)   // lower half of general purpose register file with zero register
   alias register SP : Address = S(31) // stack pointer
   alias register LR : Address = S(30) // link register (return address)
 
-  [negative status register]
   register NZCV_N : Bits1             // Negative
-  [zero status register]
   register NZCV_Z : Bits1             // Zero
-  [carry status register]
   register NZCV_C : Bits1             // Carry
-  [overflow status register]
   register NZCV_V : Bits1             // oVerflow
 
   enumeration CondCode : Bits<4> =    // condition code encodings, do not change order
@@ -225,6 +219,16 @@ instruction set architecture AArch64Base = {
   model-type MemoryModel = (InstrNoFunct, Memory) -> IsaDefs
 
 
+// models for selecting W or X register ****************************************
+
+  model WXReg (index: Id, size: Id): CallEx = {
+    match: Id ($size = WSize => W ; _ => X)($index)
+  }
+
+  model RSReg (index: Id, size: Id): CallEx = {
+    match: Id ($size = WSize => R ; _ => S)($index)
+  }
+
 // models for setting flags ****************************************************
 
   // set no flags
@@ -285,7 +289,7 @@ instruction set architecture AArch64Base = {
   model AddSubExtInstrBase (i: InstrWithFunct, extId: Id, size: Id, f: Flags, extEx: Ex, optId: Id, enc: Encs, asm: Ex): IsaDefs = {
     [undefined when : imm3(2) = 1 && imm3(1..0) != 0]
     instruction AsId ($i.id, $extId): AddSubExtFormat =
-      let result, flags = VADL::$i.funct (S(rn) as Bits<Size::$size>, ($extEx) as Bits<Size::$size>) in {
+      let result, flags = VADL::$i.funct ($RSReg(rn; $size), ($extEx) as Bits<Size::$size>) in {
         $f.resModel (match: Id ($f.ff = OffFlags => S ; _ => X)(rd) ; result )
         }
     encoding AsId ($i.id, $extId) = { op = $i.opcode, sf = SF::$size, ff = FF::$f.ff, option = ExtendType::$optId, $enc }
@@ -330,7 +334,7 @@ instruction set architecture AArch64Base = {
 
   model AddSubImmInstrShft (i: InstrWithFunct, size: Id, f: Flags, immEx: Ex, sh: Lit, asm: Str): IsaDefs = {
     instruction $i.id: AddSubImmFormat =
-      let result, flags = VADL::$i.funct (S(rn) as Bits<Size::$size>, ($immEx) as Bits<Size::$size>) in {
+      let result, flags = VADL::$i.funct ($RSReg(rn; $size), ($immEx) as Bits<Size::$size>) in {
         $f.resModel (match: Id ($f.ff = OffFlags => S ; _ => X)(rd) ; result )
         }
     encoding $i.id = { op = $i.opcode, sf = SF::$size, ff = FF::$f.ff, sh = $sh }
@@ -365,7 +369,7 @@ instruction set architecture AArch64Base = {
     // shift is set explicitely, therefore no undefined check for a shift of 0b11 is required
     [undefined when : sf = 0 && imm6(5) = 1]
     instruction $i.id: AddSubSftFormat =
-      let result, flags = VADL::$i.funct (X(rn) as Bits<Size::$size>, ($sftex) as Bits<Size::$size>) in {
+      let result, flags = VADL::$i.funct ($WXReg(rn; $size), ($sftex) as Bits<Size::$size>) in {
         $f.resModel (X(rd) ; result )
       }
     encoding $i.id = { op = $i.opcode, sf = SF::$size, ff = FF::$f.ff, $enc }
@@ -400,14 +404,14 @@ instruction set architecture AArch64Base = {
 
   model AddSubCarryInstr (i: InstrWithFunct, size: Id): IsaDefs = {
     instruction $i.id: ThreeRegOpFormat =
-      let result, flags = VADL::$i.funct(X(rn) as Bits<Size::$size>, X(rm) as Bits<Size::$size>, NZCV_C) in
+      let result, flags = VADL::$i.funct($WXReg(rn; $size), $WXReg(rm; $size), NZCV_C) in
         X(rd) := result as Bits<Size::$size> as BitsX
     $ThreeRegOpEncAsm ($i; $size)
     }
 
   model AddSubCarryFlagInstr (i: InstrWithFunct, size: Id): IsaDefs = {
     instruction $i.id: ThreeRegOpFormat =
-      let result, flags = VADL::$i.funct(X(rn) as Bits<Size::$size>, X(rm) as Bits<Size::$size>, NZCV_C) in {
+      let result, flags = VADL::$i.funct($WXReg(rn; $size), $WXReg(rm; $size), NZCV_C) in {
         X(rd) := result as Bits<Size::$size> as BitsX
         $SetFlags()
         }
@@ -453,7 +457,7 @@ instruction set architecture AArch64Base = {
 
   model MulAddSubInstr (i: InstrWithFunct, size: Id): IsaDefs = {
     instruction $i.id: MulAddSubFormat =
-      let result = VADL::$i.funct (X(ra) as Bits<Size::$size>, (X(rn) as Bits<Size::$size> * X(rm) as Bits<Size::$size>)) in
+      let result = VADL::$i.funct ($WXReg(ra; $size), $WXReg(rn; $size) * $WXReg(rm; $size)) in
         X(rd) := result as Bits<Size::$size> as BitsX
     encoding $i.id = { op = $i.opcode, sf = SF::$size }
     assembly $i.id = ($i.mnemo, ' ', $size(rd), ', ', $size(rn), ', ', $size(rm), ', ', $size(ra))
@@ -461,7 +465,7 @@ instruction set architecture AArch64Base = {
 
   model MulAddSubLongInstr (i: InstrWithFunct, type: Id): IsaDefs = {
     instruction $i.id: MulAddSubFormat =
-      X(rd) := VADL::$i.funct (X(ra), (X(rn) as $type<Size::WSize> *# X(rm) as $type<Size::WSize>))
+      X(rd) := VADL::$i.funct (X(ra), $WXReg(rn; WSize) *# $WXReg(rm; WSize))
     encoding $i.id = { op = $i.opcode, sf = SF::XSize }
     assembly $i.id = ($i.mnemo, ' ', XSize(rd), ', ', WSize(rn), ', ', WSize(rm), ', ', XSize(ra))
     }
@@ -483,8 +487,8 @@ instruction set architecture AArch64Base = {
 
   model DivInstr (i: InstrWithFunct, size: Id): IsaDefs = {
     instruction $i.id: ThreeRegOpFormat =
-      let dividend = X(rn) as $i.funct<Size::$size> in
-      let divisor  = X(rm) as $i.funct<Size::$size> in
+      let dividend = $WXReg(rn; $size) as $i.funct in
+      let divisor  = $WXReg(rm; $size) as $i.funct in
         let result =
           if divisor = 0
             then 0
@@ -623,7 +627,7 @@ instruction set architecture AArch64Base = {
   model LogicImmFlagInstr (i: InstrWithFunct, size: Id): IsaDefs = {
     [undefined when : imm13Decode (imm13) = 0 || sf = 0 && imm13(12) = 1]
     instruction $i.id: LogicImmFormat =
-      let result, flags = VADL::$i.funct (X(rn) as Bits<Size::$size>, AsId(imm, $size)) in {
+      let result, flags = VADL::$i.funct ($WXReg(rn; $size), AsId(imm, $size)) in {
         X(rd) := result as Bits<Size::$size> as BitsX
         $SetNZClearCVFlags ()
         }
@@ -633,7 +637,7 @@ instruction set architecture AArch64Base = {
   model LogicImmInstr (i: InstrWithFunct, size: Id): IsaDefs = {
     [undefined when : imm13Decode (imm13) = 0 || sf = 0 && imm13(12) = 1]
     instruction $i.id: LogicImmFormat =
-      let result = VADL::$i.funct (X(rn) as Bits<Size::$size>, AsId(imm, $size)) in
+      let result = VADL::$i.funct ($WXReg(rn; $size), AsId(imm, $size)) in
         S(rd) := result as Bits<Size::$size> as BitsX
     $LogicImmEncAsm ($i; $size; "SP")
     }
@@ -654,7 +658,7 @@ instruction set architecture AArch64Base = {
   model LogicRegGeneralInstr (i: InstrWithFunct, size: Id, s: RegShift, f: NoSetFlags): IsaDefs = {
     [undefined when : sf = 0 && imm6(5) = 1]
     instruction $i.id: LogicRegShiftFormat =
-      let result, flags = VADL::$i.funct (X(rn) as Bits<Size::$size>, $s.ex) in {
+      let result, flags = VADL::$i.funct ($WXReg(rn; $size), $s.ex) in {
         X(rd) := result as Bits<Size::$size> as BitsX
         $f ()
         }
@@ -683,11 +687,11 @@ instruction set architecture AArch64Base = {
     }
 
   model LogicRegShiftInstr (modelid: InstrWithFunctSizeRegShift, i: InstrWithFunct, size: Id): IsaDefs = {
-    $LogicRegShiftExtInstr ($modelid; $i; ""   ; $size; (X(rm) as Bits<Size::$size>; imm6 = 0, shift = ShiftType::LSL;  $size(rm))) // TODO pseudo instruction
-    $LogicRegShiftExtInstr ($modelid; $i; "LSL"; $size; (X(rm) as Bits<Size::$size>  << imm6;  shift = ShiftType::LSL; ($size(rm), ", lsl #", decimal(imm6))))
-    $LogicRegShiftExtInstr ($modelid; $i; "LSR"; $size; (X(rm) as UInt<Size::$size>  >> imm6;  shift = ShiftType::LSR; ($size(rm), ", lsr #", decimal(imm6))))
-    $LogicRegShiftExtInstr ($modelid; $i; "ASR"; $size; (X(rm) as SInt<Size::$size>  >> imm6;  shift = ShiftType::ASR; ($size(rm), ", asr #", decimal(imm6))))
-    $LogicRegShiftExtInstr ($modelid; $i; "ROR"; $size; (X(rm) as Bits<Size::$size> <>> imm6;  shift = ShiftType::ROR; ($size(rm), ", ror #", decimal(imm6))))
+    $LogicRegShiftExtInstr ($modelid; $i; ""   ; $size; ($WXReg(rm; $size) as Bits; imm6 = 0, shift = ShiftType::LSL;  $size(rm))) // TODO pseudo instruction
+    $LogicRegShiftExtInstr ($modelid; $i; "LSL"; $size; ($WXReg(rm; $size) as Bits  << imm6;  shift = ShiftType::LSL; ($size(rm), ", lsl #", decimal(imm6))))
+    $LogicRegShiftExtInstr ($modelid; $i; "LSR"; $size; ($WXReg(rm; $size) as UInt  >> imm6;  shift = ShiftType::LSR; ($size(rm), ", lsr #", decimal(imm6))))
+    $LogicRegShiftExtInstr ($modelid; $i; "ASR"; $size; ($WXReg(rm; $size) as SInt  >> imm6;  shift = ShiftType::ASR; ($size(rm), ", asr #", decimal(imm6))))
+    $LogicRegShiftExtInstr ($modelid; $i; "ROR"; $size; ($WXReg(rm; $size) as Bits <>> imm6;  shift = ShiftType::ROR; ($size(rm), ", ror #", decimal(imm6))))
     }
 
 
@@ -704,7 +708,7 @@ instruction set architecture AArch64Base = {
 
   model ShiftRegInstr (i: InstrWithFunct, size: Id): IsaDefs = {
     instruction $i.id: ShiftRegFormat =
-      X(rd) :=  VADL::$i.funct (X(rn) as Bits<Size::$size>, X(rm) as Bits<Size::$size>) as Bits as BitsX
+      X(rd) :=  VADL::$i.funct ($WXReg(rn; $size), $WXReg(rm; $size)) as Bits as BitsX
     encoding $i.id = { op = 0b0011'0101'1000'10, sf = SF::$size, shift = ShiftType::$i.opcode }
     assembly $i.id = ($i.mnemo, ' ', $size(rd), ', ', $size(rn), ', ', $size(rm))
     }
@@ -783,7 +787,7 @@ instruction set architecture AArch64Base = {
     // N is set explicitely, therefore no undefined check for sf != N is required
     [undefined when : sf = 0 && imms(5)]
     instruction $i.id: ExtractRegFormat =
-      let pair = (X(rn) as Bits<Size::$size>, X(rm) as Bits<Size::$size>) in
+      let pair = ($WXReg(rn; $size), $WXReg(rm; $size)) in
         X(rd) :=  (pair >> AsId (shift, $size)) as Bits<Size::$size> as BitsX
     encoding $i.id = { op = $i.opcode, sf = SF::$size, N = SF::$size }
     assembly $i.id = ($i.mnemo, ' ', $size(rd), ', ', $size(rn), ', ', $size(rm), ', #', decimal(imms))
@@ -846,7 +850,7 @@ instruction set architecture AArch64Base = {
     instruction $i.id: BitFieldMoveFormat =
       let left = AsId (left, $size) in
         let right = AsId (right, $size) in
-          let xrn = X(rn) as $i.funct<Size::$size> << left >> right in
+          let xrn = $WXReg(rn; $size) as $i.funct << left >> right in
             let result = match: Ex ($i.mnemo = "bfm" =>
               let mask = ~(~(0 as Bits<Size::$size>) << left >> right) in
                 X(rd) as Bits<Size::$size> & mask | xrn
@@ -874,7 +878,7 @@ instruction set architecture AArch64Base = {
 
   model CountBitsInstr (i: InstrWithFunct, size: Id): IsaDefs = {
     instruction $i.id: TwoRegOpFormat =
-      let result = VADL::$i.funct (X(rn) as Bits<Size::$size>) in
+      let result = VADL::$i.funct ($WXReg(rn; $size)) in
         X(rd) := result as Bits<Size::$size> as BitsX
     $TwoRegOpEncAsm ($i; $size)
     }
@@ -894,7 +898,7 @@ instruction set architecture AArch64Base = {
 
   model ReverseBitsInstr (i: InstrWithFunct, size: Id): IsaDefs = {
     instruction $i.id: TwoRegOpFormat =
-      let result = AsId (revBits, $size) (X(rn) as Bits<Size::$size>) in
+      let result = AsId (revBits, $size) ($WXReg(rn; $size)) in
         X(rd) := result as Bits<Size::$size> as BitsX
     $TwoRegOpEncAsm ($i; $size)
     }
@@ -942,7 +946,7 @@ instruction set architecture AArch64Base = {
   model CondCompareBaseInstr (i: InstrWithFunct, c: Cond, size: Id, ex: Ex, asm: Ex): IsaDefs = {
     instruction $i.id: CondCompareFormat =
       if $c.ex
-        then let result, flags = VADL::$i.funct(X(rn) as Bits<Size::$size>, $ex) in {
+        then let result, flags = VADL::$i.funct($WXReg(rn; $size), $ex) in {
           $SetFlags()
           }
         else {
@@ -961,7 +965,7 @@ instruction set architecture AArch64Base = {
     }
 
   model CondCompareRegInstr (i: InstrWithFunct, c: Cond): IsaDefs = {
-    $CondCompareBaseInstr ($ExtInstrStr ($i; "W"); $c; WSize; X(rm) as BitsW; (', ', WSize(rm)))
+    $CondCompareBaseInstr ($ExtInstrStr ($i; "W"); $c; WSize; W(rm)         ; (', ', WSize(rm)))
     $CondCompareBaseInstr ($ExtInstrStr ($i; "X"); $c; XSize; X(rm)         ; (', ', XSize(rm)))
     }
 
@@ -1099,7 +1103,7 @@ instruction set architecture AArch64Base = {
 
   model CompareBranchInstr (i: InstrWithFunct, size: Id): IsaDefs = {
     instruction $i.id: CompareBranchFormat =
-      if VADL::$i.funct (X(rt) as Bits<Size::$size>, 0) then
+      if VADL::$i.funct ($WXReg(rt; $size), 0) then
         PC := PC + offset
     encoding $i.id = { op = $i.opcode, sf = SF::$size }
     assembly $i.id = ($i.mnemo, ' ', $size(rt), ', ', decimal(imm19))
@@ -1223,14 +1227,14 @@ instruction set architecture AArch64Base = {
     }
 
   model MemoryRegisterInstr (i: InstrNoFunct, m: Memory): IsaDefs = {
-      $MemoryRegisterXtd ($i; $m; UXTW; Un; (WSize(rm), ", uxtw"   );                              X(rm) as UIntW as BitsX)
-      $MemoryRegisterXtd ($i; $m; UXTW; Is; (WSize(rm), ", uxtw #", decimal(AccSize::$m.accsize)); X(rm) as UIntW as BitsX << AccSize::$m.accsize)
-      $MemoryRegisterXtd ($i; $m; UXTX; Un; (XSize(rm)             );                              X(rm))
-      $MemoryRegisterXtd ($i; $m; UXTX; Is; (XSize(rm), ", lsl #",  decimal(AccSize::$m.accsize)); X(rm) << AccSize::$m.accsize)
-      $MemoryRegisterXtd ($i; $m; SXTW; Un; (WSize(rm), ", sxtw"   );                              X(rm) as SIntW as BitsX)
-      $MemoryRegisterXtd ($i; $m; SXTW; Is; (WSize(rm), ", sxtw #", decimal(AccSize::$m.accsize)); X(rm) as SIntW as BitsX << AccSize::$m.accsize)
-      $MemoryRegisterXtd ($i; $m; SXTX; Un; (XSize(rm), ", sxtx"   );                              X(rm))
-      $MemoryRegisterXtd ($i; $m; SXTX; Is; (XSize(rm), ", sxtx #", decimal(AccSize::$m.accsize)); X(rm) << AccSize::$m.accsize)
+    $MemoryRegisterXtd ($i; $m; UXTW; Un; (WSize(rm), ", uxtw"   );                              X(rm) as UIntW as BitsX)
+    $MemoryRegisterXtd ($i; $m; UXTW; Is; (WSize(rm), ", uxtw #", decimal(AccSize::$m.accsize)); X(rm) as UIntW as BitsX << AccSize::$m.accsize)
+    $MemoryRegisterXtd ($i; $m; UXTX; Un; (XSize(rm)             );                              X(rm))
+    $MemoryRegisterXtd ($i; $m; UXTX; Is; (XSize(rm), ", lsl #",  decimal(AccSize::$m.accsize)); X(rm) << AccSize::$m.accsize)
+    $MemoryRegisterXtd ($i; $m; SXTW; Un; (WSize(rm), ", sxtw"   );                              X(rm) as SIntW as BitsX)
+    $MemoryRegisterXtd ($i; $m; SXTW; Is; (WSize(rm), ", sxtw #", decimal(AccSize::$m.accsize)); X(rm) as SIntW as BitsX << AccSize::$m.accsize)
+    $MemoryRegisterXtd ($i; $m; SXTX; Un; (XSize(rm), ", sxtx"   );                              X(rm))
+    $MemoryRegisterXtd ($i; $m; SXTX; Is; (XSize(rm), ", sxtx #", decimal(AccSize::$m.accsize)); X(rm) << AccSize::$m.accsize)
     }
 
 // memory literal model ********************************************************
@@ -1753,7 +1757,6 @@ instruction set architecture AArch64Base = {
     assembly $i.id = ($i.mnemo, ' ', SysRegName(sysreg), ', ', XSize(rt))
     }
 
-  /*
   model ExceptionCallEncAsm (i: InstrWithFunct): IsaDefs = {
     encoding $i.id = {op = $i.opcode}
     assembly $i.id = ($i.mnemo, ' #', decimal(imm16))
@@ -1778,7 +1781,6 @@ instruction set architecture AArch64Base = {
     encoding $i.id = {op = $i.opcode, imm16 = 0b0000'0011'1110'0000}
     assembly $i.id = ($i.mnemo)
     }
-  */
 
   model NopInstr (i: InstrNoFunct): IsaDefs = {
     instruction $i.id: UndefinedInstrFormat = {}
@@ -1816,5 +1818,4 @@ instruction set architecture AArch64Base = {
   $NopInstr              ((YIELD  ; "yield" ; 0b0010'0000'0011'1111                        ))
   // $BTIInstr              ((BTI    ; "bti"   ; 0b0010'0100'''01'1111                        ))
   // $UndefinedInstr        ((UDF    ; "udf"   ; 0b0000'0000'0000'0000                        ))
-
 }

--- a/vadl/test/resources/testSource/sys/aarch64/aarch64.vadl
+++ b/vadl/test/resources/testSource/sys/aarch64/aarch64.vadl
@@ -63,6 +63,7 @@ instruction set architecture AArch64Base = {
   alias register R(i) = S(i)(31..0)   // lower half of general purpose register file with stack pointer
   [zero : X(31)]                      // X(31) is the zero register
   alias register  X = S               // general purpose register file with zero register
+  [zero : W(31)]                      // X(31) is the zero register
   alias register W(i) = X(i)(31..0)   // lower half of general purpose register file with zero register
   alias register SP : Address = S(31) // stack pointer
   alias register LR : Address = S(30) // link register (return address)


### PR DESCRIPTION
The https://github.com/OpenVADL/openvadl/discussions/441 implemented sliced alias registers. This PR applies them for the `W` register.