### PR TITLE
lcb: Render alias registers as separate register class with subregister indexing

### DIFF
--- a/vadl/main/resources/templates/lcb/llvm/lib/Target/RegisterInfo.td
+++ b/vadl/main/resources/templates/lcb/llvm/lib/Target/RegisterInfo.td
@@ -1,3 +1,28 @@
+let Namespace = "[(${namespace})]" in {
+  // SubRegIndexes for GPR registers
+  def sub_32   : SubRegIndex<32>;
+  def sub_32_hi : SubRegIndex<32, 32>;
+  def full_64    : SubRegIndex<64>;
+}
+
+[# th:each="register, iterStat : ${aliasRegisters}" ]
+def [(${register.name})] : Register<"[(${register.name})]">
+{
+    let Namespace = "[(${register.namespace.value})]";
+    let AsmName = "[(${register.asmName})]";
+    let AltNames = [ [(${register.altNamesString})]  ];
+    let Aliases = [ ];
+    let SubRegs = [ [(${register.subRegs})] ];
+    let SubRegIndices = [ [(${register.subRegIndices})] ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ [(${register.dwarfNumber})] ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
+    let HWEncoding = [(${register.hwEncodingValue})];
+    let isArtificial = [(${register.isArtificial})];
+}
+[/]
+
 [# th:each="register, iterStat : ${registers}" ]
 def [(${register.name})] : Register<"[(${register.name})]">
 {
@@ -5,8 +30,8 @@ def [(${register.name})] : Register<"[(${register.name})]">
     let AsmName = "[(${register.asmName})]";
     let AltNames = [ [(${register.altNamesString})]  ];
     let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
+    let SubRegs = [ [(${register.subRegs})] ];
+    let SubRegIndices = [ [(${register.subRegIndices})] ];
     let RegAltNameIndices = [];
     let DwarfNumbers = [ [(${register.dwarfNumber})] ];
     list<int> CostPerUse = [0];
@@ -17,24 +42,6 @@ def [(${register.name})] : Register<"[(${register.name})]">
     [#th:block th:if="${register.hwEncodingMsb == 0}"]
     let HWEncoding = [(${register.hwEncodingValue})];
     [/th:block]
-    let isArtificial = [(${register.isArtificial})];
-}
-[/]
-
-[# th:each="register, iterStat : ${aliasRegisters}" ]
-def [(${register.name})] : Register<"[(${register.name})]">
-{
-    let Namespace = "[(${register.namespace.value})]";
-    let AsmName = "[(${register.asmName})]";
-    let AltNames = [ [(${register.altNamesString})]  ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ [(${register.dwarfNumber})] ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-    let HWEncoding = [(${register.hwEncodingValue})];
     let isArtificial = [(${register.isArtificial})];
 }
 [/]

--- a/vadl/main/vadl/gcb/passes/GenerateCompilerRegistersPass.java
+++ b/vadl/main/vadl/gcb/passes/GenerateCompilerRegistersPass.java
@@ -32,6 +32,7 @@ import vadl.gcb.valuetypes.IndexedCompilerRegister;
 import vadl.pass.Pass;
 import vadl.pass.PassName;
 import vadl.pass.PassResults;
+import vadl.types.BitsType;
 import vadl.utils.Pair;
 import vadl.viam.Abi;
 import vadl.viam.ArtificialResource;
@@ -82,11 +83,42 @@ public class GenerateCompilerRegistersPass extends Pass {
         viam.artificialResources().filter(ArtificialResource::isRegisterFile).toList(), abi,
         registerClasses.right());
 
+    createSubRegisters(aliasRegisterFiles.left(), registerClasses.left());
+
     return new Output(generalRegisters,
         aliasRegisters.left(),
         registerClasses.left(),
         aliasRegisterFiles.left());
   }
+
+  private void createSubRegisters(List<CompilerRegisterClass> aliasRegisterClasses,
+                                  List<CompilerRegisterClass> registerClasses) {
+
+    for (var registerClass : registerClasses) {
+      for (var aliasRegisterClass : aliasRegisterClasses) {
+        var artificialResource = (ArtificialResource) aliasRegisterClass.registerFile();
+        var referencesResource = (RegisterTensor) artificialResource.innerResourceRef();
+
+        // If yes then the alias points to real register file.
+        if (registerClass.registerFile().equals(referencesResource)) {
+          var hasEqualType = artificialResource.type().asDataType()
+              .equals(referencesResource.resultType().asDataType());
+
+          for (int i = 0; i < registerClass.registers().size(); i++) {
+            var aliasRegister = aliasRegisterClass.registers().get(i);
+            var realRegister = registerClass.registers().get(i);
+
+            if (hasEqualType && artificialResource.type().equals(BitsType.bits(64))) {
+              realRegister.addSubReg(aliasRegister, CompilerRegister.SubRegIndex.FULL_64);
+            } else {
+              realRegister.addSubReg(aliasRegister, CompilerRegister.SubRegIndex.SUB_32);
+            }
+          }
+        }
+      }
+    }
+  }
+
 
   private List<CompilerRegister> generalRegisters(List<RegisterTensor> registers) {
     var compilerRegisters = new ArrayList<CompilerRegister>();
@@ -152,7 +184,7 @@ public class GenerateCompilerRegistersPass extends Pass {
       if (artificialResource.innerResourceRef() instanceof RegisterTensor registerTensor
           && registerTensor.isRegisterFile()) {
         var registers =
-            IndexedCompilerRegister.fromRegisterFile(artificialResource, abi, dwarfOffset, true);
+            IndexedCompilerRegister.fromRegisterFile(artificialResource, abi, dwarfOffset, false);
         dwarfOffset += registers.size();
 
         var alignment = ensureNonNull(abi.registerFileAlignment().get(registerTensor),

--- a/vadl/main/vadl/gcb/valuetypes/CompilerRegister.java
+++ b/vadl/main/vadl/gcb/valuetypes/CompilerRegister.java
@@ -16,15 +16,38 @@
 
 package vadl.gcb.valuetypes;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
  * Extends the register with information which a compiler requires.
  */
 public abstract class CompilerRegister {
+  /**
+   * Indicates the indices for sub registers.
+   */
+  public enum SubRegIndex {
+    SUB_32("sub_32"),
+    SUB_32_HI("sub_32_hi"),
+    FULL_64("full_64");
+
+    private final String name;
+
+    SubRegIndex(String name) {
+      this.name = name;
+    }
+
+    public String getName() {
+      return name;
+    }
+  }
+
   protected final String name;
   protected final String asmName;
   protected final List<String> altNames;
+  protected final List<CompilerRegister> subRegs;
+  protected final List<SubRegIndex> subRegIndices;
+
   protected final int dwarfNumber;
   protected final int hwEncodingValue;
   protected final boolean isArtificial;
@@ -43,6 +66,8 @@ public abstract class CompilerRegister {
     this.altNames = altNames;
     this.dwarfNumber = dwarfNumber;
     this.hwEncodingValue = hwEncodingValue;
+    this.subRegs = new ArrayList<>();
+    this.subRegIndices = new ArrayList<>();
     this.isArtificial = isArtificial;
   }
 
@@ -68,5 +93,21 @@ public abstract class CompilerRegister {
 
   public boolean isArtificial() {
     return isArtificial;
+  }
+
+  public List<CompilerRegister> subRegs() {
+    return subRegs;
+  }
+
+  public List<SubRegIndex> subRegIndices() {
+    return subRegIndices;
+  }
+
+  /**
+   * Adding {@link CompilerRegister} as {@link #subRegs}.
+   */
+  public void addSubReg(CompilerRegister subRegister, SubRegIndex subRegIndex) {
+    subRegIndices.add(subRegIndex);
+    subRegs.add(subRegister);
   }
 }

--- a/vadl/main/vadl/gcb/valuetypes/ValueType.java
+++ b/vadl/main/vadl/gcb/valuetypes/ValueType.java
@@ -34,13 +34,15 @@ public enum ValueType implements Renderable {
   I32("i32", "Int32", "Int32", 32),
 
   I64("i64", "Int64", "Int64", 64),
+  I128("i128", "Int128", "Int128", 128),
 
   // LLVM has no concept of unsigned integers because it's all interpretation.
   // That's why sometimes have to use signed names.
   U8("u8", "Uint8", "Int8", 8),
   U16("u16", "Uint16", "Int16", 16),
   U32("u32", "Uint32", "Int32", 32),
-  U64("u64", "Uint64", "Int64", 64);
+  U64("u64", "Uint64", "Int64", 64),
+  U128("u128", "Int128", "Int128", 128);
 
   private final String llvmType;
   private final String fancyName;
@@ -63,10 +65,12 @@ public enum ValueType implements Renderable {
       case I16 -> 16;
       case I32 -> 32;
       case I64 -> 64;
+      case I128 -> 128;
       case U8 -> 8;
       case U16 -> 16;
       case U32 -> 32;
       case U64 -> 64;
+      case U128 -> 128;
     };
   }
 
@@ -85,6 +89,8 @@ public enum ValueType implements Renderable {
         return Optional.of(ValueType.I32);
       } else if (sint.bitWidth() == 64) {
         return Optional.of(ValueType.I64);
+      } else if (sint.bitWidth() == 128) {
+        return Optional.of(ValueType.I128);
       }
     } else if (type instanceof UIntType uint) {
       if (uint.bitWidth() == 8) {
@@ -95,6 +101,8 @@ public enum ValueType implements Renderable {
         return Optional.of(ValueType.U32);
       } else if (uint.bitWidth() == 64) {
         return Optional.of(ValueType.U64);
+      } else if (uint.bitWidth() == 128) {
+        return Optional.of(ValueType.U128);
       }
     } else if (type instanceof BitsType bitsType) {
       if (bitsType.bitWidth() == 8) {
@@ -105,6 +113,8 @@ public enum ValueType implements Renderable {
         return Optional.of(ValueType.I32);
       } else if (bitsType.bitWidth() == 64) {
         return Optional.of(ValueType.I64);
+      } else if (bitsType.bitWidth() == 128) {
+        return Optional.of(ValueType.I128);
       }
     }
 
@@ -128,7 +138,7 @@ public enum ValueType implements Renderable {
    */
   public boolean isSigned() {
     return switch (this) {
-      case I8, I16, I32, I64 -> true;
+      case I8, I16, I32, I64, I128 -> true;
       default -> false;
     };
   }

--- a/vadl/main/vadl/lcb/passes/llvmLowering/GenerateTableGenRegistersPass.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/GenerateTableGenRegistersPass.java
@@ -23,7 +23,6 @@ import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import vadl.configuration.LcbConfiguration;
-import vadl.gcb.annotations.HalfWidthOfAnnotation;
 import vadl.gcb.passes.GenerateCompilerRegistersPass;
 import vadl.gcb.valuetypes.CompilerRegister;
 import vadl.gcb.valuetypes.CompilerRegisterClass;
@@ -90,6 +89,8 @@ public class GenerateTableGenRegistersPass extends Pass {
       var register = new TableGenRegister(
           configuration.targetName(),
           compilerRegister,
+          compilerRegister.subRegs(),
+          compilerRegister.subRegIndices(),
           compilerRegister.hwEncodingValue(),
           Optional.empty(),
           compilerRegister.isArtificial()
@@ -113,6 +114,8 @@ public class GenerateTableGenRegistersPass extends Pass {
         var register = new TableGenRegister(
             configuration.targetName(),
             compilerRegister,
+            compilerRegister.subRegs(),
+            compilerRegister.subRegIndices(),
             Objects.requireNonNull(compilerRegisterClass.registerFile().addressType()).bitWidth()
                 - 1,
             Optional.of(compilerRegister.hwEncodingValue()),
@@ -140,6 +143,8 @@ public class GenerateTableGenRegistersPass extends Pass {
         var register = new TableGenRegister(
             configuration.targetName(),
             compilerRegister,
+            compilerRegister.subRegs(),
+            compilerRegister.subRegIndices(),
             Objects.requireNonNull(compilerRegisterClass.registerFile().addressType()).bitWidth()
                 - 1,
             Optional.of(compilerRegister.hwEncodingValue()),
@@ -150,12 +155,6 @@ public class GenerateTableGenRegistersPass extends Pass {
       }
 
       var type = ValueType.from(compilerRegisterClass.registerFile().resultType()).get();
-
-      if (compilerRegisterClass.registerFile() instanceof Definition def
-          && def.hasAnnotation(HalfWidthOfAnnotation.class)) {
-        var annotation = Objects.requireNonNull(def.annotation(HalfWidthOfAnnotation.class));
-        type = ValueType.from(Type.bits(1 + annotation.hi() - annotation.lo())).get();
-      }
 
       aliasRegisterClasses.add(
           new TableGenRegisterClass(

--- a/vadl/main/vadl/lcb/passes/llvmLowering/tablegen/model/register/TableGenRegister.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/tablegen/model/register/TableGenRegister.java
@@ -17,8 +17,10 @@
 package vadl.lcb.passes.llvmLowering.tablegen.model.register;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import vadl.gcb.valuetypes.CompilerRegister;
 import vadl.gcb.valuetypes.TargetName;
 import vadl.template.Renderable;
@@ -28,6 +30,8 @@ import vadl.template.Renderable;
  */
 public record TableGenRegister(TargetName namespace,
                                CompilerRegister compilerRegister,
+                               List<CompilerRegister> subRegs,
+                               List<CompilerRegister.SubRegIndex> subRegIndices,
                                int hwEncodingMsb,
                                Optional<Integer> index,
                                boolean isArtificial) implements Renderable {
@@ -47,7 +51,11 @@ public record TableGenRegister(TargetName namespace,
     map.put("hwEncodingMsb", hwEncodingMsb);
     map.put("hwEncodingValue", compilerRegister.hwEncodingValue());
     map.put("altNamesString", altNamesString());
-    map.put("isArtificial", isArtificial ? 1 : 0);
+    map.put("isArtificial", isArtificial);
+    map.put("subRegs",
+        subRegs.stream().map(CompilerRegister::name).collect(Collectors.joining(", ")));
+    map.put("subRegIndices",
+        subRegIndices.stream().map(Enum::name).collect(Collectors.joining(", ")));
     index.ifPresent(integer -> map.put("index", integer));
     return map;
   }

--- a/vadl/test/resources/snapshots/aarch64/RegisterInfo.td
+++ b/vadl/test/resources/snapshots/aarch64/RegisterInfo.td
@@ -1,2014 +1,2021 @@
-
-def NZCV_N : Register<"NZCV_N">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "NZCV_N";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 0 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-
-    let HWEncoding = 0;
-
-    let isArtificial = 0;
+let Namespace = "aarch64temp" in {
+// SubRegIndexes for GPR registers
+def sub_32   : SubRegIndex<32>;
+def sub_32_hi : SubRegIndex<32, 32>;
+def full_64    : SubRegIndex<64>;
 }
-def NZCV_Z : Register<"NZCV_Z">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "NZCV_Z";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 1 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-
-    let HWEncoding = 0;
-
-    let isArtificial = 0;
-}
-def NZCV_C : Register<"NZCV_C">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "NZCV_C";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 2 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-
-    let HWEncoding = 0;
-
-    let isArtificial = 0;
-}
-def NZCV_V : Register<"NZCV_V">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "NZCV_V";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 3 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-
-    let HWEncoding = 0;
-
-    let isArtificial = 0;
-}
-def CurrentEL : Register<"CurrentEL">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "CurrentEL";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 4 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-
-    let HWEncoding = 0;
-
-    let isArtificial = 0;
-}
-def SPSel : Register<"SPSel">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "SPSel";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 5 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-
-    let HWEncoding = 0;
-
-    let isArtificial = 0;
-}
-def SP_EL0 : Register<"SP_EL0">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "SP_EL0";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 6 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-
-    let HWEncoding = 0;
-
-    let isArtificial = 0;
-}
-def SP_EL1 : Register<"SP_EL1">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "SP_EL1";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 7 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-
-    let HWEncoding = 0;
-
-    let isArtificial = 0;
-}
-def ELR_EL1 : Register<"ELR_EL1">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "ELR_EL1";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 8 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-
-    let HWEncoding = 0;
-
-    let isArtificial = 0;
-}
-def VBAR_EL1 : Register<"VBAR_EL1">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "VBAR_EL1";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 9 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-
-    let HWEncoding = 0;
-
-    let isArtificial = 0;
-}
-def ESR_EL1 : Register<"ESR_EL1">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "ESR_EL1";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 10 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-
-    let HWEncoding = 0;
-
-    let isArtificial = 0;
-}
-def SPSR_EL1 : Register<"SPSR_EL1">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "SPSR_EL1";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 11 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-
-    let HWEncoding = 0;
-
-    let isArtificial = 0;
-}
-def PC : Register<"PC">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "PC";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 12 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-
-    let HWEncoding = 0;
-
-    let isArtificial = 0;
-}
-def S0 : Register<"S0">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X0";
-    let AltNames = [ "X0"  ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 15 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 0;
-
-
-    let isArtificial = 0;
-}
-def S1 : Register<"S1">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X1";
-    let AltNames = [ "X1"  ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 16 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 1;
-
-
-    let isArtificial = 0;
-}
-def S2 : Register<"S2">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X2";
-    let AltNames = [ "X2"  ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 17 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 2;
-
-
-    let isArtificial = 0;
-}
-def S3 : Register<"S3">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X3";
-    let AltNames = [ "X3"  ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 18 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 3;
-
-
-    let isArtificial = 0;
-}
-def S4 : Register<"S4">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X4";
-    let AltNames = [ "X4"  ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 19 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 4;
-
-
-    let isArtificial = 0;
-}
-def S5 : Register<"S5">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X5";
-    let AltNames = [ "X5"  ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 20 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 5;
-
-
-    let isArtificial = 0;
-}
-def S6 : Register<"S6">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X6";
-    let AltNames = [ "X6"  ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 21 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 6;
-
-
-    let isArtificial = 0;
-}
-def S7 : Register<"S7">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X7";
-    let AltNames = [ "X7"  ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 22 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 7;
-
-
-    let isArtificial = 0;
-}
-def S8 : Register<"S8">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X8";
-    let AltNames = [ "X8"  ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 23 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 8;
-
-
-    let isArtificial = 0;
-}
-def S9 : Register<"S9">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X9";
-    let AltNames = [ "X9"  ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 24 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 9;
-
-
-    let isArtificial = 0;
-}
-def S10 : Register<"S10">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X10";
-    let AltNames = [ "X10"  ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 25 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 10;
-
-
-    let isArtificial = 0;
-}
-def S11 : Register<"S11">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X11";
-    let AltNames = [ "X11"  ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 26 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 11;
-
-
-    let isArtificial = 0;
-}
-def S12 : Register<"S12">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X12";
-    let AltNames = [ "X12"  ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 27 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 12;
-
-
-    let isArtificial = 0;
-}
-def S13 : Register<"S13">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X13";
-    let AltNames = [ "X13"  ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 28 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 13;
-
-
-    let isArtificial = 0;
-}
-def S14 : Register<"S14">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X14";
-    let AltNames = [ "X14"  ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 29 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 14;
-
-
-    let isArtificial = 0;
-}
-def S15 : Register<"S15">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X15";
-    let AltNames = [ "X15"  ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 30 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 15;
-
-
-    let isArtificial = 0;
-}
-def S16 : Register<"S16">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X16";
-    let AltNames = [ "X16"  ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 31 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 16;
-
-
-    let isArtificial = 0;
-}
-def S17 : Register<"S17">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X17";
-    let AltNames = [ "X17"  ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 32 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 17;
-
-
-    let isArtificial = 0;
-}
-def S18 : Register<"S18">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X18";
-    let AltNames = [ "X18"  ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 33 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 18;
-
-
-    let isArtificial = 0;
-}
-def S19 : Register<"S19">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X19";
-    let AltNames = [ "X19"  ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 34 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 19;
-
-
-    let isArtificial = 0;
-}
-def S20 : Register<"S20">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X20";
-    let AltNames = [ "X20"  ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 35 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 20;
-
-
-    let isArtificial = 0;
-}
-def S21 : Register<"S21">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X21";
-    let AltNames = [ "X21"  ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 36 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 21;
-
-
-    let isArtificial = 0;
-}
-def S22 : Register<"S22">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X22";
-    let AltNames = [ "X22"  ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 37 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 22;
-
-
-    let isArtificial = 0;
-}
-def S23 : Register<"S23">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X23";
-    let AltNames = [ "X23"  ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 38 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 23;
-
-
-    let isArtificial = 0;
-}
-def S24 : Register<"S24">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X24";
-    let AltNames = [ "X24"  ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 39 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 24;
-
-
-    let isArtificial = 0;
-}
-def S25 : Register<"S25">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X25";
-    let AltNames = [ "X25"  ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 40 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 25;
-
-
-    let isArtificial = 0;
-}
-def S26 : Register<"S26">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X26";
-    let AltNames = [ "X26"  ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 41 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 26;
-
-
-    let isArtificial = 0;
-}
-def S27 : Register<"S27">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X27";
-    let AltNames = [ "X27"  ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 42 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 27;
-
-
-    let isArtificial = 0;
-}
-def S28 : Register<"S28">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X28";
-    let AltNames = [ "X28"  ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 43 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 28;
-
-
-    let isArtificial = 0;
-}
-def S29 : Register<"S29">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "A_FP";
-    let AltNames = [ "A_FP"  ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 44 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 29;
-
-
-    let isArtificial = 0;
-}
-def S30 : Register<"S30">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "A_LR";
-    let AltNames = [ "A_LR"  ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 45 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 30;
-
-
-    let isArtificial = 0;
-}
-def S31 : Register<"S31">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "A_SP";
-    let AltNames = [ "A_SP"  ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 46 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 31;
-
-
-    let isArtificial = 0;
-}
-def X0 : Register<"X0">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X0";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 47 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 0;
-
-
-    let isArtificial = 1;
-}
-def X1 : Register<"X1">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X1";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 48 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 1;
-
-
-    let isArtificial = 1;
-}
-def X2 : Register<"X2">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X2";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 49 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 2;
-
-
-    let isArtificial = 1;
-}
-def X3 : Register<"X3">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X3";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 50 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 3;
-
-
-    let isArtificial = 1;
-}
-def X4 : Register<"X4">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X4";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 51 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 4;
-
-
-    let isArtificial = 1;
-}
-def X5 : Register<"X5">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X5";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 52 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 5;
-
-
-    let isArtificial = 1;
-}
-def X6 : Register<"X6">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X6";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 53 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 6;
-
-
-    let isArtificial = 1;
-}
-def X7 : Register<"X7">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X7";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 54 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 7;
-
-
-    let isArtificial = 1;
-}
-def X8 : Register<"X8">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X8";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 55 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 8;
-
-
-    let isArtificial = 1;
-}
-def X9 : Register<"X9">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X9";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 56 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 9;
-
-
-    let isArtificial = 1;
-}
-def X10 : Register<"X10">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X10";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 57 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 10;
-
-
-    let isArtificial = 1;
-}
-def X11 : Register<"X11">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X11";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 58 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 11;
-
-
-    let isArtificial = 1;
-}
-def X12 : Register<"X12">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X12";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 59 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 12;
-
-
-    let isArtificial = 1;
-}
-def X13 : Register<"X13">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X13";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 60 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 13;
-
-
-    let isArtificial = 1;
-}
-def X14 : Register<"X14">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X14";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 61 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 14;
-
-
-    let isArtificial = 1;
-}
-def X15 : Register<"X15">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X15";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 62 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 15;
-
-
-    let isArtificial = 1;
-}
-def X16 : Register<"X16">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X16";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 63 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 16;
-
-
-    let isArtificial = 1;
-}
-def X17 : Register<"X17">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X17";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 64 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 17;
-
-
-    let isArtificial = 1;
-}
-def X18 : Register<"X18">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X18";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 65 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 18;
-
-
-    let isArtificial = 1;
-}
-def X19 : Register<"X19">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X19";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 66 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 19;
-
-
-    let isArtificial = 1;
-}
-def X20 : Register<"X20">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X20";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 67 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 20;
-
-
-    let isArtificial = 1;
-}
-def X21 : Register<"X21">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X21";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 68 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 21;
-
-
-    let isArtificial = 1;
-}
-def X22 : Register<"X22">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X22";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 69 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 22;
-
-
-    let isArtificial = 1;
-}
-def X23 : Register<"X23">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X23";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 70 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 23;
-
-
-    let isArtificial = 1;
-}
-def X24 : Register<"X24">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X24";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 71 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 24;
-
-
-    let isArtificial = 1;
-}
-def X25 : Register<"X25">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X25";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 72 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 25;
-
-
-    let isArtificial = 1;
-}
-def X26 : Register<"X26">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X26";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 73 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 26;
-
-
-    let isArtificial = 1;
-}
-def X27 : Register<"X27">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X27";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 74 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 27;
-
-
-    let isArtificial = 1;
-}
-def X28 : Register<"X28">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X28";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 75 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 28;
-
-
-    let isArtificial = 1;
-}
-def X29 : Register<"X29">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X29";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 76 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 29;
-
-
-    let isArtificial = 1;
-}
-def X30 : Register<"X30">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X30";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 77 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 30;
-
-
-    let isArtificial = 1;
-}
-def X31 : Register<"X31">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "X31";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 78 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 31;
-
-
-    let isArtificial = 1;
-}
-def W0 : Register<"W0">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "W0";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 79 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 0;
-
-
-    let isArtificial = 1;
-}
-def W1 : Register<"W1">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "W1";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 80 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 1;
-
-
-    let isArtificial = 1;
-}
-def W2 : Register<"W2">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "W2";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 81 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 2;
-
-
-    let isArtificial = 1;
-}
-def W3 : Register<"W3">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "W3";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 82 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 3;
-
-
-    let isArtificial = 1;
-}
-def W4 : Register<"W4">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "W4";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 83 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 4;
-
-
-    let isArtificial = 1;
-}
-def W5 : Register<"W5">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "W5";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 84 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 5;
-
-
-    let isArtificial = 1;
-}
-def W6 : Register<"W6">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "W6";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 85 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 6;
-
-
-    let isArtificial = 1;
-}
-def W7 : Register<"W7">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "W7";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 86 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 7;
-
-
-    let isArtificial = 1;
-}
-def W8 : Register<"W8">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "W8";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 87 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 8;
-
-
-    let isArtificial = 1;
-}
-def W9 : Register<"W9">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "W9";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 88 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 9;
-
-
-    let isArtificial = 1;
-}
-def W10 : Register<"W10">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "W10";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 89 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 10;
-
-
-    let isArtificial = 1;
-}
-def W11 : Register<"W11">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "W11";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 90 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 11;
-
-
-    let isArtificial = 1;
-}
-def W12 : Register<"W12">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "W12";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 91 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 12;
-
-
-    let isArtificial = 1;
-}
-def W13 : Register<"W13">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "W13";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 92 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 13;
-
-
-    let isArtificial = 1;
-}
-def W14 : Register<"W14">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "W14";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 93 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 14;
-
-
-    let isArtificial = 1;
-}
-def W15 : Register<"W15">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "W15";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 94 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 15;
-
-
-    let isArtificial = 1;
-}
-def W16 : Register<"W16">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "W16";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 95 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 16;
-
-
-    let isArtificial = 1;
-}
-def W17 : Register<"W17">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "W17";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 96 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 17;
-
-
-    let isArtificial = 1;
-}
-def W18 : Register<"W18">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "W18";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 97 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 18;
-
-
-    let isArtificial = 1;
-}
-def W19 : Register<"W19">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "W19";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 98 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 19;
-
-
-    let isArtificial = 1;
-}
-def W20 : Register<"W20">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "W20";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 99 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 20;
-
-
-    let isArtificial = 1;
-}
-def W21 : Register<"W21">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "W21";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 100 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 21;
-
-
-    let isArtificial = 1;
-}
-def W22 : Register<"W22">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "W22";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 101 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 22;
-
-
-    let isArtificial = 1;
-}
-def W23 : Register<"W23">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "W23";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 102 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 23;
-
-
-    let isArtificial = 1;
-}
-def W24 : Register<"W24">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "W24";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 103 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 24;
-
-
-    let isArtificial = 1;
-}
-def W25 : Register<"W25">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "W25";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 104 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 25;
-
-
-    let isArtificial = 1;
-}
-def W26 : Register<"W26">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "W26";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 105 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 26;
-
-
-    let isArtificial = 1;
-}
-def W27 : Register<"W27">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "W27";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 106 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 27;
-
-
-    let isArtificial = 1;
-}
-def W28 : Register<"W28">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "W28";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 107 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 28;
-
-
-    let isArtificial = 1;
-}
-def W29 : Register<"W29">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "W29";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 108 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 29;
-
-
-    let isArtificial = 1;
-}
-def W30 : Register<"W30">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "W30";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 109 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 30;
-
-
-    let isArtificial = 1;
-}
-def W31 : Register<"W31">
-{
-    let Namespace = "aarch64temp";
-    let AsmName = "W31";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 110 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-
-    let HWEncoding{4-0} = 31;
-
-
-    let isArtificial = 1;
-}
-
 
 
 def SP : Register<"SP">
 {
-    let Namespace = "aarch64temp";
-    let AsmName = "SP";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 13 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-    let HWEncoding = 31;
-    let isArtificial = 1;
+let Namespace = "aarch64temp";
+let AsmName = "SP";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 13 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+let HWEncoding = 31;
+let isArtificial = 1;
 }
 def LR : Register<"LR">
 {
-    let Namespace = "aarch64temp";
-    let AsmName = "LR";
-    let AltNames = [   ];
-    let Aliases = [ ];
-    let SubRegs = [ ];
-    let SubRegIndices = [ ];
-    let RegAltNameIndices = [];
-    let DwarfNumbers = [ 14 ];
-    list<int> CostPerUse = [0];
-    let CoveredBySubRegs = 0;
-    let HWEncoding = 30;
-    let isArtificial = 1;
+let Namespace = "aarch64temp";
+let AsmName = "LR";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 14 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+let HWEncoding = 30;
+let isArtificial = 1;
+}
+
+
+
+def NZCV_N : Register<"NZCV_N">
+{
+let Namespace = "aarch64temp";
+let AsmName = "NZCV_N";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 0 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+
+let HWEncoding = 0;
+
+let isArtificial = false;
+}
+def NZCV_Z : Register<"NZCV_Z">
+{
+let Namespace = "aarch64temp";
+let AsmName = "NZCV_Z";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 1 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+
+let HWEncoding = 0;
+
+let isArtificial = false;
+}
+def NZCV_C : Register<"NZCV_C">
+{
+let Namespace = "aarch64temp";
+let AsmName = "NZCV_C";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 2 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+
+let HWEncoding = 0;
+
+let isArtificial = false;
+}
+def NZCV_V : Register<"NZCV_V">
+{
+let Namespace = "aarch64temp";
+let AsmName = "NZCV_V";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 3 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+
+let HWEncoding = 0;
+
+let isArtificial = false;
+}
+def CurrentEL : Register<"CurrentEL">
+{
+let Namespace = "aarch64temp";
+let AsmName = "CurrentEL";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 4 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+
+let HWEncoding = 0;
+
+let isArtificial = false;
+}
+def SPSel : Register<"SPSel">
+{
+let Namespace = "aarch64temp";
+let AsmName = "SPSel";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 5 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+
+let HWEncoding = 0;
+
+let isArtificial = false;
+}
+def SP_EL0 : Register<"SP_EL0">
+{
+let Namespace = "aarch64temp";
+let AsmName = "SP_EL0";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 6 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+
+let HWEncoding = 0;
+
+let isArtificial = false;
+}
+def SP_EL1 : Register<"SP_EL1">
+{
+let Namespace = "aarch64temp";
+let AsmName = "SP_EL1";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 7 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+
+let HWEncoding = 0;
+
+let isArtificial = false;
+}
+def ELR_EL1 : Register<"ELR_EL1">
+{
+let Namespace = "aarch64temp";
+let AsmName = "ELR_EL1";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 8 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+
+let HWEncoding = 0;
+
+let isArtificial = false;
+}
+def VBAR_EL1 : Register<"VBAR_EL1">
+{
+let Namespace = "aarch64temp";
+let AsmName = "VBAR_EL1";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 9 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+
+let HWEncoding = 0;
+
+let isArtificial = false;
+}
+def ESR_EL1 : Register<"ESR_EL1">
+{
+let Namespace = "aarch64temp";
+let AsmName = "ESR_EL1";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 10 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+
+let HWEncoding = 0;
+
+let isArtificial = false;
+}
+def SPSR_EL1 : Register<"SPSR_EL1">
+{
+let Namespace = "aarch64temp";
+let AsmName = "SPSR_EL1";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 11 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+
+let HWEncoding = 0;
+
+let isArtificial = false;
+}
+def PC : Register<"PC">
+{
+let Namespace = "aarch64temp";
+let AsmName = "PC";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 12 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+
+let HWEncoding = 0;
+
+let isArtificial = false;
+}
+def S0 : Register<"S0">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X0";
+let AltNames = [ "X0"  ];
+let Aliases = [ ];
+let SubRegs = [ X0, W0 ];
+let SubRegIndices = [ FULL_64, FULL_64 ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 15 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 0;
+
+
+let isArtificial = false;
+}
+def S1 : Register<"S1">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X1";
+let AltNames = [ "X1"  ];
+let Aliases = [ ];
+let SubRegs = [ X1, W1 ];
+let SubRegIndices = [ FULL_64, FULL_64 ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 16 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 1;
+
+
+let isArtificial = false;
+}
+def S2 : Register<"S2">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X2";
+let AltNames = [ "X2"  ];
+let Aliases = [ ];
+let SubRegs = [ X2, W2 ];
+let SubRegIndices = [ FULL_64, FULL_64 ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 17 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 2;
+
+
+let isArtificial = false;
+}
+def S3 : Register<"S3">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X3";
+let AltNames = [ "X3"  ];
+let Aliases = [ ];
+let SubRegs = [ X3, W3 ];
+let SubRegIndices = [ FULL_64, FULL_64 ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 18 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 3;
+
+
+let isArtificial = false;
+}
+def S4 : Register<"S4">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X4";
+let AltNames = [ "X4"  ];
+let Aliases = [ ];
+let SubRegs = [ X4, W4 ];
+let SubRegIndices = [ FULL_64, FULL_64 ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 19 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 4;
+
+
+let isArtificial = false;
+}
+def S5 : Register<"S5">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X5";
+let AltNames = [ "X5"  ];
+let Aliases = [ ];
+let SubRegs = [ X5, W5 ];
+let SubRegIndices = [ FULL_64, FULL_64 ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 20 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 5;
+
+
+let isArtificial = false;
+}
+def S6 : Register<"S6">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X6";
+let AltNames = [ "X6"  ];
+let Aliases = [ ];
+let SubRegs = [ X6, W6 ];
+let SubRegIndices = [ FULL_64, FULL_64 ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 21 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 6;
+
+
+let isArtificial = false;
+}
+def S7 : Register<"S7">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X7";
+let AltNames = [ "X7"  ];
+let Aliases = [ ];
+let SubRegs = [ X7, W7 ];
+let SubRegIndices = [ FULL_64, FULL_64 ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 22 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 7;
+
+
+let isArtificial = false;
+}
+def S8 : Register<"S8">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X8";
+let AltNames = [ "X8"  ];
+let Aliases = [ ];
+let SubRegs = [ X8, W8 ];
+let SubRegIndices = [ FULL_64, FULL_64 ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 23 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 8;
+
+
+let isArtificial = false;
+}
+def S9 : Register<"S9">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X9";
+let AltNames = [ "X9"  ];
+let Aliases = [ ];
+let SubRegs = [ X9, W9 ];
+let SubRegIndices = [ FULL_64, FULL_64 ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 24 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 9;
+
+
+let isArtificial = false;
+}
+def S10 : Register<"S10">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X10";
+let AltNames = [ "X10"  ];
+let Aliases = [ ];
+let SubRegs = [ X10, W10 ];
+let SubRegIndices = [ FULL_64, FULL_64 ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 25 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 10;
+
+
+let isArtificial = false;
+}
+def S11 : Register<"S11">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X11";
+let AltNames = [ "X11"  ];
+let Aliases = [ ];
+let SubRegs = [ X11, W11 ];
+let SubRegIndices = [ FULL_64, FULL_64 ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 26 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 11;
+
+
+let isArtificial = false;
+}
+def S12 : Register<"S12">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X12";
+let AltNames = [ "X12"  ];
+let Aliases = [ ];
+let SubRegs = [ X12, W12 ];
+let SubRegIndices = [ FULL_64, FULL_64 ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 27 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 12;
+
+
+let isArtificial = false;
+}
+def S13 : Register<"S13">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X13";
+let AltNames = [ "X13"  ];
+let Aliases = [ ];
+let SubRegs = [ X13, W13 ];
+let SubRegIndices = [ FULL_64, FULL_64 ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 28 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 13;
+
+
+let isArtificial = false;
+}
+def S14 : Register<"S14">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X14";
+let AltNames = [ "X14"  ];
+let Aliases = [ ];
+let SubRegs = [ X14, W14 ];
+let SubRegIndices = [ FULL_64, FULL_64 ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 29 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 14;
+
+
+let isArtificial = false;
+}
+def S15 : Register<"S15">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X15";
+let AltNames = [ "X15"  ];
+let Aliases = [ ];
+let SubRegs = [ X15, W15 ];
+let SubRegIndices = [ FULL_64, FULL_64 ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 30 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 15;
+
+
+let isArtificial = false;
+}
+def S16 : Register<"S16">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X16";
+let AltNames = [ "X16"  ];
+let Aliases = [ ];
+let SubRegs = [ X16, W16 ];
+let SubRegIndices = [ FULL_64, FULL_64 ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 31 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 16;
+
+
+let isArtificial = false;
+}
+def S17 : Register<"S17">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X17";
+let AltNames = [ "X17"  ];
+let Aliases = [ ];
+let SubRegs = [ X17, W17 ];
+let SubRegIndices = [ FULL_64, FULL_64 ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 32 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 17;
+
+
+let isArtificial = false;
+}
+def S18 : Register<"S18">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X18";
+let AltNames = [ "X18"  ];
+let Aliases = [ ];
+let SubRegs = [ X18, W18 ];
+let SubRegIndices = [ FULL_64, FULL_64 ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 33 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 18;
+
+
+let isArtificial = false;
+}
+def S19 : Register<"S19">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X19";
+let AltNames = [ "X19"  ];
+let Aliases = [ ];
+let SubRegs = [ X19, W19 ];
+let SubRegIndices = [ FULL_64, FULL_64 ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 34 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 19;
+
+
+let isArtificial = false;
+}
+def S20 : Register<"S20">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X20";
+let AltNames = [ "X20"  ];
+let Aliases = [ ];
+let SubRegs = [ X20, W20 ];
+let SubRegIndices = [ FULL_64, FULL_64 ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 35 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 20;
+
+
+let isArtificial = false;
+}
+def S21 : Register<"S21">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X21";
+let AltNames = [ "X21"  ];
+let Aliases = [ ];
+let SubRegs = [ X21, W21 ];
+let SubRegIndices = [ FULL_64, FULL_64 ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 36 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 21;
+
+
+let isArtificial = false;
+}
+def S22 : Register<"S22">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X22";
+let AltNames = [ "X22"  ];
+let Aliases = [ ];
+let SubRegs = [ X22, W22 ];
+let SubRegIndices = [ FULL_64, FULL_64 ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 37 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 22;
+
+
+let isArtificial = false;
+}
+def S23 : Register<"S23">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X23";
+let AltNames = [ "X23"  ];
+let Aliases = [ ];
+let SubRegs = [ X23, W23 ];
+let SubRegIndices = [ FULL_64, FULL_64 ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 38 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 23;
+
+
+let isArtificial = false;
+}
+def S24 : Register<"S24">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X24";
+let AltNames = [ "X24"  ];
+let Aliases = [ ];
+let SubRegs = [ X24, W24 ];
+let SubRegIndices = [ FULL_64, FULL_64 ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 39 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 24;
+
+
+let isArtificial = false;
+}
+def S25 : Register<"S25">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X25";
+let AltNames = [ "X25"  ];
+let Aliases = [ ];
+let SubRegs = [ X25, W25 ];
+let SubRegIndices = [ FULL_64, FULL_64 ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 40 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 25;
+
+
+let isArtificial = false;
+}
+def S26 : Register<"S26">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X26";
+let AltNames = [ "X26"  ];
+let Aliases = [ ];
+let SubRegs = [ X26, W26 ];
+let SubRegIndices = [ FULL_64, FULL_64 ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 41 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 26;
+
+
+let isArtificial = false;
+}
+def S27 : Register<"S27">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X27";
+let AltNames = [ "X27"  ];
+let Aliases = [ ];
+let SubRegs = [ X27, W27 ];
+let SubRegIndices = [ FULL_64, FULL_64 ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 42 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 27;
+
+
+let isArtificial = false;
+}
+def S28 : Register<"S28">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X28";
+let AltNames = [ "X28"  ];
+let Aliases = [ ];
+let SubRegs = [ X28, W28 ];
+let SubRegIndices = [ FULL_64, FULL_64 ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 43 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 28;
+
+
+let isArtificial = false;
+}
+def S29 : Register<"S29">
+{
+let Namespace = "aarch64temp";
+let AsmName = "A_FP";
+let AltNames = [ "A_FP"  ];
+let Aliases = [ ];
+let SubRegs = [ X29, W29 ];
+let SubRegIndices = [ FULL_64, FULL_64 ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 44 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 29;
+
+
+let isArtificial = false;
+}
+def S30 : Register<"S30">
+{
+let Namespace = "aarch64temp";
+let AsmName = "A_LR";
+let AltNames = [ "A_LR"  ];
+let Aliases = [ ];
+let SubRegs = [ X30, W30 ];
+let SubRegIndices = [ FULL_64, FULL_64 ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 45 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 30;
+
+
+let isArtificial = false;
+}
+def S31 : Register<"S31">
+{
+let Namespace = "aarch64temp";
+let AsmName = "A_SP";
+let AltNames = [ "A_SP"  ];
+let Aliases = [ ];
+let SubRegs = [ X31, W31 ];
+let SubRegIndices = [ FULL_64, FULL_64 ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 46 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 31;
+
+
+let isArtificial = false;
+}
+def X0 : Register<"X0">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X0";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 47 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 0;
+
+
+let isArtificial = false;
+}
+def X1 : Register<"X1">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X1";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 48 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 1;
+
+
+let isArtificial = false;
+}
+def X2 : Register<"X2">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X2";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 49 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 2;
+
+
+let isArtificial = false;
+}
+def X3 : Register<"X3">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X3";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 50 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 3;
+
+
+let isArtificial = false;
+}
+def X4 : Register<"X4">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X4";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 51 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 4;
+
+
+let isArtificial = false;
+}
+def X5 : Register<"X5">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X5";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 52 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 5;
+
+
+let isArtificial = false;
+}
+def X6 : Register<"X6">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X6";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 53 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 6;
+
+
+let isArtificial = false;
+}
+def X7 : Register<"X7">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X7";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 54 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 7;
+
+
+let isArtificial = false;
+}
+def X8 : Register<"X8">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X8";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 55 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 8;
+
+
+let isArtificial = false;
+}
+def X9 : Register<"X9">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X9";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 56 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 9;
+
+
+let isArtificial = false;
+}
+def X10 : Register<"X10">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X10";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 57 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 10;
+
+
+let isArtificial = false;
+}
+def X11 : Register<"X11">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X11";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 58 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 11;
+
+
+let isArtificial = false;
+}
+def X12 : Register<"X12">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X12";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 59 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 12;
+
+
+let isArtificial = false;
+}
+def X13 : Register<"X13">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X13";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 60 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 13;
+
+
+let isArtificial = false;
+}
+def X14 : Register<"X14">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X14";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 61 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 14;
+
+
+let isArtificial = false;
+}
+def X15 : Register<"X15">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X15";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 62 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 15;
+
+
+let isArtificial = false;
+}
+def X16 : Register<"X16">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X16";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 63 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 16;
+
+
+let isArtificial = false;
+}
+def X17 : Register<"X17">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X17";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 64 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 17;
+
+
+let isArtificial = false;
+}
+def X18 : Register<"X18">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X18";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 65 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 18;
+
+
+let isArtificial = false;
+}
+def X19 : Register<"X19">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X19";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 66 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 19;
+
+
+let isArtificial = false;
+}
+def X20 : Register<"X20">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X20";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 67 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 20;
+
+
+let isArtificial = false;
+}
+def X21 : Register<"X21">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X21";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 68 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 21;
+
+
+let isArtificial = false;
+}
+def X22 : Register<"X22">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X22";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 69 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 22;
+
+
+let isArtificial = false;
+}
+def X23 : Register<"X23">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X23";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 70 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 23;
+
+
+let isArtificial = false;
+}
+def X24 : Register<"X24">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X24";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 71 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 24;
+
+
+let isArtificial = false;
+}
+def X25 : Register<"X25">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X25";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 72 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 25;
+
+
+let isArtificial = false;
+}
+def X26 : Register<"X26">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X26";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 73 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 26;
+
+
+let isArtificial = false;
+}
+def X27 : Register<"X27">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X27";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 74 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 27;
+
+
+let isArtificial = false;
+}
+def X28 : Register<"X28">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X28";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 75 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 28;
+
+
+let isArtificial = false;
+}
+def X29 : Register<"X29">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X29";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 76 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 29;
+
+
+let isArtificial = false;
+}
+def X30 : Register<"X30">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X30";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 77 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 30;
+
+
+let isArtificial = false;
+}
+def X31 : Register<"X31">
+{
+let Namespace = "aarch64temp";
+let AsmName = "X31";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 78 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 31;
+
+
+let isArtificial = false;
+}
+def W0 : Register<"W0">
+{
+let Namespace = "aarch64temp";
+let AsmName = "W0";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 79 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 0;
+
+
+let isArtificial = false;
+}
+def W1 : Register<"W1">
+{
+let Namespace = "aarch64temp";
+let AsmName = "W1";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 80 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 1;
+
+
+let isArtificial = false;
+}
+def W2 : Register<"W2">
+{
+let Namespace = "aarch64temp";
+let AsmName = "W2";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 81 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 2;
+
+
+let isArtificial = false;
+}
+def W3 : Register<"W3">
+{
+let Namespace = "aarch64temp";
+let AsmName = "W3";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 82 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 3;
+
+
+let isArtificial = false;
+}
+def W4 : Register<"W4">
+{
+let Namespace = "aarch64temp";
+let AsmName = "W4";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 83 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 4;
+
+
+let isArtificial = false;
+}
+def W5 : Register<"W5">
+{
+let Namespace = "aarch64temp";
+let AsmName = "W5";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 84 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 5;
+
+
+let isArtificial = false;
+}
+def W6 : Register<"W6">
+{
+let Namespace = "aarch64temp";
+let AsmName = "W6";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 85 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 6;
+
+
+let isArtificial = false;
+}
+def W7 : Register<"W7">
+{
+let Namespace = "aarch64temp";
+let AsmName = "W7";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 86 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 7;
+
+
+let isArtificial = false;
+}
+def W8 : Register<"W8">
+{
+let Namespace = "aarch64temp";
+let AsmName = "W8";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 87 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 8;
+
+
+let isArtificial = false;
+}
+def W9 : Register<"W9">
+{
+let Namespace = "aarch64temp";
+let AsmName = "W9";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 88 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 9;
+
+
+let isArtificial = false;
+}
+def W10 : Register<"W10">
+{
+let Namespace = "aarch64temp";
+let AsmName = "W10";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 89 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 10;
+
+
+let isArtificial = false;
+}
+def W11 : Register<"W11">
+{
+let Namespace = "aarch64temp";
+let AsmName = "W11";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 90 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 11;
+
+
+let isArtificial = false;
+}
+def W12 : Register<"W12">
+{
+let Namespace = "aarch64temp";
+let AsmName = "W12";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 91 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 12;
+
+
+let isArtificial = false;
+}
+def W13 : Register<"W13">
+{
+let Namespace = "aarch64temp";
+let AsmName = "W13";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 92 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 13;
+
+
+let isArtificial = false;
+}
+def W14 : Register<"W14">
+{
+let Namespace = "aarch64temp";
+let AsmName = "W14";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 93 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 14;
+
+
+let isArtificial = false;
+}
+def W15 : Register<"W15">
+{
+let Namespace = "aarch64temp";
+let AsmName = "W15";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 94 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 15;
+
+
+let isArtificial = false;
+}
+def W16 : Register<"W16">
+{
+let Namespace = "aarch64temp";
+let AsmName = "W16";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 95 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 16;
+
+
+let isArtificial = false;
+}
+def W17 : Register<"W17">
+{
+let Namespace = "aarch64temp";
+let AsmName = "W17";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 96 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 17;
+
+
+let isArtificial = false;
+}
+def W18 : Register<"W18">
+{
+let Namespace = "aarch64temp";
+let AsmName = "W18";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 97 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 18;
+
+
+let isArtificial = false;
+}
+def W19 : Register<"W19">
+{
+let Namespace = "aarch64temp";
+let AsmName = "W19";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 98 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 19;
+
+
+let isArtificial = false;
+}
+def W20 : Register<"W20">
+{
+let Namespace = "aarch64temp";
+let AsmName = "W20";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 99 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 20;
+
+
+let isArtificial = false;
+}
+def W21 : Register<"W21">
+{
+let Namespace = "aarch64temp";
+let AsmName = "W21";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 100 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 21;
+
+
+let isArtificial = false;
+}
+def W22 : Register<"W22">
+{
+let Namespace = "aarch64temp";
+let AsmName = "W22";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 101 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 22;
+
+
+let isArtificial = false;
+}
+def W23 : Register<"W23">
+{
+let Namespace = "aarch64temp";
+let AsmName = "W23";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 102 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 23;
+
+
+let isArtificial = false;
+}
+def W24 : Register<"W24">
+{
+let Namespace = "aarch64temp";
+let AsmName = "W24";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 103 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 24;
+
+
+let isArtificial = false;
+}
+def W25 : Register<"W25">
+{
+let Namespace = "aarch64temp";
+let AsmName = "W25";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 104 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 25;
+
+
+let isArtificial = false;
+}
+def W26 : Register<"W26">
+{
+let Namespace = "aarch64temp";
+let AsmName = "W26";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 105 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 26;
+
+
+let isArtificial = false;
+}
+def W27 : Register<"W27">
+{
+let Namespace = "aarch64temp";
+let AsmName = "W27";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 106 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 27;
+
+
+let isArtificial = false;
+}
+def W28 : Register<"W28">
+{
+let Namespace = "aarch64temp";
+let AsmName = "W28";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 107 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 28;
+
+
+let isArtificial = false;
+}
+def W29 : Register<"W29">
+{
+let Namespace = "aarch64temp";
+let AsmName = "W29";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 108 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 29;
+
+
+let isArtificial = false;
+}
+def W30 : Register<"W30">
+{
+let Namespace = "aarch64temp";
+let AsmName = "W30";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 109 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 30;
+
+
+let isArtificial = false;
+}
+def W31 : Register<"W31">
+{
+let Namespace = "aarch64temp";
+let AsmName = "W31";
+let AltNames = [   ];
+let Aliases = [ ];
+let SubRegs = [  ];
+let SubRegIndices = [  ];
+let RegAltNameIndices = [];
+let DwarfNumbers = [ 110 ];
+list<int> CostPerUse = [0];
+let CoveredBySubRegs = 0;
+
+let HWEncoding{4-0} = 31;
+
+
+let isArtificial = false;
 }
 
 
 defvar aarch64temp = DefaultMode;
 
 def SLenRI : RegInfoByHwMode<
