### PR TITLE
frontend: Turn alias register arguments to wildcards

### DIFF
--- a/sys/aarch64/aarch64.vadl
+++ b/sys/aarch64/aarch64.vadl
@@ -60,11 +60,11 @@ instruction set architecture AArch64Base = {
   memory        MEM : Address -> Byte // byte addressed memory
  
   register        S : Index -> BitsX  // general purpose register file with stack pointer
-  alias register R(i) = S(i)(31..0)   // lower half of general purpose register file with stack pointer
+  alias register R = S(*)(31..0)   // lower half of general purpose register file with stack pointer
   [zero : X(31)]                      // X(31) is the zero register
   alias register  X = S               // general purpose register file with zero register
   [zero : W(31)]                      // X(31) is the zero register
-  alias register W(i) = X(i)(31..0)   // lower half of general purpose register file with zero register
+  alias register W = X(*)(31..0)   // lower half of general purpose register file with zero register
   alias register SP : Address = S(31) // stack pointer
   alias register LR : Address = S(30) // link register (return address)
 

--- a/vadl/main/vadl/ast/AstVisitor.java
+++ b/vadl/main/vadl/ast/AstVisitor.java
@@ -595,6 +595,14 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   }
 
   @Override
+  public Void visit(WildcardLiteral expr) {
+    beforeTravel(expr);
+    expr.children().forEach(this::travel);
+    afterTravel(expr);
+    return null;
+  }
+
+  @Override
   public Void visit(BinaryLiteral expr) {
     beforeTravel(expr);
     expr.children().forEach(this::travel);

--- a/vadl/main/vadl/ast/BehaviorLowering.java
+++ b/vadl/main/vadl/ast/BehaviorLowering.java
@@ -674,6 +674,12 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
   }
 
   @Override
