### PR TITLE
typechecker: Improve fault tolerance

### DIFF
--- a/vadl/main/vadl/ast/InternalErrorType.java
+++ b/vadl/main/vadl/ast/InternalErrorType.java
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.ast;
+
+import vadl.types.Type;
+
+/**
+ * This type is used to communicate that the typechecker wasn't able to determine the type of an
+ * expression. This differes from null, which means we haven't visited the expression yet.
+ */
+public class InternalErrorType extends Type {
+  @Override
+  public String name() {
+    return "InternalErrorType";
+  }
+}

--- a/vadl/main/vadl/ast/TypeChecker.java
+++ b/vadl/main/vadl/ast/TypeChecker.java
@@ -17,7 +17,6 @@
 package vadl.ast;
 
 import static java.util.Objects.requireNonNull;
-import static vadl.error.Diagnostic.ensure;
 import static vadl.error.Diagnostic.error;
 import static vadl.error.Diagnostic.warning;
 
@@ -85,7 +84,21 @@ public class TypeChecker
     ONE,
   }
 
+  /**
+   * A custom exception to be thrown to partially stop evaluating to recover to a point where it
+   * makes sense to resume typechecking.
+   */
+  static class StopPartialCheckingSignal extends RuntimeException {
+  }
+
+  /**
+   * Recoverable errors are stored in this list.
+   */
   private final List<Diagnostic> errors = new ArrayList<>();
+
+  /**
+   * Often the typechecker needs to evaluate constants in type literals.
+   */
   final ConstantEvaluator constantEvaluator;
 
   /**
@@ -104,6 +117,16 @@ public class TypeChecker
   private final Set<Definition> checkedDefinitions =
       Collections.newSetFromMap(new IdentityHashMap<>());
 
+  /**
+   * If checking a statments that cannot be correctly checked will be added to these lists.
+   * Checking them again will throw a {@link StopPartialCheckingSignal}.
+   */
+  private final Set<Statement> erroredStatements =
+      Collections.newSetFromMap(new IdentityHashMap<>());
+  private final Set<Definition> erroredDefinitions =
+      Collections.newSetFromMap(new IdentityHashMap<>());
+
+
   public TypeChecker() {
     constantEvaluator = new ConstantEvaluator();
   }
@@ -118,6 +141,9 @@ public class TypeChecker
   Type check(Expr expr) {
     // Expressions store their type so we can look at them to see if they were already evaluated.
     if (expr.type != null) {
+      if (expr.type instanceof InternalErrorType) {
+        throw new StopPartialCheckingSignal();
+      }
       return requireNonNull(expr.type);
     }
 
@@ -129,8 +155,16 @@ public class TypeChecker
     }
 
     currentlyVisiting.add(nodeId);
-    expr.accept(this);
-    currentlyVisiting.pop();
+    try {
+      expr.accept(this);
+    } catch (StopPartialCheckingSignal signal) {
+      if (expr.type == null) {
+        expr.type = new InternalErrorType();
+      }
+      throw signal;
+    } finally {
+      currentlyVisiting.pop();
+    }
     return expr.type();
   }
 
@@ -140,6 +174,10 @@ public class TypeChecker
    * @param stmt to check.
    */
   void check(Statement stmt) {
+    if (erroredStatements.contains(stmt)) {
+      throw new StopPartialCheckingSignal();
+    }
+
     if (checkedStatements.contains(stmt)) {
       return;
     }
@@ -152,7 +190,13 @@ public class TypeChecker
     }
 
     currentlyVisiting.add(nodeId);
-    stmt.accept(this);
+    try {
+      stmt.accept(this);
+    } catch (StopPartialCheckingSignal signal) {
+      // Add the statement to remember that it wasn't sucessfully checked and continue with the next
+      // one on purpose.
+      erroredStatements.add(stmt);
+    }
     currentlyVisiting.pop();
     checkedStatements.add(stmt);
   }
@@ -163,9 +207,10 @@ public class TypeChecker
     Map<String, AnnotationDefinition> annotationNames = new HashMap<>();
     def.annotations.forEach(annotation -> {
       if (annotationNames.containsKey(annotation.name())) {
-        throw error("Duplicate Annotation", def)
+        errors.add(error("Duplicate Annotation", def)
             .locationNote(annotationNames.get(annotation.name()), "First used here")
-            .build();
+            .build()
+        );
       }
 
       // check annotation definition itself
@@ -187,6 +232,10 @@ public class TypeChecker
    * @param def to check.
    */
   private void check(Definition def) {
+    if (erroredDefinitions.contains(def)) {
+      throw new StopPartialCheckingSignal();
+    }
+
     if (checkedDefinitions.contains(def)) {
       return;
     }
@@ -206,7 +255,12 @@ public class TypeChecker
 
     // Visit the definitions
     currentlyVisiting.add(nodeId);
-    def.accept(this);
+    try {
+      def.accept(this);
+    } catch (StopPartialCheckingSignal signal) {
+      // Add the node to the list of errored nodes and continue with the next one.
+      erroredDefinitions.add(def);
+    }
     currentlyVisiting.pop();
     checkedDefinitions.add(def);
 
@@ -216,12 +270,21 @@ public class TypeChecker
   /**
    * Verify that the program is well-typed.
    *
+   * <p>This also modiefies the AST and adds types to all expressions and possibly attaches other
+   * data to AST nodes that might be usefull for lowering.
+   *
    * @param ast to verify
-   * @throws Diagnostic if the program isn't well typed
+   * @throws DiagnosticList if the program isn't well typed.
    */
   public void verify(Ast ast) {
     var startTime = System.nanoTime();
-    ast.definitions.forEach(this::check);
+    try {
+      ast.definitions.forEach(this::check);
+    } catch (Diagnostic error) {
+      errors.add(error);
+    } catch (StopPartialCheckingSignal signal) {
+      // do nothing on purpose.
+    }
     ast.passTimings.add(
         new Ast.PassTimings("Type Checking", (System.nanoTime() - startTime) / 1_000_000));
 
@@ -234,6 +297,19 @@ public class TypeChecker
     throw new RuntimeException(
         "The typechecker doesn't know how to handle `%s` yet, found in %s".formatted(
             node.getClass().getSimpleName(), node.location().toIDEString()));
+  }
+
+  /**
+   * Add a recoverable error to the internal list and throw a StopPartialCheckingSignal.
+   *
+   * @param error to be recorded.
+   * @return StopPartialCheckingSignal is never actually returned but thrown, however sometimes it
+   *     is used to trick the compiler.
+   * @throws StopPartialCheckingSignal always.
+   */
+  private StopPartialCheckingSignal addErrorAndStopChecking(Diagnostic error) {
+    errors.add(error);
+    throw new StopPartialCheckingSignal();
   }
 
   private static Diagnostic typeMismatchError(WithLocation locatable, Type expected, Type actual) {
@@ -255,9 +331,9 @@ public class TypeChecker
   }
 
   private void throwInvalidAsmCast(AsmType from, AsmType to, WithLocation location) {
-    throw error("Type Mismatch", location)
+    addErrorAndStopChecking(error("Type Mismatch", location)
         .description("Invalid cast from `%s` to `%s`.", from, to)
-        .build();
+        .build());
   }
 
   /**
@@ -465,15 +541,15 @@ public class TypeChecker
    * @param inner expression to wrap.
    * @param to    which the expression should be cast.
    * @return the original expression.
-   * @throws Diagnostic if the inner expression cannot be implicitly cast to type.
+   * @throws StopPartialCheckingSignal if the inner expression cannot be implicitly cast to type.
    */
-  private static Expr tryWrapExplicitCast(Expr inner, Type to) {
+  private Expr tryWrapExplicitCast(Expr inner, Type to) {
     if (inner.type == null) {
       throw new IllegalStateException("The type of the inner expression must be known.");
     }
     var wrapped = wrapExplicitCast(inner, to);
     if (!wrapped.type().equals(to)) {
-      throw typeMismatchError(inner, to, inner.type());
+      addErrorAndStopChecking(typeMismatchError(inner, to, inner.type()));
     }
     return wrapped;
   }
@@ -487,15 +563,15 @@ public class TypeChecker
    * @param inner expression to wrap.
    * @param to    which the expression should be cast.
    * @return the original expression.
-   * @throws Diagnostic if the inner expression cannot be implicitly cast to type.
+   * @throws StopPartialCheckingSignal if the inner expression cannot be implicitly cast to type.
    */
-  private static Expr tryWrapImplicitCast(Expr inner, Type to) {
+  private Expr tryWrapImplicitCast(Expr inner, Type to) {
     if (inner.type == null) {
       throw new IllegalStateException("The type of the inner expression must be known.");
     }
     var wrapped = wrapImplicitCast(inner, to);
     if (!wrapped.type().equals(to)) {
-      throw typeMismatchError(inner, to, inner.type());
+      addErrorAndStopChecking(typeMismatchError(inner, to, inner.type()));
     }
     return wrapped;
   }
@@ -526,7 +602,7 @@ public class TypeChecker
       Type litType = requireNonNull(definition.typeLiteral.type);
 
       if (!canImplicitCast(valType, litType)) {
-        throw typeMismatchError(definition.value, litType, valType);
+        addErrorAndStopChecking(typeMismatchError(definition.value, litType, valType));
       }
 
       // Insert a cast if needed
@@ -540,10 +616,10 @@ public class TypeChecker
     try {
       constantEvaluator.eval(definition.value);
     } catch (EvaluationError e) {
-      throw error("Invalid constant value", definition.value)
+      addErrorAndStopChecking(error("Invalid constant value", definition.value)
           .locationDescription(e.location, "%s", requireNonNull(e.getMessage()))
           .description("All constants must be able to be evaluated")
-          .build();
+          .build());
     }
 
     return null;
@@ -553,7 +629,8 @@ public class TypeChecker
   public Void visit(FormatDefinition definition) {
     var type = check(definition.typeLiteral);
     if (!(type instanceof BitsType bitsType)) {
-      throw typeMismatchError(definition.typeLiteral, "bits type", type);
+      // Not actually thrown here but used to signal that this if will never suceed.
+      throw addErrorAndStopChecking(typeMismatchError(definition.typeLiteral, "bits type", type));
     }
 
     var bitWidth = bitsType.bitWidth();
@@ -565,9 +642,9 @@ public class TypeChecker
         var fieldType = check(typedField.typeLiteral);
 
         if (!(fieldType instanceof BitsType fieldBitsType)) {
-          throw error("Bits Type expected", typedField.typeLiteral)
+          throw addErrorAndStopChecking(error("Bits Type expected", typedField.typeLiteral)
               .description("Format fields can only be assigned a bits type.")
-              .build();
+              .build());
         }
         typedField.range = new FormatDefinition.BitRange(nextOccupiedBit,
             nextOccupiedBit - (fieldBitsType.bitWidth() - 1));
@@ -598,21 +675,21 @@ public class TypeChecker
           // NOTE: From is always larger than to
           var rangeSize = (from - to) + 1;
           if (rangeSize < 1) {
-            throw error("Invalid Range", range)
+            addErrorAndStopChecking(error("Invalid Range", range)
                 .locationDescription(range, "Range must span more than one bit but was %s",
                     fieldBitWidth)
                 .locationNote(range,
                     "Ranges are specified as `from..to` where from is always larger than to.")
-                .build();
+                .build());
           }
 
           // Check range is not out of bounds.
           if (from < 0 || from >= bitWidth || to < 0 || to > bitWidth) {
-            throw error("Invalid Range", range)
+            addErrorAndStopChecking(error("Invalid Range", range)
                 .locationDescription(range,
                     "Provided range `%d..%d` out of bounds for available range `%d..0`",
                     from, to, bitWidth - 1)
-                .build();
+                .build());
           }
 
           fieldBitWidth += rangeSize;
@@ -621,9 +698,9 @@ public class TypeChecker
         }
 
         if (fieldBitWidth < 1) {
-          throw error("Invalid Field", rangeField)
+          addErrorAndStopChecking(error("Invalid Field", rangeField)
               .description("Field must be at least one bit but was %s", fieldBitWidth)
-              .build();
+              .build());
         }
 
         if (rangeField.type == null) {
@@ -633,10 +710,10 @@ public class TypeChecker
           // Verify the received type with the one provided in the literal.
           var rangeBitsType = Type.bits(fieldBitWidth);
           if (!canImplicitCast(rangeField.type, rangeBitsType)) {
-            throw error("Type Mismatch", rangeField)
+            addErrorAndStopChecking(error("Type Mismatch", rangeField)
                 .description("Type declared as `%s`, but the range is `%s`", rangeField.type,
                     rangeBitsType)
-                .build();
+                .build());
           }
         }
 
@@ -655,20 +732,20 @@ public class TypeChecker
       if (aux.kind == FormatDefinition.AuxiliaryField.AuxKind.PREDICATE) {
         var conflict = derivedFieldsWithPredicate.get(aux.fieldDef());
         if (conflict != null) {
-          throw error("Conflicting field access predicates", aux.field)
+          addErrorAndStopChecking(error("Conflicting field access predicates", aux.field)
               .locationDescription(aux.field,
                   "A predicate for the field access `%s` already exists.", aux.field.name)
               .locationHelp(conflict, "Predicate already defined here.")
-              .build();
+              .build());
         }
         derivedFieldsWithPredicate.put((DerivedFormatField) aux.fieldDef(), aux);
       }
     }
 
     if (bitsVerifier.hasViolations()) {
-      throw error("Invalid Format", definition)
+      addErrorAndStopChecking(error("Invalid Format", definition)
           .description("%s", requireNonNull(bitsVerifier.getViolationsMessage()))
-          .build();
+          .build());
     }
 
     return null;
@@ -707,9 +784,11 @@ public class TypeChecker
     var fieldType = switch (field) {
       case RangeFormatField r -> requireNonNull(r.type);
       case TypedFormatField f -> f.typeLiteral.type();
-      default -> throw error("Invalid format field encoding", auxiliaryField.field)
-          .locationDescription(auxiliaryField.field, "The encoding must reference a format field.")
-          .build();
+      default ->
+          throw addErrorAndStopChecking(error("Invalid format field encoding", auxiliaryField.field)
+              .locationDescription(auxiliaryField.field,
+                  "The encoding must reference a format field.")
+              .build());
     };
     auxiliaryField.expr = tryWrapImplicitCast(auxiliaryField.expr, fieldType);
   }
@@ -722,11 +801,12 @@ public class TypeChecker
               "The predicate must reference a field access function.")
           .build();
     }
-    ensure(auxiliaryField.expr.type() == Type.bool(),
-        () -> error("Invalid field access predicate", auxiliaryField.field)
-            .locationDescription(auxiliaryField.field,
-                "The predicate must be a `Bool` expression, but was `%s`.",
-                auxiliaryField.expr.type()));
+    if (auxiliaryField.expr.type() != Type.bool()) {
+      addErrorAndStopChecking(error("Invalid field access predicate", auxiliaryField.field)
+          .locationDescription(auxiliaryField.field,
+              "The predicate must be a `Bool` expression, but was `%s`.",
+              auxiliaryField.expr.type()).build());
+    }
   }
 
   @Override
