### PR TITLE
cli: Fix qemu source archive extraction

### DIFF
--- a/vadl-cli/main/vadl/cli/Utils.java
+++ b/vadl-cli/main/vadl/cli/Utils.java
@@ -157,7 +157,7 @@ class TarGzExtractor {
           continue; // Skip entries that are stripped to an empty name
         }
 
-        Path outputPath = outputDir.resolve(entryName).normalize();
+        Path outputPath = outputDir.resolve(entryName);
         if (!outputPath.startsWith(outputDir)) {
           throw new IOException("Entry is outside of the target dir: " + entryName);
         }


### PR DESCRIPTION
Extraction of the quemu source archive fails on Ubuntu 24.04.3 LTS, because the call of normalize() removes a preceeding './' from outputPath. This fails the comparison at line 161 with an IOException. Removing the normalize() call fixes the issue.