### PR TITLE
ci: Fix trigger condition for refman

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -8,7 +8,6 @@ on:
     paths:
       - 'docs/**'
       - '.github/workflows/publish-docs.yml'
-  create:
     tags:
       - 'v*'
 


### PR DESCRIPTION
According to ChatGpt, the `create` is always executed because it does not have any tags filter. That's why this job ran for random branches as well. I couldn't verify it in the docs. But I found https://stackoverflow.com/questions/59874409/trigger-github-workflow-only-if-pushed-to-specific-branch-and-tag-exists. The question has exactly the behavior which we want.