@@ -1068,19 +1148,27 @@ public class TypeChecker
         var dummyArgs = new ArrayList<CallIndexExpr.Arguments>();
 
         for (var arg : expr.argsIndices) {
-          ensure(arg.values.size() == 1,
-              () -> error("All arguments must have exactly one value", definition.value));
-
+          if (arg.values.size() != 1) {
+            addErrorAndStopChecking(
+                error("All arguments must have exactly one value", definition.value)
+                    .build()
+            );
+          }
           var argVal = arg.values.getFirst();
           if (argVal instanceof WildcardLiteral) {
             wildcardIndices.add(i);
           } else if (argVal instanceof RangeExpr) {
-            ensure(i == expr.argsIndices.size() - 1, () ->
-                error("Slices can only be done on the innermost dimension.", argVal));
+            if (i != expr.argsIndices.size() - 1) {
+              addErrorAndStopChecking(
+                  error("Slices can only be done on the innermost dimension.", argVal).build());
+            }
             slice = arg;
           } else {
-            ensure(wildcardIndices.isEmpty(),
-                () -> error("Constant accesses cannot occure after param accesses.", argVal));
+            if (!wildcardIndices.isEmpty()) {
+              addErrorAndStopChecking(
+                  error("Constant accesses cannot occure after param accesses.",
+                      argVal).build());
+            }
             dummyArgs.add(arg);
           }
 
@@ -1107,18 +1195,21 @@ public class TypeChecker
         if (slice != null) {
           var typeBeforeSlice = switch (expr.type()) {
             case TensorType type -> {
-              ensure(type.numberOfIndexDims() >= wildcardIndices.size(),
-                  () -> error("Invalid number of parameters", expr));
+              if (type.numberOfIndexDims() < wildcardIndices.size()) {
+                addErrorAndStopChecking(error("Invalid number of parameters", expr).build());
+              }
               yield type.innerType();
             }
             case ConcreteRelationType type -> {
-              ensure(type.argTypes().size() == wildcardIndices.size(), () ->
-                  error("Invalid number of parameters", expr));
+              if (type.argTypes().size() != wildcardIndices.size()) {
+                addErrorAndStopChecking(error("Invalid number of parameters", expr).build());
+              }
               yield type.resultType();
             }
             default -> {
-              ensure(wildcardIndices.isEmpty(),
-                  () -> error("Params can only access tensor types", expr));
+              if (!wildcardIndices.isEmpty()) {
+                addErrorAndStopChecking(error("Params can only acess tensor types", expr).build());
+              }
               yield expr.type();
             }
           };
@@ -1323,28 +1414,28 @@ public class TypeChecker
       switch (entry.getValue()) {
         case ONE -> {
           if (registers.isEmpty()) {
-            throw error(
+            addErrorAndStopChecking(error(
                 "No " + purpose.name() + " registers were declared but one was expected",
-                definition.location()).build();
+                definition.location()).build());
           } else if (registers.size() != 1) {
-            throw error(
+            addErrorAndStopChecking(error(
                 "Multiple " + purpose.name() + " registers were declared but only one was expected",
-                SourceLocation.join(registers.stream().map(Node::location).toList())).build();
+                SourceLocation.join(registers.stream().map(Node::location).toList())).build());
           }
         }
         case OPTIONAL -> {
           if (!(registers.isEmpty() || registers.size() == 1)) {
-            throw error(
+            addErrorAndStopChecking(error(
                 "Multiple " + purpose.name()
                     + " registers were declared but zero or one was expected",
-                SourceLocation.join(registers.stream().map(Node::location).toList())).build();
+                SourceLocation.join(registers.stream().map(Node::location).toList())).build());
           }
         }
         case AT_LEAST_ONE -> {
           if (registers.isEmpty()) {
-            throw error(
+            addErrorAndStopChecking(error(
                 "Zero " + purpose.name() + " registers were declared but at least one was expected",
-                definition.location()).build();
+                definition.location()).build());
           }
         }
         default -> throw new RuntimeException("enum variant not handled");
@@ -1986,22 +2077,22 @@ public class TypeChecker
         SpecialPurposeRegisterDefinition.Purpose.numberOfExpectedArguments.get(definition.purpose);
 
     if (actual == null) {
-      throw error("Cannot determine number of expected registers",
-          definition.location()).build();
+      errors.add(error("Cannot determine number of expected registers",
+          definition.location()).build());
     }
 
     if (actual == Occurrence.ONE) {
       if (definition.exprs.size() != 1) {
-        throw error("Number of registers is incorrect. This definition expects only one",
-            definition.location()).build();
+        errors.add(error("Number of registers is incorrect. This definition expects only one",
+            definition.location()).build());
       }
     }
 
     if (actual == Occurrence.ONE) {
       if (definition.exprs.isEmpty()) {
-        throw error(
+        errors.add(error(
             "Number of registers is incorrect. This definition expects at least one.",
-            definition.location()).build();
+            definition.location()).build());
       }
     }
 
@@ -2235,10 +2326,13 @@ public class TypeChecker
       check(functionDefinition);
 
       if (!functionDefinition.params.isEmpty()) {
-        throw error("Invalid Function Call", expr)
+        // We can still continue after the error here, no need to stop checking. We simply assume
+        // it returns the type of the function. This is only possible because we don't have
+        // function overloading.
+        errors.add(error("Invalid Function Call", expr)
             .description("Expected `%s` arguments but got `%s`", functionDefinition.params.size(),
                 0)
-            .build();
+            .build());
       }
       expr.type = functionDefinition.retType.type;
       return;
@@ -2250,10 +2344,11 @@ public class TypeChecker
       check(exceptionDef);
 
       if (!exceptionDef.params.isEmpty()) {
-        throw error("Invalid Exception Raise", expr)
+        // No need to stop evaluation we can still continue.
+        errors.add(error("Invalid Exception Raise", expr)
             .description("Expected `%s` arguments but got `%s`", exceptionDef.params.size(),
                 0)
-            .build();
+            .build());
       }
 
       expr.type = Type.void_();
@@ -2280,11 +2375,11 @@ public class TypeChecker
       // We might be here from a call expr and it might be necessary to handle the call for another
       // definition.
 
-      throw error("Invalid Expression", expr)
+      throw addErrorAndStopChecking(error("Invalid Expression", expr)
           .locationDescription(expr,
               "The name '%s' points to a `%s` which cannot be used as an expression.", fullName,
               origin.getClass().getSimpleName())
-          .build();
+          .build());
     }
 
     // It's also possible to call functions without parenthesis if the function doesn't take any
@@ -2299,9 +2394,9 @@ public class TypeChecker
       return;
     }
 
-    // The symbol resolver should have caught that
     throw new IllegalStateException(
-        "Cannot find symbol `%s` found at: %s".formatted(fullName, expr.location().toIDEString()));
+        "Cannot find symbol `%s` found at: %s (The symbol resolver should already have caught that)"
+            .formatted(fullName, expr.location().toIDEString()));
   }
 
   @Override
@@ -2315,21 +2410,23 @@ public class TypeChecker
 
     // Both sides must be boolean
     if (!(leftTyp instanceof BoolType) && !canImplicitCast(leftTyp, Type.bool())) {
-      throw error("Type Mismatch", expr)
+      // We can still continue here, the expression still returns a boolean.
+      errors.add(error("Type Mismatch", expr)
           .locationDescription(expr, "Expected a `Bool` here but the left side was an `%s`",
               leftTyp)
           .description("The `%s` operator only works on booleans.", expr.operator())
-          .build();
+          .build());
     }
     expr.left = wrapImplicitCast(expr.left, Type.bool());
 
     var rightTyp = requireNonNull(expr.right.type);
     if (!(rightTyp instanceof BoolType) && !canImplicitCast(rightTyp, Type.bool())) {
-      throw error("Type Mismatch", expr)
+      // We can still continue here, the expression still returns a boolean.
+      errors.add(error("Type Mismatch", expr)
           .locationDescription(expr, "Expected a `Bool` here but the right side was an `%s`",
               rightTyp)
           .description("The `%s` operator only works on booleans.", expr.operator())
-          .build();
+          .build());
     }
     expr.right = wrapImplicitCast(expr.right, Type.bool());
 
@@ -2370,23 +2467,23 @@ public class TypeChecker
       }
 
       if (!(leftTyp instanceof BitsType) && !(leftTyp instanceof ConstantType)) {
-        throw error("Type Mismatch", expr)
+        addErrorAndStopChecking(error("Type Mismatch", expr)
             .locationDescription(expr, "Expected a number here but the left side was an `%s`",
                 leftTyp)
             .description("The `%s` operator only works on pairs of numbers or strings.",
                 expr.operator())
-            .build();
+            .build());
       }
       if (!(rightTyp instanceof BitsType) && !(rightTyp instanceof ConstantType)) {
-        throw error("Type Mismatch", expr)
+        addErrorAndStopChecking(error("Type Mismatch", expr)
             .locationDescription(expr, "Expected a number here but the right side was an `%s`",
                 rightTyp)
             .description("The `%s` operator only works on pairs of numbers or string.s",
                 expr.operator())
-            .build();
+            .build());
       }
     } else {
-      throw new RuntimeException("Don't handle operator " + expr.operator());
+      throw new RuntimeException("Don't know how to handle operator " + expr.operator());
     }
 
     // Shifts and rotates require that the right type is uint and the left can be anything.
