### PR TITLE
fix: dynamic z3 bootstrapping triggers native-access warning (java 25)

### DIFF
--- a/vadl-cli/build.gradle.kts
+++ b/vadl-cli/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
 application {
     applicationName = "openvadl"
     mainClass.set("vadl.cli.Main")
+    applicationDefaultJvmArgs = listOf("--enable-native-access=ALL-UNNAMED")
 }
 
 graalvmNative {
@@ -38,13 +39,19 @@ graalvmNative {
             buildArgs.addAll("-O2", "--gc=epsilon")
             // some tools require network access to download source code (QEMU, LLVM)
             buildArgs.add("--enable-url-protocols=https")
+            // Z3 platform binaries are loaded via JNI
+            buildArgs.add("--enable-native-access=ALL-UNNAMED")
 
         }
     }
 }
 
 tasks.startScripts {
-    defaultJvmOpts = listOf("-XX:TieredStopAtLevel=1")
+    defaultJvmOpts = listOf(
+        "-XX:TieredStopAtLevel=1",
+        // Z3 platform binaries are loaded via JNI
+        "--enable-native-access=ALL-UNNAMED"
+    )
 }
 
 tasks.test {


### PR DESCRIPTION
- With Java 25, accessing 'restricted' methods without explicitly allowing them triggers a warning (and will be disabled in the future).

- Since openvadl doen't specify a module, it's placed into the unnamed module. Thus we'll add native access permissions for that. (via ALL-UNNAMED)

See also https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/lang/doc-files/RestrictedMethods.html
