### PR TITLE
chore: Add snapshot tests for typechecker

### DIFF
--- a/vadl/main/vadl/error/DiagnosticPrinter.java
+++ b/vadl/main/vadl/error/DiagnosticPrinter.java
@@ -34,6 +34,7 @@ import vadl.utils.SourceLocation;
  */
 public class DiagnosticPrinter {
 
+  public boolean forceRelativePaths = false;
   private final PrinterColors colors;
   private final Map<Path, List<String>> fileLineCache = new HashMap<>();
 
@@ -120,7 +121,9 @@ public class DiagnosticPrinter {
   private void printMultiSourcePreview(Diagnostic diagnostic, StringBuilder builder) {
     // Print preview header
     builder.append("     %s╭──[%s]\n".formatted(colors.cyan(),
-        diagnostic.multiLocation.primaryLocation().location().toIDEString()));
+        diagnostic.multiLocation.primaryLocation().location().toIDEString(
+            forceRelativePaths ? SourceLocation.IDEDetectionMode.RELATIVE :
+                SourceLocation.IDEDetectionMode.AUTO)));
     builder.append("     │\n");
 
     // TODO: Sort them accordig to their line number in the future
@@ -157,7 +160,9 @@ public class DiagnosticPrinter {
     if (!previous.uri().equals(next.uri())) {
       // This is so unusual that we print the location everytime
       var message = "     %s⋮\n".formatted(colors.cyan());
-      message += "     ╭─ %s\n".formatted(next.toIDEString());
+      message += "     ╭─ %s\n".formatted(
+          next.toIDEString(forceRelativePaths ? SourceLocation.IDEDetectionMode.RELATIVE :
+              SourceLocation.IDEDetectionMode.AUTO));
       return message;
     } else if (next.begin().line() == previous.end().line() + 1) {
       return "     %s│\n".formatted(colors.cyan());

--- a/vadl/main/vadl/utils/SourceLocation.java
+++ b/vadl/main/vadl/utils/SourceLocation.java
@@ -162,6 +162,13 @@ public record SourceLocation(
   }
 
   /**
+   * Modes of how the IDE should be detected or one format be forced.
+   */
+  public enum IDEDetectionMode {
+    AUTO, RELATIVE, ABSOLUTE
+  }
+
+  /**
    * Produces version that is easily understandable for IDE's.
    *
    * <p>E.g.: {@code SourceLocation("relative/path/to/file.vadl", (1, 3), (2, 4))}
@@ -169,13 +176,25 @@ public record SourceLocation(
    * </p>
    */
   public String toIDEString() {
+    return toIDEString(IDEDetectionMode.AUTO);
+  }
+
+  /**
+   * Produces version that is easily understandable for IDE's.
+   *
+   * <p>E.g.: {@code SourceLocation("relative/path/to/file.vadl", (1, 3), (2, 4))}
+   * becomes  {@code "relative/path/to/file.vadl:1:3"}
+   * </p>
+   */
+  public String toIDEString(IDEDetectionMode mode) {
     if (!this.isValid()) {
       return "Source Location was lost";
     }
 
     String printablePath;
 
-    if (isIntelliJIDE() || this.uri.getScheme().equals("memory")) {
+    if (mode == IDEDetectionMode.ABSOLUTE || (mode == IDEDetectionMode.AUTO && (isIntelliJIDE()
+        || this.uri.getScheme().equals("memory")))) {
       // IntelliJ integrated terminal needs special treatment
       printablePath = this.uri.toString();
     } else {

--- a/vadl/test/resources/diagnostics/invalidBooleanType.vadl
+++ b/vadl/test/resources/diagnostics/invalidBooleanType.vadl
@@ -1,0 +1,16 @@
+constant b: Bool<1> = true
+
+
+// Reported Diagnostics:
+//
+//  error: Invalid Type Notation
+//       ╭──[test/resources/diagnostics/invalidBooleanType.vadl:1:13]
+//       │
+//     1 │ constant b: Bool<1> = true
+//       │             ^^^^^^^
+//       │
+//       The Bool type doesn't use the size notation.
+//       help: Try removing the size parameter here.
+//
+//
+// Part of the class vadl.ast.DiagnosticsTest

--- a/vadl/test/resources/diagnostics/invalidCastAfterEvalTruncates.vadl
+++ b/vadl/test/resources/diagnostics/invalidCastAfterEvalTruncates.vadl
@@ -1,0 +1,15 @@
+constant a = 9 as UInt<3>
+constant b: UInt<a> = 3
+
+
+// Reported Diagnostics:
+//
+//  error: Type Mismatch
+//       ╭──[test/resources/diagnostics/invalidCastAfterEvalTruncates.vadl:2:23]
+//       │
+//     2 │ constant b: UInt<a> = 3
+//       │                       ^Expected `UInt<1>` but got `Const<3>`.
+//       │
+//
+//
+// Part of the class vadl.ast.DiagnosticsTest

--- a/vadl/test/resources/diagnostics/invalidConstantAssignmentIntToBool.vadl
+++ b/vadl/test/resources/diagnostics/invalidConstantAssignmentIntToBool.vadl
@@ -1,0 +1,14 @@
+constant b: Bool = 42
+
+
+// Reported Diagnostics:
+//
+//  error: Type Mismatch
+//       ╭──[test/resources/diagnostics/invalidConstantAssignmentIntToBool.vadl:1:20]
+//       │
+//     1 │ constant b: Bool = 42
+//       │                    ^^Expected `Bool` but got `Const<42>`.
+//       │
+//
+//
+// Part of the class vadl.ast.DiagnosticsTest

--- a/vadl/test/resources/diagnostics/invalidDeclaredSIntTooNarrow.vadl
+++ b/vadl/test/resources/diagnostics/invalidDeclaredSIntTooNarrow.vadl
@@ -1,0 +1,14 @@
+constant b: SInt<3> = 8
+
+
+// Reported Diagnostics:
+//
+//  error: Type Mismatch
+//       ╭──[test/resources/diagnostics/invalidDeclaredSIntTooNarrow.vadl:1:23]
+//       │
+//     1 │ constant b: SInt<3> = 8
+//       │                       ^Expected `SInt<3>` but got `Const<8>`.
+//       │
+//
+//
+// Part of the class vadl.ast.DiagnosticsTest

--- a/vadl/test/resources/diagnostics/invalidEnumWithTypes.vadl
+++ b/vadl/test/resources/diagnostics/invalidEnumWithTypes.vadl
@@ -1,0 +1,18 @@
+enumeration ENUM: Bits<2> =
+{ A = 0b00 + 0b01
+, B = 0b0111111
+, C = 0b10
+}
+
+
+// Reported Diagnostics:
+//
+//  error: Type Mismatch
+//       ╭──[test/resources/diagnostics/invalidEnumWithTypes.vadl:3:7]
+//       │
+//     3 │ , B = 0b0111111
+//       │       ^^^^^^^^^Expected `Bits<2>` but got `Bits<6>`.
+//       │
+//
+//
+// Part of the class vadl.ast.DiagnosticsTest

--- a/vadl/test/resources/diagnostics/invalidFormatOutOfBoundsRange.vadl
+++ b/vadl/test/resources/diagnostics/invalidFormatOutOfBoundsRange.vadl
@@ -1,0 +1,19 @@
+instruction set architecture TEST = {
+  format Format: Bits<32> =
+  { field   [32..0]             // wrong higher offset
+  , accFunc = field as SInt
+  }
+}
+
+
+// Reported Diagnostics:
+//
+//  error: Invalid Range
+//       ╭──[test/resources/diagnostics/invalidFormatOutOfBoundsRange.vadl:3:14]
+//       │
+//     3 │   { field   [32..0]             // wrong higher offset
+//       │              ^^^^^Provided range `32..0` out of bounds for available range `31..0`
+//       │
+//
+//
+// Part of the class vadl.ast.DiagnosticsTest

--- a/vadl/test/resources/diagnostics/invalidFormatOverusedBitsWithTypes.vadl
+++ b/vadl/test/resources/diagnostics/invalidFormatOverusedBitsWithTypes.vadl
@@ -1,0 +1,21 @@
+format f : Bits<8> =
+ { first: Bits<6>
+ , second: Bits<4>
+ }
+
+
+// Reported Diagnostics:
+//
+//  error: Invalid Format
+//       ╭──[test/resources/diagnostics/invalidFormatOverusedBitsWithTypes.vadl:1:1]
+//       │
+//     1 │> format f : Bits<8> =
+//     2 │>  { first: Bits<6>
+//     3 │>  , second: Bits<4>
+//     4 │>  }
+//       │    
+//       │
+//       Declared as bitwidth of size 8 but actually size is 10
+//
+//
+// Part of the class vadl.ast.DiagnosticsTest

--- a/vadl/test/resources/diagnostics/invalidFormatUnusedBitsWithTypes.vadl
+++ b/vadl/test/resources/diagnostics/invalidFormatUnusedBitsWithTypes.vadl
@@ -1,0 +1,21 @@
+format f : Bits<8> =
+{ first: Bits<3>
+, second: Bits<4>
+}
+
+
+// Reported Diagnostics:
+//
+//  error: Invalid Format
+//       ╭──[test/resources/diagnostics/invalidFormatUnusedBitsWithTypes.vadl:1:1]
+//       │
+//     1 │> format f : Bits<8> =
+//     2 │> { first: Bits<3>
+//     3 │> , second: Bits<4>
+//     4 │> }
+//       │    
+//       │
+//       Declared as bitwidth of size 8 but actually size is 7
+//
+//
+// Part of the class vadl.ast.DiagnosticsTest

--- a/vadl/test/resources/diagnostics/invalidFunctionDefinitionWrongReturnType.vadl
+++ b/vadl/test/resources/diagnostics/invalidFunctionDefinitionWrongReturnType.vadl
@@ -1,0 +1,17 @@
+function addOne(n: SInt<8>) -> SInt<8> = false
+
+
+// Reported Diagnostics:
+//
+//  error: Type Mismatch
+//       ╭──[test/resources/diagnostics/invalidFunctionDefinitionWrongReturnType.vadl:1:42]
+//       │
+//     1 │ function addOne(n: SInt<8>) -> SInt<8> = false
+//       │                                -------Return type defined here as `SInt<8>`
+//       ⋮
+//     1 │ function addOne(n: SInt<8>) -> SInt<8> = false
+//       │                                          ^^^^^Expected `SInt<8>` but got `Bool`
+//       │
+//
+//
+// Part of the class vadl.ast.DiagnosticsTest

--- a/vadl/test/resources/diagnostics/invalidIfExprBranchesDifferentTypesInFunction.vadl
+++ b/vadl/test/resources/diagnostics/invalidIfExprBranchesDifferentTypesInFunction.vadl
@@ -1,0 +1,17 @@
+function abc(n: SInt<8>) -> SInt<8> = if n = 7 then 3 else 4
+
+
+// Reported Diagnostics:
+//
+//  error: Type Mismatch
+//       ╭──[test/resources/diagnostics/invalidIfExprBranchesDifferentTypesInFunction.vadl:1:39]
+//       │
+//     1 │ function abc(n: SInt<8>) -> SInt<8> = if n = 7 then 3 else 4
+//       │                                       ^^^^^^^^^^^^^^^^^^^^^^
+//       │
+//       Both branches return different constant types.
+//       help: Add an explicit cast on one of the branches.
+//       note: In the future this will work without a cast.
+//
+//
+// Part of the class vadl.ast.DiagnosticsTest

--- a/vadl/test/resources/diagnostics/invalidIfExprConditionNoBoolTest.vadl
+++ b/vadl/test/resources/diagnostics/invalidIfExprConditionNoBoolTest.vadl
@@ -1,0 +1,14 @@
+constant x = if 4 then 3 as Bits<32> else 4 as Bits<32>
+
+
+// Reported Diagnostics:
+//
+//  error: Type Mismatch
+//       ╭──[test/resources/diagnostics/invalidIfExprConditionNoBoolTest.vadl:1:14]
+//       │
+//     1 │ constant x = if 4 then 3 as Bits<32> else 4 as Bits<32>
+//       │              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^Expected `Bool` but got `Bits<3>`.
+//       │
+//
+//
+// Part of the class vadl.ast.DiagnosticsTest

--- a/vadl/test/resources/diagnostics/invalidMatchExprBranchesDifferentTypeInFunction.vadl
+++ b/vadl/test/resources/diagnostics/invalidMatchExprBranchesDifferentTypeInFunction.vadl
@@ -1,0 +1,20 @@
+function x(n: SInt<8>) -> Bits<64> = (match n with
+{ 1 => 2 as Bits<16>
+, 2 => 4 as Bits<32>
+, 3 => 6 as Bits<8>
+, _ => 42 as Bits<64>
+} ) as Bits<64>
+
+
+// Reported Diagnostics:
+//
+//  error: Type Mismatch
+//       ╭──[test/resources/diagnostics/invalidMatchExprBranchesDifferentTypeInFunction.vadl:3:8]
+//       │
+//     3 │ , 2 => 4 as Bits<32>
+//       │        ^^^^^^^^^note: All previous branches were of type `Bits<16>`, but this is `Bits<32>`
+//       │
+//       All branches of a match must have the same type
+//
+//
+// Part of the class vadl.ast.DiagnosticsTest

--- a/vadl/test/resources/diagnostics/invalidMatchExprPatternDifferentType.vadl
+++ b/vadl/test/resources/diagnostics/invalidMatchExprPatternDifferentType.vadl
@@ -1,0 +1,20 @@
+constant x = match 4 as Bits<32> with
+{ 1 => 2 as Bits<16>
+, 2 as Bits<8> => 4 as Bits<16>
+, 3 => 6 as Bits<16>
+, _ => 42 as Bits<16>
+}
+
+
+// Reported Diagnostics:
+//
+//  error: Type Mismatch
+//       ╭──[test/resources/diagnostics/invalidMatchExprPatternDifferentType.vadl:3:3]
+//       │
+//     3 │ , 2 as Bits<8> => 4 as Bits<16>
+//       │   ^^^^^^^^^Expected `Bits<32>`, but got `Bits<8>`
+//       │
+//       note: The type of the candidate and the pattern must be the same.
+//
+//
+// Part of the class vadl.ast.DiagnosticsTest

--- a/vadl/test/resources/diagnostics/invalidMinusOnBoolean.vadl
+++ b/vadl/test/resources/diagnostics/invalidMinusOnBoolean.vadl
@@ -1,0 +1,15 @@
+constant i = -true
+
+
+// Reported Diagnostics:
+//
+//  error: Type Mismatch
+//       ╭──[test/resources/diagnostics/invalidMinusOnBoolean.vadl:1:15]
+//       │
+//     1 │ constant i = -true
+//       │               ^^^^
+//       │
+//       Expected a numerical type but got `Bool`
+//
+//
+// Part of the class vadl.ast.DiagnosticsTest

--- a/vadl/test/resources/diagnostics/invalidNegateInt.vadl
+++ b/vadl/test/resources/diagnostics/invalidNegateInt.vadl
@@ -1,0 +1,15 @@
+constant b = !5
+
+
+// Reported Diagnostics:
+//
+//  error: Type Mismatch: expected `Bool`, got `Const<5>`
+//       ╭──[test/resources/diagnostics/invalidNegateInt.vadl:1:15]
+//       │
+//     1 │ constant b = !5
+//       │               ^
+//       │
+//       help: For numerical types you can negate them with a minus `-`
+//
+//
+// Part of the class vadl.ast.DiagnosticsTest

--- a/vadl/test/resources/diagnostics/invalidSintType.vadl
+++ b/vadl/test/resources/diagnostics/invalidSintType.vadl
@@ -1,0 +1,16 @@
+constant i: SInt = 42
+
+
+// Reported Diagnostics:
+//
+//  error: Invalid Type Notation
+//       ╭──[test/resources/diagnostics/invalidSintType.vadl:1:13]
+//       │
+//     1 │ constant i: SInt = 42
+//       │             ^^^^
+//       │
+//       Unsized `SInt` can only be used in special places when it's obvious what the bit width should be.
+//       help: Try adding a size parameter here.
+//
+//
+// Part of the class vadl.ast.DiagnosticsTest

--- a/vadl/test/vadl/TestUtils.java
+++ b/vadl/test/vadl/TestUtils.java
@@ -20,7 +20,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static vadl.utils.ViamUtils.findDefinitionsByFilter;
 
+import java.io.IOException;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -29,6 +33,8 @@ import net.jqwik.api.Arbitraries;
 import net.jqwik.api.Arbitrary;
 import net.jqwik.api.arbitraries.BigIntegerArbitrary;
 import org.junit.jupiter.api.Assertions;
+import org.opentest4j.AssertionFailedError;
+import org.opentest4j.FileInfo;
 import vadl.ast.TypeChecker;
 import vadl.ast.VadlParser;
 import vadl.ast.ViamLowering;
@@ -109,6 +115,29 @@ public class TestUtils {
     var spec = Assertions.assertDoesNotThrow(() -> lowering.generate(ast), "Cannot generate VIAM");
     ViamVerifier.verifyAllIn(spec);
     return spec;
+  }
+
+  /**
+   * Asserts that the File referenced with the provided Path contains equals the actual string.
+   * This test is optimized for IntelliJ and by throwing a custom AssertionFailedError the IDE will
+   * show a diff editor in which the user can accept the changes into the referenced filed.
+   *
+   * @param expectedPath the file to compare the actual string with
+   * @param actual       the actual string the test produced.
+   * @throws IOException if the file cannot be read.
+   */
+  public static void assertEqualsFileContent(Path expectedPath, String actual)
+      throws
+      IOException {
+    var expected = Files.readString(expectedPath);
+    if (!expected.equals(actual)) {
+      throw new AssertionFailedError(
+          "Actual data differs from file.",
+          new FileInfo(expectedPath.toAbsolutePath().toString(),
+              expected.getBytes(StandardCharsets.UTF_8)),
+          actual
+      );
+    }
   }
 
   /**

--- a/vadl/test/vadl/ast/DiagnosticsTest.java
+++ b/vadl/test/vadl/ast/DiagnosticsTest.java
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.ast;
+
+import static vadl.TestUtils.assertEqualsFileContent;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+import vadl.error.Diagnostic;
+import vadl.error.DiagnosticList;
+import vadl.error.DiagnosticPrinter;
+import vadl.viam.passes.verification.ViamVerifier;
+
+/**
+ * Runs all files in the test/resources/diagnostics directory.
+ * The files are fed into the compilation pipeline and the thrown diagnostics are stored.
+ * Then the original file is read again and compared if it reported the same diagnostics.
+ *
+ * <p>To update the snapshots, set the environment variable UPDATE_SNAPSHOTS.
+ * {@code UPDATE_SNAPSHOTS=true ./gradlew test --tests vadl.ast.DiagnosticsTest}
+ */
+public class DiagnosticsTest {
+  @TestFactory
+  Stream<DynamicTest> snapshotTests() throws IOException {
+    return Files.walk(Paths.get("test/resources/diagnostics"))
+        .filter(path -> path.toString().endsWith(".vadl"))
+        .map(path -> DynamicTest.dynamicTest(
+            path.toString(),
+            () -> runSnapshotTest(path)
+        ));
+  }
+
+  private Pattern commentPattern =
+      Pattern.compile("// Reported Diagnostics:.*$", Pattern.DOTALL);
+
+  void runSnapshotTest(Path path) throws IOException {
+
+    List<Diagnostic> diagnostics = List.of();
+    try {
+      var ast = VadlParser.parse(path);
+      var typechecker = new TypeChecker();
+      typechecker.verify(ast);
+      var lowering = new ViamLowering();
+      var spec = lowering.generate(ast);
+      ViamVerifier.verifyAllIn(spec);
+    } catch (DiagnosticList d) {
+      diagnostics = d.items;
+    } catch (Diagnostic d) {
+      diagnostics = List.of(d);
+    }
+
+    // FIXME: Maybe deferred diagnostic store here but add later because it might have problems
+    // being global state not reset by the test suite.
+
+    // Force relative paths because the tests must always produce the same and the absolut path
+    // will differ on different machines.
+    DiagnosticPrinter printer = new DiagnosticPrinter(false);
+    printer.forceRelativePaths = true;
+    var output = !diagnostics.isEmpty() ? printer.toString(diagnostics).stripTrailing() : "_none_";
+    output = "//  " + output.replaceAll("\n", "\n//  ") + "\n//\n//\n// Part of the %s".formatted(
+        this.getClass());
+
+    var input = Files.readString(path);
+    var stripped = commentPattern.matcher(input).replaceAll("").strip();
+    var actual = stripped + "\n\n\n// Reported Diagnostics:\n//\n" + output;
+
+
+    if (System.getenv("UPDATE_SNAPSHOTS") != null) {
+      Files.writeString(path, actual);
+      return;
+    }
+
+    assertEqualsFileContent(path, actual);
+  }
+}

--- a/vadl/test/vadl/ast/TypecheckerTest.java
+++ b/vadl/test/vadl/ast/TypecheckerTest.java
@@ -20,7 +20,6 @@ import java.math.BigInteger;
 import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import vadl.error.DiagnosticList;
 import vadl.types.Type;
 
 public class TypecheckerTest {
@@ -48,16 +47,6 @@ public class TypecheckerTest {
     Assertions.assertEquals(Type.bool(), typeFinder.getConstantType(ast, "b"));
   }
 
-  @Test
-  public void invalidBooleanType() {
-    var prog = """
-        constant b: Bool<1> = true
-        """;
-    var ast = Assertions.assertDoesNotThrow(() -> VadlParser.parse(prog), "Cannot parse input");
-    var typechecker = new TypeChecker();
-    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
-    Assertions.assertEquals(1, diags.items.size());
-  }
 
   @Test
   public void sintConstant() {
@@ -70,41 +59,6 @@ public class TypecheckerTest {
     var typeFinder = new AstFinder();
     Assertions.assertEquals(Type.signedInt(32), typeFinder.getConstantType(ast, "i"));
   }
-
-  @Test
-  public void invalidSintType() {
-    var prog = """
-        constant i: SInt = 42
-        """;
-    var ast = Assertions.assertDoesNotThrow(() -> VadlParser.parse(prog), "Cannot parse input");
-    var typechecker = new TypeChecker();
-    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
-    Assertions.assertEquals(1, diags.items.size());
-  }
-
-
-  @Test
-  public void invalidConstantAssignementIntToBool() {
-    var prog = """
-        constant b: Bool = 42
-        """;
-    var ast = Assertions.assertDoesNotThrow(() -> VadlParser.parse(prog), "Cannot parse input");
-    var typechecker = new TypeChecker();
-    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
-    Assertions.assertEquals(1, diags.items.size());
-  }
-
-  @Test
-  public void invalidDeclaredSIntTooNarrow() {
-    var prog = """
-        constant b: SInt<3> = 8
-        """;
-    var ast = Assertions.assertDoesNotThrow(() -> VadlParser.parse(prog), "Cannot parse input");
-    var typechecker = new TypeChecker();
-    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
-    Assertions.assertEquals(1, diags.items.size());
-  }
-
 
   @Test
   public void unaryMinusIntExpression() {
@@ -133,17 +87,6 @@ public class TypecheckerTest {
   }
 
   @Test
-  public void invalidMinusOnBoolean() {
-    var prog = """
-        constant i = -true
-        """;
-    var ast = Assertions.assertDoesNotThrow(() -> VadlParser.parse(prog), "Cannot parse input");
-    var typechecker = new TypeChecker();
-    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
-    Assertions.assertEquals(1, diags.items.size());
-  }
-
-  @Test
   public void unaryNegateBool() {
     var prog = """
         // It's funny because it's true.
@@ -168,17 +111,6 @@ public class TypecheckerTest {
     var typeFinder = new AstFinder();
     Assertions.assertEquals(Type.bool(),
         typeFinder.getConstantType(ast, "b"));
-  }
-
-  @Test
-  public void invalidNegateInt() {
-    var prog = """
-        constant b = !5
-        """;
-    var ast = Assertions.assertDoesNotThrow(() -> VadlParser.parse(prog), "Cannot parse input");
-    var typechecker = new TypeChecker();
-    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
-    Assertions.assertEquals(1, diags.items.size());
   }
 
   @Test
@@ -236,18 +168,6 @@ public class TypecheckerTest {
     var typeFinder = new AstFinder();
     Assertions.assertEquals(Type.unsignedInt(3), typeFinder.getConstantType(ast, "a"));
     Assertions.assertEquals(Type.unsignedInt(1), typeFinder.getConstantType(ast, "b"));
-  }
-
-  @Test
-  public void invalidCastAfterEvalTruncates() {
-    var prog = """
-        constant a = 9 as UInt<3>
-        constant b: UInt<a> = 3
-        """;
-    var ast = Assertions.assertDoesNotThrow(() -> VadlParser.parse(prog), "Cannot parse input");
-    var typechecker = new TypeChecker();
-    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
-    Assertions.assertEquals(1, diags.items.size());
   }
 
   @Test
@@ -646,17 +566,6 @@ public class TypecheckerTest {
   }
 
   @Test
-  public void invalidFunctionDefinitionWrongReturnType() {
-    var prog = """
-        function addOne(n: SInt<8>) -> SInt<8> = false
-        """;
-    var ast = Assertions.assertDoesNotThrow(() -> VadlParser.parse(prog), "Cannot parse input");
-    var typechecker = new TypeChecker();
-    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
-    Assertions.assertEquals(1, diags.items.size());
-  }
-
-  @Test
   public void formatWithTypes() {
     var prog = """
          format f : Bits<8> =
@@ -709,80 +618,6 @@ public class TypecheckerTest {
 
 
   @Test
-  public void invalidFormatUnusedBitsWithTypes() {
-    var prog = """
-        format f : Bits<8> =
-         { first: Bits<3>
-         , second: Bits<4>
-         }
-        """;
-    var ast = Assertions.assertDoesNotThrow(() -> VadlParser.parse(prog), "Cannot parse input");
-    var typechecker = new TypeChecker();
-    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
-    Assertions.assertEquals(1, diags.items.size());
-  }
-
-  @Test
-  public void invalidFormatOverusedBitsWithTypes() {
-    var prog = """
-        format f : Bits<8> =
-         { first: Bits<6>
-         , second: Bits<4>
-         }
-        """;
-    var ast = Assertions.assertDoesNotThrow(() -> VadlParser.parse(prog), "Cannot parse input");
-    var typechecker = new TypeChecker();
-    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
-    Assertions.assertEquals(1, diags.items.size());
-  }
-
-  @Test
-  public void invalidFormatUnusedBitsWithRanges() {
-    var prog = """
-        format f : Bits<8> =
-         { first   [7..6]
-         , second  [4..0]
-         }
-        """;
-    var ast = Assertions.assertDoesNotThrow(() -> VadlParser.parse(prog), "Cannot parse input");
-    var typechecker = new TypeChecker();
-    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
-    Assertions.assertEquals(1, diags.items.size());
-  }
-
-  @Test
-  public void invalidFormatOverusedBitsWithRanges() {
-    var prog = """
-        format f : Bits<8> =
-         { first   [7..3]
-         , second  [5..0]
-         }
-        """;
-    var ast = Assertions.assertDoesNotThrow(() -> VadlParser.parse(prog), "Cannot parse input");
-    var typechecker = new TypeChecker();
-    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
-    Assertions.assertEquals(1, diags.items.size());
-  }
-
-  @Test
-  public void invalidFormatOutOfBoundsRange() {
-    var prog = """
-        instruction set architecture TEST = {
-          format Format: Bits<32> =
-          { field   [32..0]             // wrong higher offset
-          , accFunc = field as SInt
-          }
-        }
-        
-        """;
-    var ast = Assertions.assertDoesNotThrow(() -> VadlParser.parse(prog), "Cannot parse input");
-    var typechecker = new TypeChecker();
-    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
-    Assertions.assertEquals(1, diags.items.size());
-  }
-
-
-  @Test
   public void enumWithTypes() {
     var prog = """
           enumeration ENUM: Bits<2> =
@@ -799,21 +634,6 @@ public class TypecheckerTest {
     Assertions.assertEquals(Type.bits(2), enumeration.getEntryType("A"));
     Assertions.assertEquals(Type.bits(2), enumeration.getEntryType("B"));
     Assertions.assertEquals(Type.bits(2), enumeration.getEntryType("C"));
-  }
-
-  @Test
-  public void invalidEnumWithTypes() {
-    var prog = """
-          enumeration ENUM: Bits<2> =
-          { A = 0b00 + 0b01
-          , B = 0b0111111
-          , C = 0b10
-          }
-        """;
-    var ast = Assertions.assertDoesNotThrow(() -> VadlParser.parse(prog), "Cannot parse input");
-    var typechecker = new TypeChecker();
-    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
-    Assertions.assertEquals(1, diags.items.size());
   }
 
   @Test
@@ -906,16 +726,6 @@ public class TypecheckerTest {
     Assertions.assertEquals(Type.bits(32), finder.getConstantType(ast, "x"));
   }
 
-  @Test
-  public void inValidIfExprConditionNoBoolTest() {
-    var prog = """
-          constant x = if 4 then 3 as Bits<32> else 4 as Bits<32>
-        """;
-    var ast = Assertions.assertDoesNotThrow(() -> VadlParser.parse(prog), "Cannot parse input");
-    var typechecker = new TypeChecker();
-    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
-    Assertions.assertEquals(1, diags.items.size());
-  }
 
   @Test
   public void ifExprBranchesDifferentTypesInConstantTest() {
@@ -928,18 +738,6 @@ public class TypecheckerTest {
     Assertions.assertDoesNotThrow(() -> typechecker.verify(ast), "Program isn't typesafe");
     var finder = new AstFinder();
     Assertions.assertEquals(Type.bits(16), finder.getConstantType(ast, "x"));
-  }
-
-  @Test
-  public void invalidIfExprBranchesDifferentTypesInFunctionTest() {
-    // FIXME: In the future bidirectional typechecking should fix that.
-    var prog = """
-          function abc(n: SInt<8>) -> SInt<8> = if n = 7 then 3 else 4
-        """;
-    var ast = Assertions.assertDoesNotThrow(() -> VadlParser.parse(prog), "Cannot parse input");
-    var typechecker = new TypeChecker();
-    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
-    Assertions.assertEquals(1, diags.items.size());
   }
 
 
@@ -960,21 +758,6 @@ public class TypecheckerTest {
     Assertions.assertEquals(Type.bits(16), finder.getConstantType(ast, "x"));
   }
 
-  @Test
-  public void invalidMatchExprPatternDifferentTypeTest() {
-    var prog = """
-          constant x = match 4 as Bits<32> with 
-          { 1 => 2 as Bits<16>
-          , 2 as Bits<8> => 4 as Bits<16>
-          , 3 => 6 as Bits<16>
-          , _ => 42 as Bits<16>
-          } 
-        """;
-    var ast = Assertions.assertDoesNotThrow(() -> VadlParser.parse(prog), "Cannot parse input");
-    var typechecker = new TypeChecker();
-    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
-    Assertions.assertEquals(1, diags.items.size());
-  }
 
   @Test
   public void matchExprBranchesDifferentTypeInConstantTest() {
@@ -992,22 +775,6 @@ public class TypecheckerTest {
     Assertions.assertDoesNotThrow(() -> typechecker.verify(ast), "Program isn't typesafe");
     var finder = new AstFinder();
     Assertions.assertEquals(Type.bits(64), finder.getConstantType(ast, "x"));
-  }
-
-  @Test
-  public void invalidMatchExprBranchesDifferentTypeInFunctionTest() {
-    var prog = """
-          function x(n: SInt<8>) -> Bits<64> = (match n with 
-          { 1 => 2 as Bits<16>
-          , 2 => 4 as Bits<32>
-          , 3 => 6 as Bits<8>
-          , _ => 42 as Bits<64>
-          } ) as Bits<64>
-        """;
-    var ast = Assertions.assertDoesNotThrow(() -> VadlParser.parse(prog), "Cannot parse input");
-    var typechecker = new TypeChecker();
-    var diags = Assertions.assertThrows(DiagnosticList.class, () -> typechecker.verify(ast));
-    Assertions.assertEquals(1, diags.items.size());
   }
 
 
@@ -1235,6 +1002,5 @@ public class TypecheckerTest {
     var typechecker = new TypeChecker();
     Assertions.assertDoesNotThrow(() -> typechecker.verify(ast), "Program isn't typesafe");
   }
-
 
 }


### PR DESCRIPTION
For now this only includes the typechecker because I wanted to get some feedback here.


**Question for the reviewers:**

1) Are you happy with the snapshot layout, I deviated a bit from the issue but I think it's still quite clear what's happending in the tests.

2) Is the updating process clear and simple enough with: `UPDATE_SNAPSHOTS=true ./gradlew test --tests vadl.ast.DiagnosticsTest`?


I think these tests already found some regressions in the diagnostic printing because some diagnostics don't look as good as I remember them, and I'm quite happy we finally have tests that show that. Though this PR doesn't make any attempts to fix them and they will be improved in future releases.