@@ -2405,9 +2502,9 @@ public class TypeChecker
 
       if (!(rightTyp instanceof UIntType || rightTyp instanceof BitsType)
           && !canImplicitCast(rightTyp, closestUIntType)) {
-        throw error("Type Mismatch", expr)
+        addErrorAndStopChecking(error("Type Mismatch", expr)
             .locationNote(expr, "The right type must be unsigned but is %s", rightTyp)
-            .build();
+            .build());
       }
 
       if (!(rightTyp instanceof UIntType)) {
@@ -2419,10 +2516,10 @@ public class TypeChecker
       if (leftTyp instanceof ConstantType) {
 
         if (List.of(Operator.RotateLeft, Operator.RotateRight).contains(expr.operator())) {
-          throw error("Type Mismatch", expr)
+          addErrorAndStopChecking(error("Type Mismatch", expr)
               .locationNote(expr, "The left side must be a concrete type but was %s", rightTyp)
               .description("Rotate operations require a type with a fixed bit width.")
-              .build();
+              .build());
         }
 
         var result = constantEvaluator.eval(expr);
@@ -2457,10 +2554,10 @@ public class TypeChecker
       var leftBitWidth = ((BitsType) leftTyp).bitWidth();
       var rightBitWidth = ((BitsType) rightTyp).bitWidth();
       if (leftBitWidth != rightBitWidth) {
-        throw error("Type Mismatch", expr)
+        addErrorAndStopChecking(error("Type Mismatch", expr)
             .description("Both sides must have the same width but left is `%s` while right is `%s`",
                 leftTyp, rightTyp)
-            .build();
+            .build());
       }
 
       // Rules determining the return type (switched input operators omitted because of
@@ -2513,11 +2610,11 @@ public class TypeChecker
     rightTyp = expr.right.type();
 
     if (!leftTyp.equals(rightTyp)) {
-      throw error("Type Mismatch", expr)
+      addErrorAndStopChecking(error("Type Mismatch", expr)
           .locationNote(expr, "The left type is %s while right is %s", leftTyp, rightTyp)
           .description(
               "Both types on the left and right side of an binary operation should be equal.")
-          .build();
+          .build());
     }
 
     if (Operator.artihmeticComparisons.contains(expr.operator())) {
@@ -2558,13 +2655,13 @@ public class TypeChecker
       var concreteTypes =
           types.stream().filter(x -> !(x instanceof ConstantType)).distinct().toList();
       if (concreteTypes.isEmpty()) {
-        throw error("Type Mismatch", expr)
+        addErrorAndStopChecking(error("Type Mismatch", expr)
             .locationDescription(expr,
                 "At least one value has to have a concrete bitwidth for a concatination")
-            .build();
+            .build());
       }
       if (concreteTypes.size() > 1) {
-        throw error("Type Mismatch", expr)
+        addErrorAndStopChecking(error("Type Mismatch", expr)
             .locationDescription(expr,
                 "The concatination operation can only concat bits or strings.")
             .locationNote(expr, "Provided types: %s",
@@ -2572,7 +2669,7 @@ public class TypeChecker
             .locationHelp(expr,
                 "Constant types can be implicitly casted to a concrete type if only one such "
                     + "concrete type appears.")
-            .build();
+            .build());
       }
 
       expr.expressions.replaceAll(e -> wrapImplicitCast(e, concreteTypes.get(0)));
@@ -2585,12 +2682,12 @@ public class TypeChecker
       return null;
     }
 
-    throw error("Type Mismatch", expr)
+    throw addErrorAndStopChecking(error("Type Mismatch", expr)
         .locationNote(expr, "Provided types: %s",
             String.join(", ", types.stream().map(Type::toString).toList()))
         .description(
             "The concatenation operation can only be applied on a set of strings or a set of bits.")
-        .build();
+        .build());
   }
 
   @Override
@@ -2642,24 +2739,24 @@ public class TypeChecker
     var toType = check(expr.to);
 
     if (!(fromType instanceof BitsType) && !(fromType instanceof ConstantType)) {
-      throw error("Type Mismatch", expr.from)
+      addErrorAndStopChecking(error("Type Mismatch", expr.from)
           .description("The from part of a range must be a number but was `%s`", fromType)
-          .build();
+          .build());
     }
 
     if (!(toType instanceof BitsType) && !(toType instanceof ConstantType)) {
-      throw error("Type Mismatch", expr.to)
+      addErrorAndStopChecking(error("Type Mismatch", expr.to)
           .description("The to part of a range must be a number but was `%s`", fromType)
-          .build();
+          .build());
     }
 
     var fromVal = constantEvaluator.eval(expr.from).value();
     var toVal = constantEvaluator.eval(expr.to).value();
 
     if (toVal.compareTo(fromVal) > 0) {
-      throw error("Invalid range", expr)
+      addErrorAndStopChecking(error("Invalid range", expr)
           .description("From is %s but to is %s, but ranges must be decreasing", fromVal, toVal)
-          .build();
+          .build());
     }
 
     // FIXME: The type doesn't really make sense but we don't have a propper range type
@@ -2697,10 +2794,10 @@ public class TypeChecker
       var suggestions =
           Levenshtein.suggestions(expr.baseType.pathToString(), candidateTypes);
 
-      throw error("Unknown Type `%s`".formatted(base), expr)
+      addErrorAndStopChecking(error("Unknown Type `%s`".formatted(base), expr)
           .locationDescription(expr, "No type with that name exists.")
           .suggestions(suggestions)
-          .build();
+          .build());
     }
 
     // 2. Calculate the sizes
@@ -2709,10 +2806,10 @@ public class TypeChecker
       var size = constantEvaluator.eval(sizeExpr).value().intValueExact();
 
       if (size < 1) {
-        throw error("Invalid Type Notation", sizeExpr.location())
+        addErrorAndStopChecking(error("Invalid Type Notation", sizeExpr.location())
             .locationDescription(sizeExpr.location(),
                 "Width must of a %s must be greater or equal 1 but was %d", base, size)
-            .build();
+            .build());
       }
 
       return size;
@@ -2734,10 +2831,10 @@ public class TypeChecker
 
     if (unSizedBuiltins.containsKey(base)) {
       if (!sizes.isEmpty()) {
-        throw error("Invalid Type Notation", expr.location())
+        addErrorAndStopChecking(error("Invalid Type Notation", expr.location())
             .description("The %s type doesn't use the size notation.", base)
             .help("Try removing the size parameter here.")
-            .build();
+            .build());
       }
       return unSizedBuiltins.get(base).get();
     }
@@ -2750,13 +2847,13 @@ public class TypeChecker
 
     if (sizedBuiltins.containsKey(base)) {
       if (sizes.isEmpty()) {
-        throw error("Invalid Type Notation", expr.location())
+        addErrorAndStopChecking(error("Invalid Type Notation", expr.location())
             .description(
                 "Unsized `%s` can only be used in special places when it's obvious what the bit"
                     + " width should be.",
                 base)
             .help("Try adding a size parameter here.")
-            .build();
+            .build());
       }
 
       if (sizes.size() == 1) {
@@ -2790,9 +2887,9 @@ public class TypeChecker
       return new TensorType(sizes, customTensor);
     }
 
-    throw error("Invalid Tensor Type", expr)
+    throw addErrorAndStopChecking(error("Invalid Tensor Type", expr)
         .locationDescription(expr, "You can only create tensors from data types.")
-        .build();
+        .build());
   }
 
   @Override
@@ -2815,25 +2912,26 @@ public class TypeChecker
       case NEGATIVE -> {
         expr.computedTarget = BuiltInTable.NEG;
         if (!(innerType instanceof BitsType) && !(innerType instanceof ConstantType)) {
-          throw error("Type Mismatch", expr)
+          addErrorAndStopChecking(error("Type Mismatch", expr)
               .description("Expected a numerical type but got `%s`", innerType)
-              .build();
+              .build());
         }
       }
       case COMPLEMENT -> {
         expr.computedTarget = BuiltInTable.NOT;
         if (!(innerType instanceof BitsType)) {
-          throw error("Type Mismatch", expr)
+          addErrorAndStopChecking(error("Type Mismatch", expr)
               .description("Expected a numerical type with fixed bit-width but got `%s`", innerType)
-              .build();
+              .build());
         }
       }
       case LOG_NOT -> {
         expr.computedTarget = BuiltInTable.NOT;
         if (!innerType.equals(Type.bool())) {
-          throw error("Type Mismatch: expected `Bool`, got `%s`".formatted(innerType), expr)
-              .help("For numerical types you can negate them with a minus `-`")
-              .build();
+          addErrorAndStopChecking(
+              error("Type Mismatch: expected `Bool`, got `%s`".formatted(innerType), expr)
+                  .help("For numerical types you can negate them with a minus `-`")
+                  .build());
         }
       }
       default -> throwUnimplemented(expr);
@@ -2856,20 +2954,20 @@ public class TypeChecker
     // NOTE: From is always larger than to
     var rangeSize = (from - to) + 1;
     if (rangeSize < 1) {
-      throw error("Invalid Range", range)
+      addErrorAndStopChecking(error("Invalid Range", range)
           .description("Range must be >= 1 but was %s", rangeSize)
-          .build();
+          .build());
     }
 
     if (from >= valueType.bitWidth()) {
-      throw error("Invalid Range", range)
+      addErrorAndStopChecking(error("Invalid Range", range)
           .description("Range start %d out of bounds for `%s`", from, valueType)
-          .build();
+          .build());
     }
     if (to < 0) {
-      throw error("Invalid Range", range)
+      addErrorAndStopChecking(error("Invalid Range", range)
           .description("Range end must be at least zero but was %s", to)
-          .build();
+          .build());
     }
 
     return new Constant.BitSlice.Part(from, to);
@@ -2879,14 +2977,14 @@ public class TypeChecker
     check(indexExpr);
     int sliceIndex = constantEvaluator.eval(indexExpr).value().intValueExact();
     if (sliceIndex >= valueType.bitWidth()) {
-      throw error("Invalid Index", indexExpr)
+      addErrorAndStopChecking(error("Invalid Index", indexExpr)
           .description("Index %d out of bounds for `%s`", sliceIndex, valueType)
-          .build();
+          .build());
     }
     if (sliceIndex < 0) {
-      throw error("Invalid Index", indexExpr)
+      addErrorAndStopChecking(error("Invalid Index", indexExpr)
           .description("Index must be at least zero but was %s", sliceIndex)
-          .build();
+          .build());
     }
     return new Constant.BitSlice.Part(sliceIndex, sliceIndex);
   }
@@ -2914,9 +3012,9 @@ public class TypeChecker
 
     if (!(typeBeforeSlice instanceof BitsType) && !(typeBeforeSlice instanceof TensorType)) {
       var loc = expr.target.location().join(lastSlice.location);
-      throw error("Type Mismatch", loc)
+      addErrorAndStopChecking(error("Type Mismatch", loc)
           .description("Only bit types can be sliced but the target was a `%s`", typeBeforeSlice)
-          .build();
+          .build());
     }
 
     Type currType = typeBeforeSlice;
@@ -2939,10 +3037,10 @@ public class TypeChecker
           // In the future we might want to allow overlapping slices on read values.
           // For written values (`X(1, 1) := 2`) this must not be allowed, as the same value
           // position is written twice.
-          throw error("Overlapping slice parts", slice.location)
+          addErrorAndStopChecking(error("Overlapping slice parts", slice.location)
               .locationDescription(slice.location, "Some parts of the slice are overlapping.")
               .note("Slices must have distinct, non-overlapping parts.")
-              .build();
+              .build());
         }
 
         currType = Type.bits(bitSlice.bitSize());
@@ -2953,17 +3051,17 @@ public class TypeChecker
       if (currType instanceof TensorType currTensoType) {
         if (slice.values.size() != 1) {
           var loc = slice.values.getFirst().location().join(slice.values.getLast().location());
-          throw error("Invalid Tensor Indexing", loc)
+          addErrorAndStopChecking(error("Invalid Tensor Indexing", loc)
               .locationDescription(loc,
                   "Indexing tensors only allows one argument per parenthesis group.")
-              .build();
+              .build());
         }
 
         var indexExpr = slice.values.getFirst();
         if (indexExpr instanceof RangeExpr) {
-          throw error("Invalid Tensor Slice", indexExpr)
+          addErrorAndStopChecking(error("Invalid Tensor Slice", indexExpr)
               .locationDescription(indexExpr, "Tensors cannot be sliced.")
-              .build();
+              .build());
         }
         check(indexExpr);
 
@@ -2981,10 +3079,10 @@ public class TypeChecker
         if (staticIndex != null) {
           if (staticIndex < 0
               || staticIndex >= currTensoType.outerMostDimension()) {
-            throw error("Tensor Index out of bounds", indexExpr)
+            addErrorAndStopChecking(error("Tensor Index out of bounds", indexExpr)
                 .locationDescription(indexExpr,
                     "Invalid index `%d` for tensor `%s`", staticIndex, currTensoType)
-                .build();
+                .build());
           }
 
           // Note: the computed bitslice here is already for the lowering where we assume all
@@ -3014,7 +3112,8 @@ public class TypeChecker
              also shouldn't be that strong/complex).
            */
           if (!indexExpr.type().isDataType()) {
-            throw typeMismatchError(indexExpr, "numerical datatype", indexExpr.type());
+            addErrorAndStopChecking(
+                typeMismatchError(indexExpr, "numerical datatype", indexExpr.type()));
           }
         }
       }
