### PR TITLE
lcb: Fixed constant mat type

### DIFF
--- a/vadl/main/resources/templates/lcb/llvm/lib/Target/DAGToDAGISel.cpp
+++ b/vadl/main/resources/templates/lcb/llvm/lib/Target/DAGToDAGISel.cpp
@@ -108,7 +108,7 @@ bool [(${namespace})]DAGToDAGISel::trySelect(SDNode *Node)
 
          // Handle rest
          int64_t Imm = ConstNode->getSExtValue();
-         ReplaceNode(Node, selectImm(CurDAG, SDLoc(Node), Imm, XLenVT, *Subtarget));
+         ReplaceNode(Node, selectImm(CurDAG, SDLoc(Node), Imm, VT, *Subtarget));
          return true;
        }
        default:

--- a/vadl/test/resources/testSource/sys/aarch64/aarch64-abi.vadl
+++ b/vadl/test/resources/testSource/sys/aarch64/aarch64-abi.vadl
@@ -97,7 +97,7 @@ application binary interface ABI for AArch64Temp = {
    {
       MOVZWPos00 { rd = rd, imm16 = (val & 0xFFFF) as Bits<16> }
       MOVKWPos16 { rd = rd, imm16 = ((val >> 16) & 0xFFFF) as Bits<16> }
-      SUBX { rd = rd, rn = 31, rm = rd }
+      SUBW { rd = rd, rn = 31, rm = rd }
    }
 
    /*


### PR DESCRIPTION
- `trySelect` must use the node's type
- wrong instruction during materialisation