### PR TITLE
cosim: Improve cosim error messages

### DIFF
--- a/vadl-cosim/Cargo.lock
+++ b/vadl-cosim/Cargo.lock
@@ -3,6 +3,21 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -66,12 +81,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
-
-[[package]]
 name = "atomic"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -87,13 +96,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "beau_collector"
-version = "0.2.1"
+name = "backtrace"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33a143066d3cbd3d32c15b51c39449e50e32a68293d31589fb941d6a9df0df4f"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
 dependencies = [
- "anyhow",
- "itertools",
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link",
 ]
 
 [[package]]
@@ -164,6 +178,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
+name = "color-eyre"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5920befb47832a6d61ee3a3a846565cfa39b331331e68a3b1d1116630f2f26d"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8b88ea9df13354b55bc7234ebcce36e6ef896aca2e42a15de9e10edce01b427"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,9 +228,8 @@ dependencies = [
 name = "cosim-lib"
 version = "0.1.0"
 dependencies = [
- "anyhow",
- "beau_collector",
  "clap",
+ "color-eyre",
  "figment",
  "fnv",
  "libc",
@@ -336,12 +376,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "either"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
 name = "enum-map"
 version = "2.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -399,6 +433,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "eyre"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
+dependencies = [
+ "indenter",
+ "once_cell",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -448,6 +492,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -484,6 +534,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
+name = "indenter"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
+
+[[package]]
 name = "indexmap"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -498,15 +554,6 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
-name = "itertools"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itoa"
@@ -562,6 +609,15 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
 
 [[package]]
 name = "mio"
@@ -661,6 +717,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -671,6 +736,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "owo-colors"
+version = "4.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
 
 [[package]]
 name = "parking_lot"
@@ -759,6 +830,12 @@ dependencies = [
  "libsqlite3-sys",
  "smallvec",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustix"
@@ -1040,6 +1117,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-error"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1581020d7a273442f5b45074a6a57d5757ad0a47dac0e9f0bd57b81936f3db"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-log"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1107,8 +1194,8 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 name = "vadl-cosim-broker"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "clap",
+ "color-eyre",
  "cosim-lib",
  "figment",
  "serde_yaml",
@@ -1120,8 +1207,8 @@ dependencies = [
 name = "vadl-cosim-tui"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "clap",
+ "color-eyre",
  "cosim-lib",
  "cursive",
  "figment",

--- a/vadl-cosim/broker/Cargo.toml
+++ b/vadl-cosim/broker/Cargo.toml
@@ -9,11 +9,10 @@ sqlite-tracing = ["cosim-lib/sqlite-tracing"]
 [dependencies]
 cosim-lib = { path = "../cosim-lib" }
 
-anyhow = "1.0.100"
-
 clap = { version = "4.5.51", features = ["derive"] }
 figment = { version = "0.10.19", features = ["toml"] }
 
 tracing = { version = "0.1.41", features = ["attributes"] }
 tracing-subscriber = "0.3.20"
 serde_yaml = "0.9.34"
+color-eyre = "0.6.5"

--- a/vadl-cosim/broker/src/main.rs
+++ b/vadl-cosim/broker/src/main.rs
@@ -1,7 +1,10 @@
-use std::{fs, path::Path, str::FromStr};
+use std::{path::Path, str::FromStr};
 
-use anyhow::{Result, bail};
 use clap::Parser;
+use color_eyre::{
+    Result,
+    eyre::bail,
+};
 use figment::{
     Figment,
     providers::{Format, Toml},
@@ -34,7 +37,7 @@ pub struct Cli {
     /// If set, writes the test-result to the given output-file.
     /// Overrides the value that is set in the config file at testing.protocol.out.file
     #[arg(short, long, value_name = "FILE")]
-    pub output_file: Option<String>
+    pub output_file: Option<String>,
 }
 
 fn default_config_file() -> String {
@@ -42,6 +45,8 @@ fn default_config_file() -> String {
 }
 
 fn main() -> Result<()> {
+    color_eyre::install()?;
+
     let cli = Cli::parse();
 
     let config_path = Path::new(&cli.config);
@@ -53,7 +58,7 @@ fn main() -> Result<()> {
         bail!("The provided path \"{}\" is not a file", cli.config);
     }
 
-    let mut config: Config = Figment::new().merge(Toml::file(cli.config)).extract()?
+    let mut config: Config = Figment::new().merge(Toml::file(cli.config)).extract()?;
 
     config.qemu.set_inverse_reg_map();
 
@@ -100,9 +105,9 @@ fn main() -> Result<()> {
 
     #[cfg(feature = "sqlite-tracing")]
     if config.tracing.mode.enabled() && config.tracing.clear_on_rerun {
-        use anyhow::Context;
+        use color_eyre::eyre::WrapErr;
         let mut conn = connect(&config)?;
-        setup_database(&mut conn).context("failed to setup database")?;
+        setup_database(&mut conn).wrap_err("failed to setup database")?;
     }
 
     run(config)

--- a/vadl-cosim/config.toml
+++ b/vadl-cosim/config.toml
@@ -157,7 +157,7 @@ pc = "pc"
 # "tb-strict": The execution-step is the *execution of a single translation-blocks*.
 #			   The same as "tb" but without the synchronization logic. Meaning that equal translation-blocks are assumed.
 #			   This option is useful if the instructions of the ISS are already correct and the TB-Block generator needs to be tested.
-layer = "tb"
+layer = "insn"
 
 # "lockstep": All clients are run and compared one *execution-step* at a time.
 # 			  This means that the test will exit on the first divergence (or at the end if no diffs where found) 

--- a/vadl-cosim/cosim-lib/Cargo.toml
+++ b/vadl-cosim/cosim-lib/Cargo.toml
@@ -7,10 +7,9 @@ edition = "2024"
 sqlite-tracing = ["dep:rusqlite"]
 
 [dependencies]
-anyhow = "1.0.100"
-beau_collector = "0.2.1"
 
 clap = { version = "4.5.51", features = ["derive"] }
+color-eyre = "0.6.5"
 figment = { version = "0.10.19", features = ["toml"] }
 fnv = "1.0.7"
 

--- a/vadl-cosim/cosim-lib/src/cosim/mod.rs
+++ b/vadl-cosim/cosim-lib/src/cosim/mod.rs
@@ -1,9 +1,11 @@
 use std::collections::HashSet;
-use std::fs;
 use std::path::Path;
+use std::fs;
 
-use anyhow::{Result, bail};
-use beau_collector::BeauCollector;
+use color_eyre::{
+    Result, Section,
+    eyre::{Error, anyhow, bail},
+};
 use tracing::debug;
 
 #[cfg(feature = "sqlite-tracing")]
@@ -128,11 +130,7 @@ impl Broker {
         &self.clients
     }
 
-    fn add_client_logs_to_error(
-        err: anyhow::Error,
-        client_id: &str,
-        config: &Config,
-    ) -> anyhow::Error {
+    fn add_client_logs_to_error(err: Error, client_id: &str, config: &Config) -> Error {
         let base_path = Path::new(&config.logging.dir);
         let stdout_path = base_path.join(format!("client-{client_id}-stdout.txt"));
         let stderr_path = base_path.join(format!("client-{client_id}-stderr.txt"));
@@ -142,9 +140,33 @@ impl Broker {
         let stderr_content =
             fs::read_to_string(stderr_path).expect("client stderr-file should exist");
 
-        err.context(format!(
-            "Client stdout:\n{stdout_content}\n\nClient stderr:\n{stderr_content}"
+        err.note(format!(
+            "\nClient stdout:\n{stdout_content}\n\nClient stderr:\n{stderr_content}"
         ))
+    }
+
+    fn bcollect<T>(iter: &mut impl Iterator<Item = Result<T>>) -> Result<Vec<T>> {
+        let mut errs = vec![];
+        let mut res = vec![];
+
+        while let Some(elem) = iter.next() {
+            match elem {
+                Ok(elem) => res.push(elem),
+                Err(elem) => errs.push(elem),
+            }
+        }
+
+        if errs.is_empty() {
+            Ok(res)
+        } else if errs.len() == 1 {
+            Err(errs.pop().unwrap())
+        } else {
+            let mut report = anyhow!("Multiple errors occurred");
+            while let Some(err) = errs.pop() {
+                report = report.wrap_err(format!("{err:?}"));
+            }
+            Err(report)
+        }
     }
 
     fn run_lockstep(&mut self, config: &Config) -> Result<Report> {
@@ -169,20 +191,16 @@ impl Broker {
             crate::config::ProtocolLayer::Insn => loop {
                 let c1name = self.clients[0].name_or_id();
                 let c2name = self.clients[1].name_or_id();
-                let reads = self
-                    .clients
-                    .iter_mut()
-                    .rev()
-                    .map(|client| {
-                        let res = client
-                            .shm
-                            .read_buffer()
-                            .map(|opt| opt.map(|i| i.as_insn()))
-                            .map_err(|e| Broker::add_client_logs_to_error(e, &client.id, &config));
-                        client.run_count += 1;
-                        res
-                    })
-                    .bcollect::<Vec<_>>()?;
+                let mut reads = self.clients.iter_mut().rev().map(|client| {
+                    let res = client
+                        .shm
+                        .read_buffer()
+                        .map(|opt| opt.map(|i| i.as_insn()))
+                        .map_err(|e| Broker::add_client_logs_to_error(e, &client.id, &config));
+                    client.run_count += 1;
+                    res
+                });
+                let reads = Broker::bcollect(&mut reads)?;
 
                 let c1insn = reads[0];
                 let c2insn = reads[1];
@@ -219,11 +237,8 @@ impl Broker {
                                     Broker::format_insn_for_diff(&c2insn.insn_info),
                                 ],
                                 Broker::format_missing_memory_access_msg(
-                                    &c1insn,
-                                    &c2insn,
-                                    &c1name,
-                                    &c2name,
-                                )
+                                    &c1insn, &c2insn, &c1name, &c2name,
+                                ),
                             );
                             vec![diff]
                         };
@@ -359,14 +374,24 @@ impl Broker {
     }
 
     #[allow(unused_variables)]
-    fn format_missing_memory_access_msg(c1insn: &BrokerSHMInsn, c2insn: &BrokerSHMInsn, c1: &str, c2: &str) -> String {
+    fn format_missing_memory_access_msg(
+        c1insn: &BrokerSHMInsn,
+        c2insn: &BrokerSHMInsn,
+        c1: &str,
+        c2: &str,
+    ) -> String {
         let (mem_access_client, insn_exec_client) = if c1insn.mem_access_info().is_some() {
             (c1, c2)
         } else {
             (c2, c1)
         };
 
-        format!("When executing the instruction: {}\n\"{}\" wrote memory-access info to the buffer, while \"{}\" wrote an insn-execution to the buffer", Broker::format_insn_for_diff(&c1insn.insn_info), mem_access_client, insn_exec_client)
+        format!(
+            "When executing the instruction: {}\n\"{}\" wrote memory-access info to the buffer, while \"{}\" wrote an insn-execution to the buffer",
+            Broker::format_insn_for_diff(&c1insn.insn_info),
+            mem_access_client,
+            insn_exec_client
+        )
     }
 
     fn format_insn_for_diff(insn: &TBInsnInfo) -> String {
@@ -512,7 +537,7 @@ impl Broker {
         }
     }
 
-    fn build_diff_context(&mut self, config: &Config) -> anyhow::Result<DiffContext> {
+    fn build_diff_context(&mut self, config: &Config) -> Result<DiffContext> {
         let mut before_states = get_all_clients_contexts_before(&self.clients, config);
         let mut after_states = get_all_clients_contexts_current(&mut self.clients, config)?;
         let mut error_instructions = get_all_clients_instructions(&self.clients, config);

--- a/vadl-cosim/cosim-lib/src/db/mod.rs
+++ b/vadl-cosim/cosim-lib/src/db/mod.rs
@@ -1,5 +1,5 @@
 #![cfg(feature = "sqlite-tracing")] 
-use anyhow::bail;
+use color_eyre::eyre::{Result, bail, Error};
 
 use rusqlite::{Transaction, params, Connection};
 
@@ -35,7 +35,7 @@ pub struct CosimRunInfo {
 pub fn insert_new_cosimulation_run(
     pool: &mut DBConnection,
     clients: &Vec<qemu::Client>,
-) -> Result<CosimRunInfo, anyhow::Error> {
+) -> Result<CosimRunInfo> {
     let tx = pool.transaction()?;
 
     tx.execute(r#"INSERT INTO cosimulation_run DEFAULT VALUES"#, params![])?;
@@ -57,7 +57,7 @@ pub fn finish_cosimulation_run_trace(
     pool: &mut DBConnection,
     run: CosimRunInfo,
     passed: bool,
-) -> Result<(), anyhow::Error> {
+) -> Result<()> {
     pool.execute(
         r#"UPDATE cosimulation_run SET end = CURRENT_TIMESTAMP, passed = ? WHERE id = ?"#,
         params![passed, run.run_id],
@@ -76,7 +76,7 @@ pub fn insert_client_entry(
     client_id: i64,
     broker_id: i64,
     run_count: u64,
-) -> Result<(), anyhow::Error> {
+) -> Result<()> {
     pool.execute(
         r#"INSERT INTO client_entry(client_id, broker_id, run_count) VALUES (?, ?, ?)"#,
         params![client_id, broker_id, run_count],
@@ -88,7 +88,7 @@ pub fn insert_cosim_run_client(
     tx: &rusqlite::Transaction<'_>,
     run_id: i64,
     client_id: i64,
-) -> Result<(), anyhow::Error> {
+) -> Result<()> {
     tx.execute(
         r#"INSERT INTO cosimulation_run_clients(run_id, client_id) VALUES (?, ?)"#,
         params![run_id, client_id],
@@ -99,7 +99,7 @@ pub fn insert_cosim_run_client(
 pub fn insert_broker_shm_tb(
     pool: &mut DBConnection,
     broker: &cstructs::BrokerSHMTB,
-) -> Result<i64, anyhow::Error> {
+) -> Result<i64> {
     let tx = pool.transaction()?;
 
     let tb_info_id = insert_tb_info(&tx, &broker.tb_info)?;
@@ -137,7 +137,7 @@ pub fn insert_broker_shm_tb(
 pub fn insert_broker_shm_insn(
     pool: &mut DBConnection,
     broker: &cstructs::BrokerSHMInsn,
-) -> Result<i64, anyhow::Error> {
+) -> Result<i64> {
     let tx = pool.transaction()?;
 
     let insn_info_id = insert_tb_insn_info(&tx, None, &broker.insn_info)?;
@@ -175,7 +175,7 @@ pub fn insert_broker_shm_insn(
 fn insert_tb_info(
     tx: &rusqlite::Transaction<'_>,
     tb_info: &cstructs::TBInfo,
-) -> Result<i64, anyhow::Error> {
+) -> Result<i64> {
     let pc = tb_info.pc as i64;
     tx.execute("INSERT INTO tb_info (pc) VALUES (?)", params![pc])?;
 
@@ -192,7 +192,7 @@ fn insert_tb_insn_info(
     tx: &rusqlite::Transaction<'_>,
     tb_info_id: Option<i64>,
     insn: &cstructs::TBInsnInfo,
-) -> Result<i64, anyhow::Error> {
+) -> Result<i64> {
     let pc = insn.pc as i64;
     let size = insn.size as i64;
     let symbol = insn.symbol.as_str();
@@ -225,7 +225,7 @@ fn insert_shm_cpu(
     tx: &rusqlite::Transaction<'_>,
     broker_id: i64,
     cpu: &cstructs::SHMCPU,
-) -> Result<i64, anyhow::Error> {
+) -> Result<i64> {
     tx.execute(
         "INSERT INTO cpu (idx, broker_id) VALUES (?, ?)",
         params![cpu.idx, broker_id],
@@ -238,7 +238,7 @@ fn insert_shm_registers(
     tx: &rusqlite::Transaction<'_>,
     cpu_id: i64,
     registers: &[cstructs::SHMRegister],
-) -> Result<(), anyhow::Error> {
+) -> Result<()> {
     for reg in registers {
         tx.execute(
             "INSERT INTO register (cpu_id, size, data, name) VALUES (?, ?, ?, ?)",
@@ -251,7 +251,7 @@ fn insert_shm_registers(
 pub fn select_registers(
     tx: &rusqlite::Transaction<'_>,
     cpu_id: i64,
-) -> Result<Vec<Register>, anyhow::Error> {
+) -> Result<Vec<Register>> {
     let mut stmt = tx.prepare("SELECT name, size, data FROM register WHERE cpu_id = ?")?;
     stmt.query_map([cpu_id], |row| {
         let name = row.get(0)?;
@@ -260,10 +260,10 @@ pub fn select_registers(
         Ok(Register::new(size, data, name))
     })?
     .collect::<Result<_, _>>()
-    .map_err(anyhow::Error::from)
+    .map_err(Error::from)
 }
 
-pub fn select_cpu(tx: &rusqlite::Transaction<'_>, cpu_id: i64) -> Result<CPU, anyhow::Error> {
+pub fn select_cpu(tx: &rusqlite::Transaction<'_>, cpu_id: i64) -> Result<CPU> {
     let mut stmt = tx.prepare(r#"SELECT idx FROM cpu WHERE id = ?"#)?;
     let cpu_idx = stmt.query_one(params![cpu_id], |row| row.get(0))?;
 
@@ -273,7 +273,7 @@ pub fn select_cpu(tx: &rusqlite::Transaction<'_>, cpu_id: i64) -> Result<CPU, an
     Ok(cpu)
 }
 
-pub fn select_broker_cpus(tx: &Transaction<'_>, broker_id: i32) -> Result<Vec<CPU>, anyhow::Error> {
+pub fn select_broker_cpus(tx: &Transaction<'_>, broker_id: i32) -> Result<Vec<CPU>> {
     let mut cpus = vec![];
     let mut stmt = tx.prepare(r#"SELECT c.id FROM cpu c WHERE c.broker_id = ?"#)?;
     let cpu_ids = stmt
@@ -309,7 +309,7 @@ fn map_tb_insn_info_row(row: &rusqlite::Row<'_>) -> Result<TBInsnInfo, rusqlite:
 pub fn select_tb_insn_info_by_id(
     tx: &Transaction<'_>,
     tb_insn_info_id: i64,
-) -> Result<TBInsnInfo, anyhow::Error> {
+) -> Result<TBInsnInfo> {
     let mut stmt = tx.prepare(
         r#"
         SELECT
@@ -332,7 +332,7 @@ pub fn select_tb_insn_info_by_id(
 pub fn select_tb_info_by_id(
     tx: &Transaction<'_>,
     tb_info_id: i64,
-) -> Result<TBInfo, anyhow::Error> {
+) -> Result<TBInfo> {
     let mut tb_info_stmt = tx.prepare(r#"SELECT pc FROM tb_info WHERE id = ?"#)?;
     let tb_info_pc = tb_info_stmt.query_one(params![tb_info_id], |row| row.get(0))?;
 
@@ -359,7 +359,7 @@ pub fn select_tb_info_by_id(
     Ok(tb_info)
 }
 
-pub fn select_broker_tb(tx: &Transaction<'_>, broker_id: i32) -> Result<BrokerTB, anyhow::Error> {
+pub fn select_broker_tb(tx: &Transaction<'_>, broker_id: i32) -> Result<BrokerTB> {
     let (init_mask, tb_info_id) = tx.query_one(
         r#"
             SELECT init_mask, tb_info_id
@@ -380,7 +380,7 @@ pub fn select_broker_tb(tx: &Transaction<'_>, broker_id: i32) -> Result<BrokerTB
 pub fn select_broker_insn(
     tx: &Transaction<'_>,
     broker_id: i32,
-) -> Result<BrokerInsn, anyhow::Error> {
+) -> Result<BrokerInsn> {
     let (init_mask, insn_info_id) = tx.query_one(
         r#"
             SELECT init_mask, insn_info_id
@@ -398,7 +398,7 @@ pub fn select_broker_insn(
     Ok(BrokerInsn::new(init_mask, cpus, insn_info))
 }
 
-pub fn select_broker(tx: &Transaction<'_>, broker_id: i32) -> Result<BrokerData, anyhow::Error> {
+pub fn select_broker(tx: &Transaction<'_>, broker_id: i32) -> Result<BrokerData> {
     let broker_type = tx.query_one(
         r#"SELECT type FROM broker WHERE id = ?"#,
         params![broker_id],
@@ -418,7 +418,7 @@ pub fn select_client_entry_with_run_count(
     tx: &Transaction<'_>,
     client_id: i32,
     run_count: u64,
-) -> Result<ClientEntry, anyhow::Error> {
+) -> Result<ClientEntry> {
     let (broker_id, client_id, client_name) = tx.query_one(
         r#"
             SELECT ce.broker_id, c.id, c.name 
@@ -446,7 +446,7 @@ pub fn select_cosim_run_entries_at_run_count(
     pool: &mut DBConnection,
     client_ids: &[i32],
     run_count: u64,
-) -> Result<Vec<ClientEntry>, anyhow::Error> {
+) -> Result<Vec<ClientEntry>> {
     client_ids
         .iter()
         .map(|client_id| {
@@ -455,13 +455,13 @@ pub fn select_cosim_run_entries_at_run_count(
             tx.commit()?;
             Ok(entry)
         })
-        .collect::<Result<Vec<_>, anyhow::Error>>()
+        .collect::<Result<Vec<_>>>()
 }
 
 pub fn select_cosim_run_entries_length(
     pool: &mut DBConnection,
     run_id: i64,
-) -> Result<u64, anyhow::Error> {
+) -> Result<u64> {
     let mut stmt = pool.prepare(
         r#"
         SELECT MAX(run_count)
@@ -479,7 +479,7 @@ pub fn select_cosim_run_entries_length(
 pub fn select_cosim_run_clients(
     pool: &mut DBConnection,
     run_id: i64,
-) -> Result<Vec<Client>, anyhow::Error> {
+) -> Result<Vec<Client>> {
     let mut stmt = pool.prepare(
         r#"
         SELECT c.id, c.name 

--- a/vadl-cosim/cosim-lib/src/diff/mod.rs
+++ b/vadl-cosim/cosim-lib/src/diff/mod.rs
@@ -1,6 +1,6 @@
 use std::{collections::VecDeque, fmt::Debug};
 
-use anyhow::anyhow;
+use color_eyre::{eyre::anyhow, Result};
 use serde::Serialize;
 
 use crate::{
@@ -207,7 +207,7 @@ pub fn get_client_context_before(client: &Client, config: &Config) -> DiffContex
 pub fn get_all_clients_contexts_current(
     clients: &mut [Client],
     config: &Config,
-) -> anyhow::Result<VecDeque<DiffContextClientState>> {
+) -> Result<VecDeque<DiffContextClientState>> {
     clients
         .iter_mut()
         .map(|client| get_client_context_current(client, config))
@@ -217,7 +217,7 @@ pub fn get_all_clients_contexts_current(
 pub fn get_client_context_current(
     client: &mut Client,
     config: &Config,
-) -> anyhow::Result<DiffContextClientState> {
+) -> Result<DiffContextClientState> {
     match config.testing.protocol.layer {
         crate::config::ProtocolLayer::Insn => {
             let ctx = (

--- a/vadl-cosim/cosim-lib/src/ipc/cstructs.rs
+++ b/vadl-cosim/cosim-lib/src/ipc/cstructs.rs
@@ -4,7 +4,7 @@ use std::{
     time::Duration,
 };
 
-use anyhow::bail;
+use color_eyre::{eyre::bail, Result};
 use serde::{Serialize, ser::SerializeStruct};
 use tracing::{debug, warn};
 
@@ -477,7 +477,7 @@ pub struct BrokerSHMRingBuffer<const SIZE: usize> {
 impl<const SIZE: usize> BrokerSHMRingBuffer<SIZE> {
     const MASK: usize = SIZE - 1;
 
-    pub fn init(&mut self) -> anyhow::Result<()> {
+    pub fn init(&mut self) -> Result<()> {
         debug!("init ringbuffer with size: {SIZE}");
 
         self.data = unsafe { mem::zeroed() };
@@ -509,7 +509,7 @@ impl<const SIZE: usize> BrokerSHMRingBuffer<SIZE> {
     ///
     /// NOTE: `end_read` has to be called once the reference is not needed anymore to free the
     /// index in the ringbuffer for new writes.
-    pub fn start_read(&mut self) -> anyhow::Result<Option<&BrokerSHMData>> {
+    pub fn start_read(&mut self) -> Result<Option<&BrokerSHMData>> {
         if self.count.load(Ordering::SeqCst) == 0 {
             let count_ref = &self.count;
             let write_end_ref = &self.write_end;

--- a/vadl-cosim/cosim-lib/src/ipc/qemu.rs
+++ b/vadl-cosim/cosim-lib/src/ipc/qemu.rs
@@ -4,7 +4,7 @@ use std::{
     process::{Child, Command},
 };
 
-use anyhow::{Context, Result};
+use color_eyre::{eyre::Context, Result};
 use tracing::info;
 
 use crate::{
@@ -113,7 +113,7 @@ impl Client {
             .stdout(stdout_file)
             .stderr(stderr_file)
             .spawn()
-            .with_context(|| format!("Failed to create client with idx: {client_id}"))?;
+            .wrap_err_with(|| format!("Failed to create client with idx: {client_id}"))?;
 
         Ok(Self {
             id: client_id,

--- a/vadl-cosim/cosim-lib/src/ipc/sem.rs
+++ b/vadl-cosim/cosim-lib/src/ipc/sem.rs
@@ -1,5 +1,5 @@
 use crate::{bail_on_libc_err, eprintln_on_libc_err};
-use anyhow::{Result, bail};
+use color_eyre::{Result, eyre::bail};
 use libc::{
     CLOCK_REALTIME, ETIMEDOUT, PTHREAD_PROCESS_SHARED, clock_gettime, pthread_cond_broadcast,
     pthread_cond_destroy, pthread_cond_init, pthread_cond_t, pthread_cond_timedwait,

--- a/vadl-cosim/cosim-lib/src/ipc/shm.rs
+++ b/vadl-cosim/cosim-lib/src/ipc/shm.rs
@@ -1,6 +1,6 @@
 use std::{ffi::CString, marker::PhantomData, ptr};
 
-use anyhow::{Context, Result, bail};
+use color_eyre::{eyre::{Context, bail}, Result};
 use libc::{
     close, ftruncate, mmap, munmap, shm_open, shm_unlink, MAP_FAILED, MAP_SHARED, O_CREAT, O_EXCL, O_RDWR, PROT_READ, PROT_WRITE
 };
@@ -23,7 +23,7 @@ pub struct SharedMemory<T: Sized> {
 }
 
 impl<const SIZE: usize> SharedMemory<BrokerSHMRingBuffer<SIZE>> {
-    pub fn read_buffer(&mut self) -> anyhow::Result<Option<&BrokerSHMData>> {
+    pub fn read_buffer(&mut self) -> Result<Option<&BrokerSHMData>> {
         self.get_mut().start_read()
     }
 

--- a/vadl-cosim/cosim-lib/src/trace/mod.rs
+++ b/vadl-cosim/cosim-lib/src/trace/mod.rs
@@ -2,7 +2,7 @@
 
 use std::path::Path;
 
-use anyhow::{Context, Result, anyhow};
+use color_eyre::eyre::{Result, anyhow, Context};
 
 use crate::{
     config::Config,
@@ -43,7 +43,7 @@ pub fn connect(config: &Config) -> Result<Connection> {
         | OpenFlags::SQLITE_OPEN_NO_MUTEX;
     let path = Path::new(&config.tracing.dir).join(&config.tracing.file);
     Connection::open_with_flags(path, connect_flags)
-        .context("failed to open sqlite connection for tracing")
+        .wrap_err("failed to open sqlite connection for tracing")
 }
 
 pub fn store_trace(trace: TraceEntryData, connection: &mut Connection) -> Result<()> {
@@ -67,7 +67,7 @@ pub fn store_trace(trace: TraceEntryData, connection: &mut Connection) -> Result
 pub fn get_client_trace(
     client: &mut crate::ipc::qemu::Client,
     config: &Config,
-) -> anyhow::Result<TraceBrokerData> {
+) -> Result<TraceBrokerData> {
     let data = match config.testing.protocol.layer {
         crate::config::ProtocolLayer::Insn => {
             let insn = Box::new(
@@ -101,7 +101,7 @@ pub fn trace_collect(
     client_ids: &[i64],
     config: &crate::config::Config,
     store: &mut TraceStore,
-) -> anyhow::Result<()> {
+) -> Result<()> {
     assert!(
         clients.len() == client_ids.len(),
         "illegal call to trace_collect with different client-lens: {} != {}",

--- a/vadl-cosim/tui/Cargo.toml
+++ b/vadl-cosim/tui/Cargo.toml
@@ -8,7 +8,6 @@ sqlite-tracing = ["cosim-lib/sqlite-tracing"]
 
 [dependencies]
 cosim-lib = { path = "../cosim-lib" }
-anyhow = "1.0.100"
 
 tracing = { version = "0.1.41", features = ["attributes"] }
 tracing-subscriber = "0.3.20"
@@ -16,3 +15,4 @@ figment = { version = "0.10.19", features = ["toml"] }
 clap = { version = "4.5.51", features = ["derive"] }
 rusqlite = "0.37.0"
 cursive = { version = "0.21.1", features = ["toml"] }
+color-eyre = "0.6.5"

--- a/vadl-cosim/tui/src/main.rs
+++ b/vadl-cosim/tui/src/main.rs
@@ -2,6 +2,8 @@
 
 use std::{collections::HashMap, fmt::Debug};
 
+use color_eyre::Result;
+
 use clap::Parser;
 
 use cosim_lib::{
@@ -153,7 +155,9 @@ fn default_config_file() -> String {
     "./config.toml".into()
 }
 
-fn main() -> anyhow::Result<()> {
+fn main() -> Result<()> {
+    color_eyre::install()?;
+
     let cli = Cli::parse();
 
     let mut config: Config = Figment::new().merge(Toml::file(cli.config)).extract()?;


### PR DESCRIPTION
The first commit of this PR addresses #606 

The second one migrates the error reporting from the `anyhow` crate over to the `eyre` crate (a fork of `anyhow`) which, while being a drop-in replacement, allows more detailed error-reports (such as including the file+line location by default).