### PR TITLE
asm: Rename asm builtins

### DIFF
--- a/vadl/main/vadl/types/BuiltInTable.java
+++ b/vadl/main/vadl/types/BuiltInTable.java
@@ -1102,10 +1102,10 @@ public class BuiltInTable {
   /**
    * Checks if the token at lookahead {@code n} in the AsmParser is equal to a string {@code s}.
    *
-   * <p>{@code function laideq(n: UInt<N>,s: String) -> Bool}
+   * <p>{@code function LaIdEq(n: UInt<N>,s: String) -> Bool}
    */
   public static final BuiltIn LA_ID_EQ =
-      func("laideq", null, Type.relation(UIntType.class, StringType.class, BoolType.class))
+      func("LaIdEq", null, Type.relation(UIntType.class, StringType.class, BoolType.class))
           .takesDefault()
           .noCompute()
           .returns(Type.bool())
@@ -1114,10 +1114,10 @@ public class BuiltInTable {
   /**
    * Checks if the token at lookahead {@code n} in the AsmParser is any of the strings in {@code s}.
    *
-   * <p>{@code function laidin(n: UInt<N>,s: String...) -> Bool}
+   * <p>{@code function LaIdIn(n: UInt<N>,s: String...) -> Bool}
    */
   public static final BuiltIn LA_ID_IN =
-      func("laidin", null,
+      func("LaIdIn", null,
           Type.relation(List.of(UIntType.class, StringType.class), true, BoolType.class))
           .takesDefault()
           .noCompute()

--- a/vadl/test/resources/testSource/sys/risc-v/rv32im.vadl
+++ b/vadl/test/resources/testSource/sys/risc-v/rv32im.vadl
@@ -161,9 +161,9 @@ assembly description ASM for ABI = {
       var rs1Tmp = null @operand
       var immTmp = null @operand
       mnemonic = "JALR" @operand
-      ( ?(laideq(1 as Bits<1>, ",") )
+      ( ?(LaIdEq(1 as Bits<1>, ",") )
           rdTmp = Register@operand ","
-          ( ?(laideq(1 as Bits<1>, ",") )         // jalr rd, rs, imm
+          ( ?(LaIdEq(1 as Bits<1>, ",") )         // jalr rd, rs, imm
               rs1Tmp = Register@operand ","
               immTmp = JalrImmediateOperand
             |

--- a/vadl/test/vadl/ast/AsmLL1CheckerTest.java
+++ b/vadl/test/vadl/ast/AsmLL1CheckerTest.java
@@ -457,7 +457,7 @@ public class AsmLL1CheckerTest {
   void asmBuiltInUsage() {
     var prog = """
           grammar = {
-            RuleA : ?( laidin(2,"A","B","C") ) "A" | "A";
+            RuleA : ?( LaIdIn(2,"A","B","C") ) "A" | "A";
           }
         """;
     var ast = Assertions.assertDoesNotThrow(
@@ -487,7 +487,7 @@ public class AsmLL1CheckerTest {
     var prog = """
           grammar = {
             Inst : inst = (
-              ?(laideq(0,"r1")) A
+              ?(LaIdEq(0,"r1")) A
               | B
             ) @instruction ;
         

--- a/vadl/test/vadl/ast/TypecheckerAsmTest.java
+++ b/vadl/test/vadl/ast/TypecheckerAsmTest.java
@@ -124,7 +124,7 @@ public class TypecheckerAsmTest {
               mnemonic = 'ADD' @operand
               rd   = Register  @operand
               rs1  = Register  @operand
-                 ( ?(laidin(0,"r1","r2")) rs2 = Register   @operand
+                 ( ?(LaIdIn(0,"r1","r2")) rs2 = Register   @operand
                  | imm = Expression @operand
                  )
               ) @instruction


### PR DESCRIPTION
This PR renames the assembly builtin functions `laideq` and `laidin` to `LaIdEq` and `LaIdIn`.

@AndreasKrall you expressed concern regarding the possible confusion with lower case `l` and upper case `I`.
Code editor fonts usually distinguish these letters, so I think there shouldn’t be an issue.