### PR TITLE
lcb: Defined multiple subreg index to allow aliases

### DIFF
--- a/vadl/main/resources/templates/lcb/llvm/lib/Target/RegisterInfo.td
+++ b/vadl/main/resources/templates/lcb/llvm/lib/Target/RegisterInfo.td
@@ -1,9 +1,14 @@
-[# th:each="register, iterStat : ${aliasRegisters}" ]
-[# th:each="index : ${register.maxList}" ]
-def [(${register.name})]_SUB_32_[(${index})]  : SubRegIndex<32>;
-def [(${register.name})]_SUB_32_HI_[(${index})] : SubRegIndex<32, 32>;
-def [(${register.name})]_FULL_64_[(${index})]    : SubRegIndex<64>;
+[# th:each="index : ${sub32}" ]
+def [(${index})]  : SubRegIndex<32>;
 [/]
+[# th:each="index : ${sub32Hi}" ]
+def [(${index})] : SubRegIndex<32, 32>;
+[/]
+[# th:each="index : ${full64}" ]
+def [(${index})]    : SubRegIndex<64>;
+[/]
+
+[# th:each="register, iterStat : ${aliasRegisters}" ]
 def [(${register.name})] : Register<"[(${register.name})]">
 {
     let Namespace = "[(${register.namespace.value})]";
@@ -22,11 +27,6 @@ def [(${register.name})] : Register<"[(${register.name})]">
 [/]
 
 [# th:each="register, iterStat : ${registers}" ]
-[# th:each="index : ${register.maxList}" ]
-def [(${register.name})]_SUB_32_[(${index})]  : SubRegIndex<32>;
-def [(${register.name})]_SUB_32_HI_[(${index})] : SubRegIndex<32, 32>;
-def [(${register.name})]_FULL_64_[(${index})]    : SubRegIndex<64>;
-[/]
 def [(${register.name})] : Register<"[(${register.name})]">
 {
     let Namespace = "[(${register.namespace.value})]";

--- a/vadl/main/resources/templates/lcb/llvm/lib/Target/RegisterInfo.td
+++ b/vadl/main/resources/templates/lcb/llvm/lib/Target/RegisterInfo.td
@@ -1,9 +1,9 @@
-// SubRegIndexes for GPR registers
-def SUB_32   : SubRegIndex<32>;
-def SUB_32_HI : SubRegIndex<32, 32>;
-def FULL_64    : SubRegIndex<64>;
-
 [# th:each="register, iterStat : ${aliasRegisters}" ]
+[# th:each="index : ${register.maxList}" ]
+def [(${register.name})]_SUB_32_[(${index})]  : SubRegIndex<32>;
+def [(${register.name})]_SUB_32_HI_[(${index})] : SubRegIndex<32, 32>;
+def [(${register.name})]_FULL_64_[(${index})]    : SubRegIndex<64>;
+[/]
 def [(${register.name})] : Register<"[(${register.name})]">
 {
     let Namespace = "[(${register.namespace.value})]";
@@ -22,6 +22,11 @@ def [(${register.name})] : Register<"[(${register.name})]">
 [/]
 
 [# th:each="register, iterStat : ${registers}" ]
+[# th:each="index : ${register.maxList}" ]
+def [(${register.name})]_SUB_32_[(${index})]  : SubRegIndex<32>;
+def [(${register.name})]_SUB_32_HI_[(${index})] : SubRegIndex<32, 32>;
+def [(${register.name})]_FULL_64_[(${index})]    : SubRegIndex<64>;
+[/]
 def [(${register.name})] : Register<"[(${register.name})]">
 {
     let Namespace = "[(${register.namespace.value})]";

--- a/vadl/main/vadl/gcb/passes/GenerateCompilerRegistersPass.java
+++ b/vadl/main/vadl/gcb/passes/GenerateCompilerRegistersPass.java
@@ -109,9 +109,11 @@ public class GenerateCompilerRegistersPass extends Pass {
             var realRegister = registerClass.registers().get(i);
 
             if (hasEqualType && artificialResource.type().equals(BitsType.bits(64))) {
-              realRegister.addSubReg(aliasRegister, CompilerRegister.SubRegIndex.FULL_64);
+              realRegister.addSubReg(aliasRegister, new CompilerRegister.SubRegIndex(
+                  CompilerRegister.SubRegIndexEnum.FULL_64));
             } else {
-              realRegister.addSubReg(aliasRegister, CompilerRegister.SubRegIndex.SUB_32);
+              realRegister.addSubReg(aliasRegister, new CompilerRegister.SubRegIndex(
+                  CompilerRegister.SubRegIndexEnum.SUB_32));
             }
           }
         }

--- a/vadl/main/vadl/gcb/valuetypes/CompilerRegister.java
+++ b/vadl/main/vadl/gcb/valuetypes/CompilerRegister.java
@@ -43,6 +43,9 @@ public abstract class CompilerRegister {
     }
   }
 
+  /**
+   * Represents an index for a sub register.
+   */
   public static class SubRegIndex {
     private final SubRegIndexEnum subRegIndex;
     private int version = 0;
@@ -55,6 +58,9 @@ public abstract class CompilerRegister {
       return subRegIndex;
     }
 
+    /**
+     * Get the name of the register.
+     */
     public String name() {
       if (version == 0) {
         return subRegIndex.name();

--- a/vadl/main/vadl/gcb/valuetypes/CompilerRegister.java
+++ b/vadl/main/vadl/gcb/valuetypes/CompilerRegister.java
@@ -18,6 +18,7 @@ package vadl.gcb.valuetypes;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Extends the register with information which a compiler requires.
@@ -26,19 +27,58 @@ public abstract class CompilerRegister {
   /**
    * Indicates the indices for sub registers.
    */
-  public enum SubRegIndex {
+  public enum SubRegIndexEnum {
     SUB_32("sub_32"),
     SUB_32_HI("sub_32_hi"),
     FULL_64("full_64");
 
     private final String name;
 
-    SubRegIndex(String name) {
+    SubRegIndexEnum(String name) {
       this.name = name;
     }
 
     public String getName() {
       return name;
+    }
+  }
+
+  public static class SubRegIndex {
+    private final SubRegIndexEnum subRegIndex;
+    private int version = 0;
+
+    public SubRegIndex(SubRegIndexEnum subRegIndex) {
+      this.subRegIndex = subRegIndex;
+    }
+
+    public SubRegIndexEnum inner() {
+      return subRegIndex;
+    }
+
+    public String name() {
+      if (version == 0) {
+        return subRegIndex.name();
+      } else {
+        return subRegIndex.name() + "_" + version;
+      }
+    }
+
+    public void incrementVersion() {
+      version++;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      SubRegIndex that = (SubRegIndex) o;
+      return version == that.version && subRegIndex == that.subRegIndex;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(subRegIndex, version);
     }
   }
 

--- a/vadl/main/vadl/lcb/passes/llvmLowering/tablegen/model/register/TableGenRegister.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/tablegen/model/register/TableGenRegister.java
@@ -16,7 +16,6 @@
 
 package vadl.lcb.passes.llvmLowering.tablegen.model.register;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -44,19 +43,6 @@ public record TableGenRegister(TargetName namespace,
 
   @Override
   public Map<String, Object> renderObj() {
-    var indices = new ArrayList<String>();
-    var seen = new HashMap<CompilerRegister.SubRegIndex, Integer>();
-    for (var subRegIndex : subRegIndices) {
-      seen.computeIfPresent(subRegIndex, (k, v) -> v + 1);
-      seen.putIfAbsent(subRegIndex, 0);
-      indices.add(compilerRegister.name() + "_" + subRegIndex.name() + "_" + seen.get(subRegIndex));
-    }
-
-    var maxList = new ArrayList<>();
-    for (int i = 0; i <= seen.values().stream().mapToInt(j -> j).max().orElse(0); i++) {
-      maxList.add(i);
-    }
-
     var map = new HashMap<String, Object>();
     map.put("namespace", namespace);
     map.put("name", compilerRegister.name());
@@ -66,10 +52,11 @@ public record TableGenRegister(TargetName namespace,
     map.put("hwEncodingValue", compilerRegister.hwEncodingValue());
     map.put("altNamesString", altNamesString());
     map.put("isArtificial", isArtificial);
-    map.put("maxList", maxList);
     map.put("subRegs",
         subRegs.stream().map(CompilerRegister::name).collect(Collectors.joining(", ")));
-    map.put("subRegIndices", String.join(", ", indices));
+    map.put("subRegIndices",
+        subRegIndices.stream().map(CompilerRegister.SubRegIndex::name)
+            .collect(Collectors.joining(", ")));
     index.ifPresent(integer -> map.put("index", integer));
     return map;
   }

--- a/vadl/main/vadl/lcb/passes/llvmLowering/tablegen/model/register/TableGenRegister.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/tablegen/model/register/TableGenRegister.java
@@ -16,6 +16,7 @@
 
 package vadl.lcb.passes.llvmLowering.tablegen.model.register;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -43,6 +44,19 @@ public record TableGenRegister(TargetName namespace,
 
   @Override
   public Map<String, Object> renderObj() {
+    var indices = new ArrayList<String>();
+    var seen = new HashMap<CompilerRegister.SubRegIndex, Integer>();
+    for (var subRegIndex : subRegIndices) {
+      seen.computeIfPresent(subRegIndex, (k, v) -> v + 1);
+      seen.putIfAbsent(subRegIndex, 0);
+      indices.add(compilerRegister.name() + "_" + subRegIndex.name() + "_" + seen.get(subRegIndex));
+    }
+
+    var maxList = new ArrayList<>();
+    for (int i = 0; i <= seen.values().stream().mapToInt(j -> j).max().orElse(0); i++) {
+      maxList.add(i);
+    }
+
     var map = new HashMap<String, Object>();
     map.put("namespace", namespace);
     map.put("name", compilerRegister.name());
@@ -52,10 +66,10 @@ public record TableGenRegister(TargetName namespace,
     map.put("hwEncodingValue", compilerRegister.hwEncodingValue());
     map.put("altNamesString", altNamesString());
     map.put("isArtificial", isArtificial);
+    map.put("maxList", maxList);
     map.put("subRegs",
         subRegs.stream().map(CompilerRegister::name).collect(Collectors.joining(", ")));
-    map.put("subRegIndices",
-        subRegIndices.stream().map(Enum::name).collect(Collectors.joining(", ")));
+    map.put("subRegIndices", String.join(", ", indices));
     index.ifPresent(integer -> map.put("index", integer));
     return map;
   }

--- a/vadl/main/vadl/lcb/template/lib/Target/EmitRegisterInfoTableGenFilePass.java
+++ b/vadl/main/vadl/lcb/template/lib/Target/EmitRegisterInfoTableGenFilePass.java
@@ -130,10 +130,35 @@ public class EmitRegisterInfoTableGenFilePass extends LcbTemplateRenderingPass {
     }
 
     var registers = sortRegisters(output.registers());
+
+    var sub32 = new ArrayList<String>();
+    var sub32Hi = new ArrayList<String>();
+    var full64 = new ArrayList<String>();
+
+    for (var register : registers) {
+      var seen = new HashSet<String>();
+      for (var subRegIndex : register.subRegIndices()) {
+        if (seen.contains(subRegIndex.name())) {
+          subRegIndex.incrementVersion();
+        }
+
+        var name = subRegIndex.name();
+        seen.add(name);
+        switch (subRegIndex.inner()) {
+          case SUB_32 -> sub32.add(name);
+          case FULL_64 -> full64.add(name);
+          case SUB_32_HI -> sub32Hi.add(name);
+        }
+      }
+    }
+
     return Map.of(CommonVarNames.NAMESPACE,
         lcbConfiguration().targetName().value().toLowerCase(),
         "pointerAlignment", DataLayoutProvider.pointerAlignment(abi),
         "registers", registers,
+        "sub32", sub32.stream().distinct().toList(),
+        "sub32Hi", sub32Hi.stream().distinct().toList(),
+        "full64", full64.stream().distinct().toList(),
         "aliasRegisters", output.aliasRegisters(),
         "registerFiles", outputRegisterClasses,
         "aliasRegisterFiles", outputAliasRegisterClasses

--- a/vadl/test/resources/snapshots/aarch64/RegisterInfo.td
+++ b/vadl/test/resources/snapshots/aarch64/RegisterInfo.td
@@ -1,3 +1,12 @@
+def SUB_32  : SubRegIndex<32>;
+def SUB_32_1  : SubRegIndex<32>;
+
+
+
+def FULL_64    : SubRegIndex<64>;
+
+
+
 def SP : Register<"SP">
 {
 let Namespace = "aarch64temp";
@@ -13,7 +22,6 @@ let CoveredBySubRegs = 0;
 let HWEncoding = 31;
 let isArtificial = 1;
 }
-
 def LR : Register<"LR">
 {
 let Namespace = "aarch64temp";
@@ -31,11 +39,6 @@ let isArtificial = 1;
 }
 
 
-
-
-def NZCV_N_SUB_32_0  : SubRegIndex<32>;
-def NZCV_N_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def NZCV_N_FULL_64_0    : SubRegIndex<64>;
 
 def NZCV_N : Register<"NZCV_N">
 {
@@ -55,11 +58,6 @@ let HWEncoding = 0;
 
 let isArtificial = false;
 }
-
-def NZCV_Z_SUB_32_0  : SubRegIndex<32>;
-def NZCV_Z_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def NZCV_Z_FULL_64_0    : SubRegIndex<64>;
-
 def NZCV_Z : Register<"NZCV_Z">
 {
 let Namespace = "aarch64temp";
@@ -78,11 +76,6 @@ let HWEncoding = 0;
 
 let isArtificial = false;
 }
-
-def NZCV_C_SUB_32_0  : SubRegIndex<32>;
-def NZCV_C_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def NZCV_C_FULL_64_0    : SubRegIndex<64>;
-
 def NZCV_C : Register<"NZCV_C">
 {
 let Namespace = "aarch64temp";
@@ -101,11 +94,6 @@ let HWEncoding = 0;
 
 let isArtificial = false;
 }
-
-def NZCV_V_SUB_32_0  : SubRegIndex<32>;
-def NZCV_V_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def NZCV_V_FULL_64_0    : SubRegIndex<64>;
-
 def NZCV_V : Register<"NZCV_V">
 {
 let Namespace = "aarch64temp";
@@ -124,11 +112,6 @@ let HWEncoding = 0;
 
 let isArtificial = false;
 }
-
-def CurrentEL_SUB_32_0  : SubRegIndex<32>;
-def CurrentEL_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def CurrentEL_FULL_64_0    : SubRegIndex<64>;
-
 def CurrentEL : Register<"CurrentEL">
 {
 let Namespace = "aarch64temp";
@@ -147,11 +130,6 @@ let HWEncoding = 0;
 
 let isArtificial = false;
 }
-
-def SPSel_SUB_32_0  : SubRegIndex<32>;
-def SPSel_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def SPSel_FULL_64_0    : SubRegIndex<64>;
-
 def SPSel : Register<"SPSel">
 {
 let Namespace = "aarch64temp";
@@ -170,11 +148,6 @@ let HWEncoding = 0;
 
 let isArtificial = false;
 }
-
-def SP_EL0_SUB_32_0  : SubRegIndex<32>;
-def SP_EL0_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def SP_EL0_FULL_64_0    : SubRegIndex<64>;
-
 def SP_EL0 : Register<"SP_EL0">
 {
 let Namespace = "aarch64temp";
@@ -193,11 +166,6 @@ let HWEncoding = 0;
 
 let isArtificial = false;
 }
-
-def SP_EL1_SUB_32_0  : SubRegIndex<32>;
-def SP_EL1_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def SP_EL1_FULL_64_0    : SubRegIndex<64>;
-
 def SP_EL1 : Register<"SP_EL1">
 {
 let Namespace = "aarch64temp";
@@ -216,11 +184,6 @@ let HWEncoding = 0;
 
 let isArtificial = false;
 }
-
-def ELR_EL1_SUB_32_0  : SubRegIndex<32>;
-def ELR_EL1_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def ELR_EL1_FULL_64_0    : SubRegIndex<64>;
-
 def ELR_EL1 : Register<"ELR_EL1">
 {
 let Namespace = "aarch64temp";
@@ -239,11 +202,6 @@ let HWEncoding = 0;
 
 let isArtificial = false;
 }
-
-def VBAR_EL1_SUB_32_0  : SubRegIndex<32>;
-def VBAR_EL1_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def VBAR_EL1_FULL_64_0    : SubRegIndex<64>;
-
 def VBAR_EL1 : Register<"VBAR_EL1">
 {
 let Namespace = "aarch64temp";
@@ -262,11 +220,6 @@ let HWEncoding = 0;
 
 let isArtificial = false;
 }
-
-def ESR_EL1_SUB_32_0  : SubRegIndex<32>;
-def ESR_EL1_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def ESR_EL1_FULL_64_0    : SubRegIndex<64>;
-
 def ESR_EL1 : Register<"ESR_EL1">
 {
 let Namespace = "aarch64temp";
@@ -285,11 +238,6 @@ let HWEncoding = 0;
 
 let isArtificial = false;
 }
-
-def SPSR_EL1_SUB_32_0  : SubRegIndex<32>;
-def SPSR_EL1_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def SPSR_EL1_FULL_64_0    : SubRegIndex<64>;
-
 def SPSR_EL1 : Register<"SPSR_EL1">
 {
 let Namespace = "aarch64temp";
@@ -308,11 +256,6 @@ let HWEncoding = 0;
 
 let isArtificial = false;
 }
-
-def PC_SUB_32_0  : SubRegIndex<32>;
-def PC_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def PC_FULL_64_0    : SubRegIndex<64>;
-
 def PC : Register<"PC">
 {
 let Namespace = "aarch64temp";
@@ -331,11 +274,6 @@ let HWEncoding = 0;
 
 let isArtificial = false;
 }
-
-def R0_SUB_32_0  : SubRegIndex<32>;
-def R0_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def R0_FULL_64_0    : SubRegIndex<64>;
-
 def R0 : Register<"R0">
 {
 let Namespace = "aarch64temp";
@@ -354,11 +292,6 @@ let HWEncoding{4-0} = 0;
 
 let isArtificial = false;
 }
-
-def R1_SUB_32_0  : SubRegIndex<32>;
-def R1_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def R1_FULL_64_0    : SubRegIndex<64>;
-
 def R1 : Register<"R1">
 {
 let Namespace = "aarch64temp";
@@ -377,11 +310,6 @@ let HWEncoding{4-0} = 1;
 
 let isArtificial = false;
 }
-
-def R2_SUB_32_0  : SubRegIndex<32>;
-def R2_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def R2_FULL_64_0    : SubRegIndex<64>;
-
 def R2 : Register<"R2">
 {
 let Namespace = "aarch64temp";
@@ -400,11 +328,6 @@ let HWEncoding{4-0} = 2;
 
 let isArtificial = false;
 }
-
-def R3_SUB_32_0  : SubRegIndex<32>;
-def R3_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def R3_FULL_64_0    : SubRegIndex<64>;
-
 def R3 : Register<"R3">
 {
 let Namespace = "aarch64temp";
@@ -423,11 +346,6 @@ let HWEncoding{4-0} = 3;
 
 let isArtificial = false;
 }
-
-def R4_SUB_32_0  : SubRegIndex<32>;
-def R4_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def R4_FULL_64_0    : SubRegIndex<64>;
-
 def R4 : Register<"R4">
 {
 let Namespace = "aarch64temp";
@@ -446,11 +364,6 @@ let HWEncoding{4-0} = 4;
 
 let isArtificial = false;
 }
-
-def R5_SUB_32_0  : SubRegIndex<32>;
-def R5_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def R5_FULL_64_0    : SubRegIndex<64>;
-
 def R5 : Register<"R5">
 {
 let Namespace = "aarch64temp";
@@ -469,11 +382,6 @@ let HWEncoding{4-0} = 5;
 
 let isArtificial = false;
 }
-
-def R6_SUB_32_0  : SubRegIndex<32>;
-def R6_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def R6_FULL_64_0    : SubRegIndex<64>;
-
 def R6 : Register<"R6">
 {
 let Namespace = "aarch64temp";
@@ -492,11 +400,6 @@ let HWEncoding{4-0} = 6;
 
 let isArtificial = false;
 }
-
-def R7_SUB_32_0  : SubRegIndex<32>;
-def R7_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def R7_FULL_64_0    : SubRegIndex<64>;
-
 def R7 : Register<"R7">
 {
 let Namespace = "aarch64temp";
@@ -515,11 +418,6 @@ let HWEncoding{4-0} = 7;
 
 let isArtificial = false;
 }
-
-def R8_SUB_32_0  : SubRegIndex<32>;
-def R8_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def R8_FULL_64_0    : SubRegIndex<64>;
-
 def R8 : Register<"R8">
 {
 let Namespace = "aarch64temp";
@@ -538,11 +436,6 @@ let HWEncoding{4-0} = 8;
 
 let isArtificial = false;
 }
-
-def R9_SUB_32_0  : SubRegIndex<32>;
-def R9_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def R9_FULL_64_0    : SubRegIndex<64>;
-
 def R9 : Register<"R9">
 {
 let Namespace = "aarch64temp";
@@ -561,11 +454,6 @@ let HWEncoding{4-0} = 9;
 
 let isArtificial = false;
 }
-
-def R10_SUB_32_0  : SubRegIndex<32>;
-def R10_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def R10_FULL_64_0    : SubRegIndex<64>;
-
 def R10 : Register<"R10">
 {
 let Namespace = "aarch64temp";
@@ -584,11 +472,6 @@ let HWEncoding{4-0} = 10;
 
 let isArtificial = false;
 }
-
-def R11_SUB_32_0  : SubRegIndex<32>;
-def R11_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def R11_FULL_64_0    : SubRegIndex<64>;
-
 def R11 : Register<"R11">
 {
 let Namespace = "aarch64temp";
@@ -607,11 +490,6 @@ let HWEncoding{4-0} = 11;
 
 let isArtificial = false;
 }
-
-def R12_SUB_32_0  : SubRegIndex<32>;
-def R12_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def R12_FULL_64_0    : SubRegIndex<64>;
-
 def R12 : Register<"R12">
 {
 let Namespace = "aarch64temp";
@@ -630,11 +508,6 @@ let HWEncoding{4-0} = 12;
 
 let isArtificial = false;
 }
-
-def R13_SUB_32_0  : SubRegIndex<32>;
-def R13_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def R13_FULL_64_0    : SubRegIndex<64>;
-
 def R13 : Register<"R13">
 {
 let Namespace = "aarch64temp";
@@ -653,11 +526,6 @@ let HWEncoding{4-0} = 13;
 
 let isArtificial = false;
 }
-
-def R14_SUB_32_0  : SubRegIndex<32>;
-def R14_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def R14_FULL_64_0    : SubRegIndex<64>;
-
 def R14 : Register<"R14">
 {
 let Namespace = "aarch64temp";
@@ -676,11 +544,6 @@ let HWEncoding{4-0} = 14;
 
 let isArtificial = false;
 }
-
-def R15_SUB_32_0  : SubRegIndex<32>;
-def R15_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def R15_FULL_64_0    : SubRegIndex<64>;
-
 def R15 : Register<"R15">
 {
 let Namespace = "aarch64temp";
@@ -699,11 +562,6 @@ let HWEncoding{4-0} = 15;
 
 let isArtificial = false;
 }
-
-def R16_SUB_32_0  : SubRegIndex<32>;
-def R16_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def R16_FULL_64_0    : SubRegIndex<64>;
-
 def R16 : Register<"R16">
 {
 let Namespace = "aarch64temp";
@@ -722,11 +580,6 @@ let HWEncoding{4-0} = 16;
 
 let isArtificial = false;
 }
-
-def R17_SUB_32_0  : SubRegIndex<32>;
-def R17_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def R17_FULL_64_0    : SubRegIndex<64>;
-
 def R17 : Register<"R17">
 {
 let Namespace = "aarch64temp";
@@ -745,11 +598,6 @@ let HWEncoding{4-0} = 17;
 
 let isArtificial = false;
 }
-
-def R18_SUB_32_0  : SubRegIndex<32>;
-def R18_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def R18_FULL_64_0    : SubRegIndex<64>;
-
 def R18 : Register<"R18">
 {
 let Namespace = "aarch64temp";
@@ -768,11 +616,6 @@ let HWEncoding{4-0} = 18;
 
 let isArtificial = false;
 }
-
-def R19_SUB_32_0  : SubRegIndex<32>;
-def R19_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def R19_FULL_64_0    : SubRegIndex<64>;
-
 def R19 : Register<"R19">
 {
 let Namespace = "aarch64temp";
@@ -791,11 +634,6 @@ let HWEncoding{4-0} = 19;
 
 let isArtificial = false;
 }
-
-def R20_SUB_32_0  : SubRegIndex<32>;
-def R20_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def R20_FULL_64_0    : SubRegIndex<64>;
-
 def R20 : Register<"R20">
 {
 let Namespace = "aarch64temp";
@@ -814,11 +652,6 @@ let HWEncoding{4-0} = 20;
 
 let isArtificial = false;
 }
-
-def R21_SUB_32_0  : SubRegIndex<32>;
-def R21_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def R21_FULL_64_0    : SubRegIndex<64>;
-
 def R21 : Register<"R21">
 {
 let Namespace = "aarch64temp";
@@ -837,11 +670,6 @@ let HWEncoding{4-0} = 21;
 
 let isArtificial = false;
 }
-
-def R22_SUB_32_0  : SubRegIndex<32>;
-def R22_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def R22_FULL_64_0    : SubRegIndex<64>;
-
 def R22 : Register<"R22">
 {
 let Namespace = "aarch64temp";
@@ -860,11 +688,6 @@ let HWEncoding{4-0} = 22;
 
 let isArtificial = false;
 }
-
-def R23_SUB_32_0  : SubRegIndex<32>;
-def R23_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def R23_FULL_64_0    : SubRegIndex<64>;
-
 def R23 : Register<"R23">
 {
 let Namespace = "aarch64temp";
@@ -883,11 +706,6 @@ let HWEncoding{4-0} = 23;
 
 let isArtificial = false;
 }
-
-def R24_SUB_32_0  : SubRegIndex<32>;
-def R24_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def R24_FULL_64_0    : SubRegIndex<64>;
-
 def R24 : Register<"R24">
 {
 let Namespace = "aarch64temp";
@@ -906,11 +724,6 @@ let HWEncoding{4-0} = 24;
 
 let isArtificial = false;
 }
-
-def R25_SUB_32_0  : SubRegIndex<32>;
-def R25_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def R25_FULL_64_0    : SubRegIndex<64>;
-
 def R25 : Register<"R25">
 {
 let Namespace = "aarch64temp";
@@ -929,11 +742,6 @@ let HWEncoding{4-0} = 25;
 
 let isArtificial = false;
 }
-
-def R26_SUB_32_0  : SubRegIndex<32>;
-def R26_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def R26_FULL_64_0    : SubRegIndex<64>;
-
 def R26 : Register<"R26">
 {
 let Namespace = "aarch64temp";
@@ -952,11 +760,6 @@ let HWEncoding{4-0} = 26;
 
 let isArtificial = false;
 }
-
-def R27_SUB_32_0  : SubRegIndex<32>;
-def R27_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def R27_FULL_64_0    : SubRegIndex<64>;
-
 def R27 : Register<"R27">
 {
 let Namespace = "aarch64temp";
@@ -975,11 +778,6 @@ let HWEncoding{4-0} = 27;
 
 let isArtificial = false;
 }
-
-def R28_SUB_32_0  : SubRegIndex<32>;
-def R28_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def R28_FULL_64_0    : SubRegIndex<64>;
-
 def R28 : Register<"R28">
 {
 let Namespace = "aarch64temp";
@@ -998,11 +796,6 @@ let HWEncoding{4-0} = 28;
 
 let isArtificial = false;
 }
-
-def R29_SUB_32_0  : SubRegIndex<32>;
-def R29_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def R29_FULL_64_0    : SubRegIndex<64>;
-
 def R29 : Register<"R29">
 {
 let Namespace = "aarch64temp";
@@ -1021,11 +814,6 @@ let HWEncoding{4-0} = 29;
 
 let isArtificial = false;
 }
-
-def R30_SUB_32_0  : SubRegIndex<32>;
-def R30_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def R30_FULL_64_0    : SubRegIndex<64>;
-
 def R30 : Register<"R30">
 {
 let Namespace = "aarch64temp";
@@ -1044,11 +832,6 @@ let HWEncoding{4-0} = 30;
 
 let isArtificial = false;
 }
-
-def R31_SUB_32_0  : SubRegIndex<32>;
-def R31_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def R31_FULL_64_0    : SubRegIndex<64>;
-
 def R31 : Register<"R31">
 {
 let Namespace = "aarch64temp";
@@ -1067,11 +850,6 @@ let HWEncoding{4-0} = 31;
 
 let isArtificial = false;
 }
-
-def X0_SUB_32_0  : SubRegIndex<32>;
-def X0_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def X0_FULL_64_0    : SubRegIndex<64>;
-
 def X0 : Register<"X0">
 {
 let Namespace = "aarch64temp";
@@ -1090,11 +868,6 @@ let HWEncoding{4-0} = 0;
 
 let isArtificial = false;
 }
-
-def X1_SUB_32_0  : SubRegIndex<32>;
-def X1_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def X1_FULL_64_0    : SubRegIndex<64>;
-
 def X1 : Register<"X1">
 {
 let Namespace = "aarch64temp";
@@ -1113,11 +886,6 @@ let HWEncoding{4-0} = 1;
 
 let isArtificial = false;
 }
-
-def X2_SUB_32_0  : SubRegIndex<32>;
-def X2_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def X2_FULL_64_0    : SubRegIndex<64>;
-
 def X2 : Register<"X2">
 {
 let Namespace = "aarch64temp";
@@ -1136,11 +904,6 @@ let HWEncoding{4-0} = 2;
 
 let isArtificial = false;
 }
-
-def X3_SUB_32_0  : SubRegIndex<32>;
-def X3_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def X3_FULL_64_0    : SubRegIndex<64>;
-
 def X3 : Register<"X3">
 {
 let Namespace = "aarch64temp";
@@ -1159,11 +922,6 @@ let HWEncoding{4-0} = 3;
 
 let isArtificial = false;
 }
-
-def X4_SUB_32_0  : SubRegIndex<32>;
-def X4_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def X4_FULL_64_0    : SubRegIndex<64>;
-
 def X4 : Register<"X4">
 {
 let Namespace = "aarch64temp";
@@ -1182,11 +940,6 @@ let HWEncoding{4-0} = 4;
 
 let isArtificial = false;
 }
-
-def X5_SUB_32_0  : SubRegIndex<32>;
-def X5_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def X5_FULL_64_0    : SubRegIndex<64>;
-
 def X5 : Register<"X5">
 {
 let Namespace = "aarch64temp";
@@ -1205,11 +958,6 @@ let HWEncoding{4-0} = 5;
 
 let isArtificial = false;
 }
-
-def X6_SUB_32_0  : SubRegIndex<32>;
-def X6_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def X6_FULL_64_0    : SubRegIndex<64>;
-
 def X6 : Register<"X6">
 {
 let Namespace = "aarch64temp";
@@ -1228,11 +976,6 @@ let HWEncoding{4-0} = 6;
 
 let isArtificial = false;
 }
-
-def X7_SUB_32_0  : SubRegIndex<32>;
-def X7_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def X7_FULL_64_0    : SubRegIndex<64>;
-
 def X7 : Register<"X7">
 {
 let Namespace = "aarch64temp";
@@ -1251,11 +994,6 @@ let HWEncoding{4-0} = 7;
 
 let isArtificial = false;
 }
-
-def X8_SUB_32_0  : SubRegIndex<32>;
-def X8_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def X8_FULL_64_0    : SubRegIndex<64>;
-
 def X8 : Register<"X8">
 {
 let Namespace = "aarch64temp";
@@ -1274,11 +1012,6 @@ let HWEncoding{4-0} = 8;
 
 let isArtificial = false;
 }
-
-def X9_SUB_32_0  : SubRegIndex<32>;
-def X9_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def X9_FULL_64_0    : SubRegIndex<64>;
-
 def X9 : Register<"X9">
 {
 let Namespace = "aarch64temp";
@@ -1297,11 +1030,6 @@ let HWEncoding{4-0} = 9;
 
 let isArtificial = false;
 }
-
-def X10_SUB_32_0  : SubRegIndex<32>;
-def X10_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def X10_FULL_64_0    : SubRegIndex<64>;
-
 def X10 : Register<"X10">
 {
 let Namespace = "aarch64temp";
@@ -1320,11 +1048,6 @@ let HWEncoding{4-0} = 10;
 
 let isArtificial = false;
 }
-
-def X11_SUB_32_0  : SubRegIndex<32>;
-def X11_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def X11_FULL_64_0    : SubRegIndex<64>;
-
 def X11 : Register<"X11">
 {
 let Namespace = "aarch64temp";
@@ -1343,11 +1066,6 @@ let HWEncoding{4-0} = 11;
 
 let isArtificial = false;
 }
-
-def X12_SUB_32_0  : SubRegIndex<32>;
-def X12_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def X12_FULL_64_0    : SubRegIndex<64>;
-
 def X12 : Register<"X12">
 {
 let Namespace = "aarch64temp";
@@ -1366,11 +1084,6 @@ let HWEncoding{4-0} = 12;
 
 let isArtificial = false;
 }
-
-def X13_SUB_32_0  : SubRegIndex<32>;
-def X13_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def X13_FULL_64_0    : SubRegIndex<64>;
-
 def X13 : Register<"X13">
 {
 let Namespace = "aarch64temp";
@@ -1389,11 +1102,6 @@ let HWEncoding{4-0} = 13;
 
 let isArtificial = false;
 }
-
-def X14_SUB_32_0  : SubRegIndex<32>;
-def X14_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def X14_FULL_64_0    : SubRegIndex<64>;
-
 def X14 : Register<"X14">
 {
 let Namespace = "aarch64temp";
@@ -1412,11 +1120,6 @@ let HWEncoding{4-0} = 14;
 
 let isArtificial = false;
 }
-
-def X15_SUB_32_0  : SubRegIndex<32>;
-def X15_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def X15_FULL_64_0    : SubRegIndex<64>;
-
 def X15 : Register<"X15">
 {
 let Namespace = "aarch64temp";
@@ -1435,11 +1138,6 @@ let HWEncoding{4-0} = 15;
 
 let isArtificial = false;
 }
-
-def X16_SUB_32_0  : SubRegIndex<32>;
-def X16_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def X16_FULL_64_0    : SubRegIndex<64>;
-
 def X16 : Register<"X16">
 {
 let Namespace = "aarch64temp";
@@ -1458,11 +1156,6 @@ let HWEncoding{4-0} = 16;
 
 let isArtificial = false;
 }
-
-def X17_SUB_32_0  : SubRegIndex<32>;
-def X17_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def X17_FULL_64_0    : SubRegIndex<64>;
-
 def X17 : Register<"X17">
 {
 let Namespace = "aarch64temp";
@@ -1481,11 +1174,6 @@ let HWEncoding{4-0} = 17;
 
 let isArtificial = false;
 }
-
-def X18_SUB_32_0  : SubRegIndex<32>;
-def X18_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def X18_FULL_64_0    : SubRegIndex<64>;
-
 def X18 : Register<"X18">
 {
 let Namespace = "aarch64temp";
@@ -1504,11 +1192,6 @@ let HWEncoding{4-0} = 18;
 
 let isArtificial = false;
 }
-
-def X19_SUB_32_0  : SubRegIndex<32>;
-def X19_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def X19_FULL_64_0    : SubRegIndex<64>;
-
 def X19 : Register<"X19">
 {
 let Namespace = "aarch64temp";
@@ -1527,11 +1210,6 @@ let HWEncoding{4-0} = 19;
 
 let isArtificial = false;
 }
-
-def X20_SUB_32_0  : SubRegIndex<32>;
-def X20_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def X20_FULL_64_0    : SubRegIndex<64>;
-
 def X20 : Register<"X20">
 {
 let Namespace = "aarch64temp";
@@ -1550,11 +1228,6 @@ let HWEncoding{4-0} = 20;
 
 let isArtificial = false;
 }
-
-def X21_SUB_32_0  : SubRegIndex<32>;
-def X21_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def X21_FULL_64_0    : SubRegIndex<64>;
-
 def X21 : Register<"X21">
 {
 let Namespace = "aarch64temp";
@@ -1573,11 +1246,6 @@ let HWEncoding{4-0} = 21;
 
 let isArtificial = false;
 }
-
-def X22_SUB_32_0  : SubRegIndex<32>;
-def X22_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def X22_FULL_64_0    : SubRegIndex<64>;
-
 def X22 : Register<"X22">
 {
 let Namespace = "aarch64temp";
@@ -1596,11 +1264,6 @@ let HWEncoding{4-0} = 22;
 
 let isArtificial = false;
 }
-
-def X23_SUB_32_0  : SubRegIndex<32>;
-def X23_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def X23_FULL_64_0    : SubRegIndex<64>;
-
 def X23 : Register<"X23">
 {
 let Namespace = "aarch64temp";
@@ -1619,11 +1282,6 @@ let HWEncoding{4-0} = 23;
 
 let isArtificial = false;
 }
-
-def X24_SUB_32_0  : SubRegIndex<32>;
-def X24_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def X24_FULL_64_0    : SubRegIndex<64>;
-
 def X24 : Register<"X24">
 {
 let Namespace = "aarch64temp";
@@ -1642,11 +1300,6 @@ let HWEncoding{4-0} = 24;
 
 let isArtificial = false;
 }
-
-def X25_SUB_32_0  : SubRegIndex<32>;
-def X25_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def X25_FULL_64_0    : SubRegIndex<64>;
-
 def X25 : Register<"X25">
 {
 let Namespace = "aarch64temp";
@@ -1665,11 +1318,6 @@ let HWEncoding{4-0} = 25;
 
 let isArtificial = false;
 }
-
-def X26_SUB_32_0  : SubRegIndex<32>;
-def X26_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def X26_FULL_64_0    : SubRegIndex<64>;
-
 def X26 : Register<"X26">
 {
 let Namespace = "aarch64temp";
@@ -1688,11 +1336,6 @@ let HWEncoding{4-0} = 26;
 
 let isArtificial = false;
 }
-
-def X27_SUB_32_0  : SubRegIndex<32>;
-def X27_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def X27_FULL_64_0    : SubRegIndex<64>;
-
 def X27 : Register<"X27">
 {
 let Namespace = "aarch64temp";
@@ -1711,11 +1354,6 @@ let HWEncoding{4-0} = 27;
 
 let isArtificial = false;
 }
-
-def X28_SUB_32_0  : SubRegIndex<32>;
-def X28_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def X28_FULL_64_0    : SubRegIndex<64>;
-
 def X28 : Register<"X28">
 {
 let Namespace = "aarch64temp";
@@ -1734,11 +1372,6 @@ let HWEncoding{4-0} = 28;
 
 let isArtificial = false;
 }
-
-def X29_SUB_32_0  : SubRegIndex<32>;
-def X29_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def X29_FULL_64_0    : SubRegIndex<64>;
-
 def X29 : Register<"X29">
 {
 let Namespace = "aarch64temp";
@@ -1757,11 +1390,6 @@ let HWEncoding{4-0} = 29;
 
 let isArtificial = false;
 }
-
-def X30_SUB_32_0  : SubRegIndex<32>;
-def X30_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def X30_FULL_64_0    : SubRegIndex<64>;
-
 def X30 : Register<"X30">
 {
 let Namespace = "aarch64temp";
@@ -1780,11 +1408,6 @@ let HWEncoding{4-0} = 30;
 
 let isArtificial = false;
 }
-
-def X31_SUB_32_0  : SubRegIndex<32>;
-def X31_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def X31_FULL_64_0    : SubRegIndex<64>;
-
 def X31 : Register<"X31">
 {
 let Namespace = "aarch64temp";
@@ -1803,11 +1426,6 @@ let HWEncoding{4-0} = 31;
 
 let isArtificial = false;
 }
-
-def W0_SUB_32_0  : SubRegIndex<32>;
-def W0_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def W0_FULL_64_0    : SubRegIndex<64>;
-
 def W0 : Register<"W0">
 {
 let Namespace = "aarch64temp";
@@ -1826,11 +1444,6 @@ let HWEncoding{4-0} = 0;
 
 let isArtificial = false;
 }
-
-def W1_SUB_32_0  : SubRegIndex<32>;
-def W1_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def W1_FULL_64_0    : SubRegIndex<64>;
-
 def W1 : Register<"W1">
 {
 let Namespace = "aarch64temp";
@@ -1849,11 +1462,6 @@ let HWEncoding{4-0} = 1;
 
 let isArtificial = false;
 }
-
-def W2_SUB_32_0  : SubRegIndex<32>;
-def W2_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def W2_FULL_64_0    : SubRegIndex<64>;
-
 def W2 : Register<"W2">
 {
 let Namespace = "aarch64temp";
@@ -1872,11 +1480,6 @@ let HWEncoding{4-0} = 2;
 
 let isArtificial = false;
 }
-
-def W3_SUB_32_0  : SubRegIndex<32>;
-def W3_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def W3_FULL_64_0    : SubRegIndex<64>;
-
 def W3 : Register<"W3">
 {
 let Namespace = "aarch64temp";
@@ -1895,11 +1498,6 @@ let HWEncoding{4-0} = 3;
 
 let isArtificial = false;
 }
-
-def W4_SUB_32_0  : SubRegIndex<32>;
-def W4_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def W4_FULL_64_0    : SubRegIndex<64>;
-
 def W4 : Register<"W4">
 {
 let Namespace = "aarch64temp";
@@ -1918,11 +1516,6 @@ let HWEncoding{4-0} = 4;
 
 let isArtificial = false;
 }
-
-def W5_SUB_32_0  : SubRegIndex<32>;
-def W5_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def W5_FULL_64_0    : SubRegIndex<64>;
-
 def W5 : Register<"W5">
 {
 let Namespace = "aarch64temp";
@@ -1941,11 +1534,6 @@ let HWEncoding{4-0} = 5;
 
 let isArtificial = false;
 }
-
-def W6_SUB_32_0  : SubRegIndex<32>;
-def W6_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def W6_FULL_64_0    : SubRegIndex<64>;
-
 def W6 : Register<"W6">
 {
 let Namespace = "aarch64temp";
@@ -1964,11 +1552,6 @@ let HWEncoding{4-0} = 6;
 
 let isArtificial = false;
 }
-
-def W7_SUB_32_0  : SubRegIndex<32>;
-def W7_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def W7_FULL_64_0    : SubRegIndex<64>;
-
 def W7 : Register<"W7">
 {
 let Namespace = "aarch64temp";
@@ -1987,11 +1570,6 @@ let HWEncoding{4-0} = 7;
 
 let isArtificial = false;
 }
-
-def W8_SUB_32_0  : SubRegIndex<32>;
-def W8_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def W8_FULL_64_0    : SubRegIndex<64>;
-
 def W8 : Register<"W8">
 {
 let Namespace = "aarch64temp";
@@ -2010,11 +1588,6 @@ let HWEncoding{4-0} = 8;
 
 let isArtificial = false;
 }
-
-def W9_SUB_32_0  : SubRegIndex<32>;
-def W9_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def W9_FULL_64_0    : SubRegIndex<64>;
-
 def W9 : Register<"W9">
 {
 let Namespace = "aarch64temp";
@@ -2033,11 +1606,6 @@ let HWEncoding{4-0} = 9;
 
 let isArtificial = false;
 }
-
-def W10_SUB_32_0  : SubRegIndex<32>;
-def W10_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def W10_FULL_64_0    : SubRegIndex<64>;
-
 def W10 : Register<"W10">
 {
 let Namespace = "aarch64temp";
@@ -2056,11 +1624,6 @@ let HWEncoding{4-0} = 10;
 
 let isArtificial = false;
 }
-
-def W11_SUB_32_0  : SubRegIndex<32>;
-def W11_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def W11_FULL_64_0    : SubRegIndex<64>;
-
 def W11 : Register<"W11">
 {
 let Namespace = "aarch64temp";
@@ -2079,11 +1642,6 @@ let HWEncoding{4-0} = 11;
 
 let isArtificial = false;
 }
-
-def W12_SUB_32_0  : SubRegIndex<32>;
-def W12_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def W12_FULL_64_0    : SubRegIndex<64>;
-
 def W12 : Register<"W12">
 {
 let Namespace = "aarch64temp";
@@ -2102,11 +1660,6 @@ let HWEncoding{4-0} = 12;
 
 let isArtificial = false;
 }
-
-def W13_SUB_32_0  : SubRegIndex<32>;
-def W13_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def W13_FULL_64_0    : SubRegIndex<64>;
-
 def W13 : Register<"W13">
 {
 let Namespace = "aarch64temp";
@@ -2125,11 +1678,6 @@ let HWEncoding{4-0} = 13;
 
 let isArtificial = false;
 }
-
-def W14_SUB_32_0  : SubRegIndex<32>;
-def W14_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def W14_FULL_64_0    : SubRegIndex<64>;
-
 def W14 : Register<"W14">
 {
 let Namespace = "aarch64temp";
@@ -2148,11 +1696,6 @@ let HWEncoding{4-0} = 14;
 
 let isArtificial = false;
 }
-
-def W15_SUB_32_0  : SubRegIndex<32>;
-def W15_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def W15_FULL_64_0    : SubRegIndex<64>;
-
 def W15 : Register<"W15">
 {
 let Namespace = "aarch64temp";
@@ -2171,11 +1714,6 @@ let HWEncoding{4-0} = 15;
 
 let isArtificial = false;
 }
-
-def W16_SUB_32_0  : SubRegIndex<32>;
-def W16_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def W16_FULL_64_0    : SubRegIndex<64>;
-
 def W16 : Register<"W16">
 {
 let Namespace = "aarch64temp";
@@ -2194,11 +1732,6 @@ let HWEncoding{4-0} = 16;
 
 let isArtificial = false;
 }
-
-def W17_SUB_32_0  : SubRegIndex<32>;
-def W17_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def W17_FULL_64_0    : SubRegIndex<64>;
-
 def W17 : Register<"W17">
 {
 let Namespace = "aarch64temp";
@@ -2217,11 +1750,6 @@ let HWEncoding{4-0} = 17;
 
 let isArtificial = false;
 }
-
-def W18_SUB_32_0  : SubRegIndex<32>;
-def W18_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def W18_FULL_64_0    : SubRegIndex<64>;
-
 def W18 : Register<"W18">
 {
 let Namespace = "aarch64temp";
@@ -2240,11 +1768,6 @@ let HWEncoding{4-0} = 18;
 
 let isArtificial = false;
 }
-
-def W19_SUB_32_0  : SubRegIndex<32>;
-def W19_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def W19_FULL_64_0    : SubRegIndex<64>;
-
 def W19 : Register<"W19">
 {
 let Namespace = "aarch64temp";
@@ -2263,11 +1786,6 @@ let HWEncoding{4-0} = 19;
 
 let isArtificial = false;
 }
-
-def W20_SUB_32_0  : SubRegIndex<32>;
-def W20_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def W20_FULL_64_0    : SubRegIndex<64>;
-
 def W20 : Register<"W20">
 {
 let Namespace = "aarch64temp";
@@ -2286,11 +1804,6 @@ let HWEncoding{4-0} = 20;
 
 let isArtificial = false;
 }
-
-def W21_SUB_32_0  : SubRegIndex<32>;
-def W21_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def W21_FULL_64_0    : SubRegIndex<64>;
-
 def W21 : Register<"W21">
 {
 let Namespace = "aarch64temp";
@@ -2309,11 +1822,6 @@ let HWEncoding{4-0} = 21;
 
 let isArtificial = false;
 }
-
-def W22_SUB_32_0  : SubRegIndex<32>;
-def W22_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def W22_FULL_64_0    : SubRegIndex<64>;
-
 def W22 : Register<"W22">
 {
 let Namespace = "aarch64temp";
@@ -2332,11 +1840,6 @@ let HWEncoding{4-0} = 22;
 
 let isArtificial = false;
 }
-
-def W23_SUB_32_0  : SubRegIndex<32>;
-def W23_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def W23_FULL_64_0    : SubRegIndex<64>;
-
 def W23 : Register<"W23">
 {
 let Namespace = "aarch64temp";
@@ -2355,11 +1858,6 @@ let HWEncoding{4-0} = 23;
 
 let isArtificial = false;
 }
-
-def W24_SUB_32_0  : SubRegIndex<32>;
-def W24_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def W24_FULL_64_0    : SubRegIndex<64>;
-
 def W24 : Register<"W24">
 {
 let Namespace = "aarch64temp";
@@ -2378,11 +1876,6 @@ let HWEncoding{4-0} = 24;
 
 let isArtificial = false;
 }
-
-def W25_SUB_32_0  : SubRegIndex<32>;
-def W25_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def W25_FULL_64_0    : SubRegIndex<64>;
-
 def W25 : Register<"W25">
 {
 let Namespace = "aarch64temp";
@@ -2401,11 +1894,6 @@ let HWEncoding{4-0} = 25;
 
 let isArtificial = false;
 }
-
-def W26_SUB_32_0  : SubRegIndex<32>;
-def W26_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def W26_FULL_64_0    : SubRegIndex<64>;
-
 def W26 : Register<"W26">
 {
 let Namespace = "aarch64temp";
@@ -2424,11 +1912,6 @@ let HWEncoding{4-0} = 26;
 
 let isArtificial = false;
 }
-
-def W27_SUB_32_0  : SubRegIndex<32>;
-def W27_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def W27_FULL_64_0    : SubRegIndex<64>;
-
 def W27 : Register<"W27">
 {
 let Namespace = "aarch64temp";
@@ -2447,11 +1930,6 @@ let HWEncoding{4-0} = 27;
 
 let isArtificial = false;
 }
-
-def W28_SUB_32_0  : SubRegIndex<32>;
-def W28_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def W28_FULL_64_0    : SubRegIndex<64>;
-
 def W28 : Register<"W28">
 {
 let Namespace = "aarch64temp";
@@ -2470,11 +1948,6 @@ let HWEncoding{4-0} = 28;
 
 let isArtificial = false;
 }
-
-def W29_SUB_32_0  : SubRegIndex<32>;
-def W29_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def W29_FULL_64_0    : SubRegIndex<64>;
-
 def W29 : Register<"W29">
 {
 let Namespace = "aarch64temp";
@@ -2493,11 +1966,6 @@ let HWEncoding{4-0} = 29;
 
 let isArtificial = false;
 }
-
-def W30_SUB_32_0  : SubRegIndex<32>;
-def W30_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def W30_FULL_64_0    : SubRegIndex<64>;
-
 def W30 : Register<"W30">
 {
 let Namespace = "aarch64temp";
@@ -2516,11 +1984,6 @@ let HWEncoding{4-0} = 30;
 
 let isArtificial = false;
 }
-
-def W31_SUB_32_0  : SubRegIndex<32>;
-def W31_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def W31_FULL_64_0    : SubRegIndex<64>;
-
 def W31 : Register<"W31">
 {
 let Namespace = "aarch64temp";
@@ -2539,14 +2002,6 @@ let HWEncoding{4-0} = 31;
 
 let isArtificial = false;
 }
-
-def S0_SUB_32_0  : SubRegIndex<32>;
-def S0_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def S0_FULL_64_0    : SubRegIndex<64>;
-def S0_SUB_32_1  : SubRegIndex<32>;
-def S0_SUB_32_HI_1 : SubRegIndex<32, 32>;
-def S0_FULL_64_1    : SubRegIndex<64>;
-
 def S0 : Register<"S0">
 {
 let Namespace = "aarch64temp";
@@ -2554,7 +2009,7 @@ let AsmName = "X0";
 let AltNames = [ "X0"  ];
 let Aliases = [ ];
 let SubRegs = [ R0, X0, W0 ];
-let SubRegIndices = [ S0_SUB_32_0, S0_FULL_64_0, S0_SUB_32_1 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 15 ];
 list<int> CostPerUse = [0];
@@ -2565,14 +2020,6 @@ let HWEncoding{4-0} = 0;
 
 let isArtificial = false;
 }
-
-def S1_SUB_32_0  : SubRegIndex<32>;
-def S1_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def S1_FULL_64_0    : SubRegIndex<64>;
-def S1_SUB_32_1  : SubRegIndex<32>;
-def S1_SUB_32_HI_1 : SubRegIndex<32, 32>;
-def S1_FULL_64_1    : SubRegIndex<64>;
-
 def S1 : Register<"S1">
 {
 let Namespace = "aarch64temp";
@@ -2580,7 +2027,7 @@ let AsmName = "X1";
 let AltNames = [ "X1"  ];
 let Aliases = [ ];
 let SubRegs = [ R1, X1, W1 ];
-let SubRegIndices = [ S1_SUB_32_0, S1_FULL_64_0, S1_SUB_32_1 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 16 ];
 list<int> CostPerUse = [0];
@@ -2591,14 +2038,6 @@ let HWEncoding{4-0} = 1;
 
 let isArtificial = false;
 }
-
-def S2_SUB_32_0  : SubRegIndex<32>;
-def S2_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def S2_FULL_64_0    : SubRegIndex<64>;
-def S2_SUB_32_1  : SubRegIndex<32>;
-def S2_SUB_32_HI_1 : SubRegIndex<32, 32>;
-def S2_FULL_64_1    : SubRegIndex<64>;
-
 def S2 : Register<"S2">
 {
 let Namespace = "aarch64temp";
@@ -2606,7 +2045,7 @@ let AsmName = "X2";
 let AltNames = [ "X2"  ];
 let Aliases = [ ];
 let SubRegs = [ R2, X2, W2 ];
-let SubRegIndices = [ S2_SUB_32_0, S2_FULL_64_0, S2_SUB_32_1 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 17 ];
 list<int> CostPerUse = [0];
@@ -2617,14 +2056,6 @@ let HWEncoding{4-0} = 2;
 
 let isArtificial = false;
 }
-
-def S3_SUB_32_0  : SubRegIndex<32>;
-def S3_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def S3_FULL_64_0    : SubRegIndex<64>;
-def S3_SUB_32_1  : SubRegIndex<32>;
-def S3_SUB_32_HI_1 : SubRegIndex<32, 32>;
-def S3_FULL_64_1    : SubRegIndex<64>;
-
 def S3 : Register<"S3">
 {
 let Namespace = "aarch64temp";
@@ -2632,7 +2063,7 @@ let AsmName = "X3";
 let AltNames = [ "X3"  ];
 let Aliases = [ ];
 let SubRegs = [ R3, X3, W3 ];
-let SubRegIndices = [ S3_SUB_32_0, S3_FULL_64_0, S3_SUB_32_1 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 18 ];
 list<int> CostPerUse = [0];
@@ -2643,14 +2074,6 @@ let HWEncoding{4-0} = 3;
 
 let isArtificial = false;
 }
-
-def S4_SUB_32_0  : SubRegIndex<32>;
-def S4_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def S4_FULL_64_0    : SubRegIndex<64>;
-def S4_SUB_32_1  : SubRegIndex<32>;
-def S4_SUB_32_HI_1 : SubRegIndex<32, 32>;
-def S4_FULL_64_1    : SubRegIndex<64>;
-
 def S4 : Register<"S4">
 {
 let Namespace = "aarch64temp";
@@ -2658,7 +2081,7 @@ let AsmName = "X4";
 let AltNames = [ "X4"  ];
 let Aliases = [ ];
 let SubRegs = [ R4, X4, W4 ];
-let SubRegIndices = [ S4_SUB_32_0, S4_FULL_64_0, S4_SUB_32_1 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 19 ];
 list<int> CostPerUse = [0];
@@ -2669,14 +2092,6 @@ let HWEncoding{4-0} = 4;
 
 let isArtificial = false;
 }
-
-def S5_SUB_32_0  : SubRegIndex<32>;
-def S5_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def S5_FULL_64_0    : SubRegIndex<64>;
-def S5_SUB_32_1  : SubRegIndex<32>;
-def S5_SUB_32_HI_1 : SubRegIndex<32, 32>;
-def S5_FULL_64_1    : SubRegIndex<64>;
-
 def S5 : Register<"S5">
 {
 let Namespace = "aarch64temp";
@@ -2684,7 +2099,7 @@ let AsmName = "X5";
 let AltNames = [ "X5"  ];
 let Aliases = [ ];
 let SubRegs = [ R5, X5, W5 ];
-let SubRegIndices = [ S5_SUB_32_0, S5_FULL_64_0, S5_SUB_32_1 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 20 ];
 list<int> CostPerUse = [0];
@@ -2695,14 +2110,6 @@ let HWEncoding{4-0} = 5;
 
 let isArtificial = false;
 }
-
-def S6_SUB_32_0  : SubRegIndex<32>;
-def S6_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def S6_FULL_64_0    : SubRegIndex<64>;
-def S6_SUB_32_1  : SubRegIndex<32>;
-def S6_SUB_32_HI_1 : SubRegIndex<32, 32>;
-def S6_FULL_64_1    : SubRegIndex<64>;
-
 def S6 : Register<"S6">
 {
 let Namespace = "aarch64temp";
@@ -2710,7 +2117,7 @@ let AsmName = "X6";
 let AltNames = [ "X6"  ];
 let Aliases = [ ];
 let SubRegs = [ R6, X6, W6 ];
-let SubRegIndices = [ S6_SUB_32_0, S6_FULL_64_0, S6_SUB_32_1 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 21 ];
 list<int> CostPerUse = [0];
@@ -2721,14 +2128,6 @@ let HWEncoding{4-0} = 6;
 
 let isArtificial = false;
 }
-
-def S7_SUB_32_0  : SubRegIndex<32>;
-def S7_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def S7_FULL_64_0    : SubRegIndex<64>;
-def S7_SUB_32_1  : SubRegIndex<32>;
-def S7_SUB_32_HI_1 : SubRegIndex<32, 32>;
-def S7_FULL_64_1    : SubRegIndex<64>;
-
 def S7 : Register<"S7">
 {
 let Namespace = "aarch64temp";
@@ -2736,7 +2135,7 @@ let AsmName = "X7";
 let AltNames = [ "X7"  ];
 let Aliases = [ ];
 let SubRegs = [ R7, X7, W7 ];
-let SubRegIndices = [ S7_SUB_32_0, S7_FULL_64_0, S7_SUB_32_1 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 22 ];
 list<int> CostPerUse = [0];
@@ -2747,14 +2146,6 @@ let HWEncoding{4-0} = 7;
 
 let isArtificial = false;
 }
-
-def S8_SUB_32_0  : SubRegIndex<32>;
-def S8_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def S8_FULL_64_0    : SubRegIndex<64>;
-def S8_SUB_32_1  : SubRegIndex<32>;
-def S8_SUB_32_HI_1 : SubRegIndex<32, 32>;
-def S8_FULL_64_1    : SubRegIndex<64>;
-
 def S8 : Register<"S8">
 {
 let Namespace = "aarch64temp";
@@ -2762,7 +2153,7 @@ let AsmName = "X8";
 let AltNames = [ "X8"  ];
 let Aliases = [ ];
 let SubRegs = [ R8, X8, W8 ];
-let SubRegIndices = [ S8_SUB_32_0, S8_FULL_64_0, S8_SUB_32_1 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 23 ];
 list<int> CostPerUse = [0];
@@ -2773,14 +2164,6 @@ let HWEncoding{4-0} = 8;
 
 let isArtificial = false;
 }
-
-def S9_SUB_32_0  : SubRegIndex<32>;
-def S9_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def S9_FULL_64_0    : SubRegIndex<64>;
-def S9_SUB_32_1  : SubRegIndex<32>;
-def S9_SUB_32_HI_1 : SubRegIndex<32, 32>;
-def S9_FULL_64_1    : SubRegIndex<64>;
-
 def S9 : Register<"S9">
 {
 let Namespace = "aarch64temp";
@@ -2788,7 +2171,7 @@ let AsmName = "X9";
 let AltNames = [ "X9"  ];
 let Aliases = [ ];
 let SubRegs = [ R9, X9, W9 ];
-let SubRegIndices = [ S9_SUB_32_0, S9_FULL_64_0, S9_SUB_32_1 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 24 ];
 list<int> CostPerUse = [0];
@@ -2799,14 +2182,6 @@ let HWEncoding{4-0} = 9;
 
 let isArtificial = false;
 }
-
-def S10_SUB_32_0  : SubRegIndex<32>;
-def S10_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def S10_FULL_64_0    : SubRegIndex<64>;
-def S10_SUB_32_1  : SubRegIndex<32>;
-def S10_SUB_32_HI_1 : SubRegIndex<32, 32>;
-def S10_FULL_64_1    : SubRegIndex<64>;
-
 def S10 : Register<"S10">
 {
 let Namespace = "aarch64temp";
@@ -2814,7 +2189,7 @@ let AsmName = "X10";
 let AltNames = [ "X10"  ];
 let Aliases = [ ];
 let SubRegs = [ R10, X10, W10 ];
-let SubRegIndices = [ S10_SUB_32_0, S10_FULL_64_0, S10_SUB_32_1 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 25 ];
 list<int> CostPerUse = [0];
@@ -2825,14 +2200,6 @@ let HWEncoding{4-0} = 10;
 
 let isArtificial = false;
 }
-
-def S11_SUB_32_0  : SubRegIndex<32>;
-def S11_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def S11_FULL_64_0    : SubRegIndex<64>;
-def S11_SUB_32_1  : SubRegIndex<32>;
-def S11_SUB_32_HI_1 : SubRegIndex<32, 32>;
-def S11_FULL_64_1    : SubRegIndex<64>;
-
 def S11 : Register<"S11">
 {
 let Namespace = "aarch64temp";
@@ -2840,7 +2207,7 @@ let AsmName = "X11";
 let AltNames = [ "X11"  ];
 let Aliases = [ ];
 let SubRegs = [ R11, X11, W11 ];
-let SubRegIndices = [ S11_SUB_32_0, S11_FULL_64_0, S11_SUB_32_1 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 26 ];
 list<int> CostPerUse = [0];
@@ -2851,14 +2218,6 @@ let HWEncoding{4-0} = 11;
 
 let isArtificial = false;
 }
-
-def S12_SUB_32_0  : SubRegIndex<32>;
-def S12_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def S12_FULL_64_0    : SubRegIndex<64>;
-def S12_SUB_32_1  : SubRegIndex<32>;
-def S12_SUB_32_HI_1 : SubRegIndex<32, 32>;
-def S12_FULL_64_1    : SubRegIndex<64>;
-
 def S12 : Register<"S12">
 {
 let Namespace = "aarch64temp";
@@ -2866,7 +2225,7 @@ let AsmName = "X12";
 let AltNames = [ "X12"  ];
 let Aliases = [ ];
 let SubRegs = [ R12, X12, W12 ];
-let SubRegIndices = [ S12_SUB_32_0, S12_FULL_64_0, S12_SUB_32_1 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 27 ];
 list<int> CostPerUse = [0];
@@ -2877,14 +2236,6 @@ let HWEncoding{4-0} = 12;
 
 let isArtificial = false;
 }
-
-def S13_SUB_32_0  : SubRegIndex<32>;
-def S13_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def S13_FULL_64_0    : SubRegIndex<64>;
-def S13_SUB_32_1  : SubRegIndex<32>;
-def S13_SUB_32_HI_1 : SubRegIndex<32, 32>;
-def S13_FULL_64_1    : SubRegIndex<64>;
-
 def S13 : Register<"S13">
 {
 let Namespace = "aarch64temp";
@@ -2892,7 +2243,7 @@ let AsmName = "X13";
 let AltNames = [ "X13"  ];
 let Aliases = [ ];
 let SubRegs = [ R13, X13, W13 ];
-let SubRegIndices = [ S13_SUB_32_0, S13_FULL_64_0, S13_SUB_32_1 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 28 ];
 list<int> CostPerUse = [0];
@@ -2903,14 +2254,6 @@ let HWEncoding{4-0} = 13;
 
 let isArtificial = false;
 }
-
-def S14_SUB_32_0  : SubRegIndex<32>;
-def S14_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def S14_FULL_64_0    : SubRegIndex<64>;
-def S14_SUB_32_1  : SubRegIndex<32>;
-def S14_SUB_32_HI_1 : SubRegIndex<32, 32>;
-def S14_FULL_64_1    : SubRegIndex<64>;
-
 def S14 : Register<"S14">
 {
 let Namespace = "aarch64temp";
@@ -2918,7 +2261,7 @@ let AsmName = "X14";
 let AltNames = [ "X14"  ];
 let Aliases = [ ];
 let SubRegs = [ R14, X14, W14 ];
-let SubRegIndices = [ S14_SUB_32_0, S14_FULL_64_0, S14_SUB_32_1 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 29 ];
 list<int> CostPerUse = [0];
@@ -2929,14 +2272,6 @@ let HWEncoding{4-0} = 14;
 
 let isArtificial = false;
 }
-
-def S15_SUB_32_0  : SubRegIndex<32>;
-def S15_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def S15_FULL_64_0    : SubRegIndex<64>;
-def S15_SUB_32_1  : SubRegIndex<32>;
-def S15_SUB_32_HI_1 : SubRegIndex<32, 32>;
-def S15_FULL_64_1    : SubRegIndex<64>;
-
 def S15 : Register<"S15">
 {
 let Namespace = "aarch64temp";
@@ -2944,7 +2279,7 @@ let AsmName = "X15";
 let AltNames = [ "X15"  ];
 let Aliases = [ ];
 let SubRegs = [ R15, X15, W15 ];
-let SubRegIndices = [ S15_SUB_32_0, S15_FULL_64_0, S15_SUB_32_1 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 30 ];
 list<int> CostPerUse = [0];
@@ -2955,14 +2290,6 @@ let HWEncoding{4-0} = 15;
 
 let isArtificial = false;
 }
-
-def S16_SUB_32_0  : SubRegIndex<32>;
-def S16_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def S16_FULL_64_0    : SubRegIndex<64>;
-def S16_SUB_32_1  : SubRegIndex<32>;
-def S16_SUB_32_HI_1 : SubRegIndex<32, 32>;
-def S16_FULL_64_1    : SubRegIndex<64>;
-
 def S16 : Register<"S16">
 {
 let Namespace = "aarch64temp";
@@ -2970,7 +2297,7 @@ let AsmName = "X16";
 let AltNames = [ "X16"  ];
 let Aliases = [ ];
 let SubRegs = [ R16, X16, W16 ];
-let SubRegIndices = [ S16_SUB_32_0, S16_FULL_64_0, S16_SUB_32_1 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 31 ];
 list<int> CostPerUse = [0];
@@ -2981,14 +2308,6 @@ let HWEncoding{4-0} = 16;
 
 let isArtificial = false;
 }
-
-def S17_SUB_32_0  : SubRegIndex<32>;
-def S17_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def S17_FULL_64_0    : SubRegIndex<64>;
-def S17_SUB_32_1  : SubRegIndex<32>;
-def S17_SUB_32_HI_1 : SubRegIndex<32, 32>;
-def S17_FULL_64_1    : SubRegIndex<64>;
-
 def S17 : Register<"S17">
 {
 let Namespace = "aarch64temp";
@@ -2996,7 +2315,7 @@ let AsmName = "X17";
 let AltNames = [ "X17"  ];
 let Aliases = [ ];
 let SubRegs = [ R17, X17, W17 ];
-let SubRegIndices = [ S17_SUB_32_0, S17_FULL_64_0, S17_SUB_32_1 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 32 ];
 list<int> CostPerUse = [0];
@@ -3007,14 +2326,6 @@ let HWEncoding{4-0} = 17;
 
 let isArtificial = false;
 }
-
-def S18_SUB_32_0  : SubRegIndex<32>;
-def S18_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def S18_FULL_64_0    : SubRegIndex<64>;
-def S18_SUB_32_1  : SubRegIndex<32>;
-def S18_SUB_32_HI_1 : SubRegIndex<32, 32>;
-def S18_FULL_64_1    : SubRegIndex<64>;
-
 def S18 : Register<"S18">
 {
 let Namespace = "aarch64temp";
@@ -3022,7 +2333,7 @@ let AsmName = "X18";
 let AltNames = [ "X18"  ];
 let Aliases = [ ];
 let SubRegs = [ R18, X18, W18 ];
-let SubRegIndices = [ S18_SUB_32_0, S18_FULL_64_0, S18_SUB_32_1 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 33 ];
 list<int> CostPerUse = [0];
@@ -3033,14 +2344,6 @@ let HWEncoding{4-0} = 18;
 
 let isArtificial = false;
 }
-
-def S19_SUB_32_0  : SubRegIndex<32>;
-def S19_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def S19_FULL_64_0    : SubRegIndex<64>;
-def S19_SUB_32_1  : SubRegIndex<32>;
-def S19_SUB_32_HI_1 : SubRegIndex<32, 32>;
-def S19_FULL_64_1    : SubRegIndex<64>;
-
 def S19 : Register<"S19">
 {
 let Namespace = "aarch64temp";
@@ -3048,7 +2351,7 @@ let AsmName = "X19";
 let AltNames = [ "X19"  ];
 let Aliases = [ ];
 let SubRegs = [ R19, X19, W19 ];
-let SubRegIndices = [ S19_SUB_32_0, S19_FULL_64_0, S19_SUB_32_1 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 34 ];
 list<int> CostPerUse = [0];
@@ -3059,14 +2362,6 @@ let HWEncoding{4-0} = 19;
 
 let isArtificial = false;
 }
-
-def S20_SUB_32_0  : SubRegIndex<32>;
-def S20_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def S20_FULL_64_0    : SubRegIndex<64>;
-def S20_SUB_32_1  : SubRegIndex<32>;
-def S20_SUB_32_HI_1 : SubRegIndex<32, 32>;
-def S20_FULL_64_1    : SubRegIndex<64>;
-
 def S20 : Register<"S20">
 {
 let Namespace = "aarch64temp";
@@ -3074,7 +2369,7 @@ let AsmName = "X20";
 let AltNames = [ "X20"  ];
 let Aliases = [ ];
 let SubRegs = [ R20, X20, W20 ];
-let SubRegIndices = [ S20_SUB_32_0, S20_FULL_64_0, S20_SUB_32_1 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 35 ];
 list<int> CostPerUse = [0];
@@ -3085,14 +2380,6 @@ let HWEncoding{4-0} = 20;
 
 let isArtificial = false;
 }
-
-def S21_SUB_32_0  : SubRegIndex<32>;
-def S21_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def S21_FULL_64_0    : SubRegIndex<64>;
-def S21_SUB_32_1  : SubRegIndex<32>;
-def S21_SUB_32_HI_1 : SubRegIndex<32, 32>;
-def S21_FULL_64_1    : SubRegIndex<64>;
-
 def S21 : Register<"S21">
 {
 let Namespace = "aarch64temp";
@@ -3100,7 +2387,7 @@ let AsmName = "X21";
 let AltNames = [ "X21"  ];
 let Aliases = [ ];
 let SubRegs = [ R21, X21, W21 ];
-let SubRegIndices = [ S21_SUB_32_0, S21_FULL_64_0, S21_SUB_32_1 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 36 ];
 list<int> CostPerUse = [0];
@@ -3111,14 +2398,6 @@ let HWEncoding{4-0} = 21;
 
 let isArtificial = false;
 }
-
-def S22_SUB_32_0  : SubRegIndex<32>;
-def S22_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def S22_FULL_64_0    : SubRegIndex<64>;
-def S22_SUB_32_1  : SubRegIndex<32>;
-def S22_SUB_32_HI_1 : SubRegIndex<32, 32>;
-def S22_FULL_64_1    : SubRegIndex<64>;
-
 def S22 : Register<"S22">
 {
 let Namespace = "aarch64temp";
@@ -3126,7 +2405,7 @@ let AsmName = "X22";
 let AltNames = [ "X22"  ];
 let Aliases = [ ];
 let SubRegs = [ R22, X22, W22 ];
-let SubRegIndices = [ S22_SUB_32_0, S22_FULL_64_0, S22_SUB_32_1 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 37 ];
 list<int> CostPerUse = [0];
@@ -3137,14 +2416,6 @@ let HWEncoding{4-0} = 22;
 
 let isArtificial = false;
 }
-
-def S23_SUB_32_0  : SubRegIndex<32>;
-def S23_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def S23_FULL_64_0    : SubRegIndex<64>;
-def S23_SUB_32_1  : SubRegIndex<32>;
-def S23_SUB_32_HI_1 : SubRegIndex<32, 32>;
-def S23_FULL_64_1    : SubRegIndex<64>;
-
 def S23 : Register<"S23">
 {
 let Namespace = "aarch64temp";
@@ -3152,7 +2423,7 @@ let AsmName = "X23";
 let AltNames = [ "X23"  ];
 let Aliases = [ ];
 let SubRegs = [ R23, X23, W23 ];
-let SubRegIndices = [ S23_SUB_32_0, S23_FULL_64_0, S23_SUB_32_1 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 38 ];
 list<int> CostPerUse = [0];
@@ -3163,14 +2434,6 @@ let HWEncoding{4-0} = 23;
 
 let isArtificial = false;
 }
-
-def S24_SUB_32_0  : SubRegIndex<32>;
-def S24_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def S24_FULL_64_0    : SubRegIndex<64>;
-def S24_SUB_32_1  : SubRegIndex<32>;
-def S24_SUB_32_HI_1 : SubRegIndex<32, 32>;
-def S24_FULL_64_1    : SubRegIndex<64>;
-
 def S24 : Register<"S24">
 {
 let Namespace = "aarch64temp";
@@ -3178,7 +2441,7 @@ let AsmName = "X24";
 let AltNames = [ "X24"  ];
 let Aliases = [ ];
 let SubRegs = [ R24, X24, W24 ];
-let SubRegIndices = [ S24_SUB_32_0, S24_FULL_64_0, S24_SUB_32_1 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 39 ];
 list<int> CostPerUse = [0];
@@ -3189,14 +2452,6 @@ let HWEncoding{4-0} = 24;
 
 let isArtificial = false;
 }
-
-def S25_SUB_32_0  : SubRegIndex<32>;
-def S25_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def S25_FULL_64_0    : SubRegIndex<64>;
-def S25_SUB_32_1  : SubRegIndex<32>;
-def S25_SUB_32_HI_1 : SubRegIndex<32, 32>;
-def S25_FULL_64_1    : SubRegIndex<64>;
-
 def S25 : Register<"S25">
 {
 let Namespace = "aarch64temp";
@@ -3204,7 +2459,7 @@ let AsmName = "X25";
 let AltNames = [ "X25"  ];
 let Aliases = [ ];
 let SubRegs = [ R25, X25, W25 ];
-let SubRegIndices = [ S25_SUB_32_0, S25_FULL_64_0, S25_SUB_32_1 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 40 ];
 list<int> CostPerUse = [0];
@@ -3215,14 +2470,6 @@ let HWEncoding{4-0} = 25;
 
 let isArtificial = false;
 }
-
-def S26_SUB_32_0  : SubRegIndex<32>;
-def S26_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def S26_FULL_64_0    : SubRegIndex<64>;
-def S26_SUB_32_1  : SubRegIndex<32>;
-def S26_SUB_32_HI_1 : SubRegIndex<32, 32>;
-def S26_FULL_64_1    : SubRegIndex<64>;
-
 def S26 : Register<"S26">
 {
 let Namespace = "aarch64temp";
@@ -3230,7 +2477,7 @@ let AsmName = "X26";
 let AltNames = [ "X26"  ];
 let Aliases = [ ];
 let SubRegs = [ R26, X26, W26 ];
-let SubRegIndices = [ S26_SUB_32_0, S26_FULL_64_0, S26_SUB_32_1 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 41 ];
 list<int> CostPerUse = [0];
@@ -3241,14 +2488,6 @@ let HWEncoding{4-0} = 26;
 
 let isArtificial = false;
 }
-
-def S27_SUB_32_0  : SubRegIndex<32>;
-def S27_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def S27_FULL_64_0    : SubRegIndex<64>;
-def S27_SUB_32_1  : SubRegIndex<32>;
-def S27_SUB_32_HI_1 : SubRegIndex<32, 32>;
-def S27_FULL_64_1    : SubRegIndex<64>;
-
 def S27 : Register<"S27">
 {
 let Namespace = "aarch64temp";
@@ -3256,7 +2495,7 @@ let AsmName = "X27";
 let AltNames = [ "X27"  ];
 let Aliases = [ ];
 let SubRegs = [ R27, X27, W27 ];
-let SubRegIndices = [ S27_SUB_32_0, S27_FULL_64_0, S27_SUB_32_1 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 42 ];
 list<int> CostPerUse = [0];
@@ -3267,14 +2506,6 @@ let HWEncoding{4-0} = 27;
 
 let isArtificial = false;
 }
-
-def S28_SUB_32_0  : SubRegIndex<32>;
-def S28_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def S28_FULL_64_0    : SubRegIndex<64>;
-def S28_SUB_32_1  : SubRegIndex<32>;
-def S28_SUB_32_HI_1 : SubRegIndex<32, 32>;
-def S28_FULL_64_1    : SubRegIndex<64>;
-
 def S28 : Register<"S28">
 {
 let Namespace = "aarch64temp";
@@ -3282,7 +2513,7 @@ let AsmName = "X28";
 let AltNames = [ "X28"  ];
 let Aliases = [ ];
 let SubRegs = [ R28, X28, W28 ];
-let SubRegIndices = [ S28_SUB_32_0, S28_FULL_64_0, S28_SUB_32_1 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 43 ];
 list<int> CostPerUse = [0];
@@ -3293,14 +2524,6 @@ let HWEncoding{4-0} = 28;
 
 let isArtificial = false;
 }
-
-def S29_SUB_32_0  : SubRegIndex<32>;
-def S29_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def S29_FULL_64_0    : SubRegIndex<64>;
-def S29_SUB_32_1  : SubRegIndex<32>;
-def S29_SUB_32_HI_1 : SubRegIndex<32, 32>;
-def S29_FULL_64_1    : SubRegIndex<64>;
-
 def S29 : Register<"S29">
 {
 let Namespace = "aarch64temp";
@@ -3308,7 +2531,7 @@ let AsmName = "A_FP";
 let AltNames = [ "A_FP"  ];
 let Aliases = [ ];
 let SubRegs = [ R29, X29, W29 ];
-let SubRegIndices = [ S29_SUB_32_0, S29_FULL_64_0, S29_SUB_32_1 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 44 ];
 list<int> CostPerUse = [0];
@@ -3319,14 +2542,6 @@ let HWEncoding{4-0} = 29;
 
 let isArtificial = false;
 }
-
-def S30_SUB_32_0  : SubRegIndex<32>;
-def S30_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def S30_FULL_64_0    : SubRegIndex<64>;
-def S30_SUB_32_1  : SubRegIndex<32>;
-def S30_SUB_32_HI_1 : SubRegIndex<32, 32>;
-def S30_FULL_64_1    : SubRegIndex<64>;
-
 def S30 : Register<"S30">
 {
 let Namespace = "aarch64temp";
@@ -3334,7 +2549,7 @@ let AsmName = "A_LR";
 let AltNames = [ "A_LR"  ];
 let Aliases = [ ];
 let SubRegs = [ R30, X30, W30 ];
-let SubRegIndices = [ S30_SUB_32_0, S30_FULL_64_0, S30_SUB_32_1 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 45 ];
 list<int> CostPerUse = [0];
@@ -3345,14 +2560,6 @@ let HWEncoding{4-0} = 30;
 
 let isArtificial = false;
 }
-
-def S31_SUB_32_0  : SubRegIndex<32>;
-def S31_SUB_32_HI_0 : SubRegIndex<32, 32>;
-def S31_FULL_64_0    : SubRegIndex<64>;
-def S31_SUB_32_1  : SubRegIndex<32>;
-def S31_SUB_32_HI_1 : SubRegIndex<32, 32>;
-def S31_FULL_64_1    : SubRegIndex<64>;
-
 def S31 : Register<"S31">
 {
 let Namespace = "aarch64temp";
@@ -3360,7 +2567,7 @@ let AsmName = "A_SP";
 let AltNames = [ "A_SP"  ];
 let Aliases = [ ];
 let SubRegs = [ R31, X31, W31 ];
-let SubRegIndices = [ S31_SUB_32_0, S31_FULL_64_0, S31_SUB_32_1 ];
+let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 46 ];
 list<int> CostPerUse = [0];

--- a/vadl/test/resources/snapshots/aarch64/RegisterInfo.td
+++ b/vadl/test/resources/snapshots/aarch64/RegisterInfo.td
@@ -1,9 +1,3 @@
-// SubRegIndexes for GPR registers
-def SUB_32   : SubRegIndex<32>;
-def SUB_32_HI : SubRegIndex<32, 32>;
-def FULL_64    : SubRegIndex<64>;
-
-
 def SP : Register<"SP">
 {
 let Namespace = "aarch64temp";
@@ -19,6 +13,7 @@ let CoveredBySubRegs = 0;
 let HWEncoding = 31;
 let isArtificial = 1;
 }
+
 def LR : Register<"LR">
 {
 let Namespace = "aarch64temp";
@@ -36,6 +31,11 @@ let isArtificial = 1;
 }
 
 
+
+
+def NZCV_N_SUB_32_0  : SubRegIndex<32>;
+def NZCV_N_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def NZCV_N_FULL_64_0    : SubRegIndex<64>;
 
 def NZCV_N : Register<"NZCV_N">
 {
@@ -55,6 +55,11 @@ let HWEncoding = 0;
 
 let isArtificial = false;
 }
+
+def NZCV_Z_SUB_32_0  : SubRegIndex<32>;
+def NZCV_Z_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def NZCV_Z_FULL_64_0    : SubRegIndex<64>;
+
 def NZCV_Z : Register<"NZCV_Z">
 {
 let Namespace = "aarch64temp";
@@ -73,6 +78,11 @@ let HWEncoding = 0;
 
 let isArtificial = false;
 }
+
+def NZCV_C_SUB_32_0  : SubRegIndex<32>;
+def NZCV_C_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def NZCV_C_FULL_64_0    : SubRegIndex<64>;
+
 def NZCV_C : Register<"NZCV_C">
 {
 let Namespace = "aarch64temp";
@@ -91,6 +101,11 @@ let HWEncoding = 0;
 
 let isArtificial = false;
 }
+
+def NZCV_V_SUB_32_0  : SubRegIndex<32>;
+def NZCV_V_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def NZCV_V_FULL_64_0    : SubRegIndex<64>;
+
 def NZCV_V : Register<"NZCV_V">
 {
 let Namespace = "aarch64temp";
@@ -109,6 +124,11 @@ let HWEncoding = 0;
 
 let isArtificial = false;
 }
+
+def CurrentEL_SUB_32_0  : SubRegIndex<32>;
+def CurrentEL_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def CurrentEL_FULL_64_0    : SubRegIndex<64>;
+
 def CurrentEL : Register<"CurrentEL">
 {
 let Namespace = "aarch64temp";
@@ -127,6 +147,11 @@ let HWEncoding = 0;
 
 let isArtificial = false;
 }
+
+def SPSel_SUB_32_0  : SubRegIndex<32>;
+def SPSel_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def SPSel_FULL_64_0    : SubRegIndex<64>;
+
 def SPSel : Register<"SPSel">
 {
 let Namespace = "aarch64temp";
@@ -145,6 +170,11 @@ let HWEncoding = 0;
 
 let isArtificial = false;
 }
+
+def SP_EL0_SUB_32_0  : SubRegIndex<32>;
+def SP_EL0_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def SP_EL0_FULL_64_0    : SubRegIndex<64>;
+
 def SP_EL0 : Register<"SP_EL0">
 {
 let Namespace = "aarch64temp";
@@ -163,6 +193,11 @@ let HWEncoding = 0;
 
 let isArtificial = false;
 }
+
+def SP_EL1_SUB_32_0  : SubRegIndex<32>;
+def SP_EL1_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def SP_EL1_FULL_64_0    : SubRegIndex<64>;
+
 def SP_EL1 : Register<"SP_EL1">
 {
 let Namespace = "aarch64temp";
@@ -181,6 +216,11 @@ let HWEncoding = 0;
 
 let isArtificial = false;
 }
+
+def ELR_EL1_SUB_32_0  : SubRegIndex<32>;
+def ELR_EL1_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def ELR_EL1_FULL_64_0    : SubRegIndex<64>;
+
 def ELR_EL1 : Register<"ELR_EL1">
 {
 let Namespace = "aarch64temp";
@@ -199,6 +239,11 @@ let HWEncoding = 0;
 
 let isArtificial = false;
 }
+
+def VBAR_EL1_SUB_32_0  : SubRegIndex<32>;
+def VBAR_EL1_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def VBAR_EL1_FULL_64_0    : SubRegIndex<64>;
+
 def VBAR_EL1 : Register<"VBAR_EL1">
 {
 let Namespace = "aarch64temp";
@@ -217,6 +262,11 @@ let HWEncoding = 0;
 
 let isArtificial = false;
 }
+
+def ESR_EL1_SUB_32_0  : SubRegIndex<32>;
+def ESR_EL1_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def ESR_EL1_FULL_64_0    : SubRegIndex<64>;
+
 def ESR_EL1 : Register<"ESR_EL1">
 {
 let Namespace = "aarch64temp";
@@ -235,6 +285,11 @@ let HWEncoding = 0;
 
 let isArtificial = false;
 }
+
+def SPSR_EL1_SUB_32_0  : SubRegIndex<32>;
+def SPSR_EL1_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def SPSR_EL1_FULL_64_0    : SubRegIndex<64>;
+
 def SPSR_EL1 : Register<"SPSR_EL1">
 {
 let Namespace = "aarch64temp";
@@ -253,6 +308,11 @@ let HWEncoding = 0;
 
 let isArtificial = false;
 }
+
+def PC_SUB_32_0  : SubRegIndex<32>;
+def PC_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def PC_FULL_64_0    : SubRegIndex<64>;
+
 def PC : Register<"PC">
 {
 let Namespace = "aarch64temp";
@@ -271,6 +331,11 @@ let HWEncoding = 0;
 
 let isArtificial = false;
 }
+
+def R0_SUB_32_0  : SubRegIndex<32>;
+def R0_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def R0_FULL_64_0    : SubRegIndex<64>;
+
 def R0 : Register<"R0">
 {
 let Namespace = "aarch64temp";
@@ -289,6 +354,11 @@ let HWEncoding{4-0} = 0;
 
 let isArtificial = false;
 }
+
+def R1_SUB_32_0  : SubRegIndex<32>;
+def R1_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def R1_FULL_64_0    : SubRegIndex<64>;
+
 def R1 : Register<"R1">
 {
 let Namespace = "aarch64temp";
@@ -307,6 +377,11 @@ let HWEncoding{4-0} = 1;
 
 let isArtificial = false;
 }
+
+def R2_SUB_32_0  : SubRegIndex<32>;
+def R2_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def R2_FULL_64_0    : SubRegIndex<64>;
+
 def R2 : Register<"R2">
 {
 let Namespace = "aarch64temp";
@@ -325,6 +400,11 @@ let HWEncoding{4-0} = 2;
 
 let isArtificial = false;
 }
+
+def R3_SUB_32_0  : SubRegIndex<32>;
+def R3_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def R3_FULL_64_0    : SubRegIndex<64>;
+
 def R3 : Register<"R3">
 {
 let Namespace = "aarch64temp";
@@ -343,6 +423,11 @@ let HWEncoding{4-0} = 3;
 
 let isArtificial = false;
 }
+
+def R4_SUB_32_0  : SubRegIndex<32>;
+def R4_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def R4_FULL_64_0    : SubRegIndex<64>;
+
 def R4 : Register<"R4">
 {
 let Namespace = "aarch64temp";
@@ -361,6 +446,11 @@ let HWEncoding{4-0} = 4;
 
 let isArtificial = false;
 }
+
+def R5_SUB_32_0  : SubRegIndex<32>;
+def R5_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def R5_FULL_64_0    : SubRegIndex<64>;
+
 def R5 : Register<"R5">
 {
 let Namespace = "aarch64temp";
@@ -379,6 +469,11 @@ let HWEncoding{4-0} = 5;
 
 let isArtificial = false;
 }
+
+def R6_SUB_32_0  : SubRegIndex<32>;
+def R6_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def R6_FULL_64_0    : SubRegIndex<64>;
+
 def R6 : Register<"R6">
 {
 let Namespace = "aarch64temp";
@@ -397,6 +492,11 @@ let HWEncoding{4-0} = 6;
 
 let isArtificial = false;
 }
+
+def R7_SUB_32_0  : SubRegIndex<32>;
+def R7_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def R7_FULL_64_0    : SubRegIndex<64>;
+
 def R7 : Register<"R7">
 {
 let Namespace = "aarch64temp";
@@ -415,6 +515,11 @@ let HWEncoding{4-0} = 7;
 
 let isArtificial = false;
 }
+
+def R8_SUB_32_0  : SubRegIndex<32>;
+def R8_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def R8_FULL_64_0    : SubRegIndex<64>;
+
 def R8 : Register<"R8">
 {
 let Namespace = "aarch64temp";
@@ -433,6 +538,11 @@ let HWEncoding{4-0} = 8;
 
 let isArtificial = false;
 }
+
+def R9_SUB_32_0  : SubRegIndex<32>;
+def R9_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def R9_FULL_64_0    : SubRegIndex<64>;
+
 def R9 : Register<"R9">
 {
 let Namespace = "aarch64temp";
@@ -451,6 +561,11 @@ let HWEncoding{4-0} = 9;
 
 let isArtificial = false;
 }
+
+def R10_SUB_32_0  : SubRegIndex<32>;
+def R10_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def R10_FULL_64_0    : SubRegIndex<64>;
+
 def R10 : Register<"R10">
 {
 let Namespace = "aarch64temp";
@@ -469,6 +584,11 @@ let HWEncoding{4-0} = 10;
 
 let isArtificial = false;
 }
+
+def R11_SUB_32_0  : SubRegIndex<32>;
+def R11_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def R11_FULL_64_0    : SubRegIndex<64>;
+
 def R11 : Register<"R11">
 {
 let Namespace = "aarch64temp";
@@ -487,6 +607,11 @@ let HWEncoding{4-0} = 11;
 
 let isArtificial = false;
 }
+
+def R12_SUB_32_0  : SubRegIndex<32>;
+def R12_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def R12_FULL_64_0    : SubRegIndex<64>;
+
 def R12 : Register<"R12">
 {
 let Namespace = "aarch64temp";
@@ -505,6 +630,11 @@ let HWEncoding{4-0} = 12;
 
 let isArtificial = false;
 }
+
+def R13_SUB_32_0  : SubRegIndex<32>;
+def R13_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def R13_FULL_64_0    : SubRegIndex<64>;
+
 def R13 : Register<"R13">
 {
 let Namespace = "aarch64temp";
@@ -523,6 +653,11 @@ let HWEncoding{4-0} = 13;
 
 let isArtificial = false;
 }
+
+def R14_SUB_32_0  : SubRegIndex<32>;
+def R14_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def R14_FULL_64_0    : SubRegIndex<64>;
+
 def R14 : Register<"R14">
 {
 let Namespace = "aarch64temp";
@@ -541,6 +676,11 @@ let HWEncoding{4-0} = 14;
 
 let isArtificial = false;
 }
+
+def R15_SUB_32_0  : SubRegIndex<32>;
+def R15_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def R15_FULL_64_0    : SubRegIndex<64>;
+
 def R15 : Register<"R15">
 {
 let Namespace = "aarch64temp";
@@ -559,6 +699,11 @@ let HWEncoding{4-0} = 15;
 
 let isArtificial = false;
 }
+
+def R16_SUB_32_0  : SubRegIndex<32>;
+def R16_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def R16_FULL_64_0    : SubRegIndex<64>;
+
 def R16 : Register<"R16">
 {
 let Namespace = "aarch64temp";
@@ -577,6 +722,11 @@ let HWEncoding{4-0} = 16;
 
 let isArtificial = false;
 }
+
+def R17_SUB_32_0  : SubRegIndex<32>;
+def R17_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def R17_FULL_64_0    : SubRegIndex<64>;
+
 def R17 : Register<"R17">
 {
 let Namespace = "aarch64temp";
@@ -595,6 +745,11 @@ let HWEncoding{4-0} = 17;
 
 let isArtificial = false;
 }
+
+def R18_SUB_32_0  : SubRegIndex<32>;
+def R18_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def R18_FULL_64_0    : SubRegIndex<64>;
+
 def R18 : Register<"R18">
 {
 let Namespace = "aarch64temp";
@@ -613,6 +768,11 @@ let HWEncoding{4-0} = 18;
 
 let isArtificial = false;
 }
+
+def R19_SUB_32_0  : SubRegIndex<32>;
+def R19_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def R19_FULL_64_0    : SubRegIndex<64>;
+
 def R19 : Register<"R19">
 {
 let Namespace = "aarch64temp";
@@ -631,6 +791,11 @@ let HWEncoding{4-0} = 19;
 
 let isArtificial = false;
 }
+
+def R20_SUB_32_0  : SubRegIndex<32>;
+def R20_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def R20_FULL_64_0    : SubRegIndex<64>;
+
 def R20 : Register<"R20">
 {
 let Namespace = "aarch64temp";
@@ -649,6 +814,11 @@ let HWEncoding{4-0} = 20;
 
 let isArtificial = false;
 }
+
+def R21_SUB_32_0  : SubRegIndex<32>;
+def R21_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def R21_FULL_64_0    : SubRegIndex<64>;
+
 def R21 : Register<"R21">
 {
 let Namespace = "aarch64temp";
@@ -667,6 +837,11 @@ let HWEncoding{4-0} = 21;
 
 let isArtificial = false;
 }
+
+def R22_SUB_32_0  : SubRegIndex<32>;
+def R22_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def R22_FULL_64_0    : SubRegIndex<64>;
+
 def R22 : Register<"R22">
 {
 let Namespace = "aarch64temp";
@@ -685,6 +860,11 @@ let HWEncoding{4-0} = 22;
 
 let isArtificial = false;
 }
+
+def R23_SUB_32_0  : SubRegIndex<32>;
+def R23_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def R23_FULL_64_0    : SubRegIndex<64>;
+
 def R23 : Register<"R23">
 {
 let Namespace = "aarch64temp";
@@ -703,6 +883,11 @@ let HWEncoding{4-0} = 23;
 
 let isArtificial = false;
 }
+
+def R24_SUB_32_0  : SubRegIndex<32>;
+def R24_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def R24_FULL_64_0    : SubRegIndex<64>;
+
 def R24 : Register<"R24">
 {
 let Namespace = "aarch64temp";
@@ -721,6 +906,11 @@ let HWEncoding{4-0} = 24;
 
 let isArtificial = false;
 }
+
+def R25_SUB_32_0  : SubRegIndex<32>;
+def R25_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def R25_FULL_64_0    : SubRegIndex<64>;
+
 def R25 : Register<"R25">
 {
 let Namespace = "aarch64temp";
@@ -739,6 +929,11 @@ let HWEncoding{4-0} = 25;
 
 let isArtificial = false;
 }
+
+def R26_SUB_32_0  : SubRegIndex<32>;
+def R26_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def R26_FULL_64_0    : SubRegIndex<64>;
+
 def R26 : Register<"R26">
 {
 let Namespace = "aarch64temp";
@@ -757,6 +952,11 @@ let HWEncoding{4-0} = 26;
 
 let isArtificial = false;
 }
+
+def R27_SUB_32_0  : SubRegIndex<32>;
+def R27_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def R27_FULL_64_0    : SubRegIndex<64>;
+
 def R27 : Register<"R27">
 {
 let Namespace = "aarch64temp";
@@ -775,6 +975,11 @@ let HWEncoding{4-0} = 27;
 
 let isArtificial = false;
 }
+
+def R28_SUB_32_0  : SubRegIndex<32>;
+def R28_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def R28_FULL_64_0    : SubRegIndex<64>;
+
 def R28 : Register<"R28">
 {
 let Namespace = "aarch64temp";
@@ -793,6 +998,11 @@ let HWEncoding{4-0} = 28;
 
 let isArtificial = false;
 }
+
+def R29_SUB_32_0  : SubRegIndex<32>;
+def R29_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def R29_FULL_64_0    : SubRegIndex<64>;
+
 def R29 : Register<"R29">
 {
 let Namespace = "aarch64temp";
@@ -811,6 +1021,11 @@ let HWEncoding{4-0} = 29;
 
 let isArtificial = false;
 }
+
+def R30_SUB_32_0  : SubRegIndex<32>;
+def R30_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def R30_FULL_64_0    : SubRegIndex<64>;
+
 def R30 : Register<"R30">
 {
 let Namespace = "aarch64temp";
@@ -829,6 +1044,11 @@ let HWEncoding{4-0} = 30;
 
 let isArtificial = false;
 }
+
+def R31_SUB_32_0  : SubRegIndex<32>;
+def R31_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def R31_FULL_64_0    : SubRegIndex<64>;
+
 def R31 : Register<"R31">
 {
 let Namespace = "aarch64temp";
@@ -847,6 +1067,11 @@ let HWEncoding{4-0} = 31;
 
 let isArtificial = false;
 }
+
+def X0_SUB_32_0  : SubRegIndex<32>;
+def X0_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def X0_FULL_64_0    : SubRegIndex<64>;
+
 def X0 : Register<"X0">
 {
 let Namespace = "aarch64temp";
@@ -865,6 +1090,11 @@ let HWEncoding{4-0} = 0;
 
 let isArtificial = false;
 }
+
+def X1_SUB_32_0  : SubRegIndex<32>;
+def X1_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def X1_FULL_64_0    : SubRegIndex<64>;
+
 def X1 : Register<"X1">
 {
 let Namespace = "aarch64temp";
@@ -883,6 +1113,11 @@ let HWEncoding{4-0} = 1;
 
 let isArtificial = false;
 }
+
+def X2_SUB_32_0  : SubRegIndex<32>;
+def X2_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def X2_FULL_64_0    : SubRegIndex<64>;
+
 def X2 : Register<"X2">
 {
 let Namespace = "aarch64temp";
@@ -901,6 +1136,11 @@ let HWEncoding{4-0} = 2;
 
 let isArtificial = false;
 }
+
+def X3_SUB_32_0  : SubRegIndex<32>;
+def X3_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def X3_FULL_64_0    : SubRegIndex<64>;
+
 def X3 : Register<"X3">
 {
 let Namespace = "aarch64temp";
@@ -919,6 +1159,11 @@ let HWEncoding{4-0} = 3;
 
 let isArtificial = false;
 }
+
+def X4_SUB_32_0  : SubRegIndex<32>;
+def X4_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def X4_FULL_64_0    : SubRegIndex<64>;
+
 def X4 : Register<"X4">
 {
 let Namespace = "aarch64temp";
@@ -937,6 +1182,11 @@ let HWEncoding{4-0} = 4;
 
 let isArtificial = false;
 }
+
+def X5_SUB_32_0  : SubRegIndex<32>;
+def X5_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def X5_FULL_64_0    : SubRegIndex<64>;
+
 def X5 : Register<"X5">
 {
 let Namespace = "aarch64temp";
@@ -955,6 +1205,11 @@ let HWEncoding{4-0} = 5;
 
 let isArtificial = false;
 }
+
+def X6_SUB_32_0  : SubRegIndex<32>;
+def X6_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def X6_FULL_64_0    : SubRegIndex<64>;
+
 def X6 : Register<"X6">
 {
 let Namespace = "aarch64temp";
@@ -973,6 +1228,11 @@ let HWEncoding{4-0} = 6;
 
 let isArtificial = false;
 }
+
+def X7_SUB_32_0  : SubRegIndex<32>;
+def X7_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def X7_FULL_64_0    : SubRegIndex<64>;
+
 def X7 : Register<"X7">
 {
 let Namespace = "aarch64temp";
@@ -991,6 +1251,11 @@ let HWEncoding{4-0} = 7;
 
 let isArtificial = false;
 }
+
+def X8_SUB_32_0  : SubRegIndex<32>;
+def X8_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def X8_FULL_64_0    : SubRegIndex<64>;
+
 def X8 : Register<"X8">
 {
 let Namespace = "aarch64temp";
@@ -1009,6 +1274,11 @@ let HWEncoding{4-0} = 8;
 
 let isArtificial = false;
 }
+
+def X9_SUB_32_0  : SubRegIndex<32>;
+def X9_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def X9_FULL_64_0    : SubRegIndex<64>;
+
 def X9 : Register<"X9">
 {
 let Namespace = "aarch64temp";
@@ -1027,6 +1297,11 @@ let HWEncoding{4-0} = 9;
 
 let isArtificial = false;
 }
+
+def X10_SUB_32_0  : SubRegIndex<32>;
+def X10_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def X10_FULL_64_0    : SubRegIndex<64>;
+
 def X10 : Register<"X10">
 {
 let Namespace = "aarch64temp";
@@ -1045,6 +1320,11 @@ let HWEncoding{4-0} = 10;
 
 let isArtificial = false;
 }
+
+def X11_SUB_32_0  : SubRegIndex<32>;
+def X11_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def X11_FULL_64_0    : SubRegIndex<64>;
+
 def X11 : Register<"X11">
 {
 let Namespace = "aarch64temp";
@@ -1063,6 +1343,11 @@ let HWEncoding{4-0} = 11;
 
 let isArtificial = false;
 }
+
+def X12_SUB_32_0  : SubRegIndex<32>;
+def X12_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def X12_FULL_64_0    : SubRegIndex<64>;
+
 def X12 : Register<"X12">
 {
 let Namespace = "aarch64temp";
@@ -1081,6 +1366,11 @@ let HWEncoding{4-0} = 12;
 
 let isArtificial = false;
 }
+
+def X13_SUB_32_0  : SubRegIndex<32>;
+def X13_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def X13_FULL_64_0    : SubRegIndex<64>;
+
 def X13 : Register<"X13">
 {
 let Namespace = "aarch64temp";
@@ -1099,6 +1389,11 @@ let HWEncoding{4-0} = 13;
 
 let isArtificial = false;
 }
+
+def X14_SUB_32_0  : SubRegIndex<32>;
+def X14_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def X14_FULL_64_0    : SubRegIndex<64>;
+
 def X14 : Register<"X14">
 {
 let Namespace = "aarch64temp";
@@ -1117,6 +1412,11 @@ let HWEncoding{4-0} = 14;
 
 let isArtificial = false;
 }
+
+def X15_SUB_32_0  : SubRegIndex<32>;
+def X15_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def X15_FULL_64_0    : SubRegIndex<64>;
+
 def X15 : Register<"X15">
 {
 let Namespace = "aarch64temp";
@@ -1135,6 +1435,11 @@ let HWEncoding{4-0} = 15;
 
 let isArtificial = false;
 }
+
+def X16_SUB_32_0  : SubRegIndex<32>;
+def X16_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def X16_FULL_64_0    : SubRegIndex<64>;
+
 def X16 : Register<"X16">
 {
 let Namespace = "aarch64temp";
@@ -1153,6 +1458,11 @@ let HWEncoding{4-0} = 16;
 
 let isArtificial = false;
 }
+
+def X17_SUB_32_0  : SubRegIndex<32>;
+def X17_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def X17_FULL_64_0    : SubRegIndex<64>;
+
 def X17 : Register<"X17">
 {
 let Namespace = "aarch64temp";
@@ -1171,6 +1481,11 @@ let HWEncoding{4-0} = 17;
 
 let isArtificial = false;
 }
+
+def X18_SUB_32_0  : SubRegIndex<32>;
+def X18_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def X18_FULL_64_0    : SubRegIndex<64>;
+
 def X18 : Register<"X18">
 {
 let Namespace = "aarch64temp";
@@ -1189,6 +1504,11 @@ let HWEncoding{4-0} = 18;
 
 let isArtificial = false;
 }
+
+def X19_SUB_32_0  : SubRegIndex<32>;
+def X19_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def X19_FULL_64_0    : SubRegIndex<64>;
+
 def X19 : Register<"X19">
 {
 let Namespace = "aarch64temp";
@@ -1207,6 +1527,11 @@ let HWEncoding{4-0} = 19;
 
 let isArtificial = false;
 }
+
+def X20_SUB_32_0  : SubRegIndex<32>;
+def X20_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def X20_FULL_64_0    : SubRegIndex<64>;
+
 def X20 : Register<"X20">
 {
 let Namespace = "aarch64temp";
@@ -1225,6 +1550,11 @@ let HWEncoding{4-0} = 20;
 
 let isArtificial = false;
 }
+
+def X21_SUB_32_0  : SubRegIndex<32>;
+def X21_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def X21_FULL_64_0    : SubRegIndex<64>;
+
 def X21 : Register<"X21">
 {
 let Namespace = "aarch64temp";
@@ -1243,6 +1573,11 @@ let HWEncoding{4-0} = 21;
 
 let isArtificial = false;
 }
+
+def X22_SUB_32_0  : SubRegIndex<32>;
+def X22_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def X22_FULL_64_0    : SubRegIndex<64>;
+
 def X22 : Register<"X22">
 {
 let Namespace = "aarch64temp";
@@ -1261,6 +1596,11 @@ let HWEncoding{4-0} = 22;
 
 let isArtificial = false;
 }
+
+def X23_SUB_32_0  : SubRegIndex<32>;
+def X23_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def X23_FULL_64_0    : SubRegIndex<64>;
+
 def X23 : Register<"X23">
 {
 let Namespace = "aarch64temp";
@@ -1279,6 +1619,11 @@ let HWEncoding{4-0} = 23;
 
 let isArtificial = false;
 }
+
+def X24_SUB_32_0  : SubRegIndex<32>;
+def X24_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def X24_FULL_64_0    : SubRegIndex<64>;
+
 def X24 : Register<"X24">
 {
 let Namespace = "aarch64temp";
@@ -1297,6 +1642,11 @@ let HWEncoding{4-0} = 24;
 
 let isArtificial = false;
 }
+
+def X25_SUB_32_0  : SubRegIndex<32>;
+def X25_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def X25_FULL_64_0    : SubRegIndex<64>;
+
 def X25 : Register<"X25">
 {
 let Namespace = "aarch64temp";
@@ -1315,6 +1665,11 @@ let HWEncoding{4-0} = 25;
 
 let isArtificial = false;
 }
+
+def X26_SUB_32_0  : SubRegIndex<32>;
+def X26_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def X26_FULL_64_0    : SubRegIndex<64>;
+
 def X26 : Register<"X26">
 {
 let Namespace = "aarch64temp";
@@ -1333,6 +1688,11 @@ let HWEncoding{4-0} = 26;
 
 let isArtificial = false;
 }
+
+def X27_SUB_32_0  : SubRegIndex<32>;
+def X27_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def X27_FULL_64_0    : SubRegIndex<64>;
+
 def X27 : Register<"X27">
 {
 let Namespace = "aarch64temp";
@@ -1351,6 +1711,11 @@ let HWEncoding{4-0} = 27;
 
 let isArtificial = false;
 }
+
+def X28_SUB_32_0  : SubRegIndex<32>;
+def X28_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def X28_FULL_64_0    : SubRegIndex<64>;
+
 def X28 : Register<"X28">
 {
 let Namespace = "aarch64temp";
@@ -1369,6 +1734,11 @@ let HWEncoding{4-0} = 28;
 
 let isArtificial = false;
 }
+
+def X29_SUB_32_0  : SubRegIndex<32>;
+def X29_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def X29_FULL_64_0    : SubRegIndex<64>;
+
 def X29 : Register<"X29">
 {
 let Namespace = "aarch64temp";
@@ -1387,6 +1757,11 @@ let HWEncoding{4-0} = 29;
 
 let isArtificial = false;
 }
+
+def X30_SUB_32_0  : SubRegIndex<32>;
+def X30_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def X30_FULL_64_0    : SubRegIndex<64>;
+
 def X30 : Register<"X30">
 {
 let Namespace = "aarch64temp";
@@ -1405,6 +1780,11 @@ let HWEncoding{4-0} = 30;
 
 let isArtificial = false;
 }
+
+def X31_SUB_32_0  : SubRegIndex<32>;
+def X31_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def X31_FULL_64_0    : SubRegIndex<64>;
+
 def X31 : Register<"X31">
 {
 let Namespace = "aarch64temp";
@@ -1423,6 +1803,11 @@ let HWEncoding{4-0} = 31;
 
 let isArtificial = false;
 }
+
+def W0_SUB_32_0  : SubRegIndex<32>;
+def W0_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def W0_FULL_64_0    : SubRegIndex<64>;
+
 def W0 : Register<"W0">
 {
 let Namespace = "aarch64temp";
@@ -1441,6 +1826,11 @@ let HWEncoding{4-0} = 0;
 
 let isArtificial = false;
 }
+
+def W1_SUB_32_0  : SubRegIndex<32>;
+def W1_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def W1_FULL_64_0    : SubRegIndex<64>;
+
 def W1 : Register<"W1">
 {
 let Namespace = "aarch64temp";
@@ -1459,6 +1849,11 @@ let HWEncoding{4-0} = 1;
 
 let isArtificial = false;
 }
+
+def W2_SUB_32_0  : SubRegIndex<32>;
+def W2_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def W2_FULL_64_0    : SubRegIndex<64>;
+
 def W2 : Register<"W2">
 {
 let Namespace = "aarch64temp";
@@ -1477,6 +1872,11 @@ let HWEncoding{4-0} = 2;
 
 let isArtificial = false;
 }
+
+def W3_SUB_32_0  : SubRegIndex<32>;
+def W3_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def W3_FULL_64_0    : SubRegIndex<64>;
+
 def W3 : Register<"W3">
 {
 let Namespace = "aarch64temp";
@@ -1495,6 +1895,11 @@ let HWEncoding{4-0} = 3;
 
 let isArtificial = false;
 }
+
+def W4_SUB_32_0  : SubRegIndex<32>;
+def W4_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def W4_FULL_64_0    : SubRegIndex<64>;
+
 def W4 : Register<"W4">
 {
 let Namespace = "aarch64temp";
@@ -1513,6 +1918,11 @@ let HWEncoding{4-0} = 4;
 
 let isArtificial = false;
 }
+
+def W5_SUB_32_0  : SubRegIndex<32>;
+def W5_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def W5_FULL_64_0    : SubRegIndex<64>;
+
 def W5 : Register<"W5">
 {
 let Namespace = "aarch64temp";
@@ -1531,6 +1941,11 @@ let HWEncoding{4-0} = 5;
 
 let isArtificial = false;
 }
+
+def W6_SUB_32_0  : SubRegIndex<32>;
+def W6_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def W6_FULL_64_0    : SubRegIndex<64>;
+
 def W6 : Register<"W6">
 {
 let Namespace = "aarch64temp";
@@ -1549,6 +1964,11 @@ let HWEncoding{4-0} = 6;
 
 let isArtificial = false;
 }
+
+def W7_SUB_32_0  : SubRegIndex<32>;
+def W7_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def W7_FULL_64_0    : SubRegIndex<64>;
+
 def W7 : Register<"W7">
 {
 let Namespace = "aarch64temp";
@@ -1567,6 +1987,11 @@ let HWEncoding{4-0} = 7;
 
 let isArtificial = false;
 }
+
+def W8_SUB_32_0  : SubRegIndex<32>;
+def W8_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def W8_FULL_64_0    : SubRegIndex<64>;
+
 def W8 : Register<"W8">
 {
 let Namespace = "aarch64temp";
@@ -1585,6 +2010,11 @@ let HWEncoding{4-0} = 8;
 
 let isArtificial = false;
 }
+
+def W9_SUB_32_0  : SubRegIndex<32>;
+def W9_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def W9_FULL_64_0    : SubRegIndex<64>;
+
 def W9 : Register<"W9">
 {
 let Namespace = "aarch64temp";
@@ -1603,6 +2033,11 @@ let HWEncoding{4-0} = 9;
 
 let isArtificial = false;
 }
+
+def W10_SUB_32_0  : SubRegIndex<32>;
+def W10_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def W10_FULL_64_0    : SubRegIndex<64>;
+
 def W10 : Register<"W10">
 {
 let Namespace = "aarch64temp";
@@ -1621,6 +2056,11 @@ let HWEncoding{4-0} = 10;
 
 let isArtificial = false;
 }
+
+def W11_SUB_32_0  : SubRegIndex<32>;
+def W11_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def W11_FULL_64_0    : SubRegIndex<64>;
+
 def W11 : Register<"W11">
 {
 let Namespace = "aarch64temp";
@@ -1639,6 +2079,11 @@ let HWEncoding{4-0} = 11;
 
 let isArtificial = false;
 }
+
+def W12_SUB_32_0  : SubRegIndex<32>;
+def W12_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def W12_FULL_64_0    : SubRegIndex<64>;
+
 def W12 : Register<"W12">
 {
 let Namespace = "aarch64temp";
@@ -1657,6 +2102,11 @@ let HWEncoding{4-0} = 12;
 
 let isArtificial = false;
 }
+
+def W13_SUB_32_0  : SubRegIndex<32>;
+def W13_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def W13_FULL_64_0    : SubRegIndex<64>;
+
 def W13 : Register<"W13">
 {
 let Namespace = "aarch64temp";
@@ -1675,6 +2125,11 @@ let HWEncoding{4-0} = 13;
 
 let isArtificial = false;
 }
+
+def W14_SUB_32_0  : SubRegIndex<32>;
+def W14_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def W14_FULL_64_0    : SubRegIndex<64>;
+
 def W14 : Register<"W14">
 {
 let Namespace = "aarch64temp";
@@ -1693,6 +2148,11 @@ let HWEncoding{4-0} = 14;
 
 let isArtificial = false;
 }
+
+def W15_SUB_32_0  : SubRegIndex<32>;
+def W15_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def W15_FULL_64_0    : SubRegIndex<64>;
+
 def W15 : Register<"W15">
 {
 let Namespace = "aarch64temp";
@@ -1711,6 +2171,11 @@ let HWEncoding{4-0} = 15;
 
 let isArtificial = false;
 }
+
+def W16_SUB_32_0  : SubRegIndex<32>;
+def W16_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def W16_FULL_64_0    : SubRegIndex<64>;
+
 def W16 : Register<"W16">
 {
 let Namespace = "aarch64temp";
@@ -1729,6 +2194,11 @@ let HWEncoding{4-0} = 16;
 
 let isArtificial = false;
 }
+
+def W17_SUB_32_0  : SubRegIndex<32>;
+def W17_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def W17_FULL_64_0    : SubRegIndex<64>;
+
 def W17 : Register<"W17">
 {
 let Namespace = "aarch64temp";
@@ -1747,6 +2217,11 @@ let HWEncoding{4-0} = 17;
 
 let isArtificial = false;
 }
+
+def W18_SUB_32_0  : SubRegIndex<32>;
+def W18_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def W18_FULL_64_0    : SubRegIndex<64>;
+
 def W18 : Register<"W18">
 {
 let Namespace = "aarch64temp";
@@ -1765,6 +2240,11 @@ let HWEncoding{4-0} = 18;
 
 let isArtificial = false;
 }
+
+def W19_SUB_32_0  : SubRegIndex<32>;
+def W19_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def W19_FULL_64_0    : SubRegIndex<64>;
+
 def W19 : Register<"W19">
 {
 let Namespace = "aarch64temp";
@@ -1783,6 +2263,11 @@ let HWEncoding{4-0} = 19;
 
 let isArtificial = false;
 }
+
+def W20_SUB_32_0  : SubRegIndex<32>;
+def W20_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def W20_FULL_64_0    : SubRegIndex<64>;
+
 def W20 : Register<"W20">
 {
 let Namespace = "aarch64temp";
@@ -1801,6 +2286,11 @@ let HWEncoding{4-0} = 20;
 
 let isArtificial = false;
 }
+
+def W21_SUB_32_0  : SubRegIndex<32>;
+def W21_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def W21_FULL_64_0    : SubRegIndex<64>;
+
 def W21 : Register<"W21">
 {
 let Namespace = "aarch64temp";
@@ -1819,6 +2309,11 @@ let HWEncoding{4-0} = 21;
 
 let isArtificial = false;
 }
+
+def W22_SUB_32_0  : SubRegIndex<32>;
+def W22_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def W22_FULL_64_0    : SubRegIndex<64>;
+
 def W22 : Register<"W22">
 {
 let Namespace = "aarch64temp";
@@ -1837,6 +2332,11 @@ let HWEncoding{4-0} = 22;
 
 let isArtificial = false;
 }
+
+def W23_SUB_32_0  : SubRegIndex<32>;
+def W23_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def W23_FULL_64_0    : SubRegIndex<64>;
+
 def W23 : Register<"W23">
 {
 let Namespace = "aarch64temp";
@@ -1855,6 +2355,11 @@ let HWEncoding{4-0} = 23;
 
 let isArtificial = false;
 }
+
+def W24_SUB_32_0  : SubRegIndex<32>;
+def W24_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def W24_FULL_64_0    : SubRegIndex<64>;
+
 def W24 : Register<"W24">
 {
 let Namespace = "aarch64temp";
@@ -1873,6 +2378,11 @@ let HWEncoding{4-0} = 24;
 
 let isArtificial = false;
 }
+
+def W25_SUB_32_0  : SubRegIndex<32>;
+def W25_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def W25_FULL_64_0    : SubRegIndex<64>;
+
 def W25 : Register<"W25">
 {
 let Namespace = "aarch64temp";
@@ -1891,6 +2401,11 @@ let HWEncoding{4-0} = 25;
 
 let isArtificial = false;
 }
+
+def W26_SUB_32_0  : SubRegIndex<32>;
+def W26_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def W26_FULL_64_0    : SubRegIndex<64>;
+
 def W26 : Register<"W26">
 {
 let Namespace = "aarch64temp";
@@ -1909,6 +2424,11 @@ let HWEncoding{4-0} = 26;
 
 let isArtificial = false;
 }
+
+def W27_SUB_32_0  : SubRegIndex<32>;
+def W27_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def W27_FULL_64_0    : SubRegIndex<64>;
+
 def W27 : Register<"W27">
 {
 let Namespace = "aarch64temp";
@@ -1927,6 +2447,11 @@ let HWEncoding{4-0} = 27;
 
 let isArtificial = false;
 }
+
+def W28_SUB_32_0  : SubRegIndex<32>;
+def W28_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def W28_FULL_64_0    : SubRegIndex<64>;
+
 def W28 : Register<"W28">
 {
 let Namespace = "aarch64temp";
@@ -1945,6 +2470,11 @@ let HWEncoding{4-0} = 28;
 
 let isArtificial = false;
 }
+
+def W29_SUB_32_0  : SubRegIndex<32>;
+def W29_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def W29_FULL_64_0    : SubRegIndex<64>;
+
 def W29 : Register<"W29">
 {
 let Namespace = "aarch64temp";
@@ -1963,6 +2493,11 @@ let HWEncoding{4-0} = 29;
 
 let isArtificial = false;
 }
+
+def W30_SUB_32_0  : SubRegIndex<32>;
+def W30_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def W30_FULL_64_0    : SubRegIndex<64>;
+
 def W30 : Register<"W30">
 {
 let Namespace = "aarch64temp";
@@ -1981,6 +2516,11 @@ let HWEncoding{4-0} = 30;
 
 let isArtificial = false;
 }
+
+def W31_SUB_32_0  : SubRegIndex<32>;
+def W31_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def W31_FULL_64_0    : SubRegIndex<64>;
+
 def W31 : Register<"W31">
 {
 let Namespace = "aarch64temp";
@@ -1999,6 +2539,14 @@ let HWEncoding{4-0} = 31;
 
 let isArtificial = false;
 }
+
+def S0_SUB_32_0  : SubRegIndex<32>;
+def S0_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def S0_FULL_64_0    : SubRegIndex<64>;
+def S0_SUB_32_1  : SubRegIndex<32>;
+def S0_SUB_32_HI_1 : SubRegIndex<32, 32>;
+def S0_FULL_64_1    : SubRegIndex<64>;
+
 def S0 : Register<"S0">
 {
 let Namespace = "aarch64temp";
@@ -2006,7 +2554,7 @@ let AsmName = "X0";
 let AltNames = [ "X0"  ];
 let Aliases = [ ];
 let SubRegs = [ R0, X0, W0 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
+let SubRegIndices = [ S0_SUB_32_0, S0_FULL_64_0, S0_SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 15 ];
 list<int> CostPerUse = [0];
@@ -2017,6 +2565,14 @@ let HWEncoding{4-0} = 0;
 
 let isArtificial = false;
 }
+
+def S1_SUB_32_0  : SubRegIndex<32>;
+def S1_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def S1_FULL_64_0    : SubRegIndex<64>;
+def S1_SUB_32_1  : SubRegIndex<32>;
+def S1_SUB_32_HI_1 : SubRegIndex<32, 32>;
+def S1_FULL_64_1    : SubRegIndex<64>;
+
 def S1 : Register<"S1">
 {
 let Namespace = "aarch64temp";
@@ -2024,7 +2580,7 @@ let AsmName = "X1";
 let AltNames = [ "X1"  ];
 let Aliases = [ ];
 let SubRegs = [ R1, X1, W1 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
+let SubRegIndices = [ S1_SUB_32_0, S1_FULL_64_0, S1_SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 16 ];
 list<int> CostPerUse = [0];
@@ -2035,6 +2591,14 @@ let HWEncoding{4-0} = 1;
 
 let isArtificial = false;
 }
+
+def S2_SUB_32_0  : SubRegIndex<32>;
+def S2_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def S2_FULL_64_0    : SubRegIndex<64>;
+def S2_SUB_32_1  : SubRegIndex<32>;
+def S2_SUB_32_HI_1 : SubRegIndex<32, 32>;
+def S2_FULL_64_1    : SubRegIndex<64>;
+
 def S2 : Register<"S2">
 {
 let Namespace = "aarch64temp";
@@ -2042,7 +2606,7 @@ let AsmName = "X2";
 let AltNames = [ "X2"  ];
 let Aliases = [ ];
 let SubRegs = [ R2, X2, W2 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
+let SubRegIndices = [ S2_SUB_32_0, S2_FULL_64_0, S2_SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 17 ];
 list<int> CostPerUse = [0];
@@ -2053,6 +2617,14 @@ let HWEncoding{4-0} = 2;
 
 let isArtificial = false;
 }
+
+def S3_SUB_32_0  : SubRegIndex<32>;
+def S3_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def S3_FULL_64_0    : SubRegIndex<64>;
+def S3_SUB_32_1  : SubRegIndex<32>;
+def S3_SUB_32_HI_1 : SubRegIndex<32, 32>;
+def S3_FULL_64_1    : SubRegIndex<64>;
+
 def S3 : Register<"S3">
 {
 let Namespace = "aarch64temp";
@@ -2060,7 +2632,7 @@ let AsmName = "X3";
 let AltNames = [ "X3"  ];
 let Aliases = [ ];
 let SubRegs = [ R3, X3, W3 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
+let SubRegIndices = [ S3_SUB_32_0, S3_FULL_64_0, S3_SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 18 ];
 list<int> CostPerUse = [0];
@@ -2071,6 +2643,14 @@ let HWEncoding{4-0} = 3;
 
 let isArtificial = false;
 }
+
+def S4_SUB_32_0  : SubRegIndex<32>;
+def S4_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def S4_FULL_64_0    : SubRegIndex<64>;
+def S4_SUB_32_1  : SubRegIndex<32>;
+def S4_SUB_32_HI_1 : SubRegIndex<32, 32>;
+def S4_FULL_64_1    : SubRegIndex<64>;
+
 def S4 : Register<"S4">
 {
 let Namespace = "aarch64temp";
@@ -2078,7 +2658,7 @@ let AsmName = "X4";
 let AltNames = [ "X4"  ];
 let Aliases = [ ];
 let SubRegs = [ R4, X4, W4 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
+let SubRegIndices = [ S4_SUB_32_0, S4_FULL_64_0, S4_SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 19 ];
 list<int> CostPerUse = [0];
@@ -2089,6 +2669,14 @@ let HWEncoding{4-0} = 4;
 
 let isArtificial = false;
 }
+
+def S5_SUB_32_0  : SubRegIndex<32>;
+def S5_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def S5_FULL_64_0    : SubRegIndex<64>;
+def S5_SUB_32_1  : SubRegIndex<32>;
+def S5_SUB_32_HI_1 : SubRegIndex<32, 32>;
+def S5_FULL_64_1    : SubRegIndex<64>;
+
 def S5 : Register<"S5">
 {
 let Namespace = "aarch64temp";
@@ -2096,7 +2684,7 @@ let AsmName = "X5";
 let AltNames = [ "X5"  ];
 let Aliases = [ ];
 let SubRegs = [ R5, X5, W5 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
+let SubRegIndices = [ S5_SUB_32_0, S5_FULL_64_0, S5_SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 20 ];
 list<int> CostPerUse = [0];
@@ -2107,6 +2695,14 @@ let HWEncoding{4-0} = 5;
 
 let isArtificial = false;
 }
+
+def S6_SUB_32_0  : SubRegIndex<32>;
+def S6_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def S6_FULL_64_0    : SubRegIndex<64>;
+def S6_SUB_32_1  : SubRegIndex<32>;
+def S6_SUB_32_HI_1 : SubRegIndex<32, 32>;
+def S6_FULL_64_1    : SubRegIndex<64>;
+
 def S6 : Register<"S6">
 {
 let Namespace = "aarch64temp";
@@ -2114,7 +2710,7 @@ let AsmName = "X6";
 let AltNames = [ "X6"  ];
 let Aliases = [ ];
 let SubRegs = [ R6, X6, W6 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
+let SubRegIndices = [ S6_SUB_32_0, S6_FULL_64_0, S6_SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 21 ];
 list<int> CostPerUse = [0];
@@ -2125,6 +2721,14 @@ let HWEncoding{4-0} = 6;
 
 let isArtificial = false;
 }
+
+def S7_SUB_32_0  : SubRegIndex<32>;
+def S7_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def S7_FULL_64_0    : SubRegIndex<64>;
+def S7_SUB_32_1  : SubRegIndex<32>;
+def S7_SUB_32_HI_1 : SubRegIndex<32, 32>;
+def S7_FULL_64_1    : SubRegIndex<64>;
+
 def S7 : Register<"S7">
 {
 let Namespace = "aarch64temp";
@@ -2132,7 +2736,7 @@ let AsmName = "X7";
 let AltNames = [ "X7"  ];
 let Aliases = [ ];
 let SubRegs = [ R7, X7, W7 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
+let SubRegIndices = [ S7_SUB_32_0, S7_FULL_64_0, S7_SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 22 ];
 list<int> CostPerUse = [0];
@@ -2143,6 +2747,14 @@ let HWEncoding{4-0} = 7;
 
 let isArtificial = false;
 }
+
+def S8_SUB_32_0  : SubRegIndex<32>;
+def S8_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def S8_FULL_64_0    : SubRegIndex<64>;
+def S8_SUB_32_1  : SubRegIndex<32>;
+def S8_SUB_32_HI_1 : SubRegIndex<32, 32>;
+def S8_FULL_64_1    : SubRegIndex<64>;
+
 def S8 : Register<"S8">
 {
 let Namespace = "aarch64temp";
@@ -2150,7 +2762,7 @@ let AsmName = "X8";
 let AltNames = [ "X8"  ];
 let Aliases = [ ];
 let SubRegs = [ R8, X8, W8 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
+let SubRegIndices = [ S8_SUB_32_0, S8_FULL_64_0, S8_SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 23 ];
 list<int> CostPerUse = [0];
@@ -2161,6 +2773,14 @@ let HWEncoding{4-0} = 8;
 
 let isArtificial = false;
 }
+
+def S9_SUB_32_0  : SubRegIndex<32>;
+def S9_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def S9_FULL_64_0    : SubRegIndex<64>;
+def S9_SUB_32_1  : SubRegIndex<32>;
+def S9_SUB_32_HI_1 : SubRegIndex<32, 32>;
+def S9_FULL_64_1    : SubRegIndex<64>;
+
 def S9 : Register<"S9">
 {
 let Namespace = "aarch64temp";
@@ -2168,7 +2788,7 @@ let AsmName = "X9";
 let AltNames = [ "X9"  ];
 let Aliases = [ ];
 let SubRegs = [ R9, X9, W9 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
+let SubRegIndices = [ S9_SUB_32_0, S9_FULL_64_0, S9_SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 24 ];
 list<int> CostPerUse = [0];
@@ -2179,6 +2799,14 @@ let HWEncoding{4-0} = 9;
 
 let isArtificial = false;
 }
+
+def S10_SUB_32_0  : SubRegIndex<32>;
+def S10_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def S10_FULL_64_0    : SubRegIndex<64>;
+def S10_SUB_32_1  : SubRegIndex<32>;
+def S10_SUB_32_HI_1 : SubRegIndex<32, 32>;
+def S10_FULL_64_1    : SubRegIndex<64>;
+
 def S10 : Register<"S10">
 {
 let Namespace = "aarch64temp";
@@ -2186,7 +2814,7 @@ let AsmName = "X10";
 let AltNames = [ "X10"  ];
 let Aliases = [ ];
 let SubRegs = [ R10, X10, W10 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
+let SubRegIndices = [ S10_SUB_32_0, S10_FULL_64_0, S10_SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 25 ];
 list<int> CostPerUse = [0];
@@ -2197,6 +2825,14 @@ let HWEncoding{4-0} = 10;
 
 let isArtificial = false;
 }
+
+def S11_SUB_32_0  : SubRegIndex<32>;
+def S11_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def S11_FULL_64_0    : SubRegIndex<64>;
+def S11_SUB_32_1  : SubRegIndex<32>;
+def S11_SUB_32_HI_1 : SubRegIndex<32, 32>;
+def S11_FULL_64_1    : SubRegIndex<64>;
+
 def S11 : Register<"S11">
 {
 let Namespace = "aarch64temp";
@@ -2204,7 +2840,7 @@ let AsmName = "X11";
 let AltNames = [ "X11"  ];
 let Aliases = [ ];
 let SubRegs = [ R11, X11, W11 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
+let SubRegIndices = [ S11_SUB_32_0, S11_FULL_64_0, S11_SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 26 ];
 list<int> CostPerUse = [0];
@@ -2215,6 +2851,14 @@ let HWEncoding{4-0} = 11;
 
 let isArtificial = false;
 }
+
+def S12_SUB_32_0  : SubRegIndex<32>;
+def S12_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def S12_FULL_64_0    : SubRegIndex<64>;
+def S12_SUB_32_1  : SubRegIndex<32>;
+def S12_SUB_32_HI_1 : SubRegIndex<32, 32>;
+def S12_FULL_64_1    : SubRegIndex<64>;
+
 def S12 : Register<"S12">
 {
 let Namespace = "aarch64temp";
@@ -2222,7 +2866,7 @@ let AsmName = "X12";
 let AltNames = [ "X12"  ];
 let Aliases = [ ];
 let SubRegs = [ R12, X12, W12 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
+let SubRegIndices = [ S12_SUB_32_0, S12_FULL_64_0, S12_SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 27 ];
 list<int> CostPerUse = [0];
@@ -2233,6 +2877,14 @@ let HWEncoding{4-0} = 12;
 
 let isArtificial = false;
 }
+
+def S13_SUB_32_0  : SubRegIndex<32>;
+def S13_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def S13_FULL_64_0    : SubRegIndex<64>;
+def S13_SUB_32_1  : SubRegIndex<32>;
+def S13_SUB_32_HI_1 : SubRegIndex<32, 32>;
+def S13_FULL_64_1    : SubRegIndex<64>;
+
 def S13 : Register<"S13">
 {
 let Namespace = "aarch64temp";
@@ -2240,7 +2892,7 @@ let AsmName = "X13";
 let AltNames = [ "X13"  ];
 let Aliases = [ ];
 let SubRegs = [ R13, X13, W13 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
+let SubRegIndices = [ S13_SUB_32_0, S13_FULL_64_0, S13_SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 28 ];
 list<int> CostPerUse = [0];
@@ -2251,6 +2903,14 @@ let HWEncoding{4-0} = 13;
 
 let isArtificial = false;
 }
+
+def S14_SUB_32_0  : SubRegIndex<32>;
+def S14_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def S14_FULL_64_0    : SubRegIndex<64>;
+def S14_SUB_32_1  : SubRegIndex<32>;
+def S14_SUB_32_HI_1 : SubRegIndex<32, 32>;
+def S14_FULL_64_1    : SubRegIndex<64>;
+
 def S14 : Register<"S14">
 {
 let Namespace = "aarch64temp";
@@ -2258,7 +2918,7 @@ let AsmName = "X14";
 let AltNames = [ "X14"  ];
 let Aliases = [ ];
 let SubRegs = [ R14, X14, W14 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
+let SubRegIndices = [ S14_SUB_32_0, S14_FULL_64_0, S14_SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 29 ];
 list<int> CostPerUse = [0];
@@ -2269,6 +2929,14 @@ let HWEncoding{4-0} = 14;
 
 let isArtificial = false;
 }
+
+def S15_SUB_32_0  : SubRegIndex<32>;
+def S15_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def S15_FULL_64_0    : SubRegIndex<64>;
+def S15_SUB_32_1  : SubRegIndex<32>;
+def S15_SUB_32_HI_1 : SubRegIndex<32, 32>;
+def S15_FULL_64_1    : SubRegIndex<64>;
+
 def S15 : Register<"S15">
 {
 let Namespace = "aarch64temp";
@@ -2276,7 +2944,7 @@ let AsmName = "X15";
 let AltNames = [ "X15"  ];
 let Aliases = [ ];
 let SubRegs = [ R15, X15, W15 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
+let SubRegIndices = [ S15_SUB_32_0, S15_FULL_64_0, S15_SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 30 ];
 list<int> CostPerUse = [0];
@@ -2287,6 +2955,14 @@ let HWEncoding{4-0} = 15;
 
 let isArtificial = false;
 }
+
+def S16_SUB_32_0  : SubRegIndex<32>;
+def S16_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def S16_FULL_64_0    : SubRegIndex<64>;
+def S16_SUB_32_1  : SubRegIndex<32>;
+def S16_SUB_32_HI_1 : SubRegIndex<32, 32>;
+def S16_FULL_64_1    : SubRegIndex<64>;
+
 def S16 : Register<"S16">
 {
 let Namespace = "aarch64temp";
@@ -2294,7 +2970,7 @@ let AsmName = "X16";
 let AltNames = [ "X16"  ];
 let Aliases = [ ];
 let SubRegs = [ R16, X16, W16 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
+let SubRegIndices = [ S16_SUB_32_0, S16_FULL_64_0, S16_SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 31 ];
 list<int> CostPerUse = [0];
@@ -2305,6 +2981,14 @@ let HWEncoding{4-0} = 16;
 
 let isArtificial = false;
 }
+
+def S17_SUB_32_0  : SubRegIndex<32>;
+def S17_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def S17_FULL_64_0    : SubRegIndex<64>;
+def S17_SUB_32_1  : SubRegIndex<32>;
+def S17_SUB_32_HI_1 : SubRegIndex<32, 32>;
+def S17_FULL_64_1    : SubRegIndex<64>;
+
 def S17 : Register<"S17">
 {
 let Namespace = "aarch64temp";
@@ -2312,7 +2996,7 @@ let AsmName = "X17";
 let AltNames = [ "X17"  ];
 let Aliases = [ ];
 let SubRegs = [ R17, X17, W17 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
+let SubRegIndices = [ S17_SUB_32_0, S17_FULL_64_0, S17_SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 32 ];
 list<int> CostPerUse = [0];
@@ -2323,6 +3007,14 @@ let HWEncoding{4-0} = 17;
 
 let isArtificial = false;
 }
+
+def S18_SUB_32_0  : SubRegIndex<32>;
+def S18_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def S18_FULL_64_0    : SubRegIndex<64>;
+def S18_SUB_32_1  : SubRegIndex<32>;
+def S18_SUB_32_HI_1 : SubRegIndex<32, 32>;
+def S18_FULL_64_1    : SubRegIndex<64>;
+
 def S18 : Register<"S18">
 {
 let Namespace = "aarch64temp";
@@ -2330,7 +3022,7 @@ let AsmName = "X18";
 let AltNames = [ "X18"  ];
 let Aliases = [ ];
 let SubRegs = [ R18, X18, W18 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
+let SubRegIndices = [ S18_SUB_32_0, S18_FULL_64_0, S18_SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 33 ];
 list<int> CostPerUse = [0];
@@ -2341,6 +3033,14 @@ let HWEncoding{4-0} = 18;
 
 let isArtificial = false;
 }
+
+def S19_SUB_32_0  : SubRegIndex<32>;
+def S19_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def S19_FULL_64_0    : SubRegIndex<64>;
+def S19_SUB_32_1  : SubRegIndex<32>;
+def S19_SUB_32_HI_1 : SubRegIndex<32, 32>;
+def S19_FULL_64_1    : SubRegIndex<64>;
+
 def S19 : Register<"S19">
 {
 let Namespace = "aarch64temp";
@@ -2348,7 +3048,7 @@ let AsmName = "X19";
 let AltNames = [ "X19"  ];
 let Aliases = [ ];
 let SubRegs = [ R19, X19, W19 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
+let SubRegIndices = [ S19_SUB_32_0, S19_FULL_64_0, S19_SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 34 ];
 list<int> CostPerUse = [0];
@@ -2359,6 +3059,14 @@ let HWEncoding{4-0} = 19;
 
 let isArtificial = false;
 }
+
+def S20_SUB_32_0  : SubRegIndex<32>;
+def S20_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def S20_FULL_64_0    : SubRegIndex<64>;
+def S20_SUB_32_1  : SubRegIndex<32>;
+def S20_SUB_32_HI_1 : SubRegIndex<32, 32>;
+def S20_FULL_64_1    : SubRegIndex<64>;
+
 def S20 : Register<"S20">
 {
 let Namespace = "aarch64temp";
@@ -2366,7 +3074,7 @@ let AsmName = "X20";
 let AltNames = [ "X20"  ];
 let Aliases = [ ];
 let SubRegs = [ R20, X20, W20 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
+let SubRegIndices = [ S20_SUB_32_0, S20_FULL_64_0, S20_SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 35 ];
 list<int> CostPerUse = [0];
@@ -2377,6 +3085,14 @@ let HWEncoding{4-0} = 20;
 
 let isArtificial = false;
 }
+
+def S21_SUB_32_0  : SubRegIndex<32>;
+def S21_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def S21_FULL_64_0    : SubRegIndex<64>;
+def S21_SUB_32_1  : SubRegIndex<32>;
+def S21_SUB_32_HI_1 : SubRegIndex<32, 32>;
+def S21_FULL_64_1    : SubRegIndex<64>;
+
 def S21 : Register<"S21">
 {
 let Namespace = "aarch64temp";
@@ -2384,7 +3100,7 @@ let AsmName = "X21";
 let AltNames = [ "X21"  ];
 let Aliases = [ ];
 let SubRegs = [ R21, X21, W21 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
+let SubRegIndices = [ S21_SUB_32_0, S21_FULL_64_0, S21_SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 36 ];
 list<int> CostPerUse = [0];
@@ -2395,6 +3111,14 @@ let HWEncoding{4-0} = 21;
 
 let isArtificial = false;
 }
+
+def S22_SUB_32_0  : SubRegIndex<32>;
+def S22_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def S22_FULL_64_0    : SubRegIndex<64>;
+def S22_SUB_32_1  : SubRegIndex<32>;
+def S22_SUB_32_HI_1 : SubRegIndex<32, 32>;
+def S22_FULL_64_1    : SubRegIndex<64>;
+
 def S22 : Register<"S22">
 {
 let Namespace = "aarch64temp";
@@ -2402,7 +3126,7 @@ let AsmName = "X22";
 let AltNames = [ "X22"  ];
 let Aliases = [ ];
 let SubRegs = [ R22, X22, W22 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
+let SubRegIndices = [ S22_SUB_32_0, S22_FULL_64_0, S22_SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 37 ];
 list<int> CostPerUse = [0];
@@ -2413,6 +3137,14 @@ let HWEncoding{4-0} = 22;
 
 let isArtificial = false;
 }
+
+def S23_SUB_32_0  : SubRegIndex<32>;
+def S23_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def S23_FULL_64_0    : SubRegIndex<64>;
+def S23_SUB_32_1  : SubRegIndex<32>;
+def S23_SUB_32_HI_1 : SubRegIndex<32, 32>;
+def S23_FULL_64_1    : SubRegIndex<64>;
+
 def S23 : Register<"S23">
 {
 let Namespace = "aarch64temp";
@@ -2420,7 +3152,7 @@ let AsmName = "X23";
 let AltNames = [ "X23"  ];
 let Aliases = [ ];
 let SubRegs = [ R23, X23, W23 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
+let SubRegIndices = [ S23_SUB_32_0, S23_FULL_64_0, S23_SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 38 ];
 list<int> CostPerUse = [0];
@@ -2431,6 +3163,14 @@ let HWEncoding{4-0} = 23;
 
 let isArtificial = false;
 }
+
+def S24_SUB_32_0  : SubRegIndex<32>;
+def S24_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def S24_FULL_64_0    : SubRegIndex<64>;
+def S24_SUB_32_1  : SubRegIndex<32>;
+def S24_SUB_32_HI_1 : SubRegIndex<32, 32>;
+def S24_FULL_64_1    : SubRegIndex<64>;
+
 def S24 : Register<"S24">
 {
 let Namespace = "aarch64temp";
@@ -2438,7 +3178,7 @@ let AsmName = "X24";
 let AltNames = [ "X24"  ];
 let Aliases = [ ];
 let SubRegs = [ R24, X24, W24 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
+let SubRegIndices = [ S24_SUB_32_0, S24_FULL_64_0, S24_SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 39 ];
 list<int> CostPerUse = [0];
@@ -2449,6 +3189,14 @@ let HWEncoding{4-0} = 24;
 
 let isArtificial = false;
 }
+
+def S25_SUB_32_0  : SubRegIndex<32>;
+def S25_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def S25_FULL_64_0    : SubRegIndex<64>;
+def S25_SUB_32_1  : SubRegIndex<32>;
+def S25_SUB_32_HI_1 : SubRegIndex<32, 32>;
+def S25_FULL_64_1    : SubRegIndex<64>;
+
 def S25 : Register<"S25">
 {
 let Namespace = "aarch64temp";
@@ -2456,7 +3204,7 @@ let AsmName = "X25";
 let AltNames = [ "X25"  ];
 let Aliases = [ ];
 let SubRegs = [ R25, X25, W25 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
+let SubRegIndices = [ S25_SUB_32_0, S25_FULL_64_0, S25_SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 40 ];
 list<int> CostPerUse = [0];
@@ -2467,6 +3215,14 @@ let HWEncoding{4-0} = 25;
 
 let isArtificial = false;
 }
+
+def S26_SUB_32_0  : SubRegIndex<32>;
+def S26_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def S26_FULL_64_0    : SubRegIndex<64>;
+def S26_SUB_32_1  : SubRegIndex<32>;
+def S26_SUB_32_HI_1 : SubRegIndex<32, 32>;
+def S26_FULL_64_1    : SubRegIndex<64>;
+
 def S26 : Register<"S26">
 {
 let Namespace = "aarch64temp";
@@ -2474,7 +3230,7 @@ let AsmName = "X26";
 let AltNames = [ "X26"  ];
 let Aliases = [ ];
 let SubRegs = [ R26, X26, W26 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
+let SubRegIndices = [ S26_SUB_32_0, S26_FULL_64_0, S26_SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 41 ];
 list<int> CostPerUse = [0];
@@ -2485,6 +3241,14 @@ let HWEncoding{4-0} = 26;
 
 let isArtificial = false;
 }
+
+def S27_SUB_32_0  : SubRegIndex<32>;
+def S27_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def S27_FULL_64_0    : SubRegIndex<64>;
+def S27_SUB_32_1  : SubRegIndex<32>;
+def S27_SUB_32_HI_1 : SubRegIndex<32, 32>;
+def S27_FULL_64_1    : SubRegIndex<64>;
+
 def S27 : Register<"S27">
 {
 let Namespace = "aarch64temp";
@@ -2492,7 +3256,7 @@ let AsmName = "X27";
 let AltNames = [ "X27"  ];
 let Aliases = [ ];
 let SubRegs = [ R27, X27, W27 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
+let SubRegIndices = [ S27_SUB_32_0, S27_FULL_64_0, S27_SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 42 ];
 list<int> CostPerUse = [0];
@@ -2503,6 +3267,14 @@ let HWEncoding{4-0} = 27;
 
 let isArtificial = false;
 }
+
+def S28_SUB_32_0  : SubRegIndex<32>;
+def S28_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def S28_FULL_64_0    : SubRegIndex<64>;
+def S28_SUB_32_1  : SubRegIndex<32>;
+def S28_SUB_32_HI_1 : SubRegIndex<32, 32>;
+def S28_FULL_64_1    : SubRegIndex<64>;
+
 def S28 : Register<"S28">
 {
 let Namespace = "aarch64temp";
@@ -2510,7 +3282,7 @@ let AsmName = "X28";
 let AltNames = [ "X28"  ];
 let Aliases = [ ];
 let SubRegs = [ R28, X28, W28 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
+let SubRegIndices = [ S28_SUB_32_0, S28_FULL_64_0, S28_SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 43 ];
 list<int> CostPerUse = [0];
@@ -2521,6 +3293,14 @@ let HWEncoding{4-0} = 28;
 
 let isArtificial = false;
 }
+
+def S29_SUB_32_0  : SubRegIndex<32>;
+def S29_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def S29_FULL_64_0    : SubRegIndex<64>;
+def S29_SUB_32_1  : SubRegIndex<32>;
+def S29_SUB_32_HI_1 : SubRegIndex<32, 32>;
+def S29_FULL_64_1    : SubRegIndex<64>;
+
 def S29 : Register<"S29">
 {
 let Namespace = "aarch64temp";
@@ -2528,7 +3308,7 @@ let AsmName = "A_FP";
 let AltNames = [ "A_FP"  ];
 let Aliases = [ ];
 let SubRegs = [ R29, X29, W29 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
+let SubRegIndices = [ S29_SUB_32_0, S29_FULL_64_0, S29_SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 44 ];
 list<int> CostPerUse = [0];
@@ -2539,6 +3319,14 @@ let HWEncoding{4-0} = 29;
 
 let isArtificial = false;
 }
+
+def S30_SUB_32_0  : SubRegIndex<32>;
+def S30_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def S30_FULL_64_0    : SubRegIndex<64>;
+def S30_SUB_32_1  : SubRegIndex<32>;
+def S30_SUB_32_HI_1 : SubRegIndex<32, 32>;
+def S30_FULL_64_1    : SubRegIndex<64>;
+
 def S30 : Register<"S30">
 {
 let Namespace = "aarch64temp";
@@ -2546,7 +3334,7 @@ let AsmName = "A_LR";
 let AltNames = [ "A_LR"  ];
 let Aliases = [ ];
 let SubRegs = [ R30, X30, W30 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
+let SubRegIndices = [ S30_SUB_32_0, S30_FULL_64_0, S30_SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 45 ];
 list<int> CostPerUse = [0];
@@ -2557,6 +3345,14 @@ let HWEncoding{4-0} = 30;
 
 let isArtificial = false;
 }
+
+def S31_SUB_32_0  : SubRegIndex<32>;
+def S31_SUB_32_HI_0 : SubRegIndex<32, 32>;
+def S31_FULL_64_0    : SubRegIndex<64>;
+def S31_SUB_32_1  : SubRegIndex<32>;
+def S31_SUB_32_HI_1 : SubRegIndex<32, 32>;
+def S31_FULL_64_1    : SubRegIndex<64>;
+
 def S31 : Register<"S31">
 {
 let Namespace = "aarch64temp";
@@ -2564,7 +3360,7 @@ let AsmName = "A_SP";
 let AltNames = [ "A_SP"  ];
 let Aliases = [ ];
 let SubRegs = [ R31, X31, W31 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32 ];
+let SubRegIndices = [ S31_SUB_32_0, S31_FULL_64_0, S31_SUB_32_1 ];
 let RegAltNameIndices = [];
 let DwarfNumbers = [ 46 ];
 list<int> CostPerUse = [0];

--- a/vadl/test/vadl/lcb/riscv/riscv64/template/EmitRegisterInfoTableGenFilePassTest.java
+++ b/vadl/test/vadl/lcb/riscv/riscv64/template/EmitRegisterInfoTableGenFilePassTest.java
@@ -46,14 +46,6 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
     var output = trimmed.lines();
 
     Assertions.assertLinesMatch("""
-        // SubRegIndexes for GPR registers
-        def SUB_32   : SubRegIndex<32>;
-        def SUB_32_HI : SubRegIndex<32, 32>;
-        def FULL_64    : SubRegIndex<64>;
-        
-        
-        
-        
         def PC : Register<"PC">
         {
         let Namespace = "processorNameValue";


### PR DESCRIPTION
The `S` register has two aliases which are half the size. LLVM doesn't allow duplicates for the subRegIndex. So, we have to create multiple definitions.