### PR TITLE
lcb: Add skip-pattern-generation option to the lcb command

### DIFF
--- a/vadl-cli/main/vadl/cli/LcbCommand.java
+++ b/vadl-cli/main/vadl/cli/LcbCommand.java
@@ -30,7 +30,7 @@ import vadl.pass.PassOrder;
 import vadl.pass.PassOrders;
 
 /**
- * The Command does provide the iss subcommand.
+ * The Command does provide the lcb subcommand.
  */
 @Command(
     name = "lcb",
@@ -44,9 +44,13 @@ public class LcbCommand extends BaseCommand {
       "--target"}, scope = INHERIT, description = "Target Name")
   String targetName;
 
+  @Option(names = {"--skip-pattern-generation"}, scope = INHERIT,
+      description = "Skip TableGen pattern generation")
+  boolean skipPatternGeneration = false;
+
   @Override
   PassOrder passOrder(GeneralConfiguration configuration) throws IOException {
-    var lcbConfig = new LcbConfiguration(configuration, targetName());
+    var lcbConfig = new LcbConfiguration(configuration, targetName(), skipPatternGeneration);
     return PassOrders.lcb(lcbConfig);
   }
 

--- a/vadl/main/vadl/configuration/LcbConfiguration.java
+++ b/vadl/main/vadl/configuration/LcbConfiguration.java
@@ -24,14 +24,30 @@ import vadl.gcb.valuetypes.TargetName;
  */
 public class LcbConfiguration extends GcbConfiguration {
 
+  private boolean skipPatternGeneration = false;
 
   public LcbConfiguration(GeneralConfiguration gcbConfiguration, @Nullable TargetName targetName) {
     super(gcbConfiguration, targetName);
   }
 
+  public LcbConfiguration(GeneralConfiguration gcbConfiguration, @Nullable TargetName targetName,
+                          boolean skipPatternGeneration) {
+    super(gcbConfiguration, targetName);
+    this.skipPatternGeneration = skipPatternGeneration;
+  }
+
   public static LcbConfiguration from(GcbConfiguration gcbConfiguration,
                                       TargetName targetName) {
     return new LcbConfiguration(gcbConfiguration, targetName);
+  }
+
+  public static LcbConfiguration from(GcbConfiguration gcbConfiguration,
+                                      TargetName targetName, boolean skipPatternGeneration) {
+    return new LcbConfiguration(gcbConfiguration, targetName, skipPatternGeneration);
+  }
+
+  public boolean skipPatternGeneration() {
+    return skipPatternGeneration;
   }
 
 }

