### PR TITLE
chore: Replaced @NotNull by @Nonnull

### DIFF
--- a/vadl/main/vadl/gcb/passes/IsaMatchingUtils.java
+++ b/vadl/main/vadl/gcb/passes/IsaMatchingUtils.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.jetbrains.annotations.NotNull;
 import vadl.gcb.annotations.StatusRegisterAnnotation;
 import vadl.gcb.valuetypes.RelocationCtx;
 import vadl.gcb.valuetypes.RelocationFunctionLabel;

--- a/vadl/main/vadl/lcb/codegen/expansion/CompilerInstructionExpansionCodeGenerator.java
+++ b/vadl/main/vadl/lcb/codegen/expansion/CompilerInstructionExpansionCodeGenerator.java
@@ -38,6 +38,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.jetbrains.annotations.NotNull;
 import vadl.cppCodeGen.FunctionCodeGenerator;
@@ -389,7 +390,7 @@ public class CompilerInstructionExpansionCodeGenerator extends FunctionCodeGener
   private Pair<Either<Format.Field, Format.FieldAccess>, ExpressionNode> lookupField(
       CompilerInstruction compilerInstruction,
       Instruction instruction,
-      Map<Format.Field, @NotNull ExpressionNode> lookupFields,
+      Map<Format.Field, ExpressionNode> lookupFields,
       Format.Field field, Format.Field canonicalizedField) {
     if (lookupFields.containsKey(canonicalizedField)) {
       var value = lookupFields.get(canonicalizedField);

--- a/vadl/main/vadl/viam/ArtificialResource.java
+++ b/vadl/main/vadl/viam/ArtificialResource.java
@@ -18,6 +18,7 @@ package vadl.viam;
 
 import java.util.Collections;
 import java.util.List;
+import javax.annotation.Nonnull;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import vadl.types.ConcreteRelationType;
@@ -153,7 +154,7 @@ public class ArtificialResource extends RegisterResource {
   }
 
   @Override
-  @NotNull
+  @Nonnull
   public DataType addressType() {
     ensure(hasAddress(), "Resource has no address");
     return readFunction.parameters()[0].type().asDataType();

--- a/vadl/test/vadl/AnnotationRuleParametersTest.java
+++ b/vadl/test/vadl/AnnotationRuleParametersTest.java
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl;
+
+import static vadl.AnnotationRuleTest.JAKARTA_VALIDATION_CONSTRAINTS_NOT_NULL;
+import static vadl.AnnotationRuleTest.JAVAX_VALIDATION_CONSTRAINTS_NOT_NULL;
+import static vadl.AnnotationRuleTest.ORG_JETBRAINS_ANNOTATIONS_NOT_NULL;
+
+import com.tngtech.archunit.core.domain.JavaAnnotation;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.domain.JavaMethod;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
+import org.junit.jupiter.api.Test;
+
+public class AnnotationRuleParametersTest {
+  // We needed to extract this into a separate class because the rule was not executed with
+  // ArchCondition.
+  static final ArchCondition<JavaMethod> condition =
+      new ArchCondition<>("have parameters annotated with @NotNull") {
+        @Override
+        public void check(JavaMethod method, ConditionEvents events) {
+          for (int paramIndex = 0; paramIndex < method.getParameters().size();
+               paramIndex++) {
+            var param = method.getParameters().get(paramIndex);
+            for (JavaAnnotation<?> annotation : param.getAnnotations()) {
+              String typeName = annotation.getType().getName();
+              if (isNotNull(typeName)) {
+                events.add(SimpleConditionEvent.violated(
+                    annotation,
+                    String.format("Method %s has parameter[%d] annotated with %s",
+                        method.getFullName(), paramIndex, typeName)
+                ));
+              }
+            }
+          }
+        }
+      };
+
+  @Test
+  public void checkArchitecturalRules() {
+    JavaClasses importedClasses = new ClassFileImporter().importPackages("vadl");
+
+    ArchRule rule = ArchRuleDefinition.methods()
+        .should(condition);
+
+    rule.check(importedClasses);
+  }
+
+  private static boolean isNotNull(String typeName) {
+    return typeName.equals(ORG_JETBRAINS_ANNOTATIONS_NOT_NULL)
+        || typeName.equals(JAVAX_VALIDATION_CONSTRAINTS_NOT_NULL)
+        || typeName.equals(JAKARTA_VALIDATION_CONSTRAINTS_NOT_NULL);
+  }
+}

--- a/vadl/test/vadl/AnnotationRuleTest.java
+++ b/vadl/test/vadl/AnnotationRuleTest.java
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noMethods;
+
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+
+@AnalyzeClasses(packages = "vadl")
+public class AnnotationRuleTest {
+  public static final String ORG_JETBRAINS_ANNOTATIONS_NOT_NULL =
+      "org.jetbrains.annotations.NotNull";
+  public static final String JAVAX_VALIDATION_CONSTRAINTS_NOT_NULL =
+      "javax.validation.constraints.NotNull";
+  public static final String JAKARTA_VALIDATION_CONSTRAINTS_NOT_NULL =
+      "jakarta.validation.constraints.NotNull";
+  @ArchTest
+  static final ArchRule noNotNullAnnotationsForClasses = // Intellij shows not used, but it is
+      noClasses().should().beAnnotatedWith(ORG_JETBRAINS_ANNOTATIONS_NOT_NULL)
+          .orShould().beAnnotatedWith(JAVAX_VALIDATION_CONSTRAINTS_NOT_NULL)
+          .orShould().beAnnotatedWith(JAKARTA_VALIDATION_CONSTRAINTS_NOT_NULL);
+
+  @ArchTest
+  static final ArchRule noNotNullAnnotationsForMethods = // Intellij shows not used, but it is
+      noMethods().should().beAnnotatedWith(ORG_JETBRAINS_ANNOTATIONS_NOT_NULL)
+          .orShould().beAnnotatedWith(JAVAX_VALIDATION_CONSTRAINTS_NOT_NULL)
+          .orShould().beAnnotatedWith(JAKARTA_VALIDATION_CONSTRAINTS_NOT_NULL);
+
+
+}

--- a/vadl/test/vadl/ArchitectureTest.java
+++ b/vadl/test/vadl/ArchitectureTest.java
@@ -54,4 +54,6 @@ public class ArchitectureTest {
 
     layeredArchitecture.check(jc);
   }
+
+
 }


### PR DESCRIPTION
We replaced the annotation `@NotNull` by `@Nonnull` and added an architecture test to enforce the usage.