### PR TITLE
lcb: Set OperationAction to Expand for setcc for i32

### DIFF
--- a/vadl/main/resources/templates/lcb/llvm/lib/Target/ISelLowering.cpp
+++ b/vadl/main/resources/templates/lcb/llvm/lib/Target/ISelLowering.cpp
@@ -62,6 +62,7 @@ void [(${namespace})]TargetLowering::anchor() {}
     setOperationAction(ISD::BRCOND, MVT::Other, Expand);
     setOperationAction(ISD::BR_CC, { [(${branchTypes})] }, Custom);
     setOperationAction(ISD::SELECT_CC, { [(${branchTypes})] }, Custom);
+    setOperationAction(ISD::SETCC, MVT::i32, Expand);
     setOperationAction(ISD::SETCC, MVT::[(${stackPointerType})], Expand);
     [/th:block]
     [#th:block th:if="${!mergedCmpAndBranch}"]


### PR DESCRIPTION
Fixes a selection error where the `setcc` for `i32` cannot be lowered. We can hardcode the type because if the architecture is 32 bit then it would be a duplicate. And higher bit widths require it anyways.