### PR TITLE
lcb: Set types for branch lowering

### DIFF
--- a/vadl/main/resources/templates/lcb/llvm/lib/Target/ISelLowering.cpp
+++ b/vadl/main/resources/templates/lcb/llvm/lib/Target/ISelLowering.cpp
@@ -60,8 +60,8 @@ void [(${namespace})]TargetLowering::anchor() {}
 
     [#th:block th:if="${mergedCmpAndBranch}"]
     setOperationAction(ISD::BRCOND, MVT::Other, Expand);
-    setOperationAction(ISD::BR_CC, MVT::[(${stackPointerType})], Custom);
-    setOperationAction(ISD::SELECT_CC, MVT::[(${stackPointerType})], Custom);
+    setOperationAction(ISD::BR_CC, { [(${branchTypes})] }, Custom);
+    setOperationAction(ISD::SELECT_CC, { [(${branchTypes})] }, Custom);
     setOperationAction(ISD::SETCC, MVT::[(${stackPointerType})], Expand);
     [/th:block]
     [#th:block th:if="${!mergedCmpAndBranch}"]

--- a/vadl/main/vadl/lcb/template/lib/Target/EmitISelLoweringCppFilePass.java
+++ b/vadl/main/vadl/lcb/template/lib/Target/EmitISelLoweringCppFilePass.java
@@ -134,6 +134,7 @@ public class EmitISelLoweringCppFilePass extends LcbTemplateRenderingPass {
     map.put("conditionalValueRangeLowest", conditionalValueRange.lowest());
     map.put("conditionalValueRangeHighest", conditionalValueRange.highest());
     map.put("expandableDagNodes", coverageSummary.notCoveredSelectionDagNodes());
+    map.put("branchTypes", branchTypes(stackPointerType));
     map.put("mergedCmpAndBranch",
         !database.run(
             new Query.Builder().machineInstructionLabels(List.of(
@@ -183,6 +184,14 @@ public class EmitISelLoweringCppFilePass extends LcbTemplateRenderingPass {
                     MachineInstructionLabel.CSEL_NEQ_I64)
             .build())));
     return map;
+  }
+
+  private String branchTypes(ValueType stackPointerType) {
+    if (stackPointerType == ValueType.I64) {
+      return "MVT::i32, MVT::i64";
+    } else {
+      return "MVT::i32";
+    }
   }
 
   private String getFirstNameOrEmpty(QueryResult result) {


### PR DESCRIPTION
If we have an architecture with `i64` then we also need to handle `i32`. In rv64im, this wasn't really a problem, but somehow in AArch64 it is.