### PR TITLE
gradle: Enable console input for gradlew run tasks

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -134,6 +134,7 @@ subprojects {
     }
 
     tasks.withType<JavaExec> {
+        standardInput = System.`in`
         workingDir = rootProject.projectDir
         outputs.upToDateWhen { false }
     }


### PR DESCRIPTION
When executing commands that require user input through the Gradle wrapper, an error occurs because System.in is not connected to the console.
Example Command:
```
./gradlew run --args="iss --init sys/ppc64/ppc64.vadl"
```
Output:
```
...
Do you trust this source? (y/n): Error: No line found

FAILURE: Build failed with an exception.
```

This is fixed by setting standardInput = System.in in build.gradle.kts.