+  public ExpressionNode visit(WildcardLiteral expr) {
+    throw new IllegalStateException(
+        "WildcardLiteral should never be reached in the VIAM lowering.");
+  }
+
+  @Override
   public ExpressionNode visit(BinaryLiteral expr) {
     return new ConstantNode(
         Constant.Value.fromInteger(

--- a/vadl/main/vadl/ast/ConstantEvaluator.java
+++ b/vadl/main/vadl/ast/ConstantEvaluator.java
@@ -259,6 +259,11 @@ class ConstantEvaluator implements ExprVisitor<ConstantValue> {
   }
 
   @Override
+  public ConstantValue visit(WildcardLiteral expr) {
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  @Override
   public ConstantValue visit(BinaryLiteral expr) {
     return new ConstantValue(expr.number, Type.bits(expr.bitWidth));
   }

--- a/vadl/main/vadl/ast/Definition.java
+++ b/vadl/main/vadl/ast/Definition.java
@@ -2005,7 +2005,6 @@ class FunctionDefinition extends Definition implements IdentifiableNode, TypedNo
 class AliasDefinition extends Definition implements IdentifiableNode, TypedNode {
   IdentifierOrPlaceholder id;
   AliasKind kind;
-  List<Identifier> params;
   @Nullable
   @Child
   TypeLiteral aliasType;
@@ -2033,12 +2032,11 @@ class AliasDefinition extends Definition implements IdentifiableNode, TypedNode 
   @Nullable
   Constant.BitSlice slice;
 
-  AliasDefinition(IdentifierOrPlaceholder id, AliasKind kind, List<Identifier> params,
+  AliasDefinition(IdentifierOrPlaceholder id, AliasKind kind,
                   @Nullable TypeLiteral aliasType, @Nullable TypeLiteral targetType, Expr value,
                   SourceLocation location) {
     this.id = id;
     this.kind = kind;
-    this.params = params;
     this.aliasType = aliasType;
     this.targetType = targetType;
     this.value = value;

--- a/vadl/main/vadl/ast/Expr.java
+++ b/vadl/main/vadl/ast/Expr.java
@@ -97,6 +97,8 @@ interface ExprVisitor<R> {
 
   R visit(IntegerLiteral expr);
 
+  R visit(WildcardLiteral expr);
+
   R visit(BinaryLiteral expr);
 
   R visit(BoolLiteral expr);
@@ -613,6 +615,34 @@ class IntegerLiteral extends Expr {
     int result = number.hashCode();
     result = 31 * result + Objects.hashCode(token);
     return result;
+  }
+}
+
+class WildcardLiteral extends Expr {
+  SourceLocation loc;
+
+  public WildcardLiteral(SourceLocation loc) {
+    this.loc = loc;
+  }
+
+  @Override
+  void prettyPrintExpr(int indent, StringBuilder builder, Precedence parentPrec) {
+    builder.append("*");
+  }
+
+  @Override
+  <R> R accept(ExprVisitor<R> visitor) {
+    return visitor.visit(this);
+  }
+
+  @Override
+  SyntaxType syntaxType() {
+    return BasicSyntaxType.SYM_EX;
+  }
+
+  @Override
+  public SourceLocation location() {
+    return loc;
   }
 }
 

--- a/vadl/main/vadl/ast/MacroExpander.java
+++ b/vadl/main/vadl/ast/MacroExpander.java
@@ -246,6 +246,11 @@ class MacroExpander
   }
 
   @Override
+  public Expr visit(WildcardLiteral expr) {
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  @Override
   public Expr visit(BinaryLiteral expr) {
     return new BinaryLiteral(expr.token, copyLoc(expr.loc));
   }
@@ -683,7 +688,7 @@ class MacroExpander
   public Definition visit(AliasDefinition definition) {
     var id = expandId(definition.id);
     var value = expandExpr(definition.value);
-    return new AliasDefinition(id, definition.kind, definition.params, definition.aliasType,
+    return new AliasDefinition(id, definition.kind, definition.aliasType,
         definition.targetType,
         value, copyLoc(definition.loc)).withAnnotations(definition.annotations);
   }

--- a/vadl/main/vadl/ast/SymbolTable.java
+++ b/vadl/main/vadl/ast/SymbolTable.java
@@ -822,11 +822,7 @@ class SymbolTable {
     @Override
     public Void visit(AliasDefinition definition) {
       beforeTravel(definition);
-
-      var childTable = currentSymbols().createChild();
-      definition.params.forEach(param -> childTable.defineSymbol(param.name, param));
-      withSymbols(childTable, () -> definition.children().forEach(this::travel));
-
+      definition.children().forEach(this::travel);
       afterTravel(definition);
       return null;
     }

--- a/vadl/main/vadl/ast/TypeChecker.java
+++ b/vadl/main/vadl/ast/TypeChecker.java
@@ -37,7 +37,6 @@ import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import vadl.error.DeferredDiagnosticStore;
 import vadl.error.Diagnostic;
@@ -934,19 +933,12 @@ public class TypeChecker
       }
 
       // we have to check the CallIndexExpr "manually" as the normal check cannot handle
-      // the param identifiers of the alias definition
+      // the wildcards in the alias definition
       if (definition.value instanceof Identifier targetReg) {
-        ensure(definition.params.isEmpty(), () ->
-            error("Unused alias register params", targetReg)
-                .description("All alias register parameters must be used: %s",
-                    definition.params.stream().map(i -> i.name).collect(
-                        Collectors.joining(", ")))
-        );
         check(targetReg);
       } else if (definition.value instanceof CallIndexExpr expr) {
-
         var i = 0;
-        var foundParams = new ArrayList<Pair<Integer, Identifier>>();
+        var wildcardIndices = new ArrayList<Integer>();
         CallIndexExpr.Arguments slice = null;
         var dummyArgs = new ArrayList<CallIndexExpr.Arguments>();
 
@@ -955,15 +947,14 @@ public class TypeChecker
               () -> error("All arguments must have exactly one value", definition.value));
 
           var argVal = arg.values.getFirst();
-          if (argVal instanceof Identifier paramId && definition.params.contains(
-              paramId.target())) {
-            foundParams.add(Pair.of(i, paramId));
+          if (argVal instanceof WildcardLiteral) {
+            wildcardIndices.add(i);
           } else if (argVal instanceof RangeExpr) {
             ensure(i == expr.argsIndices.size() - 1, () ->
                 error("Slices can only be done on the innermost dimension.", argVal));
             slice = arg;
           } else {
-            ensure(foundParams.isEmpty(),
+            ensure(wildcardIndices.isEmpty(),
                 () -> error("Constant accesses cannot occure after param accesses.", argVal));
             dummyArgs.add(arg);
           }
@@ -971,7 +962,8 @@ public class TypeChecker
           i++;
         }
 
-        if (dummyArgs.size() > 0) {
+        // Determine type based on the dummyArgs (none-wildcards or slice args)
+        if (!dummyArgs.isEmpty()) {
           var dummyCallIndexExpr =
               new CallIndexExpr(targetIdent, dummyArgs, List.of(), expr.location);
           dummyCallIndexExpr.symbolTable = expr.symbolTable;
@@ -990,17 +982,17 @@ public class TypeChecker
         if (slice != null) {
           var typeBeforeSlice = switch (expr.type()) {
             case TensorType type -> {
-              ensure(type.numberOfIndexDims() >= foundParams.size(),
+              ensure(type.numberOfIndexDims() >= wildcardIndices.size(),
                   () -> error("Invalid number of parameters", expr));
               yield type.innerType();
             }
             case ConcreteRelationType type -> {
-              ensure(type.argTypes().size() == foundParams.size(), () ->
+              ensure(type.argTypes().size() == wildcardIndices.size(), () ->
                   error("Invalid number of parameters", expr));
               yield type.resultType();
             }
             default -> {
-              ensure(foundParams.isEmpty(),
+              ensure(wildcardIndices.isEmpty(),
                   () -> error("Params can only access tensor types", expr));
               yield expr.type();
             }
@@ -2444,6 +2436,13 @@ public class TypeChecker
   public Void visit(IntegerLiteral expr) {
     expr.type = new ConstantType(expr.number);
     return null;
+  }
+
+  @Override
+  public Void visit(WildcardLiteral expr) {
+    // if a node contains a potential wildcard literal expression, it must ensure that
+    // it is not type checked.
+    throw new IllegalStateException("The wildcard literal should never be typechecked.");
   }
 
   @Override

--- a/vadl/main/vadl/ast/Ungrouper.java
+++ b/vadl/main/vadl/ast/Ungrouper.java
@@ -70,6 +70,11 @@ public class Ungrouper
   }
 
   @Override
+  public Expr visit(WildcardLiteral expr) {
+    return expr;
+  }
+
+  @Override
   public Expr visit(BinaryLiteral expr) {
     return expr;
   }

--- a/vadl/main/vadl/ast/vadl.ATG
+++ b/vadl/main/vadl/ast/vadl.ATG
@@ -582,16 +582,12 @@ PRODUCTIONS
 
   aliasDefinition<out Definition def>                 (. var startLocation = nextTokenLoc(); AliasDefinition.AliasKind kind = null;
                                                          TypeLiteral aliasType = null; TypeLiteral targetType = null;
-                                                         IdentifierOrPlaceholder id = null;  var params = new ArrayList<Identifier>();
+                                                         IdentifierOrPlaceholder id = null;
                                                       .)
   = ALIAS
     (
       REGISTER                                        (. kind = AliasDefinition.AliasKind.REGISTER; .)
       identifierOrPlaceholder<out id>
-      { SYM_PAREN_OPEN
-        identifier<out Identifier param>                (. params.add(param); .)
-        SYM_PAREN_CLOSE
-      }
       // FIXME: This should probably use the same relationType as the register definition
       [
         SYM_COLON
@@ -609,7 +605,7 @@ PRODUCTIONS
       ]
     )
     SYM_EQ
-    callOrBinaryExpression<out Expr value, false>     (. def = new AliasDefinition(id, kind, params, aliasType, targetType, value, startLocation.join(lastTokenLoc())); .)
+    callOrBinaryExpression<out Expr value, false, true>     (. def = new AliasDefinition(id, kind, aliasType, targetType, value, startLocation.join(lastTokenLoc())); .)
   .
 
   usingDefinition<out Definition def>                         (. var start = nextTokenLoc(); .)
@@ -1275,7 +1271,7 @@ PRODUCTIONS
     | assemblyGrammarOptional<out optionAlternatives>
     | assemblyGrammarRepetition<out repetitionAlternatives>
     | SYM_QUESTION SYM_PAREN_OPEN
-      callOrBinaryExpression<out semanticPred, false>
+      callOrBinaryExpression<out semanticPred, false, false>
       SYM_PAREN_CLOSE
     | stringLiteral<out Expr strLit>
       [assemblyGrammarTypeDefinition<out type>]                      (. asmLiteral = new AsmGrammarLiteralDefinition(null, new ArrayList<>(), strLit, type, start.join(lastTokenLoc())); type = null;.)
@@ -1360,7 +1356,7 @@ PRODUCTIONS
   .
 
   assignmentOrCallStmt<out Statement statement> (. statement = DUMMY_STAT; .)
-  = callOrBinaryExpression<out Expr target, false>
+  = callOrBinaryExpression<out Expr target, false, false>
     [
       SYM_ASSIGN
       expression<out Expr expr, BIN_OPS>        (. statement = new AssignmentStatement(target, expr); .)
@@ -1474,7 +1470,7 @@ PRODUCTIONS
 
   lockStatement<out Statement lock>         (. var start = nextTokenLoc(); .)
   = LOCK
-    callOrBinaryExpression<out Expr expr, false>
+    callOrBinaryExpression<out Expr expr, false, false>
     SYM_IN
     statement<out Statement statement>      (. lock = new LockStatement(expr, statement, start.join(lastTokenLoc())); .)
   .
@@ -1523,41 +1519,49 @@ PRODUCTIONS
   /// Call expressions of form "a::b<3>(1,2)(3,4).c()".
   /// Due to the "<"-ambiguity with the less-than operator, this rule can also return a BinaryExpr.
   /// Use the "allowLtOp" parameter to disallow this behavior, e.g. in type literals.
-  callOrBinaryExpression<out Expr expr, boolean allowLtOp> (. expr = DUMMY_EXPR; .)
+  callOrBinaryExpression<out Expr expr, boolean allowLtOp, boolean allowWildcardArgs> (. expr = DUMMY_EXPR; .)
   = IF (isIdentifierToken(la) || isMacroReplacementOfType(this, BasicSyntaxType.SYM_EX))
-    symbolOrBinaryExpression<out expr, allowLtOp>          (. List<CallIndexExpr.Arguments> argsIndices = new ArrayList<>(); .)
+    symbolOrBinaryExpression<out expr, allowLtOp>               (. List<CallIndexExpr.Arguments> argsIndices = new ArrayList<>(); .)
     {
       // Check if we received a symbol expression -> collect arguments
       // Otherwise, just return the collected binary expression
       IF (la.kind == _SYM_PAREN_OPEN && expr instanceof IsSymExpr)
-      arguments<.out CallIndexExpr.Arguments args.>        (. argsIndices.add(args); .)
-    }                                                      (. List<CallIndexExpr.SubCall> subCalls = new ArrayList<>(); .)
+      arguments<out CallIndexExpr.Arguments args, allowWildcardArgs>         (. argsIndices.add(args); .)
+    }                                                           (. List<CallIndexExpr.SubCall> subCalls = new ArrayList<>(); .)
     {
       IF (la.kind == _SYM_DOT && expr instanceof IsSymExpr)
-      SYM_DOT                                              (. var subCallArgsIndices = new ArrayList<CallIndexExpr.Arguments>(); .)
+      SYM_DOT                                                   (. var subCallArgsIndices = new ArrayList<CallIndexExpr.Arguments>(); .)
       identifier<out Identifier id>
       {
         IF (la.kind == _SYM_PAREN_OPEN)
-        arguments<.out CallIndexExpr.Arguments args.>      (. subCallArgsIndices.add(args); .)
-      }                                                    (. subCalls.add(new CallIndexExpr.SubCall(id, subCallArgsIndices)); .)
-    }                                                      (. if (expr instanceof IsSymExpr symExpr && (!argsIndices.isEmpty() || !subCalls.isEmpty()))
-                                                                expr = new CallIndexExpr(symExpr, argsIndices, subCalls, expr.location().join(lastTokenLoc()));
-                                                           .)
-  | macroReplacement<out Node node>                        (. expr = castExpr(this, node); .)
+        arguments<out CallIndexExpr.Arguments args, false>      (. subCallArgsIndices.add(args); .)
+      }                                                         (. subCalls.add(new CallIndexExpr.SubCall(id, subCallArgsIndices)); .)
+    }                                                           (. if (expr instanceof IsSymExpr symExpr && (!argsIndices.isEmpty() || !subCalls.isEmpty()))
+                                                                     expr = new CallIndexExpr(symExpr, argsIndices, subCalls, expr.location().join(lastTokenLoc()));
+                                                                .)
+  | macroReplacement<out Node node>                             (. expr = castExpr(this, node); .)
   .
 
   /// Represents one set of invocation arguments.
-  /// Multiple invocations (e.g. multi-dimensional access) will need multiple #arguments
-  arguments<.out CallIndexExpr.Arguments args.>    (. var start = nextTokenLoc(); .)
+  /// Multiple invocations (e.g. multi-dimensional access) will need multiple #arguments.
+  /// If allowWildcard is `true`, a argument may be `*`, which will yield a WildcardLiteral expression.
+  arguments<out CallIndexExpr.Arguments args, boolean allowWildcard>    (. var start = nextTokenLoc(); .)
   = SYM_PAREN_OPEN                            (. var values = new ArrayList<Expr>(); .)
-    expression<out Expr arg, BIN_OPS>         (. values.add(arg); .)
-    ( SYM_RANGE
-      expression<out Expr rangeTo, BIN_OPS>   (. values.set(0, new RangeExpr(arg, rangeTo)); .)
-    | {
+    argument<out Expr arg, allowWildcard>     (. values.add(arg); .)
+    {
       SYM_COMMA
-      expression<out Expr nextArg, BIN_OPS>   (. values.add(nextArg); .)
-    })
+      argument<out Expr nextArg, allowWildcard>   (. values.add(nextArg); .)
+    }
     SYM_PAREN_CLOSE                           (. args = new CallIndexExpr.Arguments(values, start.join(lastTokenLoc())); .)
+  .
+
+  argument<out Expr arg, boolean allowWildcard> (. arg = null; .)
+  = IF (allowWildcard && la.kind == _SYM_MUL)
+      SYM_MUL                                 (. arg = new WildcardLiteral(lastTokenLoc()); .)
+    | expression<out arg, BIN_OPS>
+    [ SYM_RANGE
+      expression<out Expr rangeTo, BIN_OPS>   (. arg = new RangeExpr(arg, rangeTo); .)
+    ]
   .
 
   /// Symbol expressions of form "a::b<3>".
@@ -1632,7 +1636,7 @@ PRODUCTIONS
   | IF (la.kind == _MATCH && scanner.Peek().kind != _SYM_COLON) // Disambiguate from macro match
     matchExpression<out expr>
   | IF (isIdentifierToken(la) || isMacroReplacementOfType(this, BasicSyntaxType.CALL_EX))
-    callOrBinaryExpression<out expr, true>
+    callOrBinaryExpression<out expr, true, false>
   | groupedExpression<out expr>
   | IF(isUnaryOperator(la) || isMacroReplacementOfType(this, BasicSyntaxType.UN_OP))
     unary<out expr, allowedOps>
@@ -1927,7 +1931,7 @@ PRODUCTIONS
   identifier<out Identifier id1> (. ident = id1; .)
   {
         // X(1)
-        arguments<out CallIndexExpr.Arguments args>
+        arguments<out CallIndexExpr.Arguments args, false>
         (. ident =  new CallIndexExpr(id1, List.of(args), List.of(), start); .)
     |  // a{0..7}
         SYM_BRACE_OPEN
@@ -2106,7 +2110,7 @@ PRODUCTIONS
     | macroReplacement<out body>
     )
   | IF (type == BasicSyntaxType.CALL_EX)
-    callOrBinaryExpression<out body, false>
+    callOrBinaryExpression<out body, false, false>
   | IF (type == BasicSyntaxType.SYM_EX)
     symbolOrBinaryExpression<out body, false>
   | IF (type == BasicSyntaxType.ID)

--- a/vadl/test/resources/testSource/sys/aarch64/aarch64.vadl
+++ b/vadl/test/resources/testSource/sys/aarch64/aarch64.vadl
@@ -60,11 +60,11 @@ instruction set architecture AArch64Base = {
   memory        MEM : Address -> Byte // byte addressed memory
 
   register        S : Index -> BitsX  // general purpose register file with stack pointer
-  alias register R(i) = S(i)(31..0)   // lower half of general purpose register file with stack pointer
+  alias register R = S(*)(31..0)   // lower half of general purpose register file with stack pointer
   [zero : X(31)]                      // X(31) is the zero register
   alias register  X = S               // general purpose register file with zero register
   [zero : W(31)]                      // X(31) is the zero register
-  alias register W(i) = X(i)(31..0)   // lower half of general purpose register file with zero register
+  alias register W = X(*)(31..0)   // lower half of general purpose register file with zero register
   alias register SP : Address = S(31) // stack pointer
   alias register LR : Address = S(30) // link register (return address)
 

--- a/vadl/test/vadl/ast/AliasDefinitionTest.java
+++ b/vadl/test/vadl/ast/AliasDefinitionTest.java
@@ -45,9 +45,9 @@ public class AliasDefinitionTest {
   void constantRegister() {
     var prog = prog("""
         alias register W = A(12..0)
-        alias register X(i) = B(i)(12..0)
-        alias register Y(i) = C(i)(12..0)
-        alias register U(j)(i) = D(j)(i)(12..0)
+        alias register X = B(*)(12..0)
+        alias register Y = C(*)(12..0)
+        alias register U = D(*)(*)(12..0)
         
         function func(a: Bits<13>) -> Bits<13> = a
         


### PR DESCRIPTION
This PR removes alias register params and introduces a new WildcardLiteral that can be used as register index placeholder.