### PR TITLE
lcb: Implemented wrapping of raw register values in assembly

### DIFF
--- a/vadl/main/resources/templates/lcb/llvm/lib/Target/MCTargetDesc/AsmUtils.h
+++ b/vadl/main/resources/templates/lcb/llvm/lib/Target/MCTargetDesc/AsmUtils.h
@@ -5,11 +5,14 @@
 #include "llvm/MC/MCInstPrinter.h"
 #include "llvm/MC/MCInst.h"
 #include "llvm/MC/MCExpr.h"
+#include "llvm/MC/MCSymbol.h"
+#include "llvm/MC/MCRegister.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/MC/MCParser/MCAsmLexer.h"
 #include "MCTargetDesc/[(${namespace})]MCExpr.h"
 #include "MCTargetDesc/[(${namespace})]MCTargetDesc.h"
 #include <string>
+#include <iostream>
 
 namespace llvm
 {
@@ -38,6 +41,27 @@ namespace llvm
             [# th:each="rg : ${registerClasses}" ]
             static std::string getRegisterNameFrom[(${rg.registerFile.name})]ByIndex( unsigned RegIndex );
             [/]
+
+            static std::string unwrapToIntegralStr(std::string reg)
+            {
+              return std::to_string(unwrapToIntegral(std::stoi(reg)));
+            }
+
+            static int64_t unwrapToIntegral(MCRegister reg)
+            {
+              return unwrapToIntegral(reg.id());
+            }
+
+            static int64_t unwrapToIntegral(int reg)
+            {
+              switch(reg) {
+              [# th:each="rg : ${registers}" ]
+              case [(${namespace})]::[(${rg.name})]: return [(${rg.index})];
+              [/]
+              }
+
+              report_fatal_error("Cannot convert register operand to integral value.");
+            }
     };
 
     class MCOperandWrapper

--- a/vadl/main/vadl/lcb/codegen/assembly/AssemblyInstructionPrinterImmediateHandler.java
+++ b/vadl/main/vadl/lcb/codegen/assembly/AssemblyInstructionPrinterImmediateHandler.java
@@ -177,13 +177,17 @@ public class AssemblyInstructionPrinterImmediateHandler
                 argument.location())
             .build();
       }
