### PR TITLE
ci: Updated conditions for benchmark lcb job

### DIFF
--- a/.github/workflows/benchmark-lcb.yml
+++ b/.github/workflows/benchmark-lcb.yml
@@ -1,13 +1,10 @@
 name: benchmark LCB
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master
-    paths:
-      - vadl/main/vadl/gcb
-      - vadl/main/vadl/lcb
-      - vadl/main/resources/lcb
 
 permissions:
   contents: read


### PR DESCRIPTION
This PR tries to update the conditions since the job isn't running on master at the moment.