### PR TITLE
rtl: Provide Firtool binaries for test base

### DIFF
--- a/.github/workflows/build-chisel-toolchain.yml
+++ b/.github/workflows/build-chisel-toolchain.yml
@@ -1,0 +1,39 @@
+name: Build Chisel Toolchain Image
+
+on:
+  workflow_dispatch: # Allows manual triggering
+
+permissions:
+  packages: write
+  contents: read
+
+jobs:
+  build:
+    uses: ./.github/workflows/reusable-image-build.yml
+    strategy:
+      matrix:
+        target:
+          - platform: linux/arm64
+            runner: self-hosted-arm64
+          # TODO: Enable once the build is stable
+          #- platform: linux/amd64
+          #  runner: self-hosted-x64
+    secrets:
+      X06_KEYCHAIN_PASSWORD: ${{ secrets.X06_KEYCHAIN_PASSWORD }}
+    with:
+      image: ghcr.io/openvadl/firtool
+      context: docker/rtl/firtool
+      platform: ${{ matrix.target.platform }}
+      runner: ${{ matrix.target.runner }}
+      tags: |
+        latest
+
+  merge:
+    needs: build
+    uses: ./.github/workflows/reusable-image-merge.yml
+    secrets:
+      X06_KEYCHAIN_PASSWORD: ${{ secrets.X06_KEYCHAIN_PASSWORD }}
+    with:
+      image: ghcr.io/openvadl/firtool
+      tags: |
+        latest

--- a/docker/rtl/firtool/Dockerfile
+++ b/docker/rtl/firtool/Dockerfile
@@ -1,0 +1,31 @@
+FROM ubuntu:22.04 AS firtool
+
+WORKDIR /build
+
+RUN apt update &&  \
+    apt install -y \
+    curl \
+    git \
+    build-essential  \
+    ninja-build  \
+    python3  \
+    python3-venv  \
+    python3-pip \
+    cmake
+
+# Clone the repository and its submodules
+RUN git clone https://github.com/llvm/circt.git --recursive
+
+WORKDIR /build/circt
+
+# Configure the build
+RUN cmake -G Ninja llvm/llvm -B build \
+    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+    -DLLVM_ENABLE_ASSERTIONS=ON \
+    -DLLVM_TARGETS_TO_BUILD=host \
+    -DLLVM_ENABLE_PROJECTS=mlir \
+    -DLLVM_EXTERNAL_PROJECTS=circt \
+    -DLLVM_EXTERNAL_CIRCT_SOURCE_DIR=$PWD
+
+# Run the build
+RUN ninja -C build firtool


### PR DESCRIPTION
Build the CIRCT Firtool from source, as it is required by Chisel and there are no prebuild ARM binaries available.