--- a/vadl/main/vadl/lcb/passes/llvmLowering/LlvmLoweringPass.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/LlvmLoweringPass.java
@@ -77,8 +77,12 @@ import vadl.viam.Specification;
  * This is a wrapper class which contains utility functions for the lowering.
  */
 public class LlvmLoweringPass extends Pass {
+
+  private boolean generatePatterns;
+
   public LlvmLoweringPass(LcbConfiguration configuration) {
     super(configuration);
+    this.generatePatterns = !((LcbConfiguration) configuration()).skipPatternGeneration();
   }
 
   /**
@@ -342,7 +346,8 @@ public class LlvmLoweringPass extends Pass {
                     instruction,
                     instruction.behavior(),
                     abi,
-                    usesDefs);
+                    usesDefs,
+                    generatePatterns);
 
             // Okay, we have to save record.
             record.ifPresent(llvmLoweringIntermediateResult -> {
@@ -386,7 +391,8 @@ public class LlvmLoweringPass extends Pass {
                     Collections.emptyList(),
                     pseudo,
                     labelledMachineInstructions,
-                    info);
+                    info,
+                    generatePatterns);
 
             record.ifPresent(llvmLoweringIntermediateResult -> tableGenRecords.put(pseudo,
                 llvmLoweringIntermediateResult));

--- a/vadl/main/vadl/lcb/passes/llvmLowering/strategies/LlvmInstructionLoweringStrategy.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/strategies/LlvmInstructionLoweringStrategy.java
@@ -20,7 +20,6 @@ import static vadl.viam.ViamError.ensureNonNull;
 import static vadl.viam.ViamError.ensurePresent;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -300,7 +299,8 @@ public abstract class LlvmInstructionLoweringStrategy {
       Instruction instruction,
       Graph unmodifiedBehavior,
       Abi abi,
-      DetermineRegisterUsesAndDefsPass.Info registerDefsUses) {
+      DetermineRegisterUsesAndDefsPass.Info registerDefsUses,
+      boolean generatePatterns) {
     var copy = unmodifiedBehavior.copy();
 
     if (!checkIfNoControlFlow(copy) && !checkIfNotAllowedDataflowNodes(copy)) {
@@ -321,34 +321,36 @@ public abstract class LlvmInstructionLoweringStrategy {
       var patterns = new ArrayList<TableGenPattern>();
       var alternatives = new ArrayList<TableGenPattern>();
 
-      // The first behavior is always the modified main behavior.
-      additionalBehaviors.add(Pair.of(copy, info.inputs()));
-      var derivedBehaviors = deriveDifferentBehaviors(instruction, copy, info.inputs());
-      additionalBehaviors.addAll(derivedBehaviors);
+      if (generatePatterns) {
+        // The first behavior is always the modified main behavior.
+        additionalBehaviors.add(Pair.of(copy, info.inputs()));
+        var derivedBehaviors = deriveDifferentBehaviors(instruction, copy, info.inputs());
+        additionalBehaviors.addAll(derivedBehaviors);
 
-      // Iterate over all the constructed behaviors.
-      for (var pair : additionalBehaviors) {
-        var optimisationResult = optimise(pair.left());
-        var behavior = optimisationResult.optimised;
-        var inputOperands = pair.right();
+        // Iterate over all the constructed behaviors.
+        for (var pair : additionalBehaviors) {
+          var optimisationResult = optimise(pair.left());
+          var behavior = optimisationResult.optimised;
+          var inputOperands = pair.right();
 
-        var localPatterns = generatePatterns(instruction,
-            behavior,
-            inputOperands,
-            behavior.getNodes(WriteResourceNode.class).toList());
-        var localAlternatives =
-            generatePatternVariations(
-                instruction,
-                labelledMachineInstructions,
-                behavior,
-                inputOperands,
-                info.outputs(),
-                localPatterns,
-                abi);
+          var localPatterns = generatePatterns(instruction,
+              behavior,
+              inputOperands,
+              behavior.getNodes(WriteResourceNode.class).toList());
+          var localAlternatives =
+              generatePatternVariations(
+                  instruction,
+                  labelledMachineInstructions,
+                  behavior,
+                  inputOperands,
+                  info.outputs(),
+                  localPatterns,
+                  abi);
 
-        patterns.addAll(localPatterns);
-        alternatives.addAll(localAlternatives);
-        additionalBehaviorsBookkeeping.add(optimisationResult);
+          patterns.addAll(localPatterns);
+          alternatives.addAll(localAlternatives);
+          additionalBehaviorsBookkeeping.add(optimisationResult);
+        }
       }
 
       return Optional.of(new LlvmLoweringRecord.Machine(

--- a/vadl/main/vadl/lcb/passes/llvmLowering/strategies/LlvmPseudoInstructionLowerStrategy.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/strategies/LlvmPseudoInstructionLowerStrategy.java
@@ -69,7 +69,8 @@ public abstract class LlvmPseudoInstructionLowerStrategy
       List<TableGenInstAlias> instAliases,
       PseudoInstruction pseudo,
       IsaMachineInstructionMatchingPass.Result supportedInstructions,
-      DetermineRegisterUsesAndDefsPass.Info registerDefsUses) {
+      DetermineRegisterUsesAndDefsPass.Info registerDefsUses,
+      boolean generatePatterns) {
     var compilerInstruction =
         super.lowerInstruction(pseudo, supportedInstructions, registerDefsUses);
 

--- a/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/LlvmInstructionLoweringConditionalBranchesStrategyImpl.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/LlvmInstructionLoweringConditionalBranchesStrategyImpl.java
@@ -29,7 +29,6 @@ import static vadl.gcb.passes.MachineInstructionLabel.BULTH;
 import static vadl.viam.ViamError.ensurePresent;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -93,7 +92,8 @@ public class LlvmInstructionLoweringConditionalBranchesStrategyImpl
       Instruction instruction,
       Graph uninlinedBehavior,
       Abi abi,
-      DetermineRegisterUsesAndDefsPass.Info registerDefsUses) {
+      DetermineRegisterUsesAndDefsPass.Info registerDefsUses,
+      boolean generatePatterns) {
     var copy = uninlinedBehavior.copy();
 
     var constraints = generateConstraints(copy);
@@ -103,7 +103,7 @@ public class LlvmInstructionLoweringConditionalBranchesStrategyImpl
 
     return Optional.of(
         createIntermediateResult(labelledMachineInstructions, instruction, copy, abi,
-            registerDefsUses, constraints));
+            registerDefsUses, constraints, generatePatterns));
   }
 
   @Override
@@ -118,7 +118,8 @@ public class LlvmInstructionLoweringConditionalBranchesStrategyImpl
       Graph visitedGraph,
       Abi abi,
       DetermineRegisterUsesAndDefsPass.Info registerDefsUses,
-      List<TableGenInstructionConstraint> constraints) {
+      List<TableGenInstructionConstraint> constraints,
+      boolean generatePatterns) {
     var info = lowerBaseInfo(instruction, visitedGraph, registerDefsUses);
 
     if (hasRedFlags(instruction, visitedGraph)) {
@@ -130,15 +131,21 @@ public class LlvmInstructionLoweringConditionalBranchesStrategyImpl
     }
 
     var writes = visitedGraph.getNodes(WriteResourceNode.class).toList();
-    var patterns = generatePatterns(instruction, instruction.behavior(), info.inputs(), writes);
-    var alternatives =
-        generatePatternVariations(instruction,
-            supportedInstructions,
-            visitedGraph,
-            info.inputs(),
-            info.outputs(),
-            patterns,
-            abi);
+
+    List<TableGenPattern> patterns = new ArrayList<>();
+    List<TableGenPattern> alternatives = new ArrayList();
+
+    if (generatePatterns) {
+      patterns = generatePatterns(instruction, instruction.behavior(), info.inputs(), writes);
+      alternatives =
+          generatePatternVariations(instruction,
+              supportedInstructions,
+              visitedGraph,
+              info.inputs(),
+              info.outputs(),
+              patterns,
+              abi);
+    }
 
     var allPatterns = Stream.concat(patterns.stream(), alternatives.stream())
         .map(LoweringStrategyUtils::replaceBasicBlockByLabelImmediateInMachineInstruction)

--- a/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/LlvmInstructionLoweringConditionalBranchesWithStatusRegistersStrategyImpl.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/LlvmInstructionLoweringConditionalBranchesWithStatusRegistersStrategyImpl.java
@@ -66,7 +66,8 @@ public class LlvmInstructionLoweringConditionalBranchesWithStatusRegistersStrate
       Instruction instruction,
       Graph uninlinedBehavior,
       Abi abi,
-      DetermineRegisterUsesAndDefsPass.Info registerDefsUses) {
+      DetermineRegisterUsesAndDefsPass.Info registerDefsUses,
+      boolean generatePatterns) {
     var copy = uninlinedBehavior.copy();
 
     var constraints = generateConstraints(copy);

--- a/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/LlvmInstructionLoweringIndirectJumpAndLinkStrategyImpl.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/LlvmInstructionLoweringIndirectJumpAndLinkStrategyImpl.java
@@ -19,7 +19,6 @@ package vadl.lcb.passes.llvmLowering.strategies.instruction;
 import static vadl.viam.ViamError.ensurePresent;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -106,10 +105,10 @@ public class LlvmInstructionLoweringIndirectJumpAndLinkStrategyImpl
       Instruction instruction,
       Graph unmodifiedBehavior,
       Abi abi,
-      DetermineRegisterUsesAndDefsPass.Info registerDefsUses) {
+      DetermineRegisterUsesAndDefsPass.Info registerDefsUses,
+      boolean generatePatterns) {
     var copy = unmodifiedBehavior.copy();
 
-    var constraints = generateConstraints(copy);
     for (var node : copy.getNodes(SideEffectNode.class).toList()) {
       replaceNode(instruction, node);
     }
@@ -119,13 +118,18 @@ public class LlvmInstructionLoweringIndirectJumpAndLinkStrategyImpl
     // Clear the flags for this strategy
     info = info.withFlags(LlvmLoweringPass.Flags.empty());
 
-    var patterns = generatePatternVariations(instruction,
-        labelledMachineInstructions,
-        copy,
-        info.inputs(),
-        info.outputs(),
-        Collections.emptyList(),
-        abi);
+    List<TableGenPattern> patterns = new ArrayList<>();
+    if (generatePatterns) {
+      patterns = generatePatternVariations(instruction,
+          labelledMachineInstructions,
+          copy,
+          info.inputs(),
+          info.outputs(),
+          Collections.emptyList(),
+          abi);
+    }
+
+    var constraints = generateConstraints(copy);
 
     return Optional.of(new LlvmLoweringRecord.Machine(
         instruction,

--- a/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/LlvmInstructionLoweringUnconditionalIndirectJumpWithoutLinkRegistersStrategyImpl.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/LlvmInstructionLoweringUnconditionalIndirectJumpWithoutLinkRegistersStrategyImpl.java
@@ -60,7 +60,8 @@ public class LlvmInstructionLoweringUnconditionalIndirectJumpWithoutLinkRegister
       Instruction instruction,
       Graph uninlinedBehavior,
       Abi abi,
-      DetermineRegisterUsesAndDefsPass.Info registerDefsUses) {
+      DetermineRegisterUsesAndDefsPass.Info registerDefsUses,
+      boolean generatePatterns) {
     var copy = uninlinedBehavior.copy();
 
     var constraints = generateConstraints(copy);

--- a/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/LlvmInstructionLoweringUnconditionalJumpWithLinkRegistersStrategyImpl.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/LlvmInstructionLoweringUnconditionalJumpWithLinkRegistersStrategyImpl.java
@@ -59,7 +59,8 @@ public class LlvmInstructionLoweringUnconditionalJumpWithLinkRegistersStrategyIm
       Instruction instruction,
       Graph uninlinedBehavior,
       Abi abi,
-      DetermineRegisterUsesAndDefsPass.Info registerDefsUses) {
+      DetermineRegisterUsesAndDefsPass.Info registerDefsUses,
+      boolean generatePatterns) {
     var copy = uninlinedBehavior.copy();
 
     var constraints = generateConstraints(copy);

--- a/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/LlvmInstructionLoweringUnconditionalJumpWithoutLinkRegistersStrategyImpl.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/LlvmInstructionLoweringUnconditionalJumpWithoutLinkRegistersStrategyImpl.java
@@ -18,6 +18,7 @@ package vadl.lcb.passes.llvmLowering.strategies.instruction;
 
 import static vadl.gcb.passes.MachineInstructionLabel.J;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -66,7 +67,8 @@ public class LlvmInstructionLoweringUnconditionalJumpWithoutLinkRegistersStrateg
       Instruction instruction,
       Graph uninlinedBehavior,
       Abi abi,
-      DetermineRegisterUsesAndDefsPass.Info registerDefsUses) {
+      DetermineRegisterUsesAndDefsPass.Info registerDefsUses,
+      boolean generatePatterns) {
     var copy = uninlinedBehavior.copy();
 
     for (var node : copy.getNodes(SideEffectNode.class).toList()) {
@@ -74,23 +76,27 @@ public class LlvmInstructionLoweringUnconditionalJumpWithoutLinkRegistersStrateg
     }
 
     return Optional.of(
-        createIntermediateResult(instruction, copy, registerDefsUses));
+        createIntermediateResult(instruction, copy, registerDefsUses, generatePatterns));
   }
 
   private LlvmLoweringRecord.Machine createIntermediateResult(
       Instruction instruction,
       Graph uninlinedGraph,
-      DetermineRegisterUsesAndDefsPass.Info registerDefsUses) {
+      DetermineRegisterUsesAndDefsPass.Info registerDefsUses,
+      boolean generatePatterns) {
     var info = lowerBaseInfo(instruction, uninlinedGraph, registerDefsUses);
     var unchangedFlags = getFlags(uninlinedGraph);
     var flags = LlvmLoweringPass.Flags.withTerminator(
         LlvmLoweringPass.Flags.withBranch(
             LlvmLoweringPass.Flags.withBarrier(unchangedFlags)));
 
-    var patterns = generatePatterns(instruction,
-        uninlinedGraph,
-        info.inputs(),
-        uninlinedGraph.getNodes(WriteResourceNode.class).toList());
+    List<TableGenPattern> patterns = new ArrayList<>();
+    if (generatePatterns) {
+      patterns = generatePatterns(instruction,
+          uninlinedGraph,
+          info.inputs(),
+          uninlinedGraph.getNodes(WriteResourceNode.class).toList());
+    }
 
     return new LlvmLoweringRecord.Machine(
         instruction,

--- a/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/LlvmPseudoInstructionLoweringLoadGlobalAddressStrategyImpl.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/LlvmPseudoInstructionLoweringLoadGlobalAddressStrategyImpl.java
@@ -70,8 +70,10 @@ public class LlvmPseudoInstructionLoweringLoadGlobalAddressStrategyImpl
       List<TableGenInstAlias> instAliases,
       PseudoInstruction pseudo,
       IsaMachineInstructionMatchingPass.Result supportedInstructions,
-      DetermineRegisterUsesAndDefsPass.Info info) {
-    var record = super.lowerInstruction(abi, instAliases, pseudo, supportedInstructions, info);
+      DetermineRegisterUsesAndDefsPass.Info info,
+      boolean generatePatterns) {
+    var record = super.lowerInstruction(abi, instAliases, pseudo, supportedInstructions, info,
+        generatePatterns);
 
     if (record.isPresent()) {
       // The pseudo instruction which loads the global address needs to have the

--- a/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/LlvmPseudoInstructionLoweringUnconditionalJumpsStrategyImpl.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/LlvmPseudoInstructionLoweringUnconditionalJumpsStrategyImpl.java
@@ -76,7 +76,8 @@ public class LlvmPseudoInstructionLoweringUnconditionalJumpsStrategyImpl extends
       List<TableGenInstAlias> instAliases,
       PseudoInstruction pseudo,
       IsaMachineInstructionMatchingPass.Result labelledMachineInstructions,
-      DetermineRegisterUsesAndDefsPass.Info info) {
+      DetermineRegisterUsesAndDefsPass.Info info,
+      boolean generatePatterns) {
     for (var callNode : pseudo.behavior().getNodes(InstrCallNode.class).toList()) {
       var instructionBehavior = callNode.target().behavior().copy();
       var label = labelledMachineInstructions.reverse().get(callNode.target());
@@ -93,7 +94,8 @@ public class LlvmPseudoInstructionLoweringUnconditionalJumpsStrategyImpl extends
             strategy.lowerInstruction(labelledMachineInstructions, callNode.target(),
                 instructionBehavior,
                 abi,
-                info);
+                info,
+                generatePatterns);
 
         if (tableGenRecord.isPresent()) {
           var record = tableGenRecord.get();

--- a/vadl/test/vadl/lcb/AsmFileCheckTest.java
+++ b/vadl/test/vadl/lcb/AsmFileCheckTest.java
@@ -20,12 +20,19 @@ import java.io.IOException;
 import java.util.List;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.TestFactory;
+import vadl.configuration.LcbConfiguration;
+import vadl.gcb.valuetypes.TargetName;
 import vadl.pass.exception.DuplicatedPassKeyException;
 
 public abstract class AsmFileCheckTest extends LcbDockerInputFileExecutionTest {
   protected abstract String getSpecPath();
 
   protected abstract String getComponent();
+
+  @Override
+  protected LcbConfiguration getConfiguration() {
+    return new LcbConfiguration(getConfiguration(false), new TargetName(getTarget()), true);
+  }
 
   @TestFactory
   List<DynamicTest> testAsm() throws DuplicatedPassKeyException, IOException {

--- a/vadl/test/vadl/lcb/LcbDockerExecutionTest.java
+++ b/vadl/test/vadl/lcb/LcbDockerExecutionTest.java
@@ -77,6 +77,10 @@ public abstract class LcbDockerExecutionTest extends AbstractLcbTest {
     return map;
   }
 
+  protected LcbConfiguration getConfiguration() {
+    return new LcbConfiguration(getConfiguration(false), new TargetName(getTarget()));
+  }
+
   protected void run(String specPath, String cmd) throws DuplicatedPassKeyException, IOException {
     var environment = defaultEnvironment();
     run(specPath, cmd, environment);
@@ -85,8 +89,7 @@ public abstract class LcbDockerExecutionTest extends AbstractLcbTest {
   protected void run(String specPath, String cmd, Map<String, String> environments)
       throws DuplicatedPassKeyException, IOException {
     var doDebug = enableDebug();
-    var configuration = new LcbConfiguration(getConfiguration(false),
-        new TargetName(getTarget()));
+    var configuration = getConfiguration();
 
     runLcb(configuration, specPath);
     copyIntoDockerContext(configuration);


### PR DESCRIPTION
This PR adds `skip-pattern-generation` as an option to the OpenVADL LCB command. Enabling it skips all pattern generation in th  LLVM lowering in the LCB.

~~This PR adds an `--assembler` (shorthand `-a`) option to the OpenVADL LCB command.~~

~~For now this option just disables TableGen pattern generation. In the future it can be extended, for example to disable passes that are not needed for assembler generation.~~