@@ -3040,16 +3139,21 @@ public class TypeChecker
     // FIXME: Make this more generic
     switch (expr.target.path().target()) {
       case CounterDefinition counter -> {
-        ensure(expr.slices().isEmpty(), () -> error("Invalid counter sub-call", expr)
-            .locationDescription(expr, "Cannot do sub call and slice on counter."));
+        if (!expr.slices().isEmpty()) {
+          addErrorAndStopChecking(error("Invalid counter sub-call", expr)
+              .locationDescription(expr, "Cannot do sub call and slice on counter.").build());
+        }
         var validSubCalls = List.of("next");
-        ensure(expr.subCalls.size() == 1, () -> error("Invalid counter sub-call", expr)
-            .locationDescription(expr, "Only a single sub-call expected."));
+        if (expr.subCalls.size() != 1) {
+          addErrorAndStopChecking(error("Invalid counter sub-call", expr)
+              .locationDescription(expr, "Only a single sub-call expected.").build());
+        }
         var subCall = expr.subCalls.getFirst();
-        ensure(validSubCalls.contains(subCall.id.name),
-            () -> error("Invalid counter sub-call", subCall.id)
-                .locationDescription(subCall.id, "Counter has no sub-call named `%s`",
-                    subCall.id.name));
+        if (!validSubCalls.contains(subCall.id.name)) {
+          addErrorAndStopChecking(error("Invalid counter sub-call", subCall.id)
+              .locationDescription(expr, "Counter has no sub-call named `%s`", subCall.id.name)
+              .build());
+        }
         return;
       }
       case null, default -> {
@@ -3072,10 +3176,10 @@ public class TypeChecker
               formatType.format.fields.stream()
                   .map(f -> f.identifier().name).toList());
 
-          throw error("Unknown format field `%s`".formatted(fieldName), expr)
+          addErrorAndStopChecking(error("Unknown format field `%s`".formatted(fieldName), expr)
               .description("Format `%s` doesn't have any field with this name", formatName)
               .suggestions(suggestions)
-              .build();
+              .build());
         }
 
         // FIXME: @flofriday replace once computed field ranges are Constant.BitSlice
@@ -3089,20 +3193,20 @@ public class TypeChecker
         var allowedStatusfields = List.of("negative", "zero", "carry", "overflow");
         if (!allowedStatusfields.contains(fieldName)) {
           var suggestions = Levenshtein.sortAll(fieldName, allowedStatusfields);
-          throw error("Unknown status field `%s`".formatted(fieldName), expr)
+          addErrorAndStopChecking(error("Unknown status field `%s`".formatted(fieldName), expr)
               .note("Allowed fields are: %s", String.join(", ", allowedStatusfields))
               .help("Maybe you meant one of these: %s", String.join(", ", suggestions))
-              .build();
+              .build());
         }
         var fieldType = Type.bool();
         subCall.computedStatusIndex = allowedStatusfields.indexOf(fieldName);
         visitSliceIndexCall(expr, fieldType, subCall.argsIndices);
         type = expr.type;
       } else {
-        throw error("Cannot resolve `%s`".formatted(fieldName), expr)
+        addErrorAndStopChecking(error("Cannot resolve `%s`".formatted(fieldName), expr)
             .description("Because the type up until it is not a format but `%s`",
                 requireNonNull(type))
-            .build();
+            .build());
       }
     }
   }
@@ -3144,10 +3248,10 @@ public class TypeChecker
     var builtin = AstUtils.getBuiltIn(expr.target.path().pathToString(), argTypes);
 
     if (builtin == null) {
-      throw error("Invalid call target", expr.target)
+      throw addErrorAndStopChecking(error("Invalid call target", expr.target)
           .locationNote(expr.target, "Couldn't find builtin function `%s`",
               expr.target.path())
-          .build();
+          .build());
     }
 
     expr.computedBuiltIn = builtin;
@@ -3185,9 +3289,9 @@ public class TypeChecker
     argTypes = requireNonNull(expr.argsIndices.get(0).values.stream().map(v -> v.type)).toList();
     if (expr.typeBeforeSlice == null && !builtin.takes(argTypes)) {
       // FIXME: Better format that error
-      throw error("Type Mismatch", expr)
+      addErrorAndStopChecking(error("Type Mismatch", expr)
           .description("Expected %s but got `%s`", builtin.signature().argTypeClasses(), argTypes)
-          .build();
+          .build());
     }
 
     // Note: cannot set the computed type because builtins aren't a definition.
@@ -3217,8 +3321,11 @@ public class TypeChecker
     var argExprs = AstUtils.flatArguments(argGroups);
 
     for (var argExpr : argExprs) {
-      ensure(!(argExpr instanceof RangeExpr), () -> error("Invalid argument", argExpr)
-          .locationNote(argExpr, "Expected argument value but got a range expression."));
+      if (argExpr instanceof RangeExpr) {
+        addErrorAndStopChecking(error("Invalid argument", argExpr)
+            .locationNote(argExpr, "Expected argument value but got a range expression.")
+            .build());
+      }
     }
 
     var type = typedNode.type();
@@ -3226,10 +3333,11 @@ public class TypeChecker
       // if a relation type expects no arguments, no argument group is considered
       expr.typeBeforeSlice = relType.resultType();
     } else if (type instanceof ConcreteRelationType relType) {
-      ensure(relType.argTypes().size() == argExprs.size(),
-          () -> error("Invalid number of arguments", expr)
-              .locationNote(expr, "Expected %s arguments but got %s.", relType.argTypes().size(),
-                  argExprs.size()));
+      if (relType.argTypes().size() != argExprs.size()) {
+        addErrorAndStopChecking(error("Invalid number of arguments", expr)
+            .locationNote(expr, "Expected %s arguments but got %s.", relType.argTypes().size(),
+                argExprs.size()).build());
+      }
 
       if (argGroups.size() != 1) {
         // concrete relations have exactly one group
@@ -3260,10 +3368,10 @@ public class TypeChecker
       for (int i = 0; i < argGroups.size(); i++) {
         var argGroup = argGroups.get(i);
         if (argGroup.values.size() != 1) {
-          throw error("Invalid tensor index", argGroup.location)
+          addErrorAndStopChecking(error("Invalid tensor index", argGroup.location)
               .locationDescription(argGroup.location,
                   "Tensor indexing expects exactly one argument.")
-              .build();
+              .build());
         }
         var arg = argGroup.values.getFirst();
         check(arg);
@@ -3285,10 +3393,10 @@ public class TypeChecker
     var targetSizeExpr = expr.target.size();
     if (targetSizeExpr != null) {
       if (!(expr.typeBeforeSlice() instanceof BitsType exprType)) {
-        throw error("Invalid scaling type", targetSizeExpr)
+        throw addErrorAndStopChecking(error("Invalid scaling type", targetSizeExpr)
             .locationDescription(targetSizeExpr, "Result type `%s` cannot be scaled.",
                 expr.typeBeforeSlice())
-            .build();
+            .build());
       }
       // handle the targetSize expression if defined
       int multiplier = constantEvaluator.eval(targetSizeExpr).value().intValueExact();
@@ -3297,9 +3405,9 @@ public class TypeChecker
         // in case of a memory definition, scale the result type
         expr.typeBeforeSlice = exprType.scaleBy(multiplier);
       } else {
-        throw error("Invalid call size", expr)
+        addErrorAndStopChecking(error("Invalid call size", expr)
             .locationDescription(expr.target, "The call target doesn't support a size expression.")
-            .build();
+            .build());
       }
     }
 
@@ -3314,7 +3422,8 @@ public class TypeChecker
     expr.condition = wrapImplicitCast(expr.condition, Type.bool());
     var condType = expr.condition.type();
     if (condType != Type.bool()) {
-      throw typeMismatchError(expr, Type.bool(), condType);
+      // We can still proceed checking the rest of the program.
+      errors.add(typeMismatchError(expr, Type.bool(), condType));
     }
 
     var thenType = check(expr.thenExpr);
@@ -3332,11 +3441,11 @@ public class TypeChecker
     // FIXME: Fix this with bidirectional checking in the future
     if (thenType instanceof ConstantType && elseType instanceof ConstantType
         && !thenType.equals(elseType)) {
-      throw error("Type Mismatch", expr)
+      addErrorAndStopChecking(error("Type Mismatch", expr)
           .description("Both branches return different constant types.")
           .help("Add an explicit cast on one of the branches.")
           .note("In the future this will work without a cast.")
-          .build();
+          .build());
     }
 
     // Apply general implicit casting rules after specialised once.
@@ -3346,12 +3455,12 @@ public class TypeChecker
     elseType = expr.elseExpr.type();
 
     if (!thenType.equals(elseType)) {
-      throw error("Type Mismatch", expr)
+      addErrorAndStopChecking(error("Type Mismatch", expr)
           .description(
               "Both the than and else branch should have the same type "
                   + "but than is `%s` and else is `%s`.",
               thenType, elseType)
-          .build();
+          .build());
     }
 
     expr.type = thenType;
@@ -3365,17 +3474,17 @@ public class TypeChecker
     if (expr.identifiers.size() > 1) {
       if (!(valType instanceof TupleType valTupleType)) {
         var loc = expr.identifiers.get(0).loc.join(expr.valueExpr.location());
-        throw error("Type Mismatch", loc)
+        throw addErrorAndStopChecking(error("Type Mismatch", loc)
             .description("Tuple unpacking only works on tuples but the type was `%s`", valType)
-            .build();
+            .build());
       }
 
       if (expr.identifiers.size() != valTupleType.size()) {
         var loc = expr.identifiers.get(0).loc.join(expr.valueExpr.location());
-        throw error("Invalid Tuple Unpacking", loc)
+        addErrorAndStopChecking(error("Invalid Tuple Unpacking", loc)
             .description("Cannot unpack %d values form a `%s`.", expr.identifiers.size(),
                 valType)
-            .build();
+            .build());
       }
     }
 
@@ -3391,9 +3500,10 @@ public class TypeChecker
     var litType = expr.typeLiteral.type();
 
     if (!canExplicitCast(valType, litType)) {
-      throw error("Invalid cast", expr)
+      // No need to stop checking we can just assume it works and assign the declared type.
+      errors.add(error("Invalid cast", expr)
           .locationDescription(expr, "Cannot cast `%s` to `%s`.", valType, litType)
-          .build();
+          .build());
     }
 
     expr.type = litType;
@@ -3423,11 +3533,11 @@ public class TypeChecker
       for (var pattern : kase.patterns) {
         var patternType = pattern.type();
         if (!candidateType.equals(patternType)) {
-          throw error("Type Mismatch", pattern)
+          addErrorAndStopChecking(error("Type Mismatch", pattern)
               .locationDescription(pattern, "Expected `%s`, but got `%s`", candidateType,
                   patternType)
               .note("The type of the candidate and the pattern must be the same.")
-              .build();
+              .build());
         }
         check(kase.result);
       }
@@ -3458,23 +3568,23 @@ public class TypeChecker
       kase.result = wrapImplicitCast(kase.result, firstResultType);
       var resultType = kase.result.type();
       if (!resultType.equals(firstResultType)) {
-        throw error("Type Mismatch", kase.result)
+        addErrorAndStopChecking(error("Type Mismatch", kase.result)
             .locationNote(kase.result, "All previous branches were of type `%s`, but this is `%s`",
                 firstResultType, resultType)
             .description("All branches of a match must have the same type")
-            .build();
+            .build());
       }
     }
 
     expr.defaultResult = wrapImplicitCast(expr.defaultResult, firstResultType);
     var defaultResultType = expr.defaultResult.type();
     if (!defaultResultType.equals(firstResultType)) {
-      throw error("Type Mismatch", expr.defaultResult)
+      addErrorAndStopChecking(error("Type Mismatch", expr.defaultResult)
           .locationNote(expr.defaultResult,
               "All previous branches were of type `%s`, but this is `%s`",
               firstResultType, defaultResultType)
           .description("All branches of a match must have the same type")
-          .build();
+          .build());
 
     }
 
@@ -3511,18 +3621,18 @@ public class TypeChecker
   public Void visit(ForallExpr expr) {
     // FIXME: multiple indexes are hard to lower so let's throw an temporary error
     if (expr.indices.size() > 1) {
-      throw error("Not Supported", expr)
+      addErrorAndStopChecking(error("Not Supported", expr)
           .locationDescription(expr, "Multiple indicies aren't yet supported.")
-          .build();
+          .build());
     }
 
     expr.indices.forEach(index -> {
       // FIXME: Until we have bidirectional typechecking we need this explicit cast
       if (index.typeLiteral == null) {
-        throw error("Type Mismatch", index)
+        throw addErrorAndStopChecking(error("Type Mismatch", index)
             .locationDescription(index, "A explicit type cast is required here.")
             .locationNote(index, "In the future this won't be necessary.")
-            .build();
+            .build());
       }
 
       index.identifier().type = check(index.typeLiteral);
@@ -3533,25 +3643,26 @@ public class TypeChecker
           index.computedFrom = constantEvaluator.eval(rangeExpr.from).value().intValueExact();
           index.computedTo = constantEvaluator.eval(rangeExpr.to).value().intValueExact();
         } catch (EvaluationError e) {
-          throw error("Constant value required", e.location)
+          addErrorAndStopChecking(error("Constant value required", e.location)
               .locationDescription(e.location, "%s", requireNonNull(e.getMessage()))
-              .build();
+              .build());
         }
       } else {
         try {
           index.computedFrom = constantEvaluator.eval(index.domain).value().intValueExact();
           index.computedTo = index.computedFrom;
         } catch (EvaluationError e) {
-          throw error("Constant value required", e.location)
+          addErrorAndStopChecking(error("Constant value required", e.location)
               .locationDescription(e.location, "%s", requireNonNull(e.getMessage()))
-              .build();
+              .build());
         }
       }
     });
 
     var bodyType = check(expr.body);
     if (!(bodyType instanceof DataType bodyDataType)) {
-      throw typeMismatchError(expr.body, "Expected a datatype but got", bodyType);
+      throw addErrorAndStopChecking(
+          typeMismatchError(expr.body, "Expected a datatype but got", bodyType));
     }
 
     var totalIterationSpan = expr.indices.stream()