-      [ aarch64temp ],
-      [RegInfo<64,64,64>]>;
+[ aarch64temp ],
+[RegInfo<64,64,64>]>;
 def S : RegisterClass
 < /* namespace = */ "aarch64temp"
 , /* regTypes  = */  [  i64 ]
 , /* alignment = */ 32
 , /* regList   = */
-  ( add S9, S10, S11, S12, S13, S14, S15, S19, S20, S21, S22, S23, S24, S25, S26, S27, S28, S0, S1, S2, S3, S4, S5, S6, S7, S8, S16, S17, S18, S29, S30, S31 )
+( add S9, S10, S11, S12, S13, S14, S15, S19, S20, S21, S22, S23, S24, S25, S26, S27, S28, S0, S1, S2, S3, S4, S5, S6, S7, S8, S16, S17, S18, S29, S30, S31 )
 > {
-  let RegInfos = SLenRI;
+let RegInfos = SLenRI;
 }
 
 
@@ -2018,14 +2025,14 @@ def X : RegisterClass
 , /* regTypes  = */  [  i64 ]
 , /* alignment = */ 32
 , /* regList   = */
-  ( add X0, X1, X2, X3, X4, X5, X6, X7, X8, X9, X10, X11, X12, X13, X14, X15, X16, X17, X18, X19, X20, X21, X22, X23, X24, X25, X26, X27, X28, X29, X30, X31 )
+( add X0, X1, X2, X3, X4, X5, X6, X7, X8, X9, X10, X11, X12, X13, X14, X15, X16, X17, X18, X19, X20, X21, X22, X23, X24, X25, X26, X27, X28, X29, X30, X31 )
 > {
 }
 def W : RegisterClass
 < /* namespace = */ "aarch64temp"
