### PR TITLE
lcb: Fixed duplicated operands

### DIFF
--- a/vadl/main/vadl/gcb/passes/operands/GenerateInstructionOperandsPass.java
+++ b/vadl/main/vadl/gcb/passes/operands/GenerateInstructionOperandsPass.java
@@ -33,6 +33,7 @@ import vadl.configuration.GeneralConfiguration;
 import vadl.error.DeferredDiagnosticStore;
 import vadl.error.Diagnostic;
 import vadl.gcb.passes.operands.model.GcbConstantOperand;
+import vadl.gcb.passes.operands.model.GcbDefaultInstructionOperand;
 import vadl.gcb.passes.operands.model.GcbInstructionBareSymbolOperand;
 import vadl.gcb.passes.operands.model.GcbInstructionImmediateOperand;
 import vadl.gcb.passes.operands.model.GcbInstructionIndexedRegisterFileOperand;
@@ -486,11 +487,13 @@ public class GenerateInstructionOperandsPass extends Pass {
         outputOperands.stream()
             .filter(x -> x instanceof GcbInstructionRegisterFileOperand
                 || x instanceof GcbInstructionIndexedRegisterFileOperand)
+            .map(x -> ((GcbDefaultInstructionOperand) x).name())
             .collect(Collectors.toSet());
 
     return stream
         .filter(
-            node -> !visited.contains(node));
+            node -> node instanceof GcbDefaultInstructionOperand defaultInstructionOperand
+                && !visited.contains(defaultInstructionOperand.name()));
   }
 
   /**

--- a/vadl/test/resources/snapshots/aarch64/InstrInfoTableGen.td
+++ b/vadl/test/resources/snapshots/aarch64/InstrInfoTableGen.td
@@ -13082,7 +13082,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins X:$rd, W:$rn, AArch64Base_BFMW_leftWSizeAsInt8:$leftWSize, AArch64Base_BFMW_rightWSizeAsInt8:$rightWSize );
+let InOperandList = ( ins W:$rn, AArch64Base_BFMW_leftWSizeAsInt8:$leftWSize, AArch64Base_BFMW_rightWSizeAsInt8:$rightWSize );
 
 field bits<32> Inst;
 
@@ -13137,7 +13137,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins X:$rd, X:$rn, AArch64Base_BFMX_leftXSizeAsInt8:$leftXSize, AArch64Base_BFMX_rightXSizeAsInt8:$rightXSize );
+let InOperandList = ( ins X:$rn, AArch64Base_BFMX_leftXSizeAsInt8:$leftXSize, AArch64Base_BFMX_rightXSizeAsInt8:$rightXSize );
 
 field bits<32> Inst;
 
@@ -38080,7 +38080,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins X:$rd, AArch64Base_MOVKWPos00_imm16AsInt16:$imm16 );
+let InOperandList = ( ins AArch64Base_MOVKWPos00_imm16AsInt16:$imm16 );
 
 field bits<32> Inst;
 
@@ -38131,7 +38131,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins X:$rd, AArch64Base_MOVKWPos16_imm16AsInt16:$imm16 );
+let InOperandList = ( ins AArch64Base_MOVKWPos16_imm16AsInt16:$imm16 );
 
 field bits<32> Inst;
 
@@ -38182,7 +38182,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins X:$rd, AArch64Base_MOVKXPos00_imm16AsInt16:$imm16 );
+let InOperandList = ( ins AArch64Base_MOVKXPos00_imm16AsInt16:$imm16 );
 
 field bits<32> Inst;
 
@@ -38233,7 +38233,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins X:$rd, AArch64Base_MOVKXPos16_imm16AsInt16:$imm16 );
+let InOperandList = ( ins AArch64Base_MOVKXPos16_imm16AsInt16:$imm16 );
 
 field bits<32> Inst;
 
@@ -38284,7 +38284,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins X:$rd, AArch64Base_MOVKXPos32_imm16AsInt16:$imm16 );
+let InOperandList = ( ins AArch64Base_MOVKXPos32_imm16AsInt16:$imm16 );
 
 field bits<32> Inst;
 
@@ -38335,7 +38335,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins X:$rd, AArch64Base_MOVKXPos48_imm16AsInt16:$imm16 );
+let InOperandList = ( ins AArch64Base_MOVKXPos48_imm16AsInt16:$imm16 );
 
 field bits<32> Inst;
 


### PR DESCRIPTION
Before we filtered based on the name + type. Now, we only filter with the name.