@@ -3598,17 +3709,17 @@ public class TypeChecker
     if (statement.identifiers.size() > 1) {
       if (!(valType instanceof TupleType valTupleType)) {
         var loc = statement.identifiers.get(0).loc.join(statement.valueExpr.location());
-        throw error("Type Mismatch", loc)
+        throw addErrorAndStopChecking(error("Type Mismatch", loc)
             .description("Tuple unpacking only works on tuples but the type was `%s`", valType)
-            .build();
+            .build());
       }
 
       if (statement.identifiers.size() != valTupleType.size()) {
         var loc = statement.identifiers.get(0).loc.join(statement.valueExpr.location());
-        throw error("Invalid Tuple Unpacking", loc)
+        addErrorAndStopChecking(error("Invalid Tuple Unpacking", loc)
             .description("Cannot unpack %d values form a `%s`.", statement.identifiers.size(),
                 valType)
-            .build();
+            .build());
       }
     }
 
@@ -3622,7 +3733,8 @@ public class TypeChecker
     statement.condition = wrapImplicitCast(statement.condition, Type.bool());
     var condType = statement.condition.type();
     if (condType != Type.bool()) {
-      throw typeMismatchError(statement.condition, Type.bool(), condType);
+      // We can continue typechecking with this error.
+      errors.add(typeMismatchError(statement.condition, Type.bool(), condType));
     }
 
     check(statement.thenStmt);
@@ -3647,7 +3759,8 @@ public class TypeChecker
     }
 
     if (!targetType.equals(valueType)) {
-      throw typeMismatchError(statement.valueExpression, targetType, valueType);
+      // We can continue after this.
+      errors.add(typeMismatchError(statement.valueExpression, targetType, valueType));
     }
 
     return null;
@@ -3663,7 +3776,9 @@ public class TypeChecker
   public Void visit(CallStatement statement) {
     check(statement.expr);
     if (statement.expr.type != Type.void_()) {
-      throw typeMismatchError(statement.expr, Type.void_(), requireNonNull(statement.expr.type));
+      errors.add(
+          // We can continue directly
+          typeMismatchError(statement.expr, Type.void_(), requireNonNull(statement.expr.type)));
     }
     return null;
   }
@@ -3695,11 +3810,11 @@ public class TypeChecker
       for (var pattern : kase.patterns) {
         var patternType = pattern.type();
         if (!candidateType.equals(patternType)) {
-          throw error("Type Mismatch", pattern)
+          addErrorAndStopChecking(error("Type Mismatch", pattern)
               .locationDescription(pattern, "Expected `%s`, but got `%s`", candidateType,
                   patternType)
               .note("The type of the candidate and the pattern must be the same.")
-              .build();
+              .build());
         }
         check(kase.result);
       }
@@ -3728,9 +3843,9 @@ public class TypeChecker
       if (!statement.unnamedArguments.isEmpty()) {
         var loc = statement.unnamedArguments.get(0).location()
             .join(statement.unnamedArguments.get(statement.unnamedArguments.size() - 1).location());
-        throw error("Invalid Arguments", loc)
+        addErrorAndStopChecking(error("Invalid Arguments", loc)
             .description("Calls to instructions only accept named arguments")
-            .build();
+            .build());
       }
 
       // Implicit cast and check the arguments
@@ -3751,7 +3866,7 @@ public class TypeChecker
         var actualType = arg.value.type();
 
         if (!targetType.equals(actualType)) {
-          throw typeMismatchError(arg, targetType, actualType);
+          addErrorAndStopChecking(typeMismatchError(arg, targetType, actualType));
         }
       }
 
@@ -3762,18 +3877,18 @@ public class TypeChecker
       if (!statement.namedArguments.isEmpty()) {
         var loc = statement.namedArguments.get(0).location()
             .join(statement.namedArguments.get(statement.namedArguments.size() - 1).location());
-        throw error("Invalid Arguments", loc)
+        addErrorAndStopChecking(error("Invalid Arguments", loc)
             .description("Calls to pseudo instructions only accept unnamed (positional) arguments")
-            .build();
+            .build());
       }
 
       // Check the argument and parameter count
       var paramCount = pseudoDef.params.size();
       var argCount = statement.unnamedArguments.size();
       if (paramCount != argCount) {
-        throw error("Arguments Mismatch", statement.location())
+        addErrorAndStopChecking(error("Arguments Mismatch", statement.location())
             .description("Expected %s arguments but got %s", paramCount, argCount)
-            .build();
+            .build());
       }
 
       // Implicit cast and check the arguments
@@ -3787,7 +3902,7 @@ public class TypeChecker
         var actualType = statement.unnamedArguments.get(i).type();
 
         if (!targetType.equals(actualType)) {
-          throw typeMismatchError(arg, targetType, actualType);
+          errors.add(typeMismatchError(arg, targetType, actualType));
         }
       }
 
@@ -3810,18 +3925,18 @@ public class TypeChecker
     // FIXME: multiple indexes are hard to lower so let's throw an temporary error
 
     if (statement.indices.size() > 1) {
-      throw error("Not Supported", statement)
+      addErrorAndStopChecking(error("Not Supported", statement)
           .locationDescription(statement, "Multiple indicies aren't yet supported.")
-          .build();
+          .build());
     }
 
     statement.indices.forEach(index -> {
       // FIXME: Until we have bidirectional typechecking we need this explicit cast
       if (index.typeLiteral == null) {
-        throw error("Type Mismatch", index)
+        throw addErrorAndStopChecking(error("Type Mismatch", index)
             .locationDescription(index, "A explicit type cast is required here.")
             .locationNote(index, "In the future this won't be necessary.")
-            .build();
+            .build());
       }
 
       index.identifier().type = check(index.typeLiteral);
@@ -3832,18 +3947,18 @@ public class TypeChecker
           index.computedFrom = constantEvaluator.eval(rangeExpr.from).value().intValueExact();
           index.computedTo = constantEvaluator.eval(rangeExpr.to).value().intValueExact();
         } catch (EvaluationError e) {
-          throw error("Constant value required", e.location)
+          addErrorAndStopChecking(error("Constant value required", e.location)
               .locationDescription(e.location, "%s", requireNonNull(e.getMessage()))
-              .build();
+              .build());
         }
       } else {
         try {
           index.computedFrom = constantEvaluator.eval(index.domain).value().intValueExact();
           index.computedTo = index.computedFrom;
         } catch (EvaluationError e) {
-          throw error("Constant value required", e.location)
+          addErrorAndStopChecking(error("Constant value required", e.location)
               .locationDescription(e.location, "%s", requireNonNull(e.getMessage()))
-              .build();
+              .build());
         }
       }
     });