-, /* regTypes  = */  [  i32 ]
+, /* regTypes  = */  [  i64 ]
 , /* alignment = */ 32
 , /* regList   = */
-  ( add W0, W1, W2, W3, W4, W5, W6, W7, W8, W9, W10, W11, W12, W13, W14, W15, W16, W17, W18, W19, W20, W21, W22, W23, W24, W25, W26, W27, W28, W29, W30, W31 )
+( add W0, W1, W2, W3, W4, W5, W6, W7, W8, W9, W10, W11, W12, W13, W14, W15, W16, W17, W18, W19, W20, W21, W22, W23, W24, W25, W26, W27, W28, W29, W30, W31 )
 > {
 }

--- a/vadl/test/vadl/lcb/riscv/riscv64/template/EmitRegisterInfoTableGenFilePassTest.java
+++ b/vadl/test/vadl/lcb/riscv/riscv64/template/EmitRegisterInfoTableGenFilePassTest.java
@@ -46,14 +46,24 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
     var output = trimmed.lines();
 
     Assertions.assertLinesMatch("""
+        let Namespace = "processornamevalue" in {
+        // SubRegIndexes for GPR registers
+        def sub_32   : SubRegIndex<32>;
+        def sub_32_hi : SubRegIndex<32, 32>;
+        def full_64    : SubRegIndex<64>;
+        }
+        
+        
+        
+        
         def PC : Register<"PC">
         {
         let Namespace = "processorNameValue";
         let AsmName = "PC";
         let AltNames = [   ];
         let Aliases = [ ];
-        let SubRegs = [ ];
-        let SubRegIndices = [ ];
+        let SubRegs = [  ];
+        let SubRegIndices = [  ];
         let RegAltNameIndices = [];
         let DwarfNumbers = [ 0 ];
         list<int> CostPerUse = [0];
@@ -62,7 +72,7 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         
         let HWEncoding = 0;
         
-        let isArtificial = 0;
+        let isArtificial = false;
         }
         def X0 : Register<"X0">
         {
@@ -70,8 +80,8 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let AsmName = "zero";
         let AltNames = [ "zero"  ];
         let Aliases = [ ];
-        let SubRegs = [ ];
-        let SubRegIndices = [ ];
+        let SubRegs = [  ];
+        let SubRegIndices = [  ];
         let RegAltNameIndices = [];
         let DwarfNumbers = [ 1 ];
         list<int> CostPerUse = [0];
@@ -80,7 +90,7 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let HWEncoding{4-0} = 0;
         
         
-        let isArtificial = 0;
+        let isArtificial = false;
         }
         def X1 : Register<"X1">
         {
@@ -88,8 +98,8 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let AsmName = "ra";
         let AltNames = [ "ra"  ];
         let Aliases = [ ];
-        let SubRegs = [ ];
-        let SubRegIndices = [ ];
+        let SubRegs = [  ];
+        let SubRegIndices = [  ];
         let RegAltNameIndices = [];
         let DwarfNumbers = [ 2 ];
         list<int> CostPerUse = [0];
@@ -98,7 +108,7 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let HWEncoding{4-0} = 1;
         
         
-        let isArtificial = 0;
+        let isArtificial = false;
         }
         def X2 : Register<"X2">
         {
@@ -106,8 +116,8 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let AsmName = "sp";
         let AltNames = [ "sp"  ];
         let Aliases = [ ];
-        let SubRegs = [ ];
-        let SubRegIndices = [ ];
+        let SubRegs = [  ];
+        let SubRegIndices = [  ];
         let RegAltNameIndices = [];
         let DwarfNumbers = [ 3 ];
         list<int> CostPerUse = [0];
@@ -116,7 +126,7 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let HWEncoding{4-0} = 2;
         
         
-        let isArtificial = 0;
+        let isArtificial = false;
         }
         def X3 : Register<"X3">
         {
@@ -124,8 +134,8 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let AsmName = "gp";
         let AltNames = [ "gp"  ];
         let Aliases = [ ];
-        let SubRegs = [ ];
-        let SubRegIndices = [ ];
+        let SubRegs = [  ];
+        let SubRegIndices = [  ];
         let RegAltNameIndices = [];
         let DwarfNumbers = [ 4 ];
         list<int> CostPerUse = [0];
@@ -134,7 +144,7 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let HWEncoding{4-0} = 3;
         
         
-        let isArtificial = 0;
+        let isArtificial = false;
         }
         def X4 : Register<"X4">
         {
@@ -142,8 +152,8 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let AsmName = "tp";
         let AltNames = [ "tp"  ];
         let Aliases = [ ];
-        let SubRegs = [ ];
-        let SubRegIndices = [ ];
+        let SubRegs = [  ];
+        let SubRegIndices = [  ];
         let RegAltNameIndices = [];
         let DwarfNumbers = [ 5 ];
         list<int> CostPerUse = [0];
@@ -152,7 +162,7 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let HWEncoding{4-0} = 4;
         
         
-        let isArtificial = 0;
+        let isArtificial = false;
         }
         def X5 : Register<"X5">
         {
@@ -160,8 +170,8 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let AsmName = "t0";
         let AltNames = [ "t0"  ];
         let Aliases = [ ];
-        let SubRegs = [ ];
-        let SubRegIndices = [ ];
+        let SubRegs = [  ];
+        let SubRegIndices = [  ];
         let RegAltNameIndices = [];
         let DwarfNumbers = [ 6 ];
         list<int> CostPerUse = [0];
@@ -170,7 +180,7 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let HWEncoding{4-0} = 5;
         
         
-        let isArtificial = 0;
+        let isArtificial = false;
         }
         def X6 : Register<"X6">
         {
@@ -178,8 +188,8 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let AsmName = "t1";
         let AltNames = [ "t1"  ];
         let Aliases = [ ];
-        let SubRegs = [ ];
-        let SubRegIndices = [ ];
+        let SubRegs = [  ];
+        let SubRegIndices = [  ];
         let RegAltNameIndices = [];
         let DwarfNumbers = [ 7 ];
         list<int> CostPerUse = [0];
@@ -188,7 +198,7 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let HWEncoding{4-0} = 6;
         
         
-        let isArtificial = 0;
+        let isArtificial = false;
         }
         def X7 : Register<"X7">
         {
@@ -196,8 +206,8 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let AsmName = "t2";
         let AltNames = [ "t2"  ];
         let Aliases = [ ];
-        let SubRegs = [ ];
-        let SubRegIndices = [ ];
+        let SubRegs = [  ];
+        let SubRegIndices = [  ];
         let RegAltNameIndices = [];
         let DwarfNumbers = [ 8 ];
         list<int> CostPerUse = [0];
@@ -206,7 +216,7 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let HWEncoding{4-0} = 7;
         
         
-        let isArtificial = 0;
+        let isArtificial = false;
         }
         def X8 : Register<"X8">
         {
@@ -214,8 +224,8 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let AsmName = "fp";
         let AltNames = [ "fp", "s0"  ];
         let Aliases = [ ];
-        let SubRegs = [ ];
-        let SubRegIndices = [ ];
+        let SubRegs = [  ];
+        let SubRegIndices = [  ];
         let RegAltNameIndices = [];
         let DwarfNumbers = [ 9 ];
         list<int> CostPerUse = [0];
@@ -224,7 +234,7 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let HWEncoding{4-0} = 8;
         
         
-        let isArtificial = 0;
+        let isArtificial = false;
         }
         def X9 : Register<"X9">
         {
@@ -232,8 +242,8 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let AsmName = "s1";
         let AltNames = [ "s1"  ];
         let Aliases = [ ];
-        let SubRegs = [ ];
-        let SubRegIndices = [ ];
+        let SubRegs = [  ];
+        let SubRegIndices = [  ];
         let RegAltNameIndices = [];
         let DwarfNumbers = [ 10 ];
         list<int> CostPerUse = [0];
@@ -242,7 +252,7 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let HWEncoding{4-0} = 9;
         
         
-        let isArtificial = 0;
+        let isArtificial = false;
         }
         def X10 : Register<"X10">
         {
@@ -250,8 +260,8 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let AsmName = "a0";
         let AltNames = [ "a0"  ];
         let Aliases = [ ];
-        let SubRegs = [ ];
-        let SubRegIndices = [ ];
+        let SubRegs = [  ];
+        let SubRegIndices = [  ];
         let RegAltNameIndices = [];
         let DwarfNumbers = [ 11 ];
         list<int> CostPerUse = [0];
@@ -260,7 +270,7 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let HWEncoding{4-0} = 10;
         
         
-        let isArtificial = 0;
+        let isArtificial = false;
         }
         def X11 : Register<"X11">
         {
@@ -268,8 +278,8 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let AsmName = "a1";
         let AltNames = [ "a1"  ];
         let Aliases = [ ];
-        let SubRegs = [ ];
-        let SubRegIndices = [ ];
+        let SubRegs = [  ];
+        let SubRegIndices = [  ];
         let RegAltNameIndices = [];
         let DwarfNumbers = [ 12 ];
         list<int> CostPerUse = [0];
@@ -278,7 +288,7 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let HWEncoding{4-0} = 11;
         
         
-        let isArtificial = 0;
+        let isArtificial = false;
         }
         def X12 : Register<"X12">
         {
@@ -286,8 +296,8 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let AsmName = "a2";
         let AltNames = [ "a2"  ];
         let Aliases = [ ];
-        let SubRegs = [ ];
-        let SubRegIndices = [ ];
+        let SubRegs = [  ];
+        let SubRegIndices = [  ];
         let RegAltNameIndices = [];
         let DwarfNumbers = [ 13 ];
         list<int> CostPerUse = [0];
@@ -296,7 +306,7 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let HWEncoding{4-0} = 12;
         
         
-        let isArtificial = 0;
+        let isArtificial = false;
         }
         def X13 : Register<"X13">
         {
@@ -304,8 +314,8 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let AsmName = "a3";
         let AltNames = [ "a3"  ];
         let Aliases = [ ];
-        let SubRegs = [ ];
-        let SubRegIndices = [ ];
+        let SubRegs = [  ];
+        let SubRegIndices = [  ];
         let RegAltNameIndices = [];
         let DwarfNumbers = [ 14 ];
         list<int> CostPerUse = [0];
@@ -314,7 +324,7 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let HWEncoding{4-0} = 13;
         
         
-        let isArtificial = 0;
+        let isArtificial = false;
         }
         def X14 : Register<"X14">
         {
@@ -322,8 +332,8 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let AsmName = "a4";
         let AltNames = [ "a4"  ];
         let Aliases = [ ];
-        let SubRegs = [ ];
-        let SubRegIndices = [ ];
+        let SubRegs = [  ];
+        let SubRegIndices = [  ];
         let RegAltNameIndices = [];
         let DwarfNumbers = [ 15 ];
         list<int> CostPerUse = [0];
@@ -332,7 +342,7 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let HWEncoding{4-0} = 14;
         
         
-        let isArtificial = 0;
+        let isArtificial = false;
         }
         def X15 : Register<"X15">
         {
@@ -340,8 +350,8 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let AsmName = "a5";
         let AltNames = [ "a5"  ];
         let Aliases = [ ];
-        let SubRegs = [ ];
-        let SubRegIndices = [ ];
+        let SubRegs = [  ];
+        let SubRegIndices = [  ];
         let RegAltNameIndices = [];
         let DwarfNumbers = [ 16 ];
         list<int> CostPerUse = [0];
@@ -350,7 +360,7 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let HWEncoding{4-0} = 15;
         
         
-        let isArtificial = 0;
+        let isArtificial = false;
         }
         def X16 : Register<"X16">
         {
@@ -358,8 +368,8 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let AsmName = "a6";
         let AltNames = [ "a6"  ];
         let Aliases = [ ];
-        let SubRegs = [ ];
-        let SubRegIndices = [ ];
+        let SubRegs = [  ];
+        let SubRegIndices = [  ];
         let RegAltNameIndices = [];
         let DwarfNumbers = [ 17 ];
         list<int> CostPerUse = [0];
@@ -368,7 +378,7 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let HWEncoding{4-0} = 16;
         
         
-        let isArtificial = 0;
+        let isArtificial = false;
         }
         def X17 : Register<"X17">
         {
@@ -376,8 +386,8 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let AsmName = "a7";
         let AltNames = [ "a7"  ];
         let Aliases = [ ];
-        let SubRegs = [ ];
-        let SubRegIndices = [ ];
+        let SubRegs = [  ];
+        let SubRegIndices = [  ];
         let RegAltNameIndices = [];
         let DwarfNumbers = [ 18 ];
         list<int> CostPerUse = [0];
@@ -386,7 +396,7 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let HWEncoding{4-0} = 17;
         
         
-        let isArtificial = 0;
+        let isArtificial = false;
         }
         def X18 : Register<"X18">
         {
@@ -394,8 +404,8 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let AsmName = "s2";
         let AltNames = [ "s2"  ];
         let Aliases = [ ];
-        let SubRegs = [ ];
-        let SubRegIndices = [ ];
+        let SubRegs = [  ];
+        let SubRegIndices = [  ];
         let RegAltNameIndices = [];
         let DwarfNumbers = [ 19 ];
         list<int> CostPerUse = [0];
@@ -404,7 +414,7 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let HWEncoding{4-0} = 18;
         
         
-        let isArtificial = 0;
+        let isArtificial = false;
         }
         def X19 : Register<"X19">
         {
@@ -412,8 +422,8 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let AsmName = "s3";
         let AltNames = [ "s3"  ];
         let Aliases = [ ];
-        let SubRegs = [ ];
-        let SubRegIndices = [ ];
+        let SubRegs = [  ];
+        let SubRegIndices = [  ];
         let RegAltNameIndices = [];
         let DwarfNumbers = [ 20 ];
         list<int> CostPerUse = [0];
@@ -422,7 +432,7 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let HWEncoding{4-0} = 19;
         
         
-        let isArtificial = 0;
+        let isArtificial = false;
         }
         def X20 : Register<"X20">
         {
@@ -430,8 +440,8 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let AsmName = "s4";
         let AltNames = [ "s4"  ];
         let Aliases = [ ];
-        let SubRegs = [ ];
-        let SubRegIndices = [ ];
+        let SubRegs = [  ];
+        let SubRegIndices = [  ];
         let RegAltNameIndices = [];
         let DwarfNumbers = [ 21 ];
         list<int> CostPerUse = [0];
@@ -440,7 +450,7 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let HWEncoding{4-0} = 20;
         
         
-        let isArtificial = 0;
+        let isArtificial = false;
         }
         def X21 : Register<"X21">
         {
@@ -448,8 +458,8 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let AsmName = "s5";
         let AltNames = [ "s5"  ];
         let Aliases = [ ];
-        let SubRegs = [ ];
-        let SubRegIndices = [ ];
+        let SubRegs = [  ];
+        let SubRegIndices = [  ];
         let RegAltNameIndices = [];
         let DwarfNumbers = [ 22 ];
         list<int> CostPerUse = [0];
@@ -458,7 +468,7 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let HWEncoding{4-0} = 21;
         
         
-        let isArtificial = 0;
+        let isArtificial = false;
         }
         def X22 : Register<"X22">
         {
@@ -466,8 +476,8 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let AsmName = "s6";
         let AltNames = [ "s6"  ];
         let Aliases = [ ];
-        let SubRegs = [ ];
-        let SubRegIndices = [ ];
+        let SubRegs = [  ];
+        let SubRegIndices = [  ];
         let RegAltNameIndices = [];
         let DwarfNumbers = [ 23 ];
         list<int> CostPerUse = [0];
@@ -476,7 +486,7 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let HWEncoding{4-0} = 22;
         
         
-        let isArtificial = 0;
+        let isArtificial = false;
         }
         def X23 : Register<"X23">
         {
@@ -484,8 +494,8 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let AsmName = "s7";
         let AltNames = [ "s7"  ];
         let Aliases = [ ];
-        let SubRegs = [ ];
-        let SubRegIndices = [ ];
+        let SubRegs = [  ];
+        let SubRegIndices = [  ];
         let RegAltNameIndices = [];
         let DwarfNumbers = [ 24 ];
         list<int> CostPerUse = [0];
@@ -494,7 +504,7 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let HWEncoding{4-0} = 23;
         
         
-        let isArtificial = 0;
+        let isArtificial = false;
         }
         def X24 : Register<"X24">
         {
@@ -502,8 +512,8 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let AsmName = "s8";
         let AltNames = [ "s8"  ];
         let Aliases = [ ];
-        let SubRegs = [ ];
-        let SubRegIndices = [ ];
+        let SubRegs = [  ];
+        let SubRegIndices = [  ];
         let RegAltNameIndices = [];
         let DwarfNumbers = [ 25 ];
         list<int> CostPerUse = [0];
@@ -512,7 +522,7 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let HWEncoding{4-0} = 24;
         
         
-        let isArtificial = 0;
+        let isArtificial = false;
         }
         def X25 : Register<"X25">
         {
@@ -520,8 +530,8 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let AsmName = "s9";
         let AltNames = [ "s9"  ];
         let Aliases = [ ];
-        let SubRegs = [ ];
-        let SubRegIndices = [ ];
+        let SubRegs = [  ];
+        let SubRegIndices = [  ];
         let RegAltNameIndices = [];
         let DwarfNumbers = [ 26 ];
         list<int> CostPerUse = [0];
@@ -530,7 +540,7 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let HWEncoding{4-0} = 25;
         
         
-        let isArtificial = 0;
+        let isArtificial = false;
         }
         def X26 : Register<"X26">
         {
@@ -538,8 +548,8 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let AsmName = "s10";
         let AltNames = [ "s10"  ];
         let Aliases = [ ];
-        let SubRegs = [ ];
-        let SubRegIndices = [ ];
+        let SubRegs = [  ];
+        let SubRegIndices = [  ];
         let RegAltNameIndices = [];
         let DwarfNumbers = [ 27 ];
         list<int> CostPerUse = [0];
@@ -548,7 +558,7 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let HWEncoding{4-0} = 26;
         
         
-        let isArtificial = 0;
+        let isArtificial = false;
         }
         def X27 : Register<"X27">
         {
@@ -556,8 +566,8 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let AsmName = "s11";
         let AltNames = [ "s11"  ];
         let Aliases = [ ];
-        let SubRegs = [ ];
-        let SubRegIndices = [ ];
+        let SubRegs = [  ];
+        let SubRegIndices = [  ];
         let RegAltNameIndices = [];
         let DwarfNumbers = [ 28 ];
         list<int> CostPerUse = [0];
@@ -566,7 +576,7 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let HWEncoding{4-0} = 27;
         
         
-        let isArtificial = 0;
+        let isArtificial = false;
         }
         def X28 : Register<"X28">
         {
@@ -574,8 +584,8 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let AsmName = "t3";
         let AltNames = [ "t3"  ];
         let Aliases = [ ];
-        let SubRegs = [ ];
-        let SubRegIndices = [ ];
+        let SubRegs = [  ];
+        let SubRegIndices = [  ];
         let RegAltNameIndices = [];
         let DwarfNumbers = [ 29 ];
         list<int> CostPerUse = [0];
@@ -584,7 +594,7 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let HWEncoding{4-0} = 28;
         
         
-        let isArtificial = 0;
+        let isArtificial = false;
         }
         def X29 : Register<"X29">
         {
@@ -592,8 +602,8 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let AsmName = "t4";
         let AltNames = [ "t4"  ];
         let Aliases = [ ];
-        let SubRegs = [ ];
-        let SubRegIndices = [ ];
+        let SubRegs = [  ];
+        let SubRegIndices = [  ];
         let RegAltNameIndices = [];
         let DwarfNumbers = [ 30 ];
         list<int> CostPerUse = [0];
@@ -602,7 +612,7 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let HWEncoding{4-0} = 29;
         
         
-        let isArtificial = 0;
+        let isArtificial = false;
         }
         def X30 : Register<"X30">
         {
@@ -610,8 +620,8 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let AsmName = "t5";
         let AltNames = [ "t5"  ];
         let Aliases = [ ];
-        let SubRegs = [ ];
-        let SubRegIndices = [ ];
+        let SubRegs = [  ];
+        let SubRegIndices = [  ];
         let RegAltNameIndices = [];
         let DwarfNumbers = [ 31 ];
         list<int> CostPerUse = [0];
@@ -620,7 +630,7 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let HWEncoding{4-0} = 30;
         
         
-        let isArtificial = 0;
+        let isArtificial = false;
         }
         def X31 : Register<"X31">
         {
@@ -628,8 +638,8 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let AsmName = "t6";
         let AltNames = [ "t6"  ];
         let Aliases = [ ];
-        let SubRegs = [ ];
-        let SubRegIndices = [ ];
+        let SubRegs = [  ];
+        let SubRegIndices = [  ];
         let RegAltNameIndices = [];
         let DwarfNumbers = [ 32 ];
         list<int> CostPerUse = [0];
@@ -638,10 +648,8 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
         let HWEncoding{4-0} = 31;
         
         
-        let isArtificial = 0;
+        let isArtificial = false;
         }
-        
-        
         
         
         defvar processornamevalue = DefaultMode;


### PR DESCRIPTION
Add alias registers as register classes which can be used in instruction selection. We have also to define relationships between the register classes since they reference the same hardware register file.