### PR TITLE
iss: Changed cosimulation config to be able to take a test-executable per client

### DIFF
--- a/vadl-cosim/broker/src/main.rs
+++ b/vadl-cosim/broker/src/main.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use clap::Parser;
 use figment::{
     Figment,
@@ -18,8 +18,12 @@ pub struct Cli {
     pub config: String,
 
     /// Defines where the test-executable is passed to when starting the QEMU-client
+    /// If not set, the values from the config-file will be taken
+    /// If only one value is set then all clients will receive this path
+    /// If multiple values are set (--test-exec foo --test-exec bar) then each path will be
+    /// assigned to each client with the same order as in the config-file.
     #[arg(short, long, value_name = "FILE")]
-    pub test_exec: Option<String>,
+    pub test_exec: Option<Vec<String>>,
 }
 
 fn default_config_file() -> String {
@@ -34,7 +38,26 @@ fn main() -> Result<()> {
     config.qemu.set_inverse_reg_map();
 
     if let Some(test_exec) = cli.test_exec {
-        config.testing.test_exec = test_exec;
+        match &test_exec[..] {
+            [test_exec] => {
+                for client in &mut config.qemu.clients {
+                    client.test_exec = test_exec.clone();
+                }
+            }
+            test_execs => {
+                if test_execs.len() != config.qemu.clients.len() {
+                    bail!(
+                        "Multiple test-execs were provided using --test-exec, but the provided amount ({}) does not match the amount of clients in the config-file ({})",
+                        test_execs.len(),
+                        config.qemu.clients.len()
+                    );
+                }
+
+                for (i, client) in config.qemu.clients.iter_mut().enumerate() {
+                    client.test_exec = test_execs[i].clone();
+                }
+            }
+        }
     }
 
     if config.logging.enable {

--- a/vadl-cosim/config.toml
+++ b/vadl-cosim/config.toml
@@ -42,6 +42,10 @@ name = "VADL"
 # The executable of the ISS
 exec = "qemu-system-a64"
 
+# The path to the compiled file to use for testing
+# This file will be passed to all clients
+test_exec="./test-execs/sglib-combined"
+
 # "bios" | "kernel": Defines where the test-executable is passed to when starting the QEMU-client
 pass_test_exec_to = "bios"
 
@@ -75,6 +79,8 @@ remote_target = "/tmp/gdb-cosim-VADL"
 name = "UPSTREAM"
 
 exec = "qemu-system-aarch64"
+
+test_exec="./test-execs/sglib-combined"
 
 pass_test_exec_to = "kernel"
 
@@ -133,15 +139,6 @@ pc = "pc"
 
 # Defines the test-source and how to test
 [testing]
-
-# The path to the compiled file to use for testing
-# This file will be passed to all clients
-test_exec="./test-execs/sglib-combined"
-
-# The maximum trace length during a test-run
-# The trace acts as a sized dequeue, meaning newer trace-entries push out the oldest trace-entries if the length has been reached
-# Use max_trace_length = -1 to keep all traces
-max_trace_length = 2
 
 # The testing-protocol defines how the clients are run and tested against eachother
 [testing.protocol]

--- a/vadl-cosim/cosim-lib/src/config/mod.rs
+++ b/vadl-cosim/cosim-lib/src/config/mod.rs
@@ -139,11 +139,7 @@ pub enum ProtocolLayer {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Testing {
-    pub test_exec: String,
-
     pub protocol: Protocol,
-
-    pub max_trace_length: i32,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -170,6 +166,8 @@ pub enum GDBTargetType {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Client {
     pub exec: String,
+
+    pub test_exec: String,
 
     pub pass_test_exec_to: TestExecDestination,
 

--- a/vadl-cosim/cosim-lib/src/ipc/qemu.rs
+++ b/vadl-cosim/cosim-lib/src/ipc/qemu.rs
@@ -56,7 +56,7 @@ impl Client {
         let plugin = plugin.join(",");
         let default_args = vec![
             format!("-{}", client_cfg.pass_test_exec_to),
-            config.testing.test_exec.clone(),
+            client_cfg.test_exec.clone(),
             "-plugin".into(),
             plugin,
         ];


### PR DESCRIPTION
This doesn't change any behaviour of the broker but simply allows to use different test-execs per client (e.g. in case of different endianess between upstream and vadl iss versions). 

Now, in the config-file, the `test_exec` field is moved to `qemu.client.test_exec`, and the cli now can take multiple `--test-exec` options; one for each client (if only one `--test-exec` is provided, then all clients will receive the same executable).