### PR TITLE
lcb: Filtered renamed fields from operands for pseudo instructions

### DIFF
--- a/vadl/main/vadl/gcb/passes/operands/GenerateInstructionOperandsPass.java
+++ b/vadl/main/vadl/gcb/passes/operands/GenerateInstructionOperandsPass.java
@@ -32,6 +32,7 @@ import javax.annotation.Nullable;
 import vadl.configuration.GeneralConfiguration;
 import vadl.error.DeferredDiagnosticStore;
 import vadl.error.Diagnostic;
+import vadl.gcb.passes.RenamedFieldRefNode;
 import vadl.gcb.passes.operands.model.GcbConstantOperand;
 import vadl.gcb.passes.operands.model.GcbDefaultInstructionOperand;
 import vadl.gcb.passes.operands.model.GcbInstructionBareSymbolOperand;
@@ -633,14 +634,22 @@ class PseudoNodeOperandCollector {
   protected void handle(ReadArtificialResNode node) {
     if (node.resourceDefinition().innerResourceRef() instanceof RegisterTensor tensor
         && tensor.isRegisterFile()) {
-      operands.add(node);
+      // We do not want renamed field ref nodes.
+      // Example: MOVKWPos16; here we would have `rd` in the outputs and `rd_1` in the input
+      if (!(node.address() instanceof RenamedFieldRefNode)) {
+        operands.add(node);
+      }
     }
   }
 
   @Handler
   protected void handle(ReadRegTensorNode node) {
     if (node.regTensor().isRegisterFile()) {
-      operands.add(node);
+      // We do not want renamed field ref nodes.
+      // Example: MOVKWPos16; here we would have `rd` in the outputs and `rd_1` in the input
+      if (!(node.address() instanceof RenamedFieldRefNode)) {
+        operands.add(node);
+      }
     }
   }
 

--- a/vadl/test/resources/snapshots/aarch64/InstrInfoTableGen.td
+++ b/vadl/test/resources/snapshots/aarch64/InstrInfoTableGen.td
@@ -50692,7 +50692,7 @@ def constMat0 : Instruction
 let Namespace = "processorNameValue";
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins bare_symbol:$val, X:$rd_1 );
+let InOperandList = ( ins bare_symbol:$val );
 
 let isTerminator  = 0;
 let isBranch      = 0;
@@ -50720,7 +50720,7 @@ def constMat1 : Instruction
 let Namespace = "processorNameValue";
 
 let OutOperandList = ( outs S:$rd );
-let InOperandList = ( ins bare_symbol:$val, X:$rd_1 );
+let InOperandList = ( ins bare_symbol:$val );
 
 let isTerminator  = 0;
 let isBranch      = 0;


### PR DESCRIPTION
The PR https://github.com/OpenVADL/openvadl/pull/479 introduced a regression for AArch64. Constant sequences have got another operand caused by field renaming which is incorrect. The simple fix is to just not consider renamed fields for pseudo instructions.