--- a/vadl/main/vadl/ast/ViamLowering.java
+++ b/vadl/main/vadl/ast/ViamLowering.java
@@ -313,8 +313,12 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
    * @return a type that is safe to be entered into the VIAM.
    */
   public static Type getViamType(Type astType) {
+    if (astType instanceof InternalErrorType) {
+      throw new IllegalStateException("No InternalErrorType type should ever reach the VIAM!");
+    }
+
     if (astType instanceof ConstantType) {
-      throw new IllegalStateException("No constant type should ever leave the VIAM!");
+      throw new IllegalStateException("No constant type should ever reach the VIAM!");
     }
 
     if (astType instanceof FormatType formatType) {

--- a/vadl/test/vadl/ast/AnnotationTest.java
+++ b/vadl/test/vadl/ast/AnnotationTest.java
@@ -23,7 +23,7 @@ import static vadl.ast.AstTestUtils.verifyPrettifiedAst;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.shaded.org.checkerframework.checker.nullness.qual.Nullable;
-import vadl.error.Diagnostic;
+import vadl.error.DiagnosticList;
 
 public class AnnotationTest {
   @Test
@@ -89,8 +89,9 @@ public class AnnotationTest {
     var prog = zeroExtendTest("[ zero : 2 + 3 - 1]", null);
     var ast = VadlParser.parse(prog);
     var typechecker = new TypeChecker();
-    var diag = Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
-    assertThat(diag)
+    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    assert diags.items.size() == 1;
+    assertThat(diags.items.getFirst())
         .hasMessageContaining("Zero annotation must be of form [ zero : <register>( <expr> ) ]");
   }
 
@@ -99,8 +100,9 @@ public class AnnotationTest {
     var prog = zeroExtendTest("[ zero : M(1)]", "memory M: Bits<5> -> Bits<64>");
     var ast = VadlParser.parse(prog);
     var typechecker = new TypeChecker();
-    var diag = Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
-    assertThat(diag)
+    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    assert diags.items.size() == 1;
+    assertThat(diags.items.getFirst())
         .hasMessageContaining("Zero annotation target must be the annotated register.");
   }
 
@@ -109,8 +111,9 @@ public class AnnotationTest {
     var prog = zeroExtendTest("[ zero : Y(1)]", "register Y: Bits<5> -> Bits<64>");
     var ast = VadlParser.parse(prog);
     var typechecker = new TypeChecker();
-    var diag = Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
-    assertThat(diag)
+    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    assert diags.items.size() == 1;
+    assertThat(diags.items.getFirst())
         .hasMessageContaining("Zero annotation target must be the annotated register.");
   }
 
@@ -119,8 +122,9 @@ public class AnnotationTest {
     var prog = zeroExtendTest("[ zero : X(1)(2) ]", null);
     var ast = VadlParser.parse(prog);
     var typechecker = new TypeChecker();
-    var diag = Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
-    assertThat(diag)
+    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    assert diags.items.size() == 1;
+    assertThat(diags.items.getFirst())
         .hasMessageContaining("Invalid zero annotation");
   }
 
@@ -129,8 +133,9 @@ public class AnnotationTest {
     var prog = zeroExtendTest("[ zero : X(Y) ]", "register Y: Bits<5>");
     var ast = VadlParser.parse(prog);
     var typechecker = new TypeChecker();
-    var diag = Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
-    assertThat(diag)
+    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    assert diags.items.size() == 1;
+    assertThat(diags.items.getFirst())
         .hasMessageContaining("Index must be a constant expression.");
   }
 }

--- a/vadl/test/vadl/ast/AsmLL1CheckerTest.java
+++ b/vadl/test/vadl/ast/AsmLL1CheckerTest.java
@@ -19,6 +19,7 @@ package vadl.ast;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import vadl.error.Diagnostic;
+import vadl.error.DiagnosticList;
 
 public class AsmLL1CheckerTest {
   private final String base = """
@@ -92,7 +93,8 @@ public class AsmLL1CheckerTest {
     var ast = Assertions.assertDoesNotThrow(
         () -> VadlParser.parse(inputWrappedByValidAsmDescription(prog)), "Cannot parse input");
     var typechecker = new TypeChecker();
-    Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
+    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diags.items.size());
   }
 
   @Test
@@ -106,7 +108,8 @@ public class AsmLL1CheckerTest {
     var ast = Assertions.assertDoesNotThrow(
         () -> VadlParser.parse(inputWrappedByValidAsmDescription(prog)), "Cannot parse input");
     var typechecker = new TypeChecker();
-    Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
+    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diags.items.size());
   }
 
   @Test
@@ -120,7 +123,8 @@ public class AsmLL1CheckerTest {
     var ast = Assertions.assertDoesNotThrow(
         () -> VadlParser.parse(inputWrappedByValidAsmDescription(prog)), "Cannot parse input");
     var typechecker = new TypeChecker();
-    Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
+    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diags.items.size());
   }
 
   @Test
@@ -134,7 +138,8 @@ public class AsmLL1CheckerTest {
     var ast = Assertions.assertDoesNotThrow(
         () -> VadlParser.parse(inputWrappedByValidAsmDescription(prog)), "Cannot parse input");
     var typechecker = new TypeChecker();
-    Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
+    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diags.items.size());
   }
 
   @Test
@@ -148,7 +153,8 @@ public class AsmLL1CheckerTest {
     var ast = Assertions.assertDoesNotThrow(
         () -> VadlParser.parse(inputWrappedByValidAsmDescription(prog)), "Cannot parse input");
     var typechecker = new TypeChecker();
-    Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
+    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diags.items.size());
   }
 
   @Test
@@ -162,15 +168,30 @@ public class AsmLL1CheckerTest {
     var ast = Assertions.assertDoesNotThrow(
         () -> VadlParser.parse(inputWrappedByValidAsmDescription(prog)), "Cannot parse input");
     var typechecker = new TypeChecker();
-    Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
+    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diags.items.size());
   }
 
   @Test
   void firstParsableElementInParamsConflict() {
     hasToWork();
     var prog = """
-          instruction set architecture ISA = {}
-          application binary interface ABI for ISA = {}
+          instruction set architecture ISA = {
+            register X : Bits<5> -> Bits<32>
+          }
+          application binary interface ABI for ISA = {
+            alias register zero = X(0)
+            stack pointer = zero
+            return address = zero
+            global pointer = zero
+            frame pointer = zero
+            thread pointer = zero
+            return value = zero
+            function argument = zero
+        
+            caller saved = zero
+            callee saved = zero
+          }
         
           assembly description AD for ABI = {
             function minusOne (x : SInt<64>) -> SInt<64> = x - 1
@@ -186,15 +207,30 @@ public class AsmLL1CheckerTest {
     var ast = Assertions.assertDoesNotThrow(
         () -> VadlParser.parse(prog), "Cannot parse input");
     var typechecker = new TypeChecker();
-    Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
+    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diags.items.size());
   }
 
   @Test
   void firstParsableElementInLastElementOfGroup() {
     hasToWork();
     var prog = """
-          instruction set architecture ISA = {}
-          application binary interface ABI for ISA = {}
+          instruction set architecture ISA = {
+            register X : Bits<5> -> Bits<32>
+          }
+          application binary interface ABI for ISA = {
+            alias register zero = X(0)
+            stack pointer = zero
+            return address = zero
+            global pointer = zero
+            frame pointer = zero
+            thread pointer = zero
+            return value = zero
+            function argument = zero
+        
+            caller saved = zero
+            callee saved = zero
+          }
         
           assembly description AD for ABI = {
             function one -> SInt<64> = 1
@@ -214,7 +250,8 @@ public class AsmLL1CheckerTest {
     var ast = Assertions.assertDoesNotThrow(
         () -> VadlParser.parse(prog), "Cannot parse input");
     var typechecker = new TypeChecker();
-    Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
+    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diags.items.size());
   }
 
   @Test
@@ -228,7 +265,8 @@ public class AsmLL1CheckerTest {
     var ast = Assertions.assertDoesNotThrow(
         () -> VadlParser.parse(inputWrappedByValidAsmDescription(prog)), "Cannot parse input");
     var typechecker = new TypeChecker();
-    Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
+    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diags.items.size());
   }
 
   @Test
@@ -244,7 +282,8 @@ public class AsmLL1CheckerTest {
     var ast = Assertions.assertDoesNotThrow(
         () -> VadlParser.parse(x), "Cannot parse input");
     var typechecker = new TypeChecker();
-    Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
+    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diags.items.size());
   }
 
   @Test
@@ -331,7 +370,8 @@ public class AsmLL1CheckerTest {
     var ast = Assertions.assertDoesNotThrow(
         () -> VadlParser.parse(inputWrappedByValidAsmDescription(prog)), "Cannot parse input");
     var typechecker = new TypeChecker();
-    Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
+    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diags.items.size());
   }
 
   @Test
@@ -345,7 +385,8 @@ public class AsmLL1CheckerTest {
     var ast = Assertions.assertDoesNotThrow(
         () -> VadlParser.parse(inputWrappedByValidAsmDescription(prog)), "Cannot parse input");
     var typechecker = new TypeChecker();
-    Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
+    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diags.items.size());
   }
 
   @Test
@@ -359,7 +400,8 @@ public class AsmLL1CheckerTest {
     var ast = Assertions.assertDoesNotThrow(
         () -> VadlParser.parse(inputWrappedByValidAsmDescription(prog)), "Cannot parse input");
     var typechecker = new TypeChecker();
-    Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
+    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diags.items.size());
   }
 
   @Test
@@ -373,7 +415,8 @@ public class AsmLL1CheckerTest {
     var ast = Assertions.assertDoesNotThrow(
         () -> VadlParser.parse(inputWrappedByValidAsmDescription(prog)), "Cannot parse input");
     var typechecker = new TypeChecker();
-    Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
+    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diags.items.size());
   }
 
   @Test
@@ -387,7 +430,8 @@ public class AsmLL1CheckerTest {
     var ast = Assertions.assertDoesNotThrow(
         () -> VadlParser.parse(inputWrappedByValidAsmDescription(prog)), "Cannot parse input");
     var typechecker = new TypeChecker();
-    Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
+    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diags.items.size());
   }
 
   @Test
@@ -401,7 +445,8 @@ public class AsmLL1CheckerTest {
     var ast = Assertions.assertDoesNotThrow(
         () -> VadlParser.parse(inputWrappedByValidAsmDescription(prog)), "Cannot parse input");
     var typechecker = new TypeChecker();
-    Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
+    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diags.items.size());
   }
 
   @Test
@@ -417,7 +462,8 @@ public class AsmLL1CheckerTest {
     var ast = Assertions.assertDoesNotThrow(
         () -> VadlParser.parse(inputWrappedByValidAsmDescription(prog)), "Cannot parse input");
     var typechecker = new TypeChecker();
-    Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
+    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diags.items.size());
   }
 
   @Test
@@ -435,7 +481,8 @@ public class AsmLL1CheckerTest {
     var ast = Assertions.assertDoesNotThrow(
         () -> VadlParser.parse(inputWrappedByValidAsmDescription(prog)), "Cannot parse input");
     var typechecker = new TypeChecker();
-    Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
+    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diags.items.size());
   }
 
   @Test
@@ -449,7 +496,8 @@ public class AsmLL1CheckerTest {
     var ast = Assertions.assertDoesNotThrow(
         () -> VadlParser.parse(inputWrappedByValidAsmDescription(prog)), "Cannot parse input");
     var typechecker = new TypeChecker();
-    Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
+    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diags.items.size());
   }
 
   // FIXME: re-enable when parameters of asm built-in functions are correctly casted
@@ -478,7 +526,8 @@ public class AsmLL1CheckerTest {
     var ast = Assertions.assertDoesNotThrow(
         () -> VadlParser.parse(inputWrappedByValidAsmDescription(prog)), "Cannot parse input");
     var typechecker = new TypeChecker();
-    Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
+    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diags.items.size());
   }
 
   // FIXME: re-enable when parameters of asm built-in functions are correctly casted

--- a/vadl/test/vadl/ast/CallIndexExprTest.java
+++ b/vadl/test/vadl/ast/CallIndexExprTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import vadl.error.Diagnostic;
+import vadl.error.DiagnosticList;
 import vadl.utils.ViamUtils;
 import vadl.viam.Function;
 import vadl.viam.passes.verification.ViamVerifier;
@@ -163,7 +163,9 @@ public class CallIndexExprTest {
     var ast = Assertions.assertDoesNotThrow(
         () -> VadlParser.parse(wrapProg(input)), "Cannot parse input");
     var typechecker = new TypeChecker();
-    var diag = Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
-    assertThat(diag).hasMessageContaining(error);
+    var diagnostics = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diagnostics.items.size());
+    var diagnostic = diagnostics.items.getFirst();
+    assertThat(diagnostic).hasMessageContaining(error);
   }
 }

--- a/vadl/test/vadl/ast/ExceptionTest.java
+++ b/vadl/test/vadl/ast/ExceptionTest.java
@@ -21,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import vadl.error.Diagnostic;
+import vadl.error.DiagnosticList;
 
 public class ExceptionTest {
 
@@ -94,8 +94,9 @@ public class ExceptionTest {
     var spec = base.formatted(body);
     var ast = Assertions.assertDoesNotThrow(() -> VadlParser.parse(spec), "Cannot parse input");
     var typechecker = new TypeChecker();
-    var throwable = assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
-    org.assertj.core.api.Assertions.assertThat(throwable.getMessage())
+    var diagnostics = assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diagnostics.items.size());
+    org.assertj.core.api.Assertions.assertThat(diagnostics.items.getFirst().getMessage())
         .contains("Only bit types can be sliced but the target was a `void`");
   }
 
@@ -107,8 +108,10 @@ public class ExceptionTest {
     var spec = base.formatted(body);
     var ast = Assertions.assertDoesNotThrow(() -> VadlParser.parse(spec), "Cannot parse input");
     var typechecker = new TypeChecker();
-    var throwable = assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
-    org.assertj.core.api.Assertions.assertThat(throwable.getMessage())
+    var diagnostics = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diagnostics.items.size());
+    var diagnostic = diagnostics.items.getFirst();
+    org.assertj.core.api.Assertions.assertThat(diagnostic.getMessage())
         .contains("Expected `Bits<5>` but got `Const<200>`.");
   }
 
@@ -122,8 +125,10 @@ public class ExceptionTest {
     var spec = base.formatted(body);
     var ast = Assertions.assertDoesNotThrow(() -> VadlParser.parse(spec), "Cannot parse input");
     var typechecker = new TypeChecker();
-    var throwable = assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
-    org.assertj.core.api.Assertions.assertThat(throwable.getMessage())
+    var diagnostics = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diagnostics.items.size());
+    var diagnostic = diagnostics.items.getFirst();
+    org.assertj.core.api.Assertions.assertThat(diagnostic.getMessage())
         .contains("Expected `void` but got `Bits<5>`.");
   }
 

--- a/vadl/test/vadl/ast/FormatFieldAccessTest.java
+++ b/vadl/test/vadl/ast/FormatFieldAccessTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import vadl.error.Diagnostic;
+import vadl.error.DiagnosticList;
 
 public class FormatFieldAccessTest {
 
@@ -98,7 +99,7 @@ public class FormatFieldAccessTest {
       var lowering = new ViamLowering();
       lowering.generate(ast);
     })
-        .isExactlyInstanceOf(Diagnostic.class)
+        .isInstanceOfAny(Diagnostic.class, DiagnosticList.class)
         .hasMessageContaining(expectedError);
   }
 

--- a/vadl/test/vadl/ast/RecursionCheckerTest.java
+++ b/vadl/test/vadl/ast/RecursionCheckerTest.java
@@ -18,7 +18,7 @@ package vadl.ast;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import vadl.error.Diagnostic;
+import vadl.error.DiagnosticList;
 
 public class RecursionCheckerTest {
   @Test
@@ -29,7 +29,9 @@ public class RecursionCheckerTest {
         """;
     var ast = Assertions.assertDoesNotThrow(() -> VadlParser.parse(prog), "Cannot parse input");
     var typechecker = new TypeChecker();
-    var diagnostic = Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
+    var diagnostics = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diagnostics.items.size());
+    var diagnostic = diagnostics.items.getFirst();
     Assertions.assertEquals("Infinite Recursion", diagnostic.reason);
   }
 
@@ -43,7 +45,9 @@ public class RecursionCheckerTest {
         """;
     var ast = Assertions.assertDoesNotThrow(() -> VadlParser.parse(prog), "Cannot parse input");
     var typechecker = new TypeChecker();
-    var diagnostic = Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
+    var diagnostics = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diagnostics.items.size());
+    var diagnostic = diagnostics.items.getFirst();
     Assertions.assertEquals("Infinite Recursion", diagnostic.reason);
   }
 
@@ -54,7 +58,9 @@ public class RecursionCheckerTest {
         """;
     var ast = Assertions.assertDoesNotThrow(() -> VadlParser.parse(prog), "Cannot parse input");
     var typechecker = new TypeChecker();
-    var diagnostic = Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
+    var diagnostics = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diagnostics.items.size());
+    var diagnostic = diagnostics.items.getFirst();
     Assertions.assertEquals("Infinite Recursion", diagnostic.reason);
   }
 
@@ -66,7 +72,9 @@ public class RecursionCheckerTest {
         """;
     var ast = Assertions.assertDoesNotThrow(() -> VadlParser.parse(prog), "Cannot parse input");
     var typechecker = new TypeChecker();
-    var diagnostic = Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
+    var diagnostics = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diagnostics.items.size());
+    var diagnostic = diagnostics.items.getFirst();
     Assertions.assertEquals("Infinite Recursion", diagnostic.reason);
   }
 
@@ -80,8 +88,9 @@ public class RecursionCheckerTest {
         """;
     var ast = Assertions.assertDoesNotThrow(() -> VadlParser.parse(prog), "Cannot parse input");
     var typechecker = new TypeChecker();
-    var diagnostic = Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
-    Assertions.assertEquals("Infinite Recursion", diagnostic.reason);
+    var diagnostics = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diagnostics.items.size());
+    Assertions.assertEquals("Infinite Recursion", diagnostics.items.getFirst().reason);
   }
 
   @Test
@@ -92,7 +101,9 @@ public class RecursionCheckerTest {
         """;
     var ast = Assertions.assertDoesNotThrow(() -> VadlParser.parse(prog), "Cannot parse input");
     var typechecker = new TypeChecker();
-    var diagnostic = Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
+    var diagnostics = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diagnostics.items.size());
+    var diagnostic = diagnostics.items.getFirst();
     Assertions.assertEquals("Infinite Recursion", diagnostic.reason);
   }
 
@@ -104,7 +115,9 @@ public class RecursionCheckerTest {
         """;
     var ast = Assertions.assertDoesNotThrow(() -> VadlParser.parse(prog), "Cannot parse input");
     var typechecker = new TypeChecker();
-    var diagnostic = Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
+    var diagnostics = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diagnostics.items.size());
+    var diagnostic = diagnostics.items.getFirst();
     Assertions.assertEquals("Infinite Recursion", diagnostic.reason);
   }
 
