### PR TITLE
lcb: Use artificial resource as register class

### DIFF
--- a/vadl/main/vadl/gcb/passes/operands/model/GcbInstructionRegisterFileOperand.java
+++ b/vadl/main/vadl/gcb/passes/operands/model/GcbInstructionRegisterFileOperand.java
@@ -19,9 +19,9 @@ package vadl.gcb.passes.operands.model;
 import java.util.List;
 import vadl.gcb.passes.operands.ReferencesFormatField;
 import vadl.viam.Format;
+import vadl.viam.GeneratesRegisterFileName;
 import vadl.viam.RegisterTensor;
 import vadl.viam.graph.dependency.FieldRefNode;
-import vadl.viam.graph.dependency.FuncParamNode;
 import vadl.viam.graph.dependency.ReadArtificialResNode;
 import vadl.viam.graph.dependency.ReadRegTensorNode;
 import vadl.viam.graph.dependency.WriteArtificialResNode;
@@ -33,7 +33,7 @@ import vadl.viam.graph.dependency.WriteRegTensorNode;
 public class GcbInstructionRegisterFileOperand
     extends GcbDefaultInstructionOperand
     implements ReferencesFormatField {
-  private final RegisterTensor registerFile;
+  private final GeneratesRegisterFileName registerFile;
   private final Format.Field formatField;
 
   /**
@@ -42,7 +42,6 @@ public class GcbInstructionRegisterFileOperand
   public GcbInstructionRegisterFileOperand(ReadRegTensorNode node, Format.Field address) {
     super(node, node.regTensor().simpleName(), address.identifier.simpleName());
     this.registerFile = node.regTensor();
-    this.registerFile.ensure(registerFile.isRegisterFile(), "must be registerfile");
     this.formatField = address;
     node.regTensor().ensure(registerFile.isRegisterFile(), "must be registerfile");
   }
@@ -51,10 +50,9 @@ public class GcbInstructionRegisterFileOperand
    * Constructor.
    */
   public GcbInstructionRegisterFileOperand(ReadArtificialResNode node, Format.Field address) {
-    super(node, node.resourceDefinition().innerResourceRef().simpleName(),
+    super(node, node.resourceDefinition().simpleName(),
         address.identifier.simpleName());
-    this.registerFile = (RegisterTensor) node.resourceDefinition().innerResourceRef();
-    this.registerFile.ensure(registerFile.isRegisterFile(), "must be registerfile");
+    this.registerFile = node.resourceDefinition();
     this.formatField = address;
     node.resourceDefinition().innerResourceRef()
         .ensure(registerFile.isRegisterFile(), "must be registerfile");
@@ -66,7 +64,6 @@ public class GcbInstructionRegisterFileOperand
   public GcbInstructionRegisterFileOperand(WriteRegTensorNode node, FieldRefNode address) {
     super(node, node.regTensor().simpleName(), address.formatField().identifier.simpleName());
     this.registerFile = node.regTensor();
-    this.registerFile.ensure(registerFile.isRegisterFile(), "must be registerfile");
     this.formatField = address.formatField();
   }
 
@@ -77,27 +74,12 @@ public class GcbInstructionRegisterFileOperand
     super(node, node.resourceDefinition().innerResourceRef().simpleName(),
         address.identifier.simpleName());
     this.registerFile = (RegisterTensor) node.resourceDefinition().innerResourceRef();
-    this.registerFile.ensure(registerFile.isRegisterFile(), "must be registerfile");
     this.formatField = address;
     node.resourceDefinition().innerResourceRef()
         .ensure(registerFile.isRegisterFile(), "must be registerfile");
   }
 
-  /**
-   * Constructor for pseudo instructions. Pseudo instructions will have a {@link ReadRegTensorNode}
-   * or {@link WriteRegTensorNode} because they are constructed over {@link FuncParamNode}.
-   */
-  public GcbInstructionRegisterFileOperand(RegisterTensor registerFile,
-                                           Format.Field field,
-                                           FuncParamNode funcParamNode) {
-    super(funcParamNode, registerFile.simpleName(),
-        funcParamNode.parameter().identifier.simpleName());
-    this.registerFile = registerFile;
-    this.formatField = field;
-    this.registerFile.ensure(registerFile.isRegisterFile(), "must be registerfile");
-  }
-
-  public RegisterTensor registerFile() {
+  public GeneratesRegisterFileName registerFile() {
     return registerFile;
   }
 

--- a/vadl/main/vadl/lcb/passes/llvmLowering/domain/selectionDag/LlvmReadResourceFactory.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/domain/selectionDag/LlvmReadResourceFactory.java
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.lcb.passes.llvmLowering.domain.selectionDag;
+
+import javax.annotation.Nullable;
+import vadl.error.Diagnostic;
+import vadl.types.DataType;
+import vadl.viam.ArtificialResource;
+import vadl.viam.Counter;
+import vadl.viam.GeneratesRegisterFileName;
+import vadl.viam.RegisterTensor;
+import vadl.viam.graph.dependency.ExpressionNode;
+import vadl.viam.graph.dependency.FieldRefNode;
+
+/**
+ * Factory for creating reading instances.
+ */
+public class LlvmReadResourceFactory {
+  /**
+   * Based on the {@code registerFile} creates a node.
+   */
+  public ExpressionNode create(GeneratesRegisterFileName registerFile,
+                               FieldRefNode address,
+                               DataType type,
+                               @Nullable Counter counter) {
+    if (registerFile instanceof RegisterTensor registerTensor) {
+      return new LlvmReadRegFileNode(registerTensor, address, type, counter);
+    } else if (registerFile instanceof ArtificialResource artificialResource) {
+      return new LlvmReadArtificialResourceNode(artificialResource, address, type);
+    } else {
+      throw Diagnostic.error("Cannot create a llvm type", registerFile.location()).build();
+    }
+  }
+}

--- a/vadl/main/vadl/lcb/passes/llvmLowering/strategies/LlvmInstructionLoweringStrategy.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/strategies/LlvmInstructionLoweringStrategy.java
@@ -90,6 +90,7 @@ import vadl.viam.graph.dependency.FuncParamNode;
 import vadl.viam.graph.dependency.ReadMemNode;
 import vadl.viam.graph.dependency.ReadRegTensorNode;
 import vadl.viam.graph.dependency.ReadResourceNode;
+import vadl.viam.graph.dependency.SelectNode;
 import vadl.viam.graph.dependency.SideEffectNode;
 import vadl.viam.graph.dependency.SignExtendNode;
 import vadl.viam.graph.dependency.WriteMemNode;
@@ -428,7 +429,8 @@ public abstract class LlvmInstructionLoweringStrategy {
         || hasMultipleOutputs(graph)
         || rejectWhenReadingFromMemory(graph)
         || rejectWhenWritingToMemory(graph)
-        || hasUnreplacedBuiltins(graph)) {
+        || hasUnreplacedBuiltins(graph)
+        || hasSelectNodes(graph)) {
       return true;
     }
 
@@ -453,6 +455,13 @@ public abstract class LlvmInstructionLoweringStrategy {
         && graph.getNodes(ReadResourceNode.class).toList().size() == 1
         && graph.getNodes(WriteResourceNode.class)
         .anyMatch(writeResourceNode -> writeResourceNode.value() instanceof ReadResourceNode);
+  }
+
+  /**
+   * If there are any {@link SelectNode} in the graph.
+   */
+  private boolean hasSelectNodes(Graph graph) {
+    return graph.getNodes(SelectNode.class).toList().size() == 1;
   }
 
   /**

--- a/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/LlvmInstructionLoweringIndirectJumpAndLinkStrategyImpl.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/LlvmInstructionLoweringIndirectJumpAndLinkStrategyImpl.java
@@ -43,6 +43,7 @@ import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmAddSD;
 import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmBrindSD;
 import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmFieldAccessRefNode;
 import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmReadRegFileNode;
+import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmReadResourceFactory;
 import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmTargetCallSD;
 import vadl.lcb.passes.llvmLowering.strategies.LlvmInstructionLoweringStrategy;
 import vadl.lcb.passes.llvmLowering.tablegen.model.TableGenPattern;
@@ -52,8 +53,8 @@ import vadl.lcb.passes.operands.TableGenInstructionImmediateOperand;
 import vadl.types.Type;
 import vadl.viam.Abi;
 import vadl.viam.Constant;
+import vadl.viam.GeneratesRegisterFileName;
 import vadl.viam.Instruction;
-import vadl.viam.RegisterTensor;
 import vadl.viam.graph.Graph;
 import vadl.viam.graph.NodeList;
 import vadl.viam.graph.dependency.ConstantNode;
@@ -166,10 +167,13 @@ public class LlvmInstructionLoweringIndirectJumpAndLinkStrategyImpl
     var selector = new Graph("selector");
     var ref = (ReadRegTensorNode) inputRegister.origin().copy();
     var address = (FieldRefNode) ref.address().copy();
-    selector.addWithInputs(new LlvmTargetCallSD(new NodeList<>(new LlvmReadRegFileNode(
-        inputRegister.registerFile(), address, inputRegister.formatField().type(),
-        ref.staticCounterAccess()
-    )),
+    var factory = new LlvmReadResourceFactory();
+    selector.addWithInputs(new LlvmTargetCallSD(
+        new NodeList<>(
+            factory.create(inputRegister.registerFile(), address,
+                inputRegister.formatField().type(),
+                ref.staticCounterAccess())
+        ),
         Type.dummy()));
 
     var database = new Database(supportedInstructions);
@@ -272,7 +276,8 @@ public class LlvmInstructionLoweringIndirectJumpAndLinkStrategyImpl
     var selector = new Graph("selector");
     var ref = (ReadRegTensorNode) inputRegister.origin().copy();
     var address = (FieldRefNode) ref.address().copy();
-    var llvmRegister = new LlvmReadRegFileNode(
+    var factory = new LlvmReadResourceFactory();
+    var llvmRegister = factory.create(
         inputRegister.registerFile(), address, inputRegister.formatField().type(),
         ref.staticCounterAccess()
     );
@@ -301,7 +306,8 @@ public class LlvmInstructionLoweringIndirectJumpAndLinkStrategyImpl
     var selector = new Graph("selector");
     var ref = (ReadRegTensorNode) inputRegister.origin().copy();
     var address = (FieldRefNode) ref.address().copy();
-    var llvmRegister = new LlvmReadRegFileNode(
+    var factory = new LlvmReadResourceFactory();
+    var llvmRegister = factory.create(
         inputRegister.registerFile(), address, inputRegister.formatField().type(),
         ref.staticCounterAccess()
     );
@@ -319,7 +325,7 @@ public class LlvmInstructionLoweringIndirectJumpAndLinkStrategyImpl
     return new TableGenSelectionWithOutputPattern(selector, machine);
   }
 
-  private static String zeroRegister(RegisterTensor registerFile) {
+  private static String zeroRegister(GeneratesRegisterFileName registerFile) {
     var constraint =
         ensurePresent(
             Arrays.stream(registerFile.constraints()).filter(x -> x.value().intValue() == 0)
@@ -328,6 +334,6 @@ public class LlvmInstructionLoweringIndirectJumpAndLinkStrategyImpl
                 registerFile.location())
         );
 
-    return registerFile.simpleName() + constraint.indices().getFirst().intValue();
+    return registerFile.identifier().simpleName() + constraint.indices().getFirst().intValue();
   }
 }

--- a/vadl/test/resources/snapshots/aarch64/InstrInfoTableGen.td
+++ b/vadl/test/resources/snapshots/aarch64/InstrInfoTableGen.td
@@ -6195,7 +6195,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins W:$rn, W:$rm );
 
 field bits<32> Inst;
 
@@ -6247,7 +6247,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -6299,7 +6299,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins W:$rn, W:$rm );
 
 field bits<32> Inst;
 
@@ -6351,7 +6351,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -6403,7 +6403,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins W:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -6462,7 +6462,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDWASR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins W:$rn, X:$rm, AArch64Base_ADDWASR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -6521,7 +6521,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, AArch64Base_ADDWI_imm12XAsInt64:$imm12X );
+let InOperandList = ( ins R:$rn, AArch64Base_ADDWI_imm12XAsInt64:$imm12X );
 
 field bits<32> Inst;
 
@@ -6577,7 +6577,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, AArch64Base_ADDWI12_imm12SAsInt64:$imm12S );
+let InOperandList = ( ins R:$rn, AArch64Base_ADDWI12_imm12SAsInt64:$imm12S );
 
 field bits<32> Inst;
 
@@ -6633,7 +6633,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDWLSL_imm6AsInt8:$imm6 );
+let InOperandList = ( ins W:$rn, X:$rm, AArch64Base_ADDWLSL_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -6692,7 +6692,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDWLSR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins W:$rn, X:$rm, AArch64Base_ADDWLSR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -6751,7 +6751,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins W:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -6810,7 +6810,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDWSASR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins W:$rn, X:$rm, AArch64Base_ADDWSASR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -6869,7 +6869,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, AArch64Base_ADDWSI_imm12XAsInt64:$imm12X );
+let InOperandList = ( ins R:$rn, AArch64Base_ADDWSI_imm12XAsInt64:$imm12X );
 
 field bits<32> Inst;
 
@@ -6925,7 +6925,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, AArch64Base_ADDWSI12_imm12SAsInt64:$imm12S );
+let InOperandList = ( ins R:$rn, AArch64Base_ADDWSI12_imm12SAsInt64:$imm12S );
 
 field bits<32> Inst;
 
@@ -6981,7 +6981,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDWSLSL_imm6AsInt8:$imm6 );
+let InOperandList = ( ins W:$rn, X:$rm, AArch64Base_ADDWSLSL_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -7040,7 +7040,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDWSLSR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins W:$rn, X:$rm, AArch64Base_ADDWSLSR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -7099,7 +7099,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDWSSXSB_imm3AsInt8:$imm3 );
+let InOperandList = ( ins R:$rn, X:$rm, AArch64Base_ADDWSSXSB_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -7157,7 +7157,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDWSSXSH_imm3AsInt8:$imm3 );
+let InOperandList = ( ins R:$rn, X:$rm, AArch64Base_ADDWSSXSH_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -7215,7 +7215,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDWSSXSW_imm3AsInt8:$imm3 );
+let InOperandList = ( ins R:$rn, X:$rm, AArch64Base_ADDWSSXSW_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -7273,7 +7273,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDWSSXSX_imm3AsInt8:$imm3 );
+let InOperandList = ( ins R:$rn, X:$rm, AArch64Base_ADDWSSXSX_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -7331,7 +7331,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins R:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -7389,7 +7389,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins R:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -7447,7 +7447,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins R:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -7505,7 +7505,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins R:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -7563,7 +7563,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDWSUXSB_imm3AsInt8:$imm3 );
+let InOperandList = ( ins R:$rn, X:$rm, AArch64Base_ADDWSUXSB_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -7621,7 +7621,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDWSUXSH_imm3AsInt8:$imm3 );
+let InOperandList = ( ins R:$rn, X:$rm, AArch64Base_ADDWSUXSH_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -7679,7 +7679,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDWSUXSW_imm3AsInt8:$imm3 );
+let InOperandList = ( ins R:$rn, X:$rm, AArch64Base_ADDWSUXSW_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -7737,7 +7737,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDWSUXSX_imm3AsInt8:$imm3 );
+let InOperandList = ( ins R:$rn, X:$rm, AArch64Base_ADDWSUXSX_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -7795,7 +7795,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins R:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -7853,7 +7853,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins R:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -7911,7 +7911,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins R:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -7969,7 +7969,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins R:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -8027,7 +8027,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDWSXSB_imm3AsInt8:$imm3 );
+let InOperandList = ( ins R:$rn, X:$rm, AArch64Base_ADDWSXSB_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -8085,7 +8085,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDWSXSH_imm3AsInt8:$imm3 );
+let InOperandList = ( ins R:$rn, X:$rm, AArch64Base_ADDWSXSH_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -8143,7 +8143,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDWSXSW_imm3AsInt8:$imm3 );
+let InOperandList = ( ins R:$rn, X:$rm, AArch64Base_ADDWSXSW_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -8201,7 +8201,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDWSXSX_imm3AsInt8:$imm3 );
+let InOperandList = ( ins R:$rn, X:$rm, AArch64Base_ADDWSXSX_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -8259,7 +8259,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins R:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -8317,7 +8317,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins R:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -8375,7 +8375,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins R:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -8433,7 +8433,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins R:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -8491,7 +8491,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDWUXSB_imm3AsInt8:$imm3 );
+let InOperandList = ( ins R:$rn, X:$rm, AArch64Base_ADDWUXSB_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -8549,7 +8549,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDWUXSH_imm3AsInt8:$imm3 );
+let InOperandList = ( ins R:$rn, X:$rm, AArch64Base_ADDWUXSH_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -8607,7 +8607,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDWUXSW_imm3AsInt8:$imm3 );
+let InOperandList = ( ins R:$rn, X:$rm, AArch64Base_ADDWUXSW_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -8665,7 +8665,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDWUXSX_imm3AsInt8:$imm3 );
+let InOperandList = ( ins R:$rn, X:$rm, AArch64Base_ADDWUXSX_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -8723,7 +8723,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins R:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -8781,7 +8781,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins R:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -8839,7 +8839,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins R:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -8897,7 +8897,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins R:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -8955,7 +8955,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -9014,7 +9014,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDXASR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_ADDXASR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -9185,7 +9185,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDXLSL_imm6AsInt8:$imm6 );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_ADDXLSL_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -9244,7 +9244,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDXLSR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_ADDXLSR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -9303,7 +9303,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -9362,7 +9362,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDXSASR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_ADDXSASR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -9533,7 +9533,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDXSLSL_imm6AsInt8:$imm6 );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_ADDXSLSL_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -9592,7 +9592,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDXSLSR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_ADDXSLSR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -9651,7 +9651,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDXSSXSB_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, X:$rm, AArch64Base_ADDXSSXSB_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -9709,7 +9709,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDXSSXSH_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, X:$rm, AArch64Base_ADDXSSXSH_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -9767,7 +9767,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDXSSXSW_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, X:$rm, AArch64Base_ADDXSSXSW_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -9825,7 +9825,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDXSSXSX_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, X:$rm, AArch64Base_ADDXSSXSX_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -9883,7 +9883,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -9941,7 +9941,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -9999,7 +9999,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -10057,7 +10057,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -10115,7 +10115,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDXSUXSB_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, X:$rm, AArch64Base_ADDXSUXSB_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -10173,7 +10173,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDXSUXSH_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, X:$rm, AArch64Base_ADDXSUXSH_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -10231,7 +10231,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDXSUXSW_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, X:$rm, AArch64Base_ADDXSUXSW_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -10289,7 +10289,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDXSUXSX_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, X:$rm, AArch64Base_ADDXSUXSX_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -10347,7 +10347,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -10405,7 +10405,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -10463,7 +10463,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -10521,7 +10521,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -10579,7 +10579,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDXSXSB_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, X:$rm, AArch64Base_ADDXSXSB_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -10637,7 +10637,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDXSXSH_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, X:$rm, AArch64Base_ADDXSXSH_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -10695,7 +10695,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDXSXSW_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, X:$rm, AArch64Base_ADDXSXSW_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -10753,7 +10753,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDXSXSX_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, X:$rm, AArch64Base_ADDXSXSX_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -10811,7 +10811,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -10869,7 +10869,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -10927,7 +10927,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -10985,7 +10985,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -11043,7 +11043,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDXUXSB_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, X:$rm, AArch64Base_ADDXUXSB_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -11101,7 +11101,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDXUXSH_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, X:$rm, AArch64Base_ADDXUXSH_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -11159,7 +11159,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDXUXSW_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, X:$rm, AArch64Base_ADDXUXSW_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -11217,7 +11217,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ADDXUXSX_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, X:$rm, AArch64Base_ADDXUXSX_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -11275,7 +11275,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -11333,7 +11333,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -11391,7 +11391,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -11449,7 +11449,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -11605,7 +11605,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, AArch64Base_ANDIW_immWSizeAsInt32:$immWSize );
+let InOperandList = ( ins W:$rn, AArch64Base_ANDIW_immWSizeAsInt32:$immWSize );
 
 field bits<32> Inst;
 
@@ -11656,7 +11656,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, AArch64Base_ANDIX_immXSizeAsInt64:$immXSize );
+let InOperandList = ( ins X:$rn, AArch64Base_ANDIX_immXSizeAsInt64:$immXSize );
 
 field bits<32> Inst;
 
@@ -11707,7 +11707,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, AArch64Base_ANDSIW_immWSizeAsInt32:$immWSize );
+let InOperandList = ( ins W:$rn, AArch64Base_ANDSIW_immWSizeAsInt32:$immWSize );
 
 field bits<32> Inst;
 
@@ -11758,7 +11758,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, AArch64Base_ANDSIX_immXSizeAsInt64:$immXSize );
+let InOperandList = ( ins X:$rn, AArch64Base_ANDSIX_immXSizeAsInt64:$immXSize );
 
 field bits<32> Inst;
 
@@ -11809,7 +11809,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins W:$rn, W:$rm );
 
 field bits<32> Inst;
 
@@ -11865,7 +11865,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ANDSWASR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_ANDSWASR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -11921,7 +11921,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ANDSWLSL_imm6AsInt8:$imm6 );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_ANDSWLSL_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -11977,7 +11977,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ANDSWLSR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_ANDSWLSR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -12033,7 +12033,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ANDSWROR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_ANDSWROR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -12089,7 +12089,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -12145,7 +12145,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ANDSXASR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_ANDSXASR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -12201,7 +12201,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ANDSXLSL_imm6AsInt8:$imm6 );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_ANDSXLSL_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -12257,7 +12257,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ANDSXLSR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_ANDSXLSR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -12313,7 +12313,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ANDSXROR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_ANDSXROR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -12369,7 +12369,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins W:$rn, W:$rm );
 
 field bits<32> Inst;
 
@@ -12425,7 +12425,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ANDWASR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_ANDWASR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -12481,7 +12481,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ANDWLSL_imm6AsInt8:$imm6 );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_ANDWLSL_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -12537,7 +12537,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ANDWLSR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_ANDWLSR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -12593,7 +12593,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ANDWROR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_ANDWROR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -12649,7 +12649,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -12705,7 +12705,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ANDXASR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_ANDXASR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -12761,7 +12761,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ANDXLSL_imm6AsInt8:$imm6 );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_ANDXLSL_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -12817,7 +12817,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ANDXLSR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_ANDXLSR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -12873,7 +12873,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ANDXROR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_ANDXROR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -12929,7 +12929,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins W:$rn, W:$rm );
 
 field bits<32> Inst;
 
@@ -12983,7 +12983,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -13082,7 +13082,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, AArch64Base_BFMW_leftWSizeAsInt8:$leftWSize, AArch64Base_BFMW_rightWSizeAsInt8:$rightWSize );
+let InOperandList = ( ins X:$rd, W:$rn, AArch64Base_BFMW_leftWSizeAsInt8:$leftWSize, AArch64Base_BFMW_rightWSizeAsInt8:$rightWSize );
 
 field bits<32> Inst;
 
@@ -13137,7 +13137,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, AArch64Base_BFMX_leftXSizeAsInt8:$leftXSize, AArch64Base_BFMX_rightXSizeAsInt8:$rightXSize );
+let InOperandList = ( ins X:$rd, X:$rn, AArch64Base_BFMX_leftXSizeAsInt8:$leftXSize, AArch64Base_BFMX_rightXSizeAsInt8:$rightXSize );
 
 field bits<32> Inst;
 
@@ -13192,7 +13192,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins W:$rn, W:$rm );
 
 field bits<32> Inst;
 
@@ -13248,7 +13248,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_BICSWASR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_BICSWASR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -13304,7 +13304,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_BICSWLSL_imm6AsInt8:$imm6 );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_BICSWLSL_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -13360,7 +13360,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_BICSWLSR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_BICSWLSR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -13416,7 +13416,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_BICSWROR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_BICSWROR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -13472,7 +13472,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -13528,7 +13528,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_BICSXASR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_BICSXASR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -13584,7 +13584,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_BICSXLSL_imm6AsInt8:$imm6 );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_BICSXLSL_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -13640,7 +13640,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_BICSXLSR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_BICSXLSR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -13696,7 +13696,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_BICSXROR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_BICSXROR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -13752,7 +13752,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins W:$rn, W:$rm );
 
 field bits<32> Inst;
 
@@ -13808,7 +13808,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_BICWASR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_BICWASR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -13864,7 +13864,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_BICWLSL_imm6AsInt8:$imm6 );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_BICWLSL_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -13920,7 +13920,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_BICWLSR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_BICWLSR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -13976,7 +13976,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_BICWROR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_BICWROR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -14032,7 +14032,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -14088,7 +14088,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_BICXASR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_BICXASR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -14144,7 +14144,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_BICXLSL_imm6AsInt8:$imm6 );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_BICXLSL_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -14200,7 +14200,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_BICXLSR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_BICXLSR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -14256,7 +14256,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_BICXROR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_BICXROR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -14357,7 +14357,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn );
+let InOperandList = ( ins X:$rn );
 
 field bits<32> Inst;
 
@@ -14403,7 +14403,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn );
+let InOperandList = ( ins X:$rn );
 
 field bits<32> Inst;
 
@@ -15217,7 +15217,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rt, AArch64Base_CBNZW_offsetAsLabel:$offset );
+let InOperandList = ( ins W:$rt, AArch64Base_CBNZW_offsetAsLabel:$offset );
 
 field bits<32> Inst;
 
@@ -15266,7 +15266,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rt, AArch64Base_CBNZX_offsetAsLabel:$offset );
+let InOperandList = ( ins X:$rt, AArch64Base_CBNZX_offsetAsLabel:$offset );
 
 field bits<32> Inst;
 
@@ -15315,7 +15315,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rt, AArch64Base_CBZW_offsetAsLabel:$offset );
+let InOperandList = ( ins W:$rt, AArch64Base_CBZW_offsetAsLabel:$offset );
 
 field bits<32> Inst;
 
@@ -15364,7 +15364,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rt, AArch64Base_CBZX_offsetAsLabel:$offset );
+let InOperandList = ( ins X:$rt, AArch64Base_CBZX_offsetAsLabel:$offset );
 
 field bits<32> Inst;
 
@@ -15413,7 +15413,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMNALW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_CCMNALW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -15468,7 +15468,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMNALX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_CCMNALX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -15523,7 +15523,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMNCCW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_CCMNCCW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -15578,7 +15578,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMNCCX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_CCMNCCX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -15633,7 +15633,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMNCSW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_CCMNCSW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -15688,7 +15688,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMNCSX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_CCMNCSX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -15743,7 +15743,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMNEQW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_CCMNEQW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -15798,7 +15798,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMNEQX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_CCMNEQX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -15853,7 +15853,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMNGEW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_CCMNGEW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -15908,7 +15908,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMNGEX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_CCMNGEX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -15963,7 +15963,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMNGTW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_CCMNGTW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -16018,7 +16018,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMNGTX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_CCMNGTX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -16073,7 +16073,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMNHIW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_CCMNHIW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -16128,7 +16128,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMNHIX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_CCMNHIX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -16183,7 +16183,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMNIALW_immXAsInt64:$immX, AArch64Base_CCMNIALW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, AArch64Base_CCMNIALW_immXAsInt64:$immX, AArch64Base_CCMNIALW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -16238,7 +16238,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMNIALX_immXAsInt64:$immX, AArch64Base_CCMNIALX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, AArch64Base_CCMNIALX_immXAsInt64:$immX, AArch64Base_CCMNIALX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -16293,7 +16293,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMNICCW_immXAsInt64:$immX, AArch64Base_CCMNICCW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, AArch64Base_CCMNICCW_immXAsInt64:$immX, AArch64Base_CCMNICCW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -16348,7 +16348,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMNICCX_immXAsInt64:$immX, AArch64Base_CCMNICCX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, AArch64Base_CCMNICCX_immXAsInt64:$immX, AArch64Base_CCMNICCX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -16403,7 +16403,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMNICSW_immXAsInt64:$immX, AArch64Base_CCMNICSW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, AArch64Base_CCMNICSW_immXAsInt64:$immX, AArch64Base_CCMNICSW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -16458,7 +16458,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMNICSX_immXAsInt64:$immX, AArch64Base_CCMNICSX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, AArch64Base_CCMNICSX_immXAsInt64:$immX, AArch64Base_CCMNICSX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -16513,7 +16513,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMNIEQW_immXAsInt64:$immX, AArch64Base_CCMNIEQW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, AArch64Base_CCMNIEQW_immXAsInt64:$immX, AArch64Base_CCMNIEQW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -16568,7 +16568,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMNIEQX_immXAsInt64:$immX, AArch64Base_CCMNIEQX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, AArch64Base_CCMNIEQX_immXAsInt64:$immX, AArch64Base_CCMNIEQX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -16623,7 +16623,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMNIGEW_immXAsInt64:$immX, AArch64Base_CCMNIGEW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, AArch64Base_CCMNIGEW_immXAsInt64:$immX, AArch64Base_CCMNIGEW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -16678,7 +16678,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMNIGEX_immXAsInt64:$immX, AArch64Base_CCMNIGEX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, AArch64Base_CCMNIGEX_immXAsInt64:$immX, AArch64Base_CCMNIGEX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -16733,7 +16733,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMNIGTW_immXAsInt64:$immX, AArch64Base_CCMNIGTW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, AArch64Base_CCMNIGTW_immXAsInt64:$immX, AArch64Base_CCMNIGTW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -16788,7 +16788,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMNIGTX_immXAsInt64:$immX, AArch64Base_CCMNIGTX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, AArch64Base_CCMNIGTX_immXAsInt64:$immX, AArch64Base_CCMNIGTX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -16843,7 +16843,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMNIHIW_immXAsInt64:$immX, AArch64Base_CCMNIHIW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, AArch64Base_CCMNIHIW_immXAsInt64:$immX, AArch64Base_CCMNIHIW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -16898,7 +16898,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMNIHIX_immXAsInt64:$immX, AArch64Base_CCMNIHIX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, AArch64Base_CCMNIHIX_immXAsInt64:$immX, AArch64Base_CCMNIHIX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -16953,7 +16953,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMNILEW_immXAsInt64:$immX, AArch64Base_CCMNILEW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, AArch64Base_CCMNILEW_immXAsInt64:$immX, AArch64Base_CCMNILEW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -17008,7 +17008,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMNILEX_immXAsInt64:$immX, AArch64Base_CCMNILEX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, AArch64Base_CCMNILEX_immXAsInt64:$immX, AArch64Base_CCMNILEX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -17063,7 +17063,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMNILSW_immXAsInt64:$immX, AArch64Base_CCMNILSW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, AArch64Base_CCMNILSW_immXAsInt64:$immX, AArch64Base_CCMNILSW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -17118,7 +17118,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMNILSX_immXAsInt64:$immX, AArch64Base_CCMNILSX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, AArch64Base_CCMNILSX_immXAsInt64:$immX, AArch64Base_CCMNILSX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -17173,7 +17173,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMNILTW_immXAsInt64:$immX, AArch64Base_CCMNILTW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, AArch64Base_CCMNILTW_immXAsInt64:$immX, AArch64Base_CCMNILTW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -17228,7 +17228,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMNILTX_immXAsInt64:$immX, AArch64Base_CCMNILTX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, AArch64Base_CCMNILTX_immXAsInt64:$immX, AArch64Base_CCMNILTX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -17283,7 +17283,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMNIMIW_immXAsInt64:$immX, AArch64Base_CCMNIMIW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, AArch64Base_CCMNIMIW_immXAsInt64:$immX, AArch64Base_CCMNIMIW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -17338,7 +17338,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMNIMIX_immXAsInt64:$immX, AArch64Base_CCMNIMIX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, AArch64Base_CCMNIMIX_immXAsInt64:$immX, AArch64Base_CCMNIMIX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -17393,7 +17393,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMNINEW_immXAsInt64:$immX, AArch64Base_CCMNINEW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, AArch64Base_CCMNINEW_immXAsInt64:$immX, AArch64Base_CCMNINEW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -17448,7 +17448,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMNINEX_immXAsInt64:$immX, AArch64Base_CCMNINEX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, AArch64Base_CCMNINEX_immXAsInt64:$immX, AArch64Base_CCMNINEX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -17503,7 +17503,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMNINVW_immXAsInt64:$immX, AArch64Base_CCMNINVW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, AArch64Base_CCMNINVW_immXAsInt64:$immX, AArch64Base_CCMNINVW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -17558,7 +17558,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMNINVX_immXAsInt64:$immX, AArch64Base_CCMNINVX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, AArch64Base_CCMNINVX_immXAsInt64:$immX, AArch64Base_CCMNINVX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -17613,7 +17613,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMNIPLW_immXAsInt64:$immX, AArch64Base_CCMNIPLW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, AArch64Base_CCMNIPLW_immXAsInt64:$immX, AArch64Base_CCMNIPLW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -17668,7 +17668,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMNIPLX_immXAsInt64:$immX, AArch64Base_CCMNIPLX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, AArch64Base_CCMNIPLX_immXAsInt64:$immX, AArch64Base_CCMNIPLX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -17723,7 +17723,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMNIVCW_immXAsInt64:$immX, AArch64Base_CCMNIVCW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, AArch64Base_CCMNIVCW_immXAsInt64:$immX, AArch64Base_CCMNIVCW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -17778,7 +17778,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMNIVCX_immXAsInt64:$immX, AArch64Base_CCMNIVCX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, AArch64Base_CCMNIVCX_immXAsInt64:$immX, AArch64Base_CCMNIVCX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -17833,7 +17833,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMNIVSW_immXAsInt64:$immX, AArch64Base_CCMNIVSW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, AArch64Base_CCMNIVSW_immXAsInt64:$immX, AArch64Base_CCMNIVSW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -17888,7 +17888,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMNIVSX_immXAsInt64:$immX, AArch64Base_CCMNIVSX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, AArch64Base_CCMNIVSX_immXAsInt64:$immX, AArch64Base_CCMNIVSX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -17943,7 +17943,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMNLEW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_CCMNLEW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -17998,7 +17998,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMNLEX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_CCMNLEX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -18053,7 +18053,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMNLSW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_CCMNLSW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -18108,7 +18108,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMNLSX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_CCMNLSX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -18163,7 +18163,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMNLTW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_CCMNLTW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -18218,7 +18218,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMNLTX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_CCMNLTX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -18273,7 +18273,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMNMIW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_CCMNMIW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -18328,7 +18328,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMNMIX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_CCMNMIX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -18383,7 +18383,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMNNEW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_CCMNNEW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -18438,7 +18438,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMNNEX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_CCMNNEX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -18493,7 +18493,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMNNVW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_CCMNNVW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -18548,7 +18548,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMNNVX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_CCMNNVX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -18603,7 +18603,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMNPLW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_CCMNPLW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -18658,7 +18658,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMNPLX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_CCMNPLX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -18713,7 +18713,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMNVCW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_CCMNVCW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -18768,7 +18768,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMNVCX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_CCMNVCX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -18823,7 +18823,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMNVSW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_CCMNVSW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -18878,7 +18878,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMNVSX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_CCMNVSX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -18933,7 +18933,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMPALW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_CCMPALW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -18988,7 +18988,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMPALX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_CCMPALX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -19043,7 +19043,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMPCCW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_CCMPCCW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -19098,7 +19098,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMPCCX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_CCMPCCX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -19153,7 +19153,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMPCSW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_CCMPCSW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -19208,7 +19208,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMPCSX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_CCMPCSX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -19263,7 +19263,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMPEQW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_CCMPEQW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -19318,7 +19318,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMPEQX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_CCMPEQX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -19373,7 +19373,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMPGEW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_CCMPGEW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -19428,7 +19428,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMPGEX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_CCMPGEX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -19483,7 +19483,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMPGTW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_CCMPGTW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -19538,7 +19538,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMPGTX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_CCMPGTX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -19593,7 +19593,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMPHIW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_CCMPHIW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -19648,7 +19648,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMPHIX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_CCMPHIX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -19703,7 +19703,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMPIALW_immXAsInt64:$immX, AArch64Base_CCMPIALW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, AArch64Base_CCMPIALW_immXAsInt64:$immX, AArch64Base_CCMPIALW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -19758,7 +19758,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMPIALX_immXAsInt64:$immX, AArch64Base_CCMPIALX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, AArch64Base_CCMPIALX_immXAsInt64:$immX, AArch64Base_CCMPIALX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -19813,7 +19813,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMPICCW_immXAsInt64:$immX, AArch64Base_CCMPICCW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, AArch64Base_CCMPICCW_immXAsInt64:$immX, AArch64Base_CCMPICCW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -19868,7 +19868,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMPICCX_immXAsInt64:$immX, AArch64Base_CCMPICCX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, AArch64Base_CCMPICCX_immXAsInt64:$immX, AArch64Base_CCMPICCX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -19923,7 +19923,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMPICSW_immXAsInt64:$immX, AArch64Base_CCMPICSW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, AArch64Base_CCMPICSW_immXAsInt64:$immX, AArch64Base_CCMPICSW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -19978,7 +19978,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMPICSX_immXAsInt64:$immX, AArch64Base_CCMPICSX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, AArch64Base_CCMPICSX_immXAsInt64:$immX, AArch64Base_CCMPICSX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -20033,7 +20033,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMPIEQW_immXAsInt64:$immX, AArch64Base_CCMPIEQW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, AArch64Base_CCMPIEQW_immXAsInt64:$immX, AArch64Base_CCMPIEQW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -20088,7 +20088,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMPIEQX_immXAsInt64:$immX, AArch64Base_CCMPIEQX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, AArch64Base_CCMPIEQX_immXAsInt64:$immX, AArch64Base_CCMPIEQX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -20143,7 +20143,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMPIGEW_immXAsInt64:$immX, AArch64Base_CCMPIGEW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, AArch64Base_CCMPIGEW_immXAsInt64:$immX, AArch64Base_CCMPIGEW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -20198,7 +20198,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMPIGEX_immXAsInt64:$immX, AArch64Base_CCMPIGEX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, AArch64Base_CCMPIGEX_immXAsInt64:$immX, AArch64Base_CCMPIGEX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -20253,7 +20253,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMPIGTW_immXAsInt64:$immX, AArch64Base_CCMPIGTW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, AArch64Base_CCMPIGTW_immXAsInt64:$immX, AArch64Base_CCMPIGTW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -20308,7 +20308,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMPIGTX_immXAsInt64:$immX, AArch64Base_CCMPIGTX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, AArch64Base_CCMPIGTX_immXAsInt64:$immX, AArch64Base_CCMPIGTX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -20363,7 +20363,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMPIHIW_immXAsInt64:$immX, AArch64Base_CCMPIHIW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, AArch64Base_CCMPIHIW_immXAsInt64:$immX, AArch64Base_CCMPIHIW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -20418,7 +20418,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMPIHIX_immXAsInt64:$immX, AArch64Base_CCMPIHIX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, AArch64Base_CCMPIHIX_immXAsInt64:$immX, AArch64Base_CCMPIHIX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -20473,7 +20473,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMPILEW_immXAsInt64:$immX, AArch64Base_CCMPILEW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, AArch64Base_CCMPILEW_immXAsInt64:$immX, AArch64Base_CCMPILEW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -20528,7 +20528,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMPILEX_immXAsInt64:$immX, AArch64Base_CCMPILEX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, AArch64Base_CCMPILEX_immXAsInt64:$immX, AArch64Base_CCMPILEX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -20583,7 +20583,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMPILSW_immXAsInt64:$immX, AArch64Base_CCMPILSW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, AArch64Base_CCMPILSW_immXAsInt64:$immX, AArch64Base_CCMPILSW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -20638,7 +20638,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMPILSX_immXAsInt64:$immX, AArch64Base_CCMPILSX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, AArch64Base_CCMPILSX_immXAsInt64:$immX, AArch64Base_CCMPILSX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -20693,7 +20693,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMPILTW_immXAsInt64:$immX, AArch64Base_CCMPILTW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, AArch64Base_CCMPILTW_immXAsInt64:$immX, AArch64Base_CCMPILTW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -20748,7 +20748,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMPILTX_immXAsInt64:$immX, AArch64Base_CCMPILTX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, AArch64Base_CCMPILTX_immXAsInt64:$immX, AArch64Base_CCMPILTX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -20803,7 +20803,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMPIMIW_immXAsInt64:$immX, AArch64Base_CCMPIMIW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, AArch64Base_CCMPIMIW_immXAsInt64:$immX, AArch64Base_CCMPIMIW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -20858,7 +20858,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMPIMIX_immXAsInt64:$immX, AArch64Base_CCMPIMIX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, AArch64Base_CCMPIMIX_immXAsInt64:$immX, AArch64Base_CCMPIMIX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -20913,7 +20913,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMPINEW_immXAsInt64:$immX, AArch64Base_CCMPINEW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, AArch64Base_CCMPINEW_immXAsInt64:$immX, AArch64Base_CCMPINEW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -20968,7 +20968,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMPINEX_immXAsInt64:$immX, AArch64Base_CCMPINEX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, AArch64Base_CCMPINEX_immXAsInt64:$immX, AArch64Base_CCMPINEX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -21023,7 +21023,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMPINVW_immXAsInt64:$immX, AArch64Base_CCMPINVW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, AArch64Base_CCMPINVW_immXAsInt64:$immX, AArch64Base_CCMPINVW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -21078,7 +21078,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMPINVX_immXAsInt64:$immX, AArch64Base_CCMPINVX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, AArch64Base_CCMPINVX_immXAsInt64:$immX, AArch64Base_CCMPINVX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -21133,7 +21133,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMPIPLW_immXAsInt64:$immX, AArch64Base_CCMPIPLW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, AArch64Base_CCMPIPLW_immXAsInt64:$immX, AArch64Base_CCMPIPLW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -21188,7 +21188,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMPIPLX_immXAsInt64:$immX, AArch64Base_CCMPIPLX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, AArch64Base_CCMPIPLX_immXAsInt64:$immX, AArch64Base_CCMPIPLX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -21243,7 +21243,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMPIVCW_immXAsInt64:$immX, AArch64Base_CCMPIVCW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, AArch64Base_CCMPIVCW_immXAsInt64:$immX, AArch64Base_CCMPIVCW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -21298,7 +21298,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMPIVCX_immXAsInt64:$immX, AArch64Base_CCMPIVCX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, AArch64Base_CCMPIVCX_immXAsInt64:$immX, AArch64Base_CCMPIVCX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -21353,7 +21353,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMPIVSW_immXAsInt64:$immX, AArch64Base_CCMPIVSW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, AArch64Base_CCMPIVSW_immXAsInt64:$immX, AArch64Base_CCMPIVSW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -21408,7 +21408,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, AArch64Base_CCMPIVSX_immXAsInt64:$immX, AArch64Base_CCMPIVSX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, AArch64Base_CCMPIVSX_immXAsInt64:$immX, AArch64Base_CCMPIVSX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -21463,7 +21463,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMPLEW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_CCMPLEW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -21518,7 +21518,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMPLEX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_CCMPLEX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -21573,7 +21573,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMPLSW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_CCMPLSW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -21628,7 +21628,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMPLSX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_CCMPLSX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -21683,7 +21683,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMPLTW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_CCMPLTW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -21738,7 +21738,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMPLTX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_CCMPLTX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -21793,7 +21793,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMPMIW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_CCMPMIW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -21848,7 +21848,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMPMIX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_CCMPMIX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -21903,7 +21903,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMPNEW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_CCMPNEW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -21958,7 +21958,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMPNEX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_CCMPNEX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -22013,7 +22013,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMPNVW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_CCMPNVW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -22068,7 +22068,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMPNVX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_CCMPNVX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -22123,7 +22123,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMPPLW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_CCMPPLW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -22178,7 +22178,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMPPLX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_CCMPPLX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -22233,7 +22233,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMPVCW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_CCMPVCW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -22288,7 +22288,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMPVCX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_CCMPVCX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -22343,7 +22343,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMPVSW_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_CCMPVSW_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -22398,7 +22398,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_CCMPVSX_nzcvAsInt8:$nzcv );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_CCMPVSX_nzcvAsInt8:$nzcv );
 
 field bits<32> Inst;
 
@@ -22453,7 +22453,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn );
+let InOperandList = ( ins W:$rn );
 
 field bits<32> Inst;
 
@@ -22502,7 +22502,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn );
+let InOperandList = ( ins X:$rn );
 
 field bits<32> Inst;
 
@@ -22551,7 +22551,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn );
+let InOperandList = ( ins W:$rn );
 
 field bits<32> Inst;
 
@@ -22600,7 +22600,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn );
+let InOperandList = ( ins X:$rn );
 
 field bits<32> Inst;
 
@@ -22649,7 +22649,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -22703,7 +22703,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -22757,7 +22757,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -22811,7 +22811,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -22865,7 +22865,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -22919,7 +22919,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -22973,7 +22973,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -23027,7 +23027,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -23081,7 +23081,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -23135,7 +23135,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -23189,7 +23189,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -23243,7 +23243,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -23297,7 +23297,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -23351,7 +23351,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -23405,7 +23405,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -23459,7 +23459,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -23513,7 +23513,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -23567,7 +23567,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -23621,7 +23621,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -23675,7 +23675,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -23729,7 +23729,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -23783,7 +23783,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -23837,7 +23837,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -23891,7 +23891,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -23945,7 +23945,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -23999,7 +23999,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -24053,7 +24053,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -24107,7 +24107,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -24161,7 +24161,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -24215,7 +24215,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -24269,7 +24269,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -24323,7 +24323,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -24377,7 +24377,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -24431,7 +24431,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -24485,7 +24485,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -24539,7 +24539,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -24593,7 +24593,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -24647,7 +24647,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -24701,7 +24701,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -24755,7 +24755,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -24809,7 +24809,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -24863,7 +24863,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -24917,7 +24917,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -24971,7 +24971,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -25025,7 +25025,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -25079,7 +25079,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -25133,7 +25133,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -25187,7 +25187,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -25241,7 +25241,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -25295,7 +25295,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -25349,7 +25349,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -25403,7 +25403,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -25457,7 +25457,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -25511,7 +25511,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -25565,7 +25565,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -25619,7 +25619,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -25673,7 +25673,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -25727,7 +25727,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -25781,7 +25781,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -25835,7 +25835,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -25889,7 +25889,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -25943,7 +25943,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -25997,7 +25997,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -26051,7 +26051,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -26105,7 +26105,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -26159,7 +26159,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -26213,7 +26213,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -26267,7 +26267,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -26321,7 +26321,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -26375,7 +26375,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -26429,7 +26429,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -26483,7 +26483,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -26537,7 +26537,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -26591,7 +26591,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -26645,7 +26645,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -26699,7 +26699,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -26753,7 +26753,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -26807,7 +26807,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -26861,7 +26861,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -26915,7 +26915,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -26969,7 +26969,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -27023,7 +27023,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -27077,7 +27077,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -27131,7 +27131,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -27185,7 +27185,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -27239,7 +27239,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -27293,7 +27293,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -27347,7 +27347,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -27401,7 +27401,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -27455,7 +27455,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -27509,7 +27509,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -27563,7 +27563,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -27617,7 +27617,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -27671,7 +27671,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -27725,7 +27725,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -27779,7 +27779,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -27833,7 +27833,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -27887,7 +27887,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -27941,7 +27941,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -27995,7 +27995,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -28049,7 +28049,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -28103,7 +28103,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -28157,7 +28157,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -28211,7 +28211,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -28265,7 +28265,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -28319,7 +28319,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -28373,7 +28373,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -28427,7 +28427,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -28481,7 +28481,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -28535,7 +28535,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -28589,7 +28589,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -28643,7 +28643,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -28697,7 +28697,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -28751,7 +28751,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -28805,7 +28805,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -28859,7 +28859,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -28913,7 +28913,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -28967,7 +28967,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -29021,7 +29021,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -29075,7 +29075,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -29129,7 +29129,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -29183,7 +29183,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -29237,7 +29237,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -29291,7 +29291,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -29345,7 +29345,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -29399,7 +29399,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -29453,7 +29453,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -29507,7 +29507,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -29561,7 +29561,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins W:$rn, W:$rm );
 
 field bits<32> Inst;
 
@@ -29617,7 +29617,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_EONWASR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_EONWASR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -29673,7 +29673,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_EONWLSL_imm6AsInt8:$imm6 );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_EONWLSL_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -29729,7 +29729,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_EONWLSR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_EONWLSR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -29785,7 +29785,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_EONWROR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_EONWROR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -29841,7 +29841,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -29897,7 +29897,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_EONXASR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_EONXASR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -29953,7 +29953,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_EONXLSL_imm6AsInt8:$imm6 );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_EONXLSL_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -30009,7 +30009,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_EONXLSR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_EONXLSR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -30065,7 +30065,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_EONXROR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_EONXROR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -30121,7 +30121,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, AArch64Base_EORIW_immWSizeAsInt32:$immWSize );
+let InOperandList = ( ins W:$rn, AArch64Base_EORIW_immWSizeAsInt32:$immWSize );
 
 field bits<32> Inst;
 
@@ -30172,7 +30172,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, AArch64Base_EORIX_immXSizeAsInt64:$immXSize );
+let InOperandList = ( ins X:$rn, AArch64Base_EORIX_immXSizeAsInt64:$immXSize );
 
 field bits<32> Inst;
 
@@ -30223,7 +30223,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins W:$rn, W:$rm );
 
 field bits<32> Inst;
 
@@ -30279,7 +30279,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_EORWASR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_EORWASR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -30335,7 +30335,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_EORWLSL_imm6AsInt8:$imm6 );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_EORWLSL_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -30391,7 +30391,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_EORWLSR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_EORWLSR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -30447,7 +30447,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_EORWROR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_EORWROR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -30503,7 +30503,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -30559,7 +30559,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_EORXASR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_EORXASR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -30615,7 +30615,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_EORXLSL_imm6AsInt8:$imm6 );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_EORXLSL_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -30671,7 +30671,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_EORXLSR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_EORXLSR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -30727,7 +30727,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_EORXROR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_EORXROR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -30783,7 +30783,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_EXTRW_shiftWSizeAsInt8:$shiftWSize );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_EXTRW_shiftWSizeAsInt8:$shiftWSize );
 
 field bits<32> Inst;
 
@@ -30839,7 +30839,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_EXTRX_shiftXSizeAsInt8:$shiftXSize );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_EXTRX_shiftXSizeAsInt8:$shiftXSize );
 
 field bits<32> Inst;
 
@@ -32642,7 +32642,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -32701,7 +32701,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -32760,7 +32760,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -32819,7 +32819,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -32878,7 +32878,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -32937,7 +32937,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -32996,7 +32996,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -33055,7 +33055,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -33114,7 +33114,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -33173,7 +33173,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -33232,7 +33232,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -33291,7 +33291,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -33350,7 +33350,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -33409,7 +33409,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -33468,7 +33468,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -33527,7 +33527,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -33586,7 +33586,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -33645,7 +33645,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -33704,7 +33704,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -33763,7 +33763,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -33822,7 +33822,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -33881,7 +33881,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -33940,7 +33940,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -33999,7 +33999,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -34058,7 +34058,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -34117,7 +34117,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -34176,7 +34176,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -34235,7 +34235,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -34294,7 +34294,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -34353,7 +34353,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -34412,7 +34412,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -34471,7 +34471,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -34530,7 +34530,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -34589,7 +34589,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -34648,7 +34648,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -34707,7 +34707,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -34766,7 +34766,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -34825,7 +34825,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -34884,7 +34884,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -34943,7 +34943,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -35002,7 +35002,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -35061,7 +35061,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -35120,7 +35120,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -35179,7 +35179,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -35238,7 +35238,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -35297,7 +35297,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -35356,7 +35356,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -35415,7 +35415,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -35474,7 +35474,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -35533,7 +35533,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -35592,7 +35592,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -35651,7 +35651,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -35710,7 +35710,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -35769,7 +35769,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -35828,7 +35828,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -35887,7 +35887,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -35946,7 +35946,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -36005,7 +36005,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -36064,7 +36064,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -36123,7 +36123,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -36182,7 +36182,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -36241,7 +36241,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -36300,7 +36300,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -36359,7 +36359,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -36418,7 +36418,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -36477,7 +36477,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -36536,7 +36536,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -36595,7 +36595,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -36654,7 +36654,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -36713,7 +36713,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -36772,7 +36772,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -36831,7 +36831,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rt );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -37756,7 +37756,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins W:$rn, W:$rm );
 
 field bits<32> Inst;
 
@@ -37810,7 +37810,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -37864,7 +37864,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins W:$rn, W:$rm );
 
 field bits<32> Inst;
 
@@ -37918,7 +37918,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -37972,7 +37972,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$ra, S:$rn, S:$rm );
+let InOperandList = ( ins W:$ra, W:$rn, W:$rm );
 
 field bits<32> Inst;
 
@@ -38026,7 +38026,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$ra, S:$rn, S:$rm );
+let InOperandList = ( ins X:$ra, X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -38080,7 +38080,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins AArch64Base_MOVKWPos00_imm16AsInt16:$imm16 );
+let InOperandList = ( ins X:$rd, AArch64Base_MOVKWPos00_imm16AsInt16:$imm16 );
 
 field bits<32> Inst;
 
@@ -38131,7 +38131,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins AArch64Base_MOVKWPos16_imm16AsInt16:$imm16 );
+let InOperandList = ( ins X:$rd, AArch64Base_MOVKWPos16_imm16AsInt16:$imm16 );
 
 field bits<32> Inst;
 
@@ -38182,7 +38182,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins AArch64Base_MOVKXPos00_imm16AsInt16:$imm16 );
+let InOperandList = ( ins X:$rd, AArch64Base_MOVKXPos00_imm16AsInt16:$imm16 );
 
 field bits<32> Inst;
 
@@ -38233,7 +38233,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins AArch64Base_MOVKXPos16_imm16AsInt16:$imm16 );
+let InOperandList = ( ins X:$rd, AArch64Base_MOVKXPos16_imm16AsInt16:$imm16 );
 
 field bits<32> Inst;
 
@@ -38284,7 +38284,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins AArch64Base_MOVKXPos32_imm16AsInt16:$imm16 );
+let InOperandList = ( ins X:$rd, AArch64Base_MOVKXPos32_imm16AsInt16:$imm16 );
 
 field bits<32> Inst;
 
@@ -38335,7 +38335,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins AArch64Base_MOVKXPos48_imm16AsInt16:$imm16 );
+let InOperandList = ( ins X:$rd, AArch64Base_MOVKXPos48_imm16AsInt16:$imm16 );
 
 field bits<32> Inst;
 
@@ -39045,7 +39045,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rt, AArch64Base_MSR_sysregAsInt16:$sysreg );
+let InOperandList = ( ins X:$rt, AArch64Base_MSR_sysregAsInt16:$sysreg );
 
 field bits<32> Inst;
 
@@ -39092,7 +39092,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$ra, S:$rn, S:$rm );
+let InOperandList = ( ins W:$ra, W:$rn, W:$rm );
 
 field bits<32> Inst;
 
@@ -39146,7 +39146,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$ra, S:$rn, S:$rm );
+let InOperandList = ( ins X:$ra, X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -39245,7 +39245,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins W:$rn, W:$rm );
 
 field bits<32> Inst;
 
@@ -39301,7 +39301,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ORNWASR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_ORNWASR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -39357,7 +39357,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ORNWLSL_imm6AsInt8:$imm6 );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_ORNWLSL_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -39413,7 +39413,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ORNWLSR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_ORNWLSR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -39469,7 +39469,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ORNWROR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_ORNWROR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -39525,7 +39525,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -39581,7 +39581,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ORNXASR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_ORNXASR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -39637,7 +39637,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ORNXLSL_imm6AsInt8:$imm6 );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_ORNXLSL_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -39693,7 +39693,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ORNXLSR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_ORNXLSR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -39749,7 +39749,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ORNXROR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_ORNXROR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -39805,7 +39805,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, AArch64Base_ORRIW_immWSizeAsInt32:$immWSize );
+let InOperandList = ( ins W:$rn, AArch64Base_ORRIW_immWSizeAsInt32:$immWSize );
 
 field bits<32> Inst;
 
@@ -39856,7 +39856,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, AArch64Base_ORRIX_immXSizeAsInt64:$immXSize );
+let InOperandList = ( ins X:$rn, AArch64Base_ORRIX_immXSizeAsInt64:$immXSize );
 
 field bits<32> Inst;
 
@@ -39907,7 +39907,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins W:$rn, W:$rm );
 
 field bits<32> Inst;
 
@@ -39963,7 +39963,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ORRWASR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_ORRWASR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -40019,7 +40019,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ORRWLSL_imm6AsInt8:$imm6 );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_ORRWLSL_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -40075,7 +40075,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ORRWLSR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_ORRWLSR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -40131,7 +40131,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ORRWROR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins W:$rn, W:$rm, AArch64Base_ORRWROR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -40187,7 +40187,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -40243,7 +40243,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ORRXASR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_ORRXASR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -40299,7 +40299,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ORRXLSL_imm6AsInt8:$imm6 );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_ORRXLSL_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -40355,7 +40355,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ORRXLSR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_ORRXLSR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -40411,7 +40411,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_ORRXROR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_ORRXROR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -40467,7 +40467,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, bare_symbol:$bits );
+let InOperandList = ( ins W:$rn, bare_symbol:$bits );
 
 field bits<32> Inst;
 
@@ -40516,7 +40516,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, bare_symbol:$bits );
+let InOperandList = ( ins X:$rn, bare_symbol:$bits );
 
 field bits<32> Inst;
 
@@ -40565,7 +40565,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn );
+let InOperandList = ( ins X:$rn );
 
 field bits<32> Inst;
 
@@ -40611,7 +40611,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn );
+let InOperandList = ( ins X:$rn );
 
 field bits<32> Inst;
 
@@ -40660,7 +40660,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn );
+let InOperandList = ( ins X:$rn );
 
 field bits<32> Inst;
 
@@ -40709,7 +40709,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn );
+let InOperandList = ( ins X:$rn );
 
 field bits<32> Inst;
 
@@ -40758,7 +40758,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn );
+let InOperandList = ( ins X:$rn );
 
 field bits<32> Inst;
 
@@ -40807,7 +40807,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn );
+let InOperandList = ( ins X:$rn );
 
 field bits<32> Inst;
 
@@ -40856,7 +40856,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins W:$rn, W:$rm );
 
 field bits<32> Inst;
 
@@ -40910,7 +40910,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -40964,7 +40964,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins W:$rn, W:$rm );
 
 field bits<32> Inst;
 
@@ -41016,7 +41016,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -41068,7 +41068,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins W:$rn, W:$rm );
 
 field bits<32> Inst;
 
@@ -41120,7 +41120,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -41172,7 +41172,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, AArch64Base_SBFMW_leftWSizeAsInt8:$leftWSize, AArch64Base_SBFMW_rightWSizeAsInt8:$rightWSize );
+let InOperandList = ( ins W:$rn, AArch64Base_SBFMW_leftWSizeAsInt8:$leftWSize, AArch64Base_SBFMW_rightWSizeAsInt8:$rightWSize );
 
 field bits<32> Inst;
 
@@ -41227,7 +41227,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, AArch64Base_SBFMX_leftXSizeAsInt8:$leftXSize, AArch64Base_SBFMX_rightXSizeAsInt8:$rightXSize );
+let InOperandList = ( ins X:$rn, AArch64Base_SBFMX_leftXSizeAsInt8:$leftXSize, AArch64Base_SBFMX_rightXSizeAsInt8:$rightXSize );
 
 field bits<32> Inst;
 
@@ -41282,7 +41282,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins W:$rm, W:$rn );
 
 field bits<32> Inst;
 
@@ -41334,7 +41334,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins X:$rm, X:$rn );
 
 field bits<32> Inst;
 
@@ -41386,7 +41386,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$ra, S:$rn, S:$rm );
+let InOperandList = ( ins X:$ra, W:$rn, W:$rm );
 
 field bits<32> Inst;
 
@@ -41440,7 +41440,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$ra, S:$rn, S:$rm );
+let InOperandList = ( ins X:$ra, W:$rn, W:$rm );
 
 field bits<32> Inst;
 
@@ -41494,7 +41494,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -41546,7 +41546,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rt, S:$rt2, AArch64Base_STPW_offWSizeAsInt64:$offWSize );
+let InOperandList = ( ins S:$rn, X:$rt, X:$rt2, AArch64Base_STPW_offWSizeAsInt64:$offWSize );
 
 field bits<32> Inst;
 
@@ -41602,7 +41602,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rn );
-let InOperandList = ( ins S:$rt, S:$rt2, AArch64Base_STPWPre_offWSizeAsInt64:$offWSize );
+let InOperandList = ( ins X:$rt, X:$rt2, AArch64Base_STPWPre_offWSizeAsInt64:$offWSize );
 
 field bits<32> Inst;
 
@@ -41658,7 +41658,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rn );
-let InOperandList = ( ins S:$rt, S:$rt2, AArch64Base_STPWPst_offWSizeAsInt64:$offWSize );
+let InOperandList = ( ins X:$rt, X:$rt2, AArch64Base_STPWPst_offWSizeAsInt64:$offWSize );
 
 field bits<32> Inst;
 
@@ -41714,7 +41714,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rt, S:$rt2, AArch64Base_STPX_offXSizeAsInt64:$offXSize );
+let InOperandList = ( ins S:$rn, X:$rt, X:$rt2, AArch64Base_STPX_offXSizeAsInt64:$offXSize );
 
 field bits<32> Inst;
 
@@ -41770,7 +41770,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rn );
-let InOperandList = ( ins S:$rt, S:$rt2, AArch64Base_STPXPre_offXSizeAsInt64:$offXSize );
+let InOperandList = ( ins X:$rt, X:$rt2, AArch64Base_STPXPre_offXSizeAsInt64:$offXSize );
 
 field bits<32> Inst;
 
@@ -41826,7 +41826,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rn );
-let InOperandList = ( ins S:$rt, S:$rt2, AArch64Base_STPXPst_offXSizeAsInt64:$offXSize );
+let InOperandList = ( ins X:$rt, X:$rt2, AArch64Base_STPXPst_offXSizeAsInt64:$offXSize );
 
 field bits<32> Inst;
 
@@ -41882,7 +41882,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rt, AArch64Base_STRB_offsetAsInt64:$offset );
+let InOperandList = ( ins S:$rn, X:$rt, AArch64Base_STRB_offsetAsInt64:$offset );
 
 field bits<32> Inst;
 
@@ -41935,7 +41935,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rt, AArch64Base_STRH_offsetAsInt64:$offset );
+let InOperandList = ( ins S:$rn, X:$rt, AArch64Base_STRH_offsetAsInt64:$offset );
 
 field bits<32> Inst;
 
@@ -41988,7 +41988,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rn );
-let InOperandList = ( ins S:$rt, AArch64Base_STRPreB_offsetAsInt64:$offset );
+let InOperandList = ( ins X:$rt, AArch64Base_STRPreB_offsetAsInt64:$offset );
 
 field bits<32> Inst;
 
@@ -42043,7 +42043,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rn );
-let InOperandList = ( ins S:$rt, AArch64Base_STRPreH_offsetAsInt64:$offset );
+let InOperandList = ( ins X:$rt, AArch64Base_STRPreH_offsetAsInt64:$offset );
 
 field bits<32> Inst;
 
@@ -42098,7 +42098,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rn );
-let InOperandList = ( ins S:$rt, AArch64Base_STRPreW_offsetAsInt64:$offset );
+let InOperandList = ( ins X:$rt, AArch64Base_STRPreW_offsetAsInt64:$offset );
 
 field bits<32> Inst;
 
@@ -42153,7 +42153,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rn );
-let InOperandList = ( ins S:$rt, AArch64Base_STRPreX_offsetAsInt64:$offset );
+let InOperandList = ( ins X:$rt, AArch64Base_STRPreX_offsetAsInt64:$offset );
 
 field bits<32> Inst;
 
@@ -42208,7 +42208,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rn );
-let InOperandList = ( ins S:$rt, AArch64Base_STRPstB_offsetAsInt64:$offset );
+let InOperandList = ( ins X:$rt, AArch64Base_STRPstB_offsetAsInt64:$offset );
 
 field bits<32> Inst;
 
@@ -42263,7 +42263,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rn );
-let InOperandList = ( ins S:$rt, AArch64Base_STRPstH_offsetAsInt64:$offset );
+let InOperandList = ( ins X:$rt, AArch64Base_STRPstH_offsetAsInt64:$offset );
 
 field bits<32> Inst;
 
@@ -42318,7 +42318,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rn );
-let InOperandList = ( ins S:$rt, AArch64Base_STRPstW_offsetAsInt64:$offset );
+let InOperandList = ( ins X:$rt, AArch64Base_STRPstW_offsetAsInt64:$offset );
 
 field bits<32> Inst;
 
@@ -42373,7 +42373,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rn );
-let InOperandList = ( ins S:$rt, AArch64Base_STRPstX_offsetAsInt64:$offset );
+let InOperandList = ( ins X:$rt, AArch64Base_STRPstX_offsetAsInt64:$offset );
 
 field bits<32> Inst;
 
@@ -42428,7 +42428,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, S:$rt );
+let InOperandList = ( ins S:$rn, X:$rm, X:$rt );
 
 field bits<32> Inst;
 
@@ -42487,7 +42487,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, S:$rt );
+let InOperandList = ( ins S:$rn, X:$rm, X:$rt );
 
 field bits<32> Inst;
 
@@ -42546,7 +42546,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, S:$rt );
+let InOperandList = ( ins S:$rn, X:$rm, X:$rt );
 
 field bits<32> Inst;
 
@@ -42605,7 +42605,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, S:$rt );
+let InOperandList = ( ins S:$rn, X:$rm, X:$rt );
 
 field bits<32> Inst;
 
@@ -42664,7 +42664,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, S:$rt );
+let InOperandList = ( ins S:$rn, X:$rm, X:$rt );
 
 field bits<32> Inst;
 
@@ -42723,7 +42723,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, S:$rt );
+let InOperandList = ( ins S:$rn, X:$rm, X:$rt );
 
 field bits<32> Inst;
 
@@ -42782,7 +42782,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, S:$rt );
+let InOperandList = ( ins S:$rn, X:$rm, X:$rt );
 
 field bits<32> Inst;
 
@@ -42841,7 +42841,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, S:$rt );
+let InOperandList = ( ins S:$rn, X:$rm, X:$rt );
 
 field bits<32> Inst;
 
@@ -42900,7 +42900,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, S:$rt );
+let InOperandList = ( ins S:$rn, X:$rm, X:$rt );
 
 field bits<32> Inst;
 
@@ -42959,7 +42959,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, S:$rt );
+let InOperandList = ( ins S:$rn, X:$rm, X:$rt );
 
 field bits<32> Inst;
 
@@ -43018,7 +43018,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, S:$rt );
+let InOperandList = ( ins S:$rn, X:$rm, X:$rt );
 
 field bits<32> Inst;
 
@@ -43077,7 +43077,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, S:$rt );
+let InOperandList = ( ins S:$rn, X:$rm, X:$rt );
 
 field bits<32> Inst;
 
@@ -43136,7 +43136,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, S:$rt );
+let InOperandList = ( ins S:$rn, X:$rm, X:$rt );
 
 field bits<32> Inst;
 
@@ -43195,7 +43195,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, S:$rt );
+let InOperandList = ( ins S:$rn, X:$rm, X:$rt );
 
 field bits<32> Inst;
 
@@ -43254,7 +43254,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, S:$rt );
+let InOperandList = ( ins S:$rn, X:$rm, X:$rt );
 
 field bits<32> Inst;
 
@@ -43313,7 +43313,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, S:$rt );
+let InOperandList = ( ins S:$rn, X:$rm, X:$rt );
 
 field bits<32> Inst;
 
@@ -43372,7 +43372,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, S:$rt );
+let InOperandList = ( ins S:$rn, X:$rm, X:$rt );
 
 field bits<32> Inst;
 
@@ -43431,7 +43431,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, S:$rt );
+let InOperandList = ( ins S:$rn, X:$rm, X:$rt );
 
 field bits<32> Inst;
 
@@ -43490,7 +43490,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, S:$rt );
+let InOperandList = ( ins S:$rn, X:$rm, X:$rt );
 
 field bits<32> Inst;
 
@@ -43549,7 +43549,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, S:$rt );
+let InOperandList = ( ins S:$rn, X:$rm, X:$rt );
 
 field bits<32> Inst;
 
@@ -43608,7 +43608,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, S:$rt );
+let InOperandList = ( ins S:$rn, X:$rm, X:$rt );
 
 field bits<32> Inst;
 
@@ -43667,7 +43667,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, S:$rt );
+let InOperandList = ( ins S:$rn, X:$rm, X:$rt );
 
 field bits<32> Inst;
 
@@ -43726,7 +43726,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, S:$rt );
+let InOperandList = ( ins S:$rn, X:$rm, X:$rt );
 
 field bits<32> Inst;
 
@@ -43785,7 +43785,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, S:$rt );
+let InOperandList = ( ins S:$rn, X:$rm, X:$rt );
 
 field bits<32> Inst;
 
@@ -43844,7 +43844,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, S:$rt );
+let InOperandList = ( ins S:$rn, X:$rm, X:$rt );
 
 field bits<32> Inst;
 
@@ -43903,7 +43903,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, S:$rt );
+let InOperandList = ( ins S:$rn, X:$rm, X:$rt );
 
 field bits<32> Inst;
 
@@ -43962,7 +43962,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, S:$rt );
+let InOperandList = ( ins S:$rn, X:$rm, X:$rt );
 
 field bits<32> Inst;
 
@@ -44021,7 +44021,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, S:$rt );
+let InOperandList = ( ins S:$rn, X:$rm, X:$rt );
 
 field bits<32> Inst;
 
@@ -44080,7 +44080,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, S:$rt );
+let InOperandList = ( ins S:$rn, X:$rm, X:$rt );
 
 field bits<32> Inst;
 
@@ -44139,7 +44139,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, S:$rt );
+let InOperandList = ( ins S:$rn, X:$rm, X:$rt );
 
 field bits<32> Inst;
 
@@ -44198,7 +44198,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, S:$rt );
+let InOperandList = ( ins S:$rn, X:$rm, X:$rt );
 
 field bits<32> Inst;
 
@@ -44257,7 +44257,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rm, S:$rt );
+let InOperandList = ( ins S:$rn, X:$rm, X:$rt );
 
 field bits<32> Inst;
 
@@ -44316,7 +44316,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rt, AArch64Base_STRW_offsetAsInt64:$offset );
+let InOperandList = ( ins S:$rn, X:$rt, AArch64Base_STRW_offsetAsInt64:$offset );
 
 field bits<32> Inst;
 
@@ -44369,7 +44369,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rt, AArch64Base_STRX_offsetAsInt64:$offset );
+let InOperandList = ( ins S:$rn, X:$rt, AArch64Base_STRX_offsetAsInt64:$offset );
 
 field bits<32> Inst;
 
@@ -44422,7 +44422,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rt, AArch64Base_STURB_offsetAsInt64:$offset );
+let InOperandList = ( ins S:$rn, X:$rt, AArch64Base_STURB_offsetAsInt64:$offset );
 
 field bits<32> Inst;
 
@@ -44477,7 +44477,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rt, AArch64Base_STURH_offsetAsInt64:$offset );
+let InOperandList = ( ins S:$rn, X:$rt, AArch64Base_STURH_offsetAsInt64:$offset );
 
 field bits<32> Inst;
 
@@ -44532,7 +44532,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rt, AArch64Base_STURW_offsetAsInt64:$offset );
+let InOperandList = ( ins S:$rn, X:$rt, AArch64Base_STURW_offsetAsInt64:$offset );
 
 field bits<32> Inst;
 
@@ -44587,7 +44587,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rn, S:$rt, AArch64Base_STURX_offsetAsInt64:$offset );
+let InOperandList = ( ins S:$rn, X:$rt, AArch64Base_STURX_offsetAsInt64:$offset );
 
 field bits<32> Inst;
 
@@ -44642,7 +44642,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins W:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -44701,7 +44701,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBWASR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins W:$rn, X:$rm, AArch64Base_SUBWASR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -44760,7 +44760,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, AArch64Base_SUBWI_imm12XAsInt64:$imm12X );
+let InOperandList = ( ins R:$rn, AArch64Base_SUBWI_imm12XAsInt64:$imm12X );
 
 field bits<32> Inst;
 
@@ -44816,7 +44816,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, AArch64Base_SUBWI12_imm12SAsInt64:$imm12S );
+let InOperandList = ( ins R:$rn, AArch64Base_SUBWI12_imm12SAsInt64:$imm12S );
 
 field bits<32> Inst;
 
@@ -44872,7 +44872,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBWLSL_imm6AsInt8:$imm6 );
+let InOperandList = ( ins W:$rn, X:$rm, AArch64Base_SUBWLSL_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -44931,7 +44931,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBWLSR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins W:$rn, X:$rm, AArch64Base_SUBWLSR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -44990,7 +44990,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins W:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -45049,7 +45049,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBWSASR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins W:$rn, X:$rm, AArch64Base_SUBWSASR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -45108,7 +45108,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, AArch64Base_SUBWSI_imm12XAsInt64:$imm12X );
+let InOperandList = ( ins R:$rn, AArch64Base_SUBWSI_imm12XAsInt64:$imm12X );
 
 field bits<32> Inst;
 
@@ -45164,7 +45164,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, AArch64Base_SUBWSI12_imm12SAsInt64:$imm12S );
+let InOperandList = ( ins R:$rn, AArch64Base_SUBWSI12_imm12SAsInt64:$imm12S );
 
 field bits<32> Inst;
 
@@ -45220,7 +45220,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBWSLSL_imm6AsInt8:$imm6 );
+let InOperandList = ( ins W:$rn, X:$rm, AArch64Base_SUBWSLSL_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -45279,7 +45279,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBWSLSR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins W:$rn, X:$rm, AArch64Base_SUBWSLSR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -45338,7 +45338,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBWSSXSB_imm3AsInt8:$imm3 );
+let InOperandList = ( ins R:$rn, X:$rm, AArch64Base_SUBWSSXSB_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -45396,7 +45396,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBWSSXSH_imm3AsInt8:$imm3 );
+let InOperandList = ( ins R:$rn, X:$rm, AArch64Base_SUBWSSXSH_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -45454,7 +45454,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBWSSXSW_imm3AsInt8:$imm3 );
+let InOperandList = ( ins R:$rn, X:$rm, AArch64Base_SUBWSSXSW_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -45512,7 +45512,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBWSSXSX_imm3AsInt8:$imm3 );
+let InOperandList = ( ins R:$rn, X:$rm, AArch64Base_SUBWSSXSX_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -45570,7 +45570,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins R:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -45628,7 +45628,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins R:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -45686,7 +45686,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins R:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -45744,7 +45744,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins R:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -45802,7 +45802,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBWSUXSB_imm3AsInt8:$imm3 );
+let InOperandList = ( ins R:$rn, X:$rm, AArch64Base_SUBWSUXSB_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -45860,7 +45860,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBWSUXSH_imm3AsInt8:$imm3 );
+let InOperandList = ( ins R:$rn, X:$rm, AArch64Base_SUBWSUXSH_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -45918,7 +45918,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBWSUXSW_imm3AsInt8:$imm3 );
+let InOperandList = ( ins R:$rn, X:$rm, AArch64Base_SUBWSUXSW_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -45976,7 +45976,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBWSUXSX_imm3AsInt8:$imm3 );
+let InOperandList = ( ins R:$rn, X:$rm, AArch64Base_SUBWSUXSX_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -46034,7 +46034,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins R:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -46092,7 +46092,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins R:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -46150,7 +46150,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins R:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -46208,7 +46208,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins R:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -46266,7 +46266,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBWSXSB_imm3AsInt8:$imm3 );
+let InOperandList = ( ins R:$rn, X:$rm, AArch64Base_SUBWSXSB_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -46324,7 +46324,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBWSXSH_imm3AsInt8:$imm3 );
+let InOperandList = ( ins R:$rn, X:$rm, AArch64Base_SUBWSXSH_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -46382,7 +46382,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBWSXSW_imm3AsInt8:$imm3 );
+let InOperandList = ( ins R:$rn, X:$rm, AArch64Base_SUBWSXSW_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -46440,7 +46440,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBWSXSX_imm3AsInt8:$imm3 );
+let InOperandList = ( ins R:$rn, X:$rm, AArch64Base_SUBWSXSX_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -46498,7 +46498,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins R:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -46556,7 +46556,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins R:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -46614,7 +46614,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins R:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -46672,7 +46672,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins R:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -46730,7 +46730,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBWUXSB_imm3AsInt8:$imm3 );
+let InOperandList = ( ins R:$rn, X:$rm, AArch64Base_SUBWUXSB_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -46788,7 +46788,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBWUXSH_imm3AsInt8:$imm3 );
+let InOperandList = ( ins R:$rn, X:$rm, AArch64Base_SUBWUXSH_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -46846,7 +46846,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBWUXSW_imm3AsInt8:$imm3 );
+let InOperandList = ( ins R:$rn, X:$rm, AArch64Base_SUBWUXSW_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -46904,7 +46904,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBWUXSX_imm3AsInt8:$imm3 );
+let InOperandList = ( ins R:$rn, X:$rm, AArch64Base_SUBWUXSX_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -46962,7 +46962,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins R:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -47020,7 +47020,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins R:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -47078,7 +47078,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins R:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -47136,7 +47136,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins R:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -47194,7 +47194,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -47253,7 +47253,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBXASR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_SUBXASR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -47424,7 +47424,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBXLSL_imm6AsInt8:$imm6 );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_SUBXLSL_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -47483,7 +47483,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBXLSR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_SUBXLSR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -47542,7 +47542,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -47601,7 +47601,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBXSASR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_SUBXSASR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -47772,7 +47772,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBXSLSL_imm6AsInt8:$imm6 );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_SUBXSLSL_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -47831,7 +47831,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBXSLSR_imm6AsInt8:$imm6 );
+let InOperandList = ( ins X:$rn, X:$rm, AArch64Base_SUBXSLSR_imm6AsInt8:$imm6 );
 
 field bits<32> Inst;
 
@@ -47890,7 +47890,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBXSSXSB_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, X:$rm, AArch64Base_SUBXSSXSB_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -47948,7 +47948,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBXSSXSH_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, X:$rm, AArch64Base_SUBXSSXSH_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -48006,7 +48006,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBXSSXSW_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, X:$rm, AArch64Base_SUBXSSXSW_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -48064,7 +48064,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBXSSXSX_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, X:$rm, AArch64Base_SUBXSSXSX_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -48122,7 +48122,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -48180,7 +48180,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -48238,7 +48238,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -48296,7 +48296,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -48354,7 +48354,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBXSUXSB_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, X:$rm, AArch64Base_SUBXSUXSB_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -48412,7 +48412,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBXSUXSH_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, X:$rm, AArch64Base_SUBXSUXSH_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -48470,7 +48470,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBXSUXSW_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, X:$rm, AArch64Base_SUBXSUXSW_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -48528,7 +48528,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBXSUXSX_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, X:$rm, AArch64Base_SUBXSUXSX_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -48586,7 +48586,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -48644,7 +48644,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -48702,7 +48702,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -48760,7 +48760,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -48818,7 +48818,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBXSXSB_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, X:$rm, AArch64Base_SUBXSXSB_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -48876,7 +48876,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBXSXSH_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, X:$rm, AArch64Base_SUBXSXSH_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -48934,7 +48934,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBXSXSW_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, X:$rm, AArch64Base_SUBXSXSW_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -48992,7 +48992,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBXSXSX_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, X:$rm, AArch64Base_SUBXSXSX_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -49050,7 +49050,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -49108,7 +49108,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -49166,7 +49166,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -49224,7 +49224,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -49282,7 +49282,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBXUXSB_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, X:$rm, AArch64Base_SUBXUXSB_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -49340,7 +49340,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBXUXSH_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, X:$rm, AArch64Base_SUBXUXSH_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -49398,7 +49398,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBXUXSW_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, X:$rm, AArch64Base_SUBXUXSW_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -49456,7 +49456,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm, AArch64Base_SUBXUXSX_imm3AsInt8:$imm3 );
+let InOperandList = ( ins S:$rn, X:$rm, AArch64Base_SUBXUXSX_imm3AsInt8:$imm3 );
 
 field bits<32> Inst;
 
@@ -49514,7 +49514,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -49572,7 +49572,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -49630,7 +49630,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -49688,7 +49688,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -49746,7 +49746,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rt, AArch64Base_TBNZ_offsetAsLabel:$offset, AArch64Base_TBNZ_imm6AsLabel:$imm6 );
+let InOperandList = ( ins X:$rt, AArch64Base_TBNZ_offsetAsLabel:$offset, AArch64Base_TBNZ_imm6AsLabel:$imm6 );
 
 field bits<32> Inst;
 
@@ -49796,7 +49796,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs  );
-let InOperandList = ( ins S:$rt, AArch64Base_TBZ_offsetAsLabel:$offset, AArch64Base_TBZ_imm6AsLabel:$imm6 );
+let InOperandList = ( ins X:$rt, AArch64Base_TBZ_offsetAsLabel:$offset, AArch64Base_TBZ_imm6AsLabel:$imm6 );
 
 field bits<32> Inst;
 
@@ -49846,7 +49846,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, AArch64Base_UBFMW_leftWSizeAsInt8:$leftWSize, AArch64Base_UBFMW_rightWSizeAsInt8:$rightWSize );
+let InOperandList = ( ins W:$rn, AArch64Base_UBFMW_leftWSizeAsInt8:$leftWSize, AArch64Base_UBFMW_rightWSizeAsInt8:$rightWSize );
 
 field bits<32> Inst;
 
@@ -49901,7 +49901,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, AArch64Base_UBFMX_leftXSizeAsInt8:$leftXSize, AArch64Base_UBFMX_rightXSizeAsInt8:$rightXSize );
+let InOperandList = ( ins X:$rn, AArch64Base_UBFMX_leftXSizeAsInt8:$leftXSize, AArch64Base_UBFMX_rightXSizeAsInt8:$rightXSize );
 
 field bits<32> Inst;
 
@@ -49956,7 +49956,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins W:$rm, W:$rn );
 
 field bits<32> Inst;
 
@@ -50008,7 +50008,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rm, S:$rn );
+let InOperandList = ( ins X:$rm, X:$rn );
 
 field bits<32> Inst;
 
@@ -50060,7 +50060,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$ra, S:$rn, S:$rm );
+let InOperandList = ( ins X:$ra, W:$rn, W:$rm );
 
 field bits<32> Inst;
 
@@ -50114,7 +50114,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$ra, S:$rn, S:$rm );
+let InOperandList = ( ins X:$ra, W:$rn, W:$rm );
 
 field bits<32> Inst;
 
@@ -50168,7 +50168,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins S:$rn, S:$rm );
+let InOperandList = ( ins X:$rn, X:$rm );
 
 field bits<32> Inst;
 
@@ -50739,91 +50739,91 @@ let Defs = [  ];
 
 
 def : Pat<(add S:$rn, S:$rm),
-        (ADDW S:$rn, S:$rm)>;
+        (ADDW W:$rn, X:$rm)>;
 
 
 def : Pat<(add S:$rn, (sra S:$rm, AArch64Base_ADDWASR_imm6AsInt8:$imm6)),
-        (ADDWASR S:$rn, S:$rm, AArch64Base_ADDWASR_imm6AsInt8:$imm6)>;
+        (ADDWASR W:$rn, X:$rm, AArch64Base_ADDWASR_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(add S:$rn, AArch64Base_ADDWI_imm12XAsInt64:$imm12X),
-        (ADDWI S:$rn, AArch64Base_ADDWI_imm12XAsInt64:$imm12X)>;
+        (ADDWI R:$rn, AArch64Base_ADDWI_imm12XAsInt64:$imm12X)>;
 
 
 def : Pat<(add S:$rn, AArch64Base_ADDWI12_imm12SAsInt64:$imm12S),
-        (ADDWI12 S:$rn, AArch64Base_ADDWI12_imm12SAsInt64:$imm12S)>;
+        (ADDWI12 R:$rn, AArch64Base_ADDWI12_imm12SAsInt64:$imm12S)>;
 
 
 def : Pat<(add S:$rn, (shl S:$rm, AArch64Base_ADDWLSL_imm6AsInt8:$imm6)),
-        (ADDWLSL S:$rn, S:$rm, AArch64Base_ADDWLSL_imm6AsInt8:$imm6)>;
+        (ADDWLSL W:$rn, X:$rm, AArch64Base_ADDWLSL_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(add S:$rn, (srl S:$rm, AArch64Base_ADDWLSR_imm6AsInt8:$imm6)),
-        (ADDWLSR S:$rn, S:$rm, AArch64Base_ADDWLSR_imm6AsInt8:$imm6)>;
+        (ADDWLSR W:$rn, X:$rm, AArch64Base_ADDWLSR_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(add S:$rn, S:$rm),
-        (ADDWS S:$rn, S:$rm)>;
+        (ADDWS W:$rn, X:$rm)>;
 
 
 def : Pat<(add S:$rn, (sra S:$rm, AArch64Base_ADDWSASR_imm6AsInt8:$imm6)),
-        (ADDWSASR S:$rn, S:$rm, AArch64Base_ADDWSASR_imm6AsInt8:$imm6)>;
+        (ADDWSASR W:$rn, X:$rm, AArch64Base_ADDWSASR_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(add S:$rn, AArch64Base_ADDWSI_imm12XAsInt64:$imm12X),
-        (ADDWSI S:$rn, AArch64Base_ADDWSI_imm12XAsInt64:$imm12X)>;
+        (ADDWSI R:$rn, AArch64Base_ADDWSI_imm12XAsInt64:$imm12X)>;
 
 
 def : Pat<(add S:$rn, AArch64Base_ADDWSI12_imm12SAsInt64:$imm12S),
-        (ADDWSI12 S:$rn, AArch64Base_ADDWSI12_imm12SAsInt64:$imm12S)>;
+        (ADDWSI12 R:$rn, AArch64Base_ADDWSI12_imm12SAsInt64:$imm12S)>;
 
 
 def : Pat<(add S:$rn, (shl S:$rm, AArch64Base_ADDWSLSL_imm6AsInt8:$imm6)),
-        (ADDWSLSL S:$rn, S:$rm, AArch64Base_ADDWSLSL_imm6AsInt8:$imm6)>;
+        (ADDWSLSL W:$rn, X:$rm, AArch64Base_ADDWSLSL_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(add S:$rn, (srl S:$rm, AArch64Base_ADDWSLSR_imm6AsInt8:$imm6)),
-        (ADDWSLSR S:$rn, S:$rm, AArch64Base_ADDWSLSR_imm6AsInt8:$imm6)>;
+        (ADDWSLSR W:$rn, X:$rm, AArch64Base_ADDWSLSR_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(add S:$rn, (shl S:$rm, AArch64Base_ADDWSSXSX_imm3AsInt8:$imm3)),
-        (ADDWSSXSX S:$rn, S:$rm, AArch64Base_ADDWSSXSX_imm3AsInt8:$imm3)>;
+        (ADDWSSXSX R:$rn, X:$rm, AArch64Base_ADDWSSXSX_imm3AsInt8:$imm3)>;
 
 
 def : Pat<(add S:$rn, S:$rm),
-        (ADDWSSXTX S:$rn, S:$rm)>;
+        (ADDWSSXTX R:$rn, X:$rm)>;
 
 
 def : Pat<(add S:$rn, (shl S:$rm, AArch64Base_ADDWSUXSX_imm3AsInt8:$imm3)),
-        (ADDWSUXSX S:$rn, S:$rm, AArch64Base_ADDWSUXSX_imm3AsInt8:$imm3)>;
+        (ADDWSUXSX R:$rn, X:$rm, AArch64Base_ADDWSUXSX_imm3AsInt8:$imm3)>;
 
 
 def : Pat<(add S:$rn, S:$rm),
-        (ADDWSUXTX S:$rn, S:$rm)>;
+        (ADDWSUXTX R:$rn, X:$rm)>;
 
 
 def : Pat<(add S:$rn, (shl S:$rm, AArch64Base_ADDWSXSX_imm3AsInt8:$imm3)),
-        (ADDWSXSX S:$rn, S:$rm, AArch64Base_ADDWSXSX_imm3AsInt8:$imm3)>;
+        (ADDWSXSX R:$rn, X:$rm, AArch64Base_ADDWSXSX_imm3AsInt8:$imm3)>;
 
 
 def : Pat<(add S:$rn, S:$rm),
-        (ADDWSXTX S:$rn, S:$rm)>;
+        (ADDWSXTX R:$rn, X:$rm)>;
 
 
 def : Pat<(add S:$rn, (shl S:$rm, AArch64Base_ADDWUXSX_imm3AsInt8:$imm3)),
-        (ADDWUXSX S:$rn, S:$rm, AArch64Base_ADDWUXSX_imm3AsInt8:$imm3)>;
+        (ADDWUXSX R:$rn, X:$rm, AArch64Base_ADDWUXSX_imm3AsInt8:$imm3)>;
 
 
 def : Pat<(add S:$rn, S:$rm),
-        (ADDWUXTX S:$rn, S:$rm)>;
+        (ADDWUXTX R:$rn, X:$rm)>;
 
 
 def : Pat<(add S:$rn, S:$rm),
-        (ADDX S:$rn, S:$rm)>;
+        (ADDX X:$rn, X:$rm)>;
 
 
 def : Pat<(add S:$rn, (sra S:$rm, AArch64Base_ADDXASR_imm6AsInt8:$imm6)),
-        (ADDXASR S:$rn, S:$rm, AArch64Base_ADDXASR_imm6AsInt8:$imm6)>;
+        (ADDXASR X:$rn, X:$rm, AArch64Base_ADDXASR_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(add S:$rn, AArch64Base_ADDXI_imm12XAsInt64:$imm12X),
@@ -50838,19 +50838,19 @@ def : Pat<(add S:$rn, AArch64Base_ADDXI12_imm12SAsInt64:$imm12S),
 
 
 def : Pat<(add S:$rn, (shl S:$rm, AArch64Base_ADDXLSL_imm6AsInt8:$imm6)),
-        (ADDXLSL S:$rn, S:$rm, AArch64Base_ADDXLSL_imm6AsInt8:$imm6)>;
+        (ADDXLSL X:$rn, X:$rm, AArch64Base_ADDXLSL_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(add S:$rn, (srl S:$rm, AArch64Base_ADDXLSR_imm6AsInt8:$imm6)),
-        (ADDXLSR S:$rn, S:$rm, AArch64Base_ADDXLSR_imm6AsInt8:$imm6)>;
+        (ADDXLSR X:$rn, X:$rm, AArch64Base_ADDXLSR_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(add S:$rn, S:$rm),
-        (ADDXS S:$rn, S:$rm)>;
+        (ADDXS X:$rn, X:$rm)>;
 
 
 def : Pat<(add S:$rn, (sra S:$rm, AArch64Base_ADDXSASR_imm6AsInt8:$imm6)),
-        (ADDXSASR S:$rn, S:$rm, AArch64Base_ADDXSASR_imm6AsInt8:$imm6)>;
+        (ADDXSASR X:$rn, X:$rm, AArch64Base_ADDXSASR_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(add S:$rn, AArch64Base_ADDXSI_imm12XAsInt64:$imm12X),
@@ -50862,259 +50862,259 @@ def : Pat<(add S:$rn, AArch64Base_ADDXSI12_imm12SAsInt64:$imm12S),
 
 
 def : Pat<(add S:$rn, (shl S:$rm, AArch64Base_ADDXSLSL_imm6AsInt8:$imm6)),
-        (ADDXSLSL S:$rn, S:$rm, AArch64Base_ADDXSLSL_imm6AsInt8:$imm6)>;
+        (ADDXSLSL X:$rn, X:$rm, AArch64Base_ADDXSLSL_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(add S:$rn, (srl S:$rm, AArch64Base_ADDXSLSR_imm6AsInt8:$imm6)),
-        (ADDXSLSR S:$rn, S:$rm, AArch64Base_ADDXSLSR_imm6AsInt8:$imm6)>;
+        (ADDXSLSR X:$rn, X:$rm, AArch64Base_ADDXSLSR_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(add S:$rn, (shl S:$rm, AArch64Base_ADDXSSXSX_imm3AsInt8:$imm3)),
-        (ADDXSSXSX S:$rn, S:$rm, AArch64Base_ADDXSSXSX_imm3AsInt8:$imm3)>;
+        (ADDXSSXSX S:$rn, X:$rm, AArch64Base_ADDXSSXSX_imm3AsInt8:$imm3)>;
 
 
 def : Pat<(add S:$rn, S:$rm),
-        (ADDXSSXTX S:$rn, S:$rm)>;
+        (ADDXSSXTX S:$rn, X:$rm)>;
 
 
 def : Pat<(add S:$rn, (shl S:$rm, AArch64Base_ADDXSUXSX_imm3AsInt8:$imm3)),
-        (ADDXSUXSX S:$rn, S:$rm, AArch64Base_ADDXSUXSX_imm3AsInt8:$imm3)>;
+        (ADDXSUXSX S:$rn, X:$rm, AArch64Base_ADDXSUXSX_imm3AsInt8:$imm3)>;
 
 
 def : Pat<(add S:$rn, S:$rm),
-        (ADDXSUXTX S:$rn, S:$rm)>;
+        (ADDXSUXTX S:$rn, X:$rm)>;
 
 
 def : Pat<(add S:$rn, (shl S:$rm, AArch64Base_ADDXSXSX_imm3AsInt8:$imm3)),
-        (ADDXSXSX S:$rn, S:$rm, AArch64Base_ADDXSXSX_imm3AsInt8:$imm3)>;
+        (ADDXSXSX S:$rn, X:$rm, AArch64Base_ADDXSXSX_imm3AsInt8:$imm3)>;
 
 
 def : Pat<(add S:$rn, S:$rm),
-        (ADDXSXTX S:$rn, S:$rm)>;
+        (ADDXSXTX S:$rn, X:$rm)>;
 
 
 def : Pat<(add S:$rn, (shl S:$rm, AArch64Base_ADDXUXSX_imm3AsInt8:$imm3)),
-        (ADDXUXSX S:$rn, S:$rm, AArch64Base_ADDXUXSX_imm3AsInt8:$imm3)>;
+        (ADDXUXSX S:$rn, X:$rm, AArch64Base_ADDXUXSX_imm3AsInt8:$imm3)>;
 
 
 def : Pat<(add S:$rn, S:$rm),
-        (ADDXUXTX S:$rn, S:$rm)>;
+        (ADDXUXTX S:$rn, X:$rm)>;
 
 
 def : Pat<(and S:$rn, AArch64Base_ANDIW_immWSizeAsInt32:$immWSize),
-        (ANDIW S:$rn, AArch64Base_ANDIW_immWSizeAsInt32:$immWSize)>;
+        (ANDIW W:$rn, AArch64Base_ANDIW_immWSizeAsInt32:$immWSize)>;
 
 
 def : Pat<(and S:$rn, AArch64Base_ANDIX_immXSizeAsInt64:$immXSize),
-        (ANDIX S:$rn, AArch64Base_ANDIX_immXSizeAsInt64:$immXSize)>;
+        (ANDIX X:$rn, AArch64Base_ANDIX_immXSizeAsInt64:$immXSize)>;
 
 
 def : Pat<(and S:$rn, AArch64Base_ANDSIW_immWSizeAsInt32:$immWSize),
-        (ANDSIW S:$rn, AArch64Base_ANDSIW_immWSizeAsInt32:$immWSize)>;
+        (ANDSIW W:$rn, AArch64Base_ANDSIW_immWSizeAsInt32:$immWSize)>;
 
 
 def : Pat<(and S:$rn, AArch64Base_ANDSIX_immXSizeAsInt64:$immXSize),
-        (ANDSIX S:$rn, AArch64Base_ANDSIX_immXSizeAsInt64:$immXSize)>;
+        (ANDSIX X:$rn, AArch64Base_ANDSIX_immXSizeAsInt64:$immXSize)>;
 
 
 def : Pat<(and S:$rn, S:$rm),
-        (ANDSW S:$rn, S:$rm)>;
+        (ANDSW W:$rn, W:$rm)>;
 
 
 def : Pat<(and S:$rn, (sra S:$rm, AArch64Base_ANDSWASR_imm6AsInt8:$imm6)),
-        (ANDSWASR S:$rn, S:$rm, AArch64Base_ANDSWASR_imm6AsInt8:$imm6)>;
+        (ANDSWASR W:$rn, W:$rm, AArch64Base_ANDSWASR_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(and S:$rn, (shl S:$rm, AArch64Base_ANDSWLSL_imm6AsInt8:$imm6)),
-        (ANDSWLSL S:$rn, S:$rm, AArch64Base_ANDSWLSL_imm6AsInt8:$imm6)>;
+        (ANDSWLSL W:$rn, W:$rm, AArch64Base_ANDSWLSL_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(and S:$rn, (srl S:$rm, AArch64Base_ANDSWLSR_imm6AsInt8:$imm6)),
-        (ANDSWLSR S:$rn, S:$rm, AArch64Base_ANDSWLSR_imm6AsInt8:$imm6)>;
+        (ANDSWLSR W:$rn, W:$rm, AArch64Base_ANDSWLSR_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(and S:$rn, S:$rm),
-        (ANDSX S:$rn, S:$rm)>;
+        (ANDSX X:$rn, X:$rm)>;
 
 
 def : Pat<(and S:$rn, (sra S:$rm, AArch64Base_ANDSXASR_imm6AsInt8:$imm6)),
-        (ANDSXASR S:$rn, S:$rm, AArch64Base_ANDSXASR_imm6AsInt8:$imm6)>;
+        (ANDSXASR X:$rn, X:$rm, AArch64Base_ANDSXASR_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(and S:$rn, (shl S:$rm, AArch64Base_ANDSXLSL_imm6AsInt8:$imm6)),
-        (ANDSXLSL S:$rn, S:$rm, AArch64Base_ANDSXLSL_imm6AsInt8:$imm6)>;
+        (ANDSXLSL X:$rn, X:$rm, AArch64Base_ANDSXLSL_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(and S:$rn, (srl S:$rm, AArch64Base_ANDSXLSR_imm6AsInt8:$imm6)),
-        (ANDSXLSR S:$rn, S:$rm, AArch64Base_ANDSXLSR_imm6AsInt8:$imm6)>;
+        (ANDSXLSR X:$rn, X:$rm, AArch64Base_ANDSXLSR_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(and S:$rn, S:$rm),
-        (ANDW S:$rn, S:$rm)>;
+        (ANDW W:$rn, W:$rm)>;
 
 
 def : Pat<(and S:$rn, (sra S:$rm, AArch64Base_ANDWASR_imm6AsInt8:$imm6)),
-        (ANDWASR S:$rn, S:$rm, AArch64Base_ANDWASR_imm6AsInt8:$imm6)>;
+        (ANDWASR W:$rn, W:$rm, AArch64Base_ANDWASR_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(and S:$rn, (shl S:$rm, AArch64Base_ANDWLSL_imm6AsInt8:$imm6)),
-        (ANDWLSL S:$rn, S:$rm, AArch64Base_ANDWLSL_imm6AsInt8:$imm6)>;
+        (ANDWLSL W:$rn, W:$rm, AArch64Base_ANDWLSL_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(and S:$rn, (srl S:$rm, AArch64Base_ANDWLSR_imm6AsInt8:$imm6)),
-        (ANDWLSR S:$rn, S:$rm, AArch64Base_ANDWLSR_imm6AsInt8:$imm6)>;
+        (ANDWLSR W:$rn, W:$rm, AArch64Base_ANDWLSR_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(and S:$rn, S:$rm),
-        (ANDX S:$rn, S:$rm)>;
+        (ANDX X:$rn, X:$rm)>;
 
 
 def : Pat<(and S:$rn, (sra S:$rm, AArch64Base_ANDXASR_imm6AsInt8:$imm6)),
-        (ANDXASR S:$rn, S:$rm, AArch64Base_ANDXASR_imm6AsInt8:$imm6)>;
+        (ANDXASR X:$rn, X:$rm, AArch64Base_ANDXASR_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(and S:$rn, (shl S:$rm, AArch64Base_ANDXLSL_imm6AsInt8:$imm6)),
-        (ANDXLSL S:$rn, S:$rm, AArch64Base_ANDXLSL_imm6AsInt8:$imm6)>;
+        (ANDXLSL X:$rn, X:$rm, AArch64Base_ANDXLSL_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(and S:$rn, (srl S:$rm, AArch64Base_ANDXLSR_imm6AsInt8:$imm6)),
-        (ANDXLSR S:$rn, S:$rm, AArch64Base_ANDXLSR_imm6AsInt8:$imm6)>;
+        (ANDXLSR X:$rn, X:$rm, AArch64Base_ANDXLSR_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(sra S:$rn, S:$rm),
-        (ASRW S:$rn, S:$rm)>;
+        (ASRW W:$rn, W:$rm)>;
 
 
 def : Pat<(sra S:$rn, S:$rm),
-        (ASRX S:$rn, S:$rm)>;
+        (ASRX X:$rn, X:$rm)>;
 
 
 def : Pat<(add S:$rm, (i64 1)),
-        (CSINCCCW S:$rn, S:$rm)>;
+        (CSINCCCW X:$rn, X:$rm)>;
 
 
 def : Pat<(add S:$rm, (i64 1)),
-        (CSINCCCX S:$rn, S:$rm)>;
+        (CSINCCCX X:$rn, X:$rm)>;
 
 
 def : Pat<(add S:$rm, (i64 1)),
-        (CSINCCSW S:$rn, S:$rm)>;
+        (CSINCCSW X:$rn, X:$rm)>;
 
 
 def : Pat<(add S:$rm, (i64 1)),
-        (CSINCCSX S:$rn, S:$rm)>;
+        (CSINCCSX X:$rn, X:$rm)>;
 
 
 def : Pat<(add S:$rm, (i64 1)),
-        (CSINCEQW S:$rn, S:$rm)>;
+        (CSINCEQW X:$rn, X:$rm)>;
 
 
 def : Pat<(add S:$rm, (i64 1)),
-        (CSINCEQX S:$rn, S:$rm)>;
+        (CSINCEQX X:$rn, X:$rm)>;
 
 
 def : Pat<(add S:$rm, (i64 1)),
-        (CSINCGEW S:$rn, S:$rm)>;
+        (CSINCGEW X:$rn, X:$rm)>;
 
 
 def : Pat<(add S:$rm, (i64 1)),
-        (CSINCGEX S:$rn, S:$rm)>;
+        (CSINCGEX X:$rn, X:$rm)>;
 
 
 def : Pat<(add S:$rm, (i64 1)),
-        (CSINCGTW S:$rn, S:$rm)>;
+        (CSINCGTW X:$rn, X:$rm)>;
 
 
 def : Pat<(add S:$rm, (i64 1)),
-        (CSINCGTX S:$rn, S:$rm)>;
+        (CSINCGTX X:$rn, X:$rm)>;
 
 
 def : Pat<(add S:$rm, (i64 1)),
-        (CSINCHIW S:$rn, S:$rm)>;
+        (CSINCHIW X:$rn, X:$rm)>;
 
 
 def : Pat<(add S:$rm, (i64 1)),
-        (CSINCHIX S:$rn, S:$rm)>;
+        (CSINCHIX X:$rn, X:$rm)>;
 
 
 def : Pat<(add S:$rm, (i64 1)),
-        (CSINCMIW S:$rn, S:$rm)>;
+        (CSINCMIW X:$rn, X:$rm)>;
 
 
 def : Pat<(add S:$rm, (i64 1)),
-        (CSINCMIX S:$rn, S:$rm)>;
+        (CSINCMIX X:$rn, X:$rm)>;
 
 
 def : Pat<(add S:$rm, (i64 1)),
-        (CSINCNEW S:$rn, S:$rm)>;
+        (CSINCNEW X:$rn, X:$rm)>;
 
 
 def : Pat<(add S:$rm, (i64 1)),
-        (CSINCNEX S:$rn, S:$rm)>;
+        (CSINCNEX X:$rn, X:$rm)>;
 
 
 def : Pat<(add S:$rm, (i64 1)),
-        (CSINCPLW S:$rn, S:$rm)>;
+        (CSINCPLW X:$rn, X:$rm)>;
 
 
 def : Pat<(add S:$rm, (i64 1)),
-        (CSINCPLX S:$rn, S:$rm)>;
+        (CSINCPLX X:$rn, X:$rm)>;
 
 
 def : Pat<(add S:$rm, (i64 1)),
-        (CSINCVCW S:$rn, S:$rm)>;
+        (CSINCVCW X:$rn, X:$rm)>;
 
 
 def : Pat<(add S:$rm, (i64 1)),
-        (CSINCVCX S:$rn, S:$rm)>;
+        (CSINCVCX X:$rn, X:$rm)>;
 
 
 def : Pat<(add S:$rm, (i64 1)),
-        (CSINCVSW S:$rn, S:$rm)>;
+        (CSINCVSW X:$rn, X:$rm)>;
 
 
 def : Pat<(add S:$rm, (i64 1)),
-        (CSINCVSX S:$rn, S:$rm)>;
+        (CSINCVSX X:$rn, X:$rm)>;
 
 
 def : Pat<(xor S:$rn, AArch64Base_EORIW_immWSizeAsInt32:$immWSize),
-        (EORIW S:$rn, AArch64Base_EORIW_immWSizeAsInt32:$immWSize)>;
+        (EORIW W:$rn, AArch64Base_EORIW_immWSizeAsInt32:$immWSize)>;
 
 
 def : Pat<(xor S:$rn, AArch64Base_EORIX_immXSizeAsInt64:$immXSize),
-        (EORIX S:$rn, AArch64Base_EORIX_immXSizeAsInt64:$immXSize)>;
+        (EORIX X:$rn, AArch64Base_EORIX_immXSizeAsInt64:$immXSize)>;
 
 
 def : Pat<(xor S:$rn, S:$rm),
-        (EORW S:$rn, S:$rm)>;
+        (EORW W:$rn, W:$rm)>;
 
 
 def : Pat<(xor S:$rn, (sra S:$rm, AArch64Base_EORWASR_imm6AsInt8:$imm6)),
-        (EORWASR S:$rn, S:$rm, AArch64Base_EORWASR_imm6AsInt8:$imm6)>;
+        (EORWASR W:$rn, W:$rm, AArch64Base_EORWASR_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(xor S:$rn, (shl S:$rm, AArch64Base_EORWLSL_imm6AsInt8:$imm6)),
-        (EORWLSL S:$rn, S:$rm, AArch64Base_EORWLSL_imm6AsInt8:$imm6)>;
+        (EORWLSL W:$rn, W:$rm, AArch64Base_EORWLSL_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(xor S:$rn, (srl S:$rm, AArch64Base_EORWLSR_imm6AsInt8:$imm6)),
-        (EORWLSR S:$rn, S:$rm, AArch64Base_EORWLSR_imm6AsInt8:$imm6)>;
+        (EORWLSR W:$rn, W:$rm, AArch64Base_EORWLSR_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(xor S:$rn, S:$rm),
-        (EORX S:$rn, S:$rm)>;
+        (EORX X:$rn, X:$rm)>;
 
 
 def : Pat<(xor S:$rn, (sra S:$rm, AArch64Base_EORXASR_imm6AsInt8:$imm6)),
-        (EORXASR S:$rn, S:$rm, AArch64Base_EORXASR_imm6AsInt8:$imm6)>;
+        (EORXASR X:$rn, X:$rm, AArch64Base_EORXASR_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(xor S:$rn, (shl S:$rm, AArch64Base_EORXLSL_imm6AsInt8:$imm6)),
-        (EORXLSL S:$rn, S:$rm, AArch64Base_EORXLSL_imm6AsInt8:$imm6)>;
+        (EORXLSL X:$rn, X:$rm, AArch64Base_EORXLSL_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(xor S:$rn, (srl S:$rm, AArch64Base_EORXLSR_imm6AsInt8:$imm6)),
-        (EORXLSR S:$rn, S:$rm, AArch64Base_EORXLSR_imm6AsInt8:$imm6)>;
+        (EORXLSR X:$rn, X:$rm, AArch64Base_EORXLSR_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(zextloadi8 (add S:$rn, AArch64Base_LDRB_offsetAsInt64:$offset)),
@@ -51358,27 +51358,27 @@ def : Pat<(load AddrFI:$rn),
 
 
 def : Pat<(shl S:$rn, S:$rm),
-        (LSLW S:$rn, S:$rm)>;
+        (LSLW W:$rn, W:$rm)>;
 
 
 def : Pat<(shl S:$rn, S:$rm),
-        (LSLX S:$rn, S:$rm)>;
+        (LSLX X:$rn, X:$rm)>;
 
 
 def : Pat<(srl S:$rn, S:$rm),
-        (LSRW S:$rn, S:$rm)>;
+        (LSRW W:$rn, W:$rm)>;
 
 
 def : Pat<(srl S:$rn, S:$rm),
-        (LSRX S:$rn, S:$rm)>;
+        (LSRX X:$rn, X:$rm)>;
 
 
 def : Pat<(add S:$ra, (mul S:$rn, S:$rm)),
-        (MADDW S:$ra, S:$rn, S:$rm)>;
+        (MADDW W:$ra, W:$rn, W:$rm)>;
 
 
 def : Pat<(add S:$ra, (mul S:$rn, S:$rm)),
-        (MADDX S:$ra, S:$rn, S:$rm)>;
+        (MADDX X:$ra, X:$rn, X:$rm)>;
 
 
 def : Pat<(shl AArch64Base_MOVZWPos16_imm16AsInt16:$imm16, (i32 16)),
@@ -51398,245 +51398,245 @@ def : Pat<(shl AArch64Base_MOVZXPos48_imm16AsInt16:$imm16, (i64 48)),
 
 
 def : Pat<(sub S:$ra, (mul S:$rn, S:$rm)),
-        (MSUBW S:$ra, S:$rn, S:$rm)>;
+        (MSUBW W:$ra, W:$rn, W:$rm)>;
 
 
 def : Pat<(sub S:$ra, (mul S:$rn, S:$rm)),
-        (MSUBX S:$ra, S:$rn, S:$rm)>;
+        (MSUBX X:$ra, X:$rn, X:$rm)>;
 
 
 def : Pat<(or S:$rn, AArch64Base_ORRIW_immWSizeAsInt32:$immWSize),
-        (ORRIW S:$rn, AArch64Base_ORRIW_immWSizeAsInt32:$immWSize)>;
+        (ORRIW W:$rn, AArch64Base_ORRIW_immWSizeAsInt32:$immWSize)>;
 
 
 def : Pat<(or S:$rn, AArch64Base_ORRIX_immXSizeAsInt64:$immXSize),
-        (ORRIX S:$rn, AArch64Base_ORRIX_immXSizeAsInt64:$immXSize)>;
+        (ORRIX X:$rn, AArch64Base_ORRIX_immXSizeAsInt64:$immXSize)>;
 
 
 def : Pat<(or S:$rn, S:$rm),
-        (ORRW S:$rn, S:$rm)>;
+        (ORRW W:$rn, W:$rm)>;
 
 
 def : Pat<(or S:$rn, (sra S:$rm, AArch64Base_ORRWASR_imm6AsInt8:$imm6)),
-        (ORRWASR S:$rn, S:$rm, AArch64Base_ORRWASR_imm6AsInt8:$imm6)>;
+        (ORRWASR W:$rn, W:$rm, AArch64Base_ORRWASR_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(or S:$rn, (shl S:$rm, AArch64Base_ORRWLSL_imm6AsInt8:$imm6)),
-        (ORRWLSL S:$rn, S:$rm, AArch64Base_ORRWLSL_imm6AsInt8:$imm6)>;
+        (ORRWLSL W:$rn, W:$rm, AArch64Base_ORRWLSL_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(or S:$rn, (srl S:$rm, AArch64Base_ORRWLSR_imm6AsInt8:$imm6)),
-        (ORRWLSR S:$rn, S:$rm, AArch64Base_ORRWLSR_imm6AsInt8:$imm6)>;
+        (ORRWLSR W:$rn, W:$rm, AArch64Base_ORRWLSR_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(or S:$rn, S:$rm),
-        (ORRX S:$rn, S:$rm)>;
+        (ORRX X:$rn, X:$rm)>;
 
 
 def : Pat<(or S:$rn, (sra S:$rm, AArch64Base_ORRXASR_imm6AsInt8:$imm6)),
-        (ORRXASR S:$rn, S:$rm, AArch64Base_ORRXASR_imm6AsInt8:$imm6)>;
+        (ORRXASR X:$rn, X:$rm, AArch64Base_ORRXASR_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(or S:$rn, (shl S:$rm, AArch64Base_ORRXLSL_imm6AsInt8:$imm6)),
-        (ORRXLSL S:$rn, S:$rm, AArch64Base_ORRXLSL_imm6AsInt8:$imm6)>;
+        (ORRXLSL X:$rn, X:$rm, AArch64Base_ORRXLSL_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(or S:$rn, (srl S:$rm, AArch64Base_ORRXLSR_imm6AsInt8:$imm6)),
-        (ORRXLSR S:$rn, S:$rm, AArch64Base_ORRXLSR_imm6AsInt8:$imm6)>;
+        (ORRXLSR X:$rn, X:$rm, AArch64Base_ORRXLSR_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(sra (shl S:$rn, AArch64Base_SBFMW_leftWSizeAsInt8:$leftWSize), AArch64Base_SBFMW_rightWSizeAsInt8:$rightWSize),
-        (SBFMW S:$rn, AArch64Base_SBFMW_leftWSizeAsInt8:$leftWSize, AArch64Base_SBFMW_rightWSizeAsInt8:$rightWSize)>;
+        (SBFMW W:$rn, AArch64Base_SBFMW_leftWSizeAsInt8:$leftWSize, AArch64Base_SBFMW_rightWSizeAsInt8:$rightWSize)>;
 
 
 def : Pat<(sra (shl S:$rn, AArch64Base_SBFMX_leftXSizeAsInt8:$leftXSize), AArch64Base_SBFMX_rightXSizeAsInt8:$rightXSize),
-        (SBFMX S:$rn, AArch64Base_SBFMX_leftXSizeAsInt8:$leftXSize, AArch64Base_SBFMX_rightXSizeAsInt8:$rightXSize)>;
+        (SBFMX X:$rn, AArch64Base_SBFMX_leftXSizeAsInt8:$leftXSize, AArch64Base_SBFMX_rightXSizeAsInt8:$rightXSize)>;
 
 
 def : Pat<(sdiv S:$rn, S:$rm),
-        (SDIVW S:$rm, S:$rn)>;
+        (SDIVW W:$rm, W:$rn)>;
 
 
 def : Pat<(sdiv S:$rn, S:$rm),
-        (SDIVX S:$rm, S:$rn)>;
+        (SDIVX X:$rm, X:$rn)>;
 
 
 def : Pat<(mulhs S:$rn, S:$rm),
-        (SMULH S:$rn, S:$rm)>;
+        (SMULH X:$rn, X:$rm)>;
 
 
 def : Pat<(truncstorei8 S:$rt, (add S:$rn, AArch64Base_STRB_offsetAsInt64:$offset)),
-        (STRB S:$rn, S:$rt, AArch64Base_STRB_offsetAsInt64:$offset)>;
+        (STRB S:$rn, X:$rt, AArch64Base_STRB_offsetAsInt64:$offset)>;
 
 def : Pat<(truncstorei8 S:$rt, (add AddrFI:$rn, AArch64Base_STRB_offsetAsInt64:$offset)),
-        (STRB AddrFI:$rn, S:$rt, AArch64Base_STRB_offsetAsInt64:$offset)>;
+        (STRB AddrFI:$rn, X:$rt, AArch64Base_STRB_offsetAsInt64:$offset)>;
 
 def : Pat<(truncstorei8 S:$rt, S:$rn),
-        (STRB S:$rn, S:$rt, (i64 0))>;
+        (STRB S:$rn, X:$rt, (i64 0))>;
 
 def : Pat<(truncstorei8 S:$rt, AddrFI:$rn),
-        (STRB AddrFI:$rn, S:$rt, (i64 0))>;
+        (STRB AddrFI:$rn, X:$rt, (i64 0))>;
 
 
 def : Pat<(truncstorei16 S:$rt, (add S:$rn, (shl AArch64Base_STRH_offsetAsInt64:$offset, (i64 1)))),
-        (STRH S:$rn, S:$rt, AArch64Base_STRH_offsetAsInt64:$offset)>;
+        (STRH S:$rn, X:$rt, AArch64Base_STRH_offsetAsInt64:$offset)>;
 
 def : Pat<(truncstorei16 S:$rt, (add AddrFI:$rn, (shl AArch64Base_STRH_offsetAsInt64:$offset, (i64 1)))),
-        (STRH AddrFI:$rn, S:$rt, AArch64Base_STRH_offsetAsInt64:$offset)>;
+        (STRH AddrFI:$rn, X:$rt, AArch64Base_STRH_offsetAsInt64:$offset)>;
 
 
 def : Pat<(truncstorei32 S:$rt, (add S:$rn, (shl AArch64Base_STRW_offsetAsInt64:$offset, (i64 2)))),
-        (STRW S:$rn, S:$rt, AArch64Base_STRW_offsetAsInt64:$offset)>;
+        (STRW S:$rn, X:$rt, AArch64Base_STRW_offsetAsInt64:$offset)>;
 
 def : Pat<(truncstorei32 S:$rt, (add AddrFI:$rn, (shl AArch64Base_STRW_offsetAsInt64:$offset, (i64 2)))),
-        (STRW AddrFI:$rn, S:$rt, AArch64Base_STRW_offsetAsInt64:$offset)>;
+        (STRW AddrFI:$rn, X:$rt, AArch64Base_STRW_offsetAsInt64:$offset)>;
 
 
 def : Pat<(store S:$rt, (add S:$rn, (shl AArch64Base_STRX_offsetAsInt64:$offset, (i64 3)))),
-        (STRX S:$rn, S:$rt, AArch64Base_STRX_offsetAsInt64:$offset)>;
+        (STRX S:$rn, X:$rt, AArch64Base_STRX_offsetAsInt64:$offset)>;
 
 def : Pat<(store S:$rt, (add AddrFI:$rn, (shl AArch64Base_STRX_offsetAsInt64:$offset, (i64 3)))),
-        (STRX AddrFI:$rn, S:$rt, AArch64Base_STRX_offsetAsInt64:$offset)>;
+        (STRX AddrFI:$rn, X:$rt, AArch64Base_STRX_offsetAsInt64:$offset)>;
 
 
 def : Pat<(truncstorei8 S:$rt, (add S:$rn, AArch64Base_STURB_offsetAsInt64:$offset)),
-        (STURB S:$rn, S:$rt, AArch64Base_STURB_offsetAsInt64:$offset)>;
+        (STURB S:$rn, X:$rt, AArch64Base_STURB_offsetAsInt64:$offset)>;
 
 def : Pat<(truncstorei8 S:$rt, (add AddrFI:$rn, AArch64Base_STURB_offsetAsInt64:$offset)),
-        (STURB AddrFI:$rn, S:$rt, AArch64Base_STURB_offsetAsInt64:$offset)>;
+        (STURB AddrFI:$rn, X:$rt, AArch64Base_STURB_offsetAsInt64:$offset)>;
 
 def : Pat<(truncstorei8 S:$rt, S:$rn),
-        (STURB S:$rn, S:$rt, (i64 0))>;
+        (STURB S:$rn, X:$rt, (i64 0))>;
 
 def : Pat<(truncstorei8 S:$rt, AddrFI:$rn),
-        (STURB AddrFI:$rn, S:$rt, (i64 0))>;
+        (STURB AddrFI:$rn, X:$rt, (i64 0))>;
 
 
 def : Pat<(truncstorei16 S:$rt, (add S:$rn, AArch64Base_STURH_offsetAsInt64:$offset)),
-        (STURH S:$rn, S:$rt, AArch64Base_STURH_offsetAsInt64:$offset)>;
+        (STURH S:$rn, X:$rt, AArch64Base_STURH_offsetAsInt64:$offset)>;
 
 def : Pat<(truncstorei16 S:$rt, (add AddrFI:$rn, AArch64Base_STURH_offsetAsInt64:$offset)),
-        (STURH AddrFI:$rn, S:$rt, AArch64Base_STURH_offsetAsInt64:$offset)>;
+        (STURH AddrFI:$rn, X:$rt, AArch64Base_STURH_offsetAsInt64:$offset)>;
 
 def : Pat<(truncstorei16 S:$rt, S:$rn),
-        (STURH S:$rn, S:$rt, (i64 0))>;
+        (STURH S:$rn, X:$rt, (i64 0))>;
 
 def : Pat<(truncstorei16 S:$rt, AddrFI:$rn),
-        (STURH AddrFI:$rn, S:$rt, (i64 0))>;
+        (STURH AddrFI:$rn, X:$rt, (i64 0))>;
 
 
 def : Pat<(truncstorei32 S:$rt, (add S:$rn, AArch64Base_STURW_offsetAsInt64:$offset)),
-        (STURW S:$rn, S:$rt, AArch64Base_STURW_offsetAsInt64:$offset)>;
+        (STURW S:$rn, X:$rt, AArch64Base_STURW_offsetAsInt64:$offset)>;
 
 def : Pat<(truncstorei32 S:$rt, (add AddrFI:$rn, AArch64Base_STURW_offsetAsInt64:$offset)),
-        (STURW AddrFI:$rn, S:$rt, AArch64Base_STURW_offsetAsInt64:$offset)>;
+        (STURW AddrFI:$rn, X:$rt, AArch64Base_STURW_offsetAsInt64:$offset)>;
 
 def : Pat<(truncstorei32 S:$rt, S:$rn),
-        (STURW S:$rn, S:$rt, (i64 0))>;
+        (STURW S:$rn, X:$rt, (i64 0))>;
 
 def : Pat<(truncstorei32 S:$rt, AddrFI:$rn),
-        (STURW AddrFI:$rn, S:$rt, (i64 0))>;
+        (STURW AddrFI:$rn, X:$rt, (i64 0))>;
 
 
 def : Pat<(store S:$rt, (add S:$rn, AArch64Base_STURX_offsetAsInt64:$offset)),
-        (STURX S:$rn, S:$rt, AArch64Base_STURX_offsetAsInt64:$offset)>;
+        (STURX S:$rn, X:$rt, AArch64Base_STURX_offsetAsInt64:$offset)>;
 
 def : Pat<(store S:$rt, (add AddrFI:$rn, AArch64Base_STURX_offsetAsInt64:$offset)),
-        (STURX AddrFI:$rn, S:$rt, AArch64Base_STURX_offsetAsInt64:$offset)>;
+        (STURX AddrFI:$rn, X:$rt, AArch64Base_STURX_offsetAsInt64:$offset)>;
 
 def : Pat<(store S:$rt, S:$rn),
-        (STURX S:$rn, S:$rt, (i64 0))>;
+        (STURX S:$rn, X:$rt, (i64 0))>;
 
 def : Pat<(store S:$rt, AddrFI:$rn),
-        (STURX AddrFI:$rn, S:$rt, (i64 0))>;
+        (STURX AddrFI:$rn, X:$rt, (i64 0))>;
 
 
 def : Pat<(sub S:$rn, S:$rm),
-        (SUBW S:$rn, S:$rm)>;
+        (SUBW W:$rn, X:$rm)>;
 
 
 def : Pat<(sub S:$rn, (sra S:$rm, AArch64Base_SUBWASR_imm6AsInt8:$imm6)),
-        (SUBWASR S:$rn, S:$rm, AArch64Base_SUBWASR_imm6AsInt8:$imm6)>;
+        (SUBWASR W:$rn, X:$rm, AArch64Base_SUBWASR_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(sub S:$rn, AArch64Base_SUBWI_imm12XAsInt64:$imm12X),
-        (SUBWI S:$rn, AArch64Base_SUBWI_imm12XAsInt64:$imm12X)>;
+        (SUBWI R:$rn, AArch64Base_SUBWI_imm12XAsInt64:$imm12X)>;
 
 
 def : Pat<(sub S:$rn, AArch64Base_SUBWI12_imm12SAsInt64:$imm12S),
-        (SUBWI12 S:$rn, AArch64Base_SUBWI12_imm12SAsInt64:$imm12S)>;
+        (SUBWI12 R:$rn, AArch64Base_SUBWI12_imm12SAsInt64:$imm12S)>;
 
 
 def : Pat<(sub S:$rn, (shl S:$rm, AArch64Base_SUBWLSL_imm6AsInt8:$imm6)),
-        (SUBWLSL S:$rn, S:$rm, AArch64Base_SUBWLSL_imm6AsInt8:$imm6)>;
+        (SUBWLSL W:$rn, X:$rm, AArch64Base_SUBWLSL_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(sub S:$rn, (srl S:$rm, AArch64Base_SUBWLSR_imm6AsInt8:$imm6)),
-        (SUBWLSR S:$rn, S:$rm, AArch64Base_SUBWLSR_imm6AsInt8:$imm6)>;
+        (SUBWLSR W:$rn, X:$rm, AArch64Base_SUBWLSR_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(sub S:$rn, S:$rm),
-        (SUBWS S:$rn, S:$rm)>;
+        (SUBWS W:$rn, X:$rm)>;
 
 
 def : Pat<(sub S:$rn, (sra S:$rm, AArch64Base_SUBWSASR_imm6AsInt8:$imm6)),
-        (SUBWSASR S:$rn, S:$rm, AArch64Base_SUBWSASR_imm6AsInt8:$imm6)>;
+        (SUBWSASR W:$rn, X:$rm, AArch64Base_SUBWSASR_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(sub S:$rn, AArch64Base_SUBWSI_imm12XAsInt64:$imm12X),
-        (SUBWSI S:$rn, AArch64Base_SUBWSI_imm12XAsInt64:$imm12X)>;
+        (SUBWSI R:$rn, AArch64Base_SUBWSI_imm12XAsInt64:$imm12X)>;
 
 
 def : Pat<(sub S:$rn, AArch64Base_SUBWSI12_imm12SAsInt64:$imm12S),
-        (SUBWSI12 S:$rn, AArch64Base_SUBWSI12_imm12SAsInt64:$imm12S)>;
+        (SUBWSI12 R:$rn, AArch64Base_SUBWSI12_imm12SAsInt64:$imm12S)>;
 
 
 def : Pat<(sub S:$rn, (shl S:$rm, AArch64Base_SUBWSLSL_imm6AsInt8:$imm6)),
-        (SUBWSLSL S:$rn, S:$rm, AArch64Base_SUBWSLSL_imm6AsInt8:$imm6)>;
+        (SUBWSLSL W:$rn, X:$rm, AArch64Base_SUBWSLSL_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(sub S:$rn, (srl S:$rm, AArch64Base_SUBWSLSR_imm6AsInt8:$imm6)),
-        (SUBWSLSR S:$rn, S:$rm, AArch64Base_SUBWSLSR_imm6AsInt8:$imm6)>;
+        (SUBWSLSR W:$rn, X:$rm, AArch64Base_SUBWSLSR_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(sub S:$rn, (shl S:$rm, AArch64Base_SUBWSSXSX_imm3AsInt8:$imm3)),
-        (SUBWSSXSX S:$rn, S:$rm, AArch64Base_SUBWSSXSX_imm3AsInt8:$imm3)>;
+        (SUBWSSXSX R:$rn, X:$rm, AArch64Base_SUBWSSXSX_imm3AsInt8:$imm3)>;
 
 
 def : Pat<(sub S:$rn, S:$rm),
-        (SUBWSSXTX S:$rn, S:$rm)>;
+        (SUBWSSXTX R:$rn, X:$rm)>;
 
 
 def : Pat<(sub S:$rn, (shl S:$rm, AArch64Base_SUBWSUXSX_imm3AsInt8:$imm3)),
-        (SUBWSUXSX S:$rn, S:$rm, AArch64Base_SUBWSUXSX_imm3AsInt8:$imm3)>;
+        (SUBWSUXSX R:$rn, X:$rm, AArch64Base_SUBWSUXSX_imm3AsInt8:$imm3)>;
 
 
 def : Pat<(sub S:$rn, S:$rm),
-        (SUBWSUXTX S:$rn, S:$rm)>;
+        (SUBWSUXTX R:$rn, X:$rm)>;
 
 
 def : Pat<(sub S:$rn, (shl S:$rm, AArch64Base_SUBWSXSX_imm3AsInt8:$imm3)),
-        (SUBWSXSX S:$rn, S:$rm, AArch64Base_SUBWSXSX_imm3AsInt8:$imm3)>;
+        (SUBWSXSX R:$rn, X:$rm, AArch64Base_SUBWSXSX_imm3AsInt8:$imm3)>;
 
 
 def : Pat<(sub S:$rn, S:$rm),
-        (SUBWSXTX S:$rn, S:$rm)>;
+        (SUBWSXTX R:$rn, X:$rm)>;
 
 
 def : Pat<(sub S:$rn, (shl S:$rm, AArch64Base_SUBWUXSX_imm3AsInt8:$imm3)),
-        (SUBWUXSX S:$rn, S:$rm, AArch64Base_SUBWUXSX_imm3AsInt8:$imm3)>;
+        (SUBWUXSX R:$rn, X:$rm, AArch64Base_SUBWUXSX_imm3AsInt8:$imm3)>;
 
 
 def : Pat<(sub S:$rn, S:$rm),
-        (SUBWUXTX S:$rn, S:$rm)>;
+        (SUBWUXTX R:$rn, X:$rm)>;
 
 
 def : Pat<(sub S:$rn, S:$rm),
-        (SUBX S:$rn, S:$rm)>;
+        (SUBX X:$rn, X:$rm)>;
 
 
 def : Pat<(sub S:$rn, (sra S:$rm, AArch64Base_SUBXASR_imm6AsInt8:$imm6)),
-        (SUBXASR S:$rn, S:$rm, AArch64Base_SUBXASR_imm6AsInt8:$imm6)>;
+        (SUBXASR X:$rn, X:$rm, AArch64Base_SUBXASR_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(sub S:$rn, AArch64Base_SUBXI_imm12XAsInt64:$imm12X),
@@ -51648,19 +51648,19 @@ def : Pat<(sub S:$rn, AArch64Base_SUBXI12_imm12SAsInt64:$imm12S),
 
 
 def : Pat<(sub S:$rn, (shl S:$rm, AArch64Base_SUBXLSL_imm6AsInt8:$imm6)),
-        (SUBXLSL S:$rn, S:$rm, AArch64Base_SUBXLSL_imm6AsInt8:$imm6)>;
+        (SUBXLSL X:$rn, X:$rm, AArch64Base_SUBXLSL_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(sub S:$rn, (srl S:$rm, AArch64Base_SUBXLSR_imm6AsInt8:$imm6)),
-        (SUBXLSR S:$rn, S:$rm, AArch64Base_SUBXLSR_imm6AsInt8:$imm6)>;
+        (SUBXLSR X:$rn, X:$rm, AArch64Base_SUBXLSR_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(sub S:$rn, S:$rm),
-        (SUBXS S:$rn, S:$rm)>;
+        (SUBXS X:$rn, X:$rm)>;
 
 
 def : Pat<(sub S:$rn, (sra S:$rm, AArch64Base_SUBXSASR_imm6AsInt8:$imm6)),
-        (SUBXSASR S:$rn, S:$rm, AArch64Base_SUBXSASR_imm6AsInt8:$imm6)>;
+        (SUBXSASR X:$rn, X:$rm, AArch64Base_SUBXSASR_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(sub S:$rn, AArch64Base_SUBXSI_imm12XAsInt64:$imm12X),
@@ -51672,60 +51672,60 @@ def : Pat<(sub S:$rn, AArch64Base_SUBXSI12_imm12SAsInt64:$imm12S),
 
 
 def : Pat<(sub S:$rn, (shl S:$rm, AArch64Base_SUBXSLSL_imm6AsInt8:$imm6)),
-        (SUBXSLSL S:$rn, S:$rm, AArch64Base_SUBXSLSL_imm6AsInt8:$imm6)>;
+        (SUBXSLSL X:$rn, X:$rm, AArch64Base_SUBXSLSL_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(sub S:$rn, (srl S:$rm, AArch64Base_SUBXSLSR_imm6AsInt8:$imm6)),
-        (SUBXSLSR S:$rn, S:$rm, AArch64Base_SUBXSLSR_imm6AsInt8:$imm6)>;
+        (SUBXSLSR X:$rn, X:$rm, AArch64Base_SUBXSLSR_imm6AsInt8:$imm6)>;
 
 
 def : Pat<(sub S:$rn, (shl S:$rm, AArch64Base_SUBXSSXSX_imm3AsInt8:$imm3)),
-        (SUBXSSXSX S:$rn, S:$rm, AArch64Base_SUBXSSXSX_imm3AsInt8:$imm3)>;
+        (SUBXSSXSX S:$rn, X:$rm, AArch64Base_SUBXSSXSX_imm3AsInt8:$imm3)>;
 
 
 def : Pat<(sub S:$rn, S:$rm),
-        (SUBXSSXTX S:$rn, S:$rm)>;
+        (SUBXSSXTX S:$rn, X:$rm)>;
 
 
 def : Pat<(sub S:$rn, (shl S:$rm, AArch64Base_SUBXSUXSX_imm3AsInt8:$imm3)),
-        (SUBXSUXSX S:$rn, S:$rm, AArch64Base_SUBXSUXSX_imm3AsInt8:$imm3)>;
+        (SUBXSUXSX S:$rn, X:$rm, AArch64Base_SUBXSUXSX_imm3AsInt8:$imm3)>;
 
 
 def : Pat<(sub S:$rn, S:$rm),
-        (SUBXSUXTX S:$rn, S:$rm)>;
+        (SUBXSUXTX S:$rn, X:$rm)>;
 
 
 def : Pat<(sub S:$rn, (shl S:$rm, AArch64Base_SUBXSXSX_imm3AsInt8:$imm3)),
-        (SUBXSXSX S:$rn, S:$rm, AArch64Base_SUBXSXSX_imm3AsInt8:$imm3)>;
+        (SUBXSXSX S:$rn, X:$rm, AArch64Base_SUBXSXSX_imm3AsInt8:$imm3)>;
 
 
 def : Pat<(sub S:$rn, S:$rm),
-        (SUBXSXTX S:$rn, S:$rm)>;
+        (SUBXSXTX S:$rn, X:$rm)>;
 
 
 def : Pat<(sub S:$rn, (shl S:$rm, AArch64Base_SUBXUXSX_imm3AsInt8:$imm3)),
-        (SUBXUXSX S:$rn, S:$rm, AArch64Base_SUBXUXSX_imm3AsInt8:$imm3)>;
+        (SUBXUXSX S:$rn, X:$rm, AArch64Base_SUBXUXSX_imm3AsInt8:$imm3)>;
 
 
 def : Pat<(sub S:$rn, S:$rm),
-        (SUBXUXTX S:$rn, S:$rm)>;
+        (SUBXUXTX S:$rn, X:$rm)>;
 
 
 def : Pat<(srl (shl S:$rn, AArch64Base_UBFMW_leftWSizeAsInt8:$leftWSize), AArch64Base_UBFMW_rightWSizeAsInt8:$rightWSize),
-        (UBFMW S:$rn, AArch64Base_UBFMW_leftWSizeAsInt8:$leftWSize, AArch64Base_UBFMW_rightWSizeAsInt8:$rightWSize)>;
+        (UBFMW W:$rn, AArch64Base_UBFMW_leftWSizeAsInt8:$leftWSize, AArch64Base_UBFMW_rightWSizeAsInt8:$rightWSize)>;
 
 
 def : Pat<(srl (shl S:$rn, AArch64Base_UBFMX_leftXSizeAsInt8:$leftXSize), AArch64Base_UBFMX_rightXSizeAsInt8:$rightXSize),
-        (UBFMX S:$rn, AArch64Base_UBFMX_leftXSizeAsInt8:$leftXSize, AArch64Base_UBFMX_rightXSizeAsInt8:$rightXSize)>;
+        (UBFMX X:$rn, AArch64Base_UBFMX_leftXSizeAsInt8:$leftXSize, AArch64Base_UBFMX_rightXSizeAsInt8:$rightXSize)>;
 
 
 def : Pat<(udiv S:$rn, S:$rm),
-        (UDIVW S:$rm, S:$rn)>;
+        (UDIVW W:$rm, W:$rn)>;
 
 
 def : Pat<(udiv S:$rn, S:$rm),
-        (UDIVX S:$rm, S:$rn)>;
+        (UDIVX X:$rm, X:$rn)>;
 
 
 def : Pat<(mulhu S:$rn, S:$rm),
-        (UMULH S:$rn, S:$rm)>;
+        (UMULH X:$rn, X:$rm)>;


### PR DESCRIPTION
Previously, we used the underlying register class of an artificial resource. But now, we want the alias.