### PR TITLE
embench: Enabled benchmarks

### DIFF
--- a/vadl/test/resources/embench/benchmark-extras/rv32-run-benchmarks-spike-clang-lcb-O0.sh
+++ b/vadl/test/resources/embench/benchmark-extras/rv32-run-benchmarks-spike-clang-lcb-O0.sh
@@ -10,7 +10,7 @@ cd $(realpath $(dirname "$0"))
 # miscompile
 rm -r ../src/cubic
 # long jump problem
-rm -r ../src/statemate
+#rm -r ../src/statemate
 
 #rm -r ../src/aha-mont64
 #rm -r ../src/crc32

--- a/vadl/test/resources/embench/benchmark-extras/rv64-run-benchmarks-spike-clang-lcb-O0.sh
+++ b/vadl/test/resources/embench/benchmark-extras/rv64-run-benchmarks-spike-clang-lcb-O0.sh
@@ -4,7 +4,7 @@ set -e
 cd $(realpath $(dirname "$0"))
 
 # Spike
-rm -r ../src/cubic
+# rm -r ../src/cubic
 
 ../build_spike-clang-O0_rv64.sh
 ./run-benchmark.sh "rv64-spike" ./benchmark_spike_rv64gc.sh

--- a/vadl/test/resources/embench/benchmark-extras/rv64-run-benchmarks-spike-clang-lcb-O3.sh
+++ b/vadl/test/resources/embench/benchmark-extras/rv64-run-benchmarks-spike-clang-lcb-O3.sh
@@ -4,7 +4,7 @@ set -e
 cd $(realpath $(dirname "$0"))
 
 # Spike
-rm -r ../src/cubic
+#rm -r ../src/cubic
 
 ../build_spike-clang-O3_rv64.sh
 ./run-benchmark.sh "rv64-spike" ./benchmark_spike_rv64gc.sh


### PR DESCRIPTION
- Enabled `statemate` for `-O0` (riscv32)
- Enabled `cubic` for all optimization levels (riscv64)