-      // TODO: Implement UDEC builtin
     } else if (node.builtIn() == BuiltInTable.UDEC) {
       writeImmediateWithRadix(node, ctx, 10, false);
     } else if (node.builtIn() == BuiltInTable.SDEC) {
       writeImmediateWithRadix(node, ctx, 10, true);
     } else if (node.builtIn() == BuiltInTable.HEX) {
       writeImmediateWithRadix(node, ctx, 16, false);
+    } else if (node.builtIn() == BuiltInTable.INTEGRAL) {
+      ctx.wr("AsmUtils::unwrapToIntegral(");
+      AssemblyInstructionPrinterImmediateHandlerDispatcher.dispatch(this, (CNodeContext) ctx,
+          node.arg(0));
+      ctx.wr(")");
     } else if (node.builtIn() == BuiltInTable.EQU) {
       handleConditional(node, ctx, "==");
     } else if (node.builtIn() == BuiltInTable.NEQ) {
@@ -442,7 +446,12 @@ public class AssemblyInstructionPrinterImmediateHandler
 
   private void writeImmediateWithRadix(BuiltInCall node, CGenContext<Node> ctx, int radix,
                                        boolean isSigned) {
-    if (node.arguments().getFirst() instanceof FieldRefNode fieldRefNode) {
+    if (node.arguments().getFirst() instanceof BuiltInCall bc
+        && bc.builtIn() == BuiltInTable.INTEGRAL) {
+      ctx.wr("AsmUtils::unwrapToIntegralStr(");
+      writeImmediateWithRadix(bc, ctx, radix, isSigned);
+      ctx.wr(")");
+    } else if (node.arguments().getFirst() instanceof FieldRefNode fieldRefNode) {
       writeImmediateWithRadix(fieldRefNode.formatField(),
           ctx,
           radix,

--- a/vadl/main/vadl/lcb/codegen/assembly/WrapInIntegralPass.java
+++ b/vadl/main/vadl/lcb/codegen/assembly/WrapInIntegralPass.java
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.lcb.codegen.assembly;
+
+import java.io.IOException;
+import java.util.List;
+import javax.annotation.Nullable;
+import vadl.configuration.GeneralConfiguration;
+import vadl.gcb.passes.IdentifyFieldUsagePass;
+import vadl.pass.Pass;
+import vadl.pass.PassName;
+import vadl.pass.PassResults;
+import vadl.types.BuiltInTable;
+import vadl.viam.InstructionSetArchitecture;
+import vadl.viam.Specification;
+import vadl.viam.graph.NodeList;
+import vadl.viam.graph.dependency.BuiltInCall;
+import vadl.viam.graph.dependency.FieldRefNode;
+
+/**
+ * Wraps the register indices in an {@code integral} function when
+ * register usage is not used with the {@code register} builtin.
+ */
+public class WrapInIntegralPass extends Pass {
+  /**
+   * Constructor.
+   */
+  public WrapInIntegralPass(GeneralConfiguration configuration) {
+    super(configuration);
+  }
+
+  @Override
+  public PassName getName() {
+    return new PassName("WrapInIntegralPass");
+  }
+
+  @Nullable
+  @Override
+  public Object execute(PassResults passResults, Specification viam) throws IOException {
+    var fieldUsages =
+        (IdentifyFieldUsagePass.ImmediateDetectionContainer) passResults.lastResultOf(
+            IdentifyFieldUsagePass.class);
+
+    viam.isa().map(InstructionSetArchitecture::ownInstructions).orElse(List.of()).forEach(
+        instruction -> {
+          var fields =
+              instruction.assembly().function().behavior().getNodes(FieldRefNode.class).toList();
+
+          for (var field : fields) {
+            var usages = fieldUsages.getFieldUsages(instruction, field.formatField());
+            // If the field is a register
+            if (usages.stream().anyMatch(x -> x == IdentifyFieldUsagePass.FieldUsage.REGISTER)) {
+              // and the number value is used
+              if (field.usages().anyMatch(x -> x instanceof BuiltInCall builtInCall
+                  && (builtInCall.builtIn() == BuiltInTable.HEX
+                  || builtInCall.builtIn() == BuiltInTable.SDEC
+                  || builtInCall.builtIn() == BuiltInTable.UDEC))) {
+                // then wrap the node with the integral function.
+                field.replace(
+                    new BuiltInCall(BuiltInTable.INTEGRAL, new NodeList<>(field), field.type()));
+              }
+            }
+          }
+        });
+
+    return null;
+  }
+}

--- a/vadl/main/vadl/lcb/template/lib/Target/MCTargetDesc/EmitAsmUtilsHeaderFilePass.java
+++ b/vadl/main/vadl/lcb/template/lib/Target/MCTargetDesc/EmitAsmUtilsHeaderFilePass.java
@@ -47,17 +47,6 @@ public class EmitAsmUtilsHeaderFilePass extends LcbTemplateRenderingPass {
         + "/MCTargetDesc/AsmUtils.h";
   }
 
-
-  record RegisterClass(String simpleName) implements Renderable {
-
-    @Override
-    public Map<String, Object> renderObj() {
-      return Map.of(
-          "simpleName", simpleName
-      );
-    }
-  }
-
   @Override
   protected Map<String, Object> createVariables(final PassResults passResults,
                                                 Specification specification) {

--- a/vadl/main/vadl/pass/PassOrders.java
+++ b/vadl/main/vadl/pass/PassOrders.java
@@ -72,6 +72,7 @@ import vadl.iss.template.target.EmitIssGdbStubPass;
 import vadl.iss.template.target.EmitIssInsnTransCIncPass;
 import vadl.iss.template.target.EmitIssMachinePass;
 import vadl.iss.template.target.EmitIssTranslateCPass;
+import vadl.lcb.codegen.assembly.WrapInIntegralPass;
 import vadl.lcb.passes.isaMatching.IsaMachineInstructionMatchingPass;
 import vadl.lcb.passes.isaMatching.IsaPseudoInstructionMatchingPass;
 import vadl.lcb.passes.isaMatching.IsaRelocationMatchingPass;
@@ -285,6 +286,8 @@ public class PassOrders {
     order.add(new CompensationPatternPass(configuration));
     order.add(new ISelLoweringOperationActionPass(configuration));
     order.add(new GenerateLinkerComponentsPass(configuration));
+
+    order.add(new WrapInIntegralPass(configuration));
 
     addHtmlDump(order, configuration,
         "lcbLlvmLowering",

--- a/vadl/main/vadl/types/BuiltInTable.java
+++ b/vadl/main/vadl/types/BuiltInTable.java
@@ -1023,6 +1023,18 @@ public class BuiltInTable {
           .build();
 
   /**
+   * Returns the register index from an internal value.
+   *
+   * <p>{@code function integral(Bits<N>) -> BitsType<M>}
+   */
+  public static final BuiltIn INTEGRAL =
+      func("integral",
+          Type.relation(BitsType.class, BitsType.class))
+          .takesDefault()
+          .returns(Type.string())
+          .build();
+
+  /**
    * Formats value to binary string.
    *
    * <p>{@code function binary(Bits<N>) -> String<M>}


### PR DESCRIPTION
We cannot use the register's raw values because the register allocator uses an internal numbering. First, we need to map the value. We do it in a separate pass when `decimal` or `hex` is used.