@@ -116,7 +129,9 @@ public class RecursionCheckerTest {
         """;
     var ast = Assertions.assertDoesNotThrow(() -> VadlParser.parse(prog), "Cannot parse input");
     var typechecker = new TypeChecker();
-    var diagnostic = Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
+    var diagnostics = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diagnostics.items.size());
+    var diagnostic = diagnostics.items.getFirst();
     Assertions.assertEquals("Infinite Recursion", diagnostic.reason);
   }
 }

--- a/vadl/test/vadl/ast/TypecheckerAbiTest.java
+++ b/vadl/test/vadl/ast/TypecheckerAbiTest.java
@@ -20,6 +20,7 @@ package vadl.ast;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import vadl.error.Diagnostic;
+import vadl.error.DiagnosticList;
 
 public class TypecheckerAbiTest {
 
@@ -123,9 +124,11 @@ public class TypecheckerAbiTest {
     var ast = Assertions.assertDoesNotThrow(
         () -> VadlParser.parse(inputWrappedByValidAbi(prog)), "Cannot parse input");
     var typechecker = new TypeChecker();
-    var throwable = Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
-    Assertions.assertEquals(Diagnostic.Level.ERROR, throwable.level);
-    Assertions.assertEquals("No RETURN was declared but one was expected", throwable.reason);
+    var diagnostics = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diagnostics.items.size());
+    var diagnostic = diagnostics.items.getFirst();
+    Assertions.assertEquals(Diagnostic.Level.ERROR, diagnostic.level);
+    Assertions.assertEquals("No RETURN was declared but one was expected", diagnostic.reason);
   }
 
   @Test
@@ -149,9 +152,11 @@ public class TypecheckerAbiTest {
     var ast = Assertions.assertDoesNotThrow(
         () -> VadlParser.parse(inputWrappedByValidAbi(prog)), "Cannot parse input");
     var typechecker = new TypeChecker();
-    var throwable = Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
-    Assertions.assertEquals(Diagnostic.Level.ERROR, throwable.level);
-    Assertions.assertEquals("No CALL was declared but one was expected", throwable.reason);
+    var diagnostics = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diagnostics.items.size());
+    var diagnostic = diagnostics.items.getFirst();
+    Assertions.assertEquals(Diagnostic.Level.ERROR, diagnostic.level);
+    Assertions.assertEquals("No CALL was declared but one was expected", diagnostic.reason);
   }
 
   @Test
@@ -175,10 +180,12 @@ public class TypecheckerAbiTest {
     var ast = Assertions.assertDoesNotThrow(
         () -> VadlParser.parse(inputWrappedByValidAbi(prog)), "Cannot parse input");
     var typechecker = new TypeChecker();
-    var throwable = Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
-    Assertions.assertEquals(Diagnostic.Level.ERROR, throwable.level);
+    var diagnostics = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diagnostics.items.size());
+    var diagnostic = diagnostics.items.getFirst();
+    Assertions.assertEquals(Diagnostic.Level.ERROR, diagnostic.level);
     Assertions.assertEquals("No ABSOLUTE_ADDRESS_LOAD was declared but one was expected",
-        throwable.reason);
+        diagnostic.reason);
   }
 
   @Test
@@ -202,10 +209,12 @@ public class TypecheckerAbiTest {
     var ast = Assertions.assertDoesNotThrow(
         () -> VadlParser.parse(inputWrappedByValidAbi(prog)), "Cannot parse input");
     var typechecker = new TypeChecker();
-    var throwable = Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
-    Assertions.assertEquals(Diagnostic.Level.ERROR, throwable.level);
+    var diagnostics = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diagnostics.items.size());
+    var diagnostic = diagnostics.items.getFirst();
+    Assertions.assertEquals(Diagnostic.Level.ERROR, diagnostic.level);
     Assertions.assertEquals("No STACK_POINTER registers were declared but one was expected",
-        throwable.reason);
+        diagnostic.reason);
   }
 
   @Test
@@ -229,10 +238,12 @@ public class TypecheckerAbiTest {
     var ast = Assertions.assertDoesNotThrow(
         () -> VadlParser.parse(inputWrappedByValidAbi(prog)), "Cannot parse input");
     var typechecker = new TypeChecker();
-    var throwable = Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
-    Assertions.assertEquals(Diagnostic.Level.ERROR, throwable.level);
+    var diagnostics = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diagnostics.items.size());
+    var diagnostic = diagnostics.items.getFirst();
+    Assertions.assertEquals(Diagnostic.Level.ERROR, diagnostic.level);
     Assertions.assertEquals("Number of registers is incorrect. This definition expects only one",
-        throwable.reason);
+        diagnostic.reason);
   }
 
   @Test
@@ -256,10 +267,12 @@ public class TypecheckerAbiTest {
     var ast = Assertions.assertDoesNotThrow(
         () -> VadlParser.parse(inputWrappedByValidAbi(prog)), "Cannot parse input");
     var typechecker = new TypeChecker();
-    var throwable = Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
-    Assertions.assertEquals(Diagnostic.Level.ERROR, throwable.level);
+    var diagnostics = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diagnostics.items.size());
+    var diagnostic = diagnostics.items.getFirst();
+    Assertions.assertEquals(Diagnostic.Level.ERROR, diagnostic.level);
     Assertions.assertEquals("Number of registers is incorrect. This definition expects only one",
-        throwable.reason);
+        diagnostic.reason);
   }
 
   @Test
@@ -283,10 +296,12 @@ public class TypecheckerAbiTest {
     var ast = Assertions.assertDoesNotThrow(
         () -> VadlParser.parse(inputWrappedByValidAbi(prog)), "Cannot parse input");
     var typechecker = new TypeChecker();
-    var throwable = Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
-    Assertions.assertEquals(Diagnostic.Level.ERROR, throwable.level);
+    var diagnostics = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diagnostics.items.size());
+    var diagnostic = diagnostics.items.getFirst();
+    Assertions.assertEquals(Diagnostic.Level.ERROR, diagnostic.level);
     Assertions.assertEquals("Number of registers is incorrect. This definition expects only one",
-        throwable.reason);
+        diagnostic.reason);
   }
 
   @Test
@@ -310,10 +325,12 @@ public class TypecheckerAbiTest {
     var ast = Assertions.assertDoesNotThrow(
         () -> VadlParser.parse(inputWrappedByValidAbi(prog)), "Cannot parse input");
     var typechecker = new TypeChecker();
-    var throwable = Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
-    Assertions.assertEquals(Diagnostic.Level.ERROR, throwable.level);
+    var diagnostics = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diagnostics.items.size());
+    var diagnostic = diagnostics.items.getFirst();
+    Assertions.assertEquals(Diagnostic.Level.ERROR, diagnostic.level);
     Assertions.assertEquals("Number of registers is incorrect. This definition expects only one",
-        throwable.reason);
+        diagnostic.reason);
   }
 
   @Test
@@ -337,10 +354,12 @@ public class TypecheckerAbiTest {
     var ast = Assertions.assertDoesNotThrow(
         () -> VadlParser.parse(inputWrappedByValidAbi(prog)), "Cannot parse input");
     var typechecker = new TypeChecker();
-    var throwable = Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
-    Assertions.assertEquals(Diagnostic.Level.ERROR, throwable.level);
+    var diagnostics = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diagnostics.items.size());
+    var diagnostic = diagnostics.items.getFirst();
+    Assertions.assertEquals(Diagnostic.Level.ERROR, diagnostic.level);
     Assertions.assertEquals("Number of registers is incorrect. This definition expects only one",
-        throwable.reason);
+        diagnostic.reason);
   }
 
   @Test
@@ -364,10 +383,12 @@ public class TypecheckerAbiTest {
     var ast = Assertions.assertDoesNotThrow(
         () -> VadlParser.parse(inputWrappedByValidAbi(prog)), "Cannot parse input");
     var typechecker = new TypeChecker();
-    var throwable = Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
-    Assertions.assertEquals(Diagnostic.Level.ERROR, throwable.level);
+    var diagnostics = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diagnostics.items.size());
+    var diagnostic = diagnostics.items.getFirst();
+    Assertions.assertEquals(Diagnostic.Level.ERROR, diagnostic.level);
     Assertions.assertEquals("No FRAME_POINTER registers were declared but one was expected",
-        throwable.reason);
+        diagnostic.reason);
   }
 
   @Test
@@ -391,11 +412,13 @@ public class TypecheckerAbiTest {
     var ast = Assertions.assertDoesNotThrow(
         () -> VadlParser.parse(inputWrappedByValidAbi(prog)), "Cannot parse input");
     var typechecker = new TypeChecker();
-    var throwable = Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
-    Assertions.assertEquals(Diagnostic.Level.ERROR, throwable.level);
+    var diagnostics = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diagnostics.items.size());
+    var diagnostic = diagnostics.items.getFirst();
+    Assertions.assertEquals(Diagnostic.Level.ERROR, diagnostic.level);
     Assertions.assertEquals(
         "Zero RETURN_VALUE registers were declared but at least one was expected",
-        throwable.reason);
+        diagnostic.reason);
   }
 
   @Test
@@ -419,10 +442,12 @@ public class TypecheckerAbiTest {
     var ast = Assertions.assertDoesNotThrow(
         () -> VadlParser.parse(inputWrappedByValidAbi(prog)), "Cannot parse input");
     var typechecker = new TypeChecker();
-    var throwable = Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
-    Assertions.assertEquals(Diagnostic.Level.ERROR, throwable.level);
+    var diagnostics = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diagnostics.items.size());
+    var diagnostic = diagnostics.items.getFirst();
+    Assertions.assertEquals(Diagnostic.Level.ERROR, diagnostic.level);
     Assertions.assertEquals("No FUNCTION_ARGUMENT registers were declared but one was expected",
-        throwable.reason);
+        diagnostic.reason);
   }
 
   @Test
@@ -446,10 +471,12 @@ public class TypecheckerAbiTest {
     var ast = Assertions.assertDoesNotThrow(
         () -> VadlParser.parse(inputWrappedByValidAbi(prog)), "Cannot parse input");
     var typechecker = new TypeChecker();
-    var throwable = Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
-    Assertions.assertEquals(Diagnostic.Level.ERROR, throwable.level);
+    var diagnostics = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diagnostics.items.size());
+    var diagnostic = diagnostics.items.getFirst();
+    Assertions.assertEquals(Diagnostic.Level.ERROR, diagnostic.level);
     Assertions.assertEquals("No CALLER_SAVED registers were declared but one was expected",
-        throwable.reason);
+        diagnostic.reason);
   }
 
   @Test
@@ -473,10 +500,12 @@ public class TypecheckerAbiTest {
     var ast = Assertions.assertDoesNotThrow(
         () -> VadlParser.parse(inputWrappedByValidAbi(prog)), "Cannot parse input");
     var typechecker = new TypeChecker();
-    var throwable = Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
-    Assertions.assertEquals(Diagnostic.Level.ERROR, throwable.level);
+    var diagnostics = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diagnostics.items.size());
+    var diagnostic = diagnostics.items.getFirst();
+    Assertions.assertEquals(Diagnostic.Level.ERROR, diagnostic.level);
     Assertions.assertEquals("No CALLEE_SAVED registers were declared but one was expected",
-        throwable.reason);
+        diagnostic.reason);
   }
 
   @Test
@@ -501,11 +530,13 @@ public class TypecheckerAbiTest {
     var ast = Assertions.assertDoesNotThrow(
         () -> VadlParser.parse(inputWrappedByValidAbi(prog)), "Cannot parse input");
     var typechecker = new TypeChecker();
-    var throwable = Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
-    Assertions.assertEquals(Diagnostic.Level.ERROR, throwable.level);
+    var diagnostics = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diagnostics.items.size());
+    var diagnostic = diagnostics.items.getFirst();
+    Assertions.assertEquals(Diagnostic.Level.ERROR, diagnostic.level);
     Assertions.assertEquals(
         "Multiple FRAME_POINTER registers were declared but only one was expected",
-        throwable.reason);
+        diagnostic.reason);
   }
 
   @Test
@@ -530,11 +561,13 @@ public class TypecheckerAbiTest {
     var ast = Assertions.assertDoesNotThrow(
         () -> VadlParser.parse(inputWrappedByValidAbi(prog)), "Cannot parse input");
     var typechecker = new TypeChecker();
-    var throwable = Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
-    Assertions.assertEquals(Diagnostic.Level.ERROR, throwable.level);
+    var diagnostics = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diagnostics.items.size());
+    var diagnostic = diagnostics.items.getFirst();
+    Assertions.assertEquals(Diagnostic.Level.ERROR, diagnostic.level);
     Assertions.assertEquals(
         "Multiple LOCAL_ADDRESS_LOAD were declared but one was expected",
-        throwable.reason);
+        diagnostic.reason);
   }
 
 }

--- a/vadl/test/vadl/ast/TypecheckerAsmTest.java
+++ b/vadl/test/vadl/ast/TypecheckerAsmTest.java
@@ -19,7 +19,7 @@ package vadl.ast;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import vadl.error.Diagnostic;
+import vadl.error.DiagnosticList;
 import vadl.types.asmTypes.ConstantAsmType;
 import vadl.types.asmTypes.InstructionAsmType;
 import vadl.types.asmTypes.ModifierAsmType;
@@ -253,7 +253,8 @@ public class TypecheckerAsmTest {
     var ast = Assertions.assertDoesNotThrow(
         () -> VadlParser.parse(inputWrappedByValidAsmDescription(prog)), "Cannot parse input");
     var typechecker = new TypeChecker();
-    Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
+    var diagnostics = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diagnostics.items.size());
   }
 
   @Test
@@ -270,7 +271,8 @@ public class TypecheckerAsmTest {
     var ast = Assertions.assertDoesNotThrow(
         () -> VadlParser.parse(inputWrappedByValidAsmDescription(prog)), "Cannot parse input");
     var typechecker = new TypeChecker();
-    Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
+    var diagnostics = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diagnostics.items.size());
   }
 
   @Test
@@ -351,7 +353,8 @@ public class TypecheckerAsmTest {
     var ast = Assertions.assertDoesNotThrow(
         () -> VadlParser.parse(inputWrappedByValidAsmDescription(prog)), "Cannot parse input");
     var typechecker = new TypeChecker();
-    Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
+    var diagnostics = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diagnostics.items.size());
   }
 
   @Test
@@ -383,7 +386,8 @@ public class TypecheckerAsmTest {
     var ast = Assertions.assertDoesNotThrow(
         () -> VadlParser.parse(inputWrappedByValidAsmDescription(prog)), "Cannot parse input");
     var typechecker = new TypeChecker();
-    Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
+    var diagnostics = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diagnostics.items.size());
   }
 
   @Test
@@ -399,7 +403,8 @@ public class TypecheckerAsmTest {
     var ast = Assertions.assertDoesNotThrow(
         () -> VadlParser.parse(inputWrappedByValidAsmDescription(prog)), "Cannot parse input");
     var typechecker = new TypeChecker();
-    Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
+    var diagnostics = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diagnostics.items.size());
   }
 
   @Test
@@ -432,7 +437,8 @@ public class TypecheckerAsmTest {
     var ast = Assertions.assertDoesNotThrow(
         () -> VadlParser.parse(inputWrappedByValidAsmDescription(prog)), "Cannot parse input");
     var typechecker = new TypeChecker();
-    Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
+    var diagnostics = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diagnostics.items.size());
   }
 
   @Test
@@ -445,7 +451,8 @@ public class TypecheckerAsmTest {
     var ast = Assertions.assertDoesNotThrow(
         () -> VadlParser.parse(inputWrappedByValidAsmDescription(prog)), "Cannot parse input");
     var typechecker = new TypeChecker();
-    Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
+    var diagnostics = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diagnostics.items.size());
   }
 
   @Test
@@ -461,7 +468,8 @@ public class TypecheckerAsmTest {
     var ast = Assertions.assertDoesNotThrow(
         () -> VadlParser.parse(inputWrappedByValidAsmDescription(prog)), "Cannot parse input");
     var typechecker = new TypeChecker();
-    Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
+    var diagnostics = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diagnostics.items.size());
   }
 
   @Test
@@ -474,7 +482,8 @@ public class TypecheckerAsmTest {
     var ast = Assertions.assertDoesNotThrow(
         () -> VadlParser.parse(inputWrappedByValidAsmDescription(prog)), "Cannot parse input");
     var typechecker = new TypeChecker();
-    Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
+    var diagnostics = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diagnostics.items.size());
   }
 
   @Test
@@ -504,7 +513,8 @@ public class TypecheckerAsmTest {
     var ast = Assertions.assertDoesNotThrow(
         () -> VadlParser.parse(inputWrappedByValidAsmDescription(prog)), "Cannot parse input");
     var typechecker = new TypeChecker();
-    Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
+    var diagnostics = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diagnostics.items.size());
   }
 
   @Test
@@ -518,7 +528,8 @@ public class TypecheckerAsmTest {
     var ast = Assertions.assertDoesNotThrow(
         () -> VadlParser.parse(inputWrappedByValidAsmDescription(prog)), "Cannot parse input");
     var typechecker = new TypeChecker();
-    Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
+    var diagnostics = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diagnostics.items.size());
   }
 
   @Test
@@ -569,7 +580,8 @@ public class TypecheckerAsmTest {
     var ast = Assertions.assertDoesNotThrow(
         () -> VadlParser.parse(inputWrappedByValidAsmDescription(prog)), "Cannot parse input");
     var typechecker = new TypeChecker();
-    Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
+    var diagnostics = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diagnostics.items.size());
   }
 
   //region casts

--- a/vadl/test/vadl/ast/TypecheckerTest.java
+++ b/vadl/test/vadl/ast/TypecheckerTest.java
@@ -20,7 +20,7 @@ import java.math.BigInteger;
 import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import vadl.error.Diagnostic;
+import vadl.error.DiagnosticList;
 import vadl.types.Type;
 
 public class TypecheckerTest {
@@ -55,8 +55,8 @@ public class TypecheckerTest {
         """;
     var ast = Assertions.assertDoesNotThrow(() -> VadlParser.parse(prog), "Cannot parse input");
     var typechecker = new TypeChecker();
-    Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast),
-        "Shouldn't accept the program");
+    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diags.items.size());
   }
 
   @Test
@@ -78,8 +78,8 @@ public class TypecheckerTest {
         """;
     var ast = Assertions.assertDoesNotThrow(() -> VadlParser.parse(prog), "Cannot parse input");
     var typechecker = new TypeChecker();
-    Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast),
-        "Shouldn't accept the program");
+    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diags.items.size());
   }
 
 
@@ -90,8 +90,8 @@ public class TypecheckerTest {
         """;
     var ast = Assertions.assertDoesNotThrow(() -> VadlParser.parse(prog), "Cannot parse input");
     var typechecker = new TypeChecker();
-    Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast),
-        "Shouldn't accept the program");
+    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diags.items.size());
   }
 
   @Test
@@ -101,8 +101,8 @@ public class TypecheckerTest {
         """;
     var ast = Assertions.assertDoesNotThrow(() -> VadlParser.parse(prog), "Cannot parse input");
     var typechecker = new TypeChecker();
-    Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast),
-        "Shouldn't accept the program");
+    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diags.items.size());
   }
 
 
@@ -139,8 +139,8 @@ public class TypecheckerTest {
         """;
     var ast = Assertions.assertDoesNotThrow(() -> VadlParser.parse(prog), "Cannot parse input");
     var typechecker = new TypeChecker();
-    Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast),
-        "Shouldn't accept the program");
+    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diags.items.size());
   }
 
   @Test
@@ -177,8 +177,8 @@ public class TypecheckerTest {
         """;
     var ast = Assertions.assertDoesNotThrow(() -> VadlParser.parse(prog), "Cannot parse input");
     var typechecker = new TypeChecker();
-    Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast),
-        "Shouldn't accept the program");
+    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diags.items.size());
   }
 
   @Test
@@ -246,8 +246,8 @@ public class TypecheckerTest {
         """;
     var ast = Assertions.assertDoesNotThrow(() -> VadlParser.parse(prog), "Cannot parse input");
     var typechecker = new TypeChecker();
-    Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast),
-        "Program isn't typesafe");
+    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diags.items.size());
   }
 
   @Test
@@ -652,8 +652,8 @@ public class TypecheckerTest {
         """;
     var ast = Assertions.assertDoesNotThrow(() -> VadlParser.parse(prog), "Cannot parse input");
     var typechecker = new TypeChecker();
-    Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast),
-        "Program isn't typesafe");
+    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diags.items.size());
   }
 
   @Test
@@ -718,8 +718,8 @@ public class TypecheckerTest {
         """;
     var ast = Assertions.assertDoesNotThrow(() -> VadlParser.parse(prog), "Cannot parse input");
     var typechecker = new TypeChecker();
-    Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast),
-        "Program isn't typesafe");
+    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diags.items.size());
   }
 
   @Test
@@ -732,8 +732,8 @@ public class TypecheckerTest {
         """;
     var ast = Assertions.assertDoesNotThrow(() -> VadlParser.parse(prog), "Cannot parse input");
     var typechecker = new TypeChecker();
-    Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast),
-        "Program isn't typesafe");
+    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diags.items.size());
   }
 
   @Test
@@ -746,8 +746,8 @@ public class TypecheckerTest {
         """;
     var ast = Assertions.assertDoesNotThrow(() -> VadlParser.parse(prog), "Cannot parse input");
     var typechecker = new TypeChecker();
-    Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast),
-        "Program isn't typesafe");
+    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diags.items.size());
   }
 
   @Test
@@ -760,8 +760,8 @@ public class TypecheckerTest {
         """;
     var ast = Assertions.assertDoesNotThrow(() -> VadlParser.parse(prog), "Cannot parse input");
     var typechecker = new TypeChecker();
-    Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast),
-        "Program isn't typesafe");
+    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diags.items.size());
   }
 
   @Test
@@ -777,8 +777,8 @@ public class TypecheckerTest {
         """;
     var ast = Assertions.assertDoesNotThrow(() -> VadlParser.parse(prog), "Cannot parse input");
     var typechecker = new TypeChecker();
-    Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast),
-        "Program isn't typesafe");
+    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diags.items.size());
   }
 
 
@@ -812,8 +812,8 @@ public class TypecheckerTest {
         """;
     var ast = Assertions.assertDoesNotThrow(() -> VadlParser.parse(prog), "Cannot parse input");
     var typechecker = new TypeChecker();
-    Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast),
-        "Program isn't typesafe");
+    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diags.items.size());
   }
 
   @Test
@@ -913,7 +913,8 @@ public class TypecheckerTest {
         """;
     var ast = Assertions.assertDoesNotThrow(() -> VadlParser.parse(prog), "Cannot parse input");
     var typechecker = new TypeChecker();
-    Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
+    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diags.items.size());
   }
 
   @Test
@@ -937,7 +938,8 @@ public class TypecheckerTest {
         """;
     var ast = Assertions.assertDoesNotThrow(() -> VadlParser.parse(prog), "Cannot parse input");
     var typechecker = new TypeChecker();
-    Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
+    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diags.items.size());
   }
 
 
@@ -970,7 +972,8 @@ public class TypecheckerTest {
         """;
     var ast = Assertions.assertDoesNotThrow(() -> VadlParser.parse(prog), "Cannot parse input");
     var typechecker = new TypeChecker();
-    Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
+    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diags.items.size());
   }
 
   @Test
@@ -1003,7 +1006,8 @@ public class TypecheckerTest {
         """;
     var ast = Assertions.assertDoesNotThrow(() -> VadlParser.parse(prog), "Cannot parse input");
     var typechecker = new TypeChecker();
-    Assertions.assertThrows(Diagnostic.class, () -> typechecker.verify(ast));
+    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
+    Assertions.assertEquals(1, diags.items.size());
   }
 
 

--- a/vadl/test/vadl/vdt/passes/VdtEncodingConstraintTest.java
+++ b/vadl/test/vadl/vdt/passes/VdtEncodingConstraintTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import vadl.TestUtils;
 import vadl.error.Diagnostic;
+import vadl.error.DiagnosticList;
 import vadl.vdt.passes.validate.EncodingConstraintValidator;
 import vadl.viam.Encoding;
 
@@ -108,7 +109,7 @@ public class VdtEncodingConstraintTest {
       var validator = new EncodingConstraintValidator(encoding);
       validator.check();
     })
-        .isExactlyInstanceOf(Diagnostic.class)
+        .isInstanceOfAny(Diagnostic.class, DiagnosticList.class)
         .hasMessageContaining(error);
   }
 


### PR DESCRIPTION
Previously the typechecker reported the first error it encountered and exited. Now it can figure out how to recover in many cases. These changes are mostly important for the LSP.

**Changes in the API**
- The typechecker no longer throws a `Diagnostic` but always a `DiagnosticList` even if it just contains a single diagnostic.
- The typechecker will try to recover to a recovery point once a typeerror was found and continue from there. This is so that it can find more typeerrors and report as many as possible to the user.

**Three ways to report errors**
There are now three errors to report errors in the typechecker.
1. `throw error(...)` this was the common approach before and will interrupt the checking process. It is now only used for fatal errors where the type-checker is unrecoverable confused.
2. `addErrorAndStopPartialChecking(error(...))` and `throw new StopPartialCheckingSignal()` this interrupts the checking until a recovery point (the next statement of next definition.
3. `errors.add(error(...))` this is for errors where we can continue directly because the result of the check isn't important for future checks. A good example for this one is the check if a the condition of an if is a bool because if not we can simply report the error and continue as usual.