### PR TITLE
iss: Fix CTZ normalization

### DIFF
--- a/sys/ppc64/ppc64.vadl
+++ b/sys/ppc64/ppc64.vadl
@@ -1466,8 +1466,8 @@ instruction set architecture PPC64SFS = {
   $XFormExCRInstr((("EXTSB" ; 0b11101'11010); XB(rs) as SDWord                                            ))
   $XFormExCRInstr((("EXTSH" ; 0b11100'11010); XH(rs) as SDWord                                            ))
   $XFormExCRInstr((("CNTLZW"; 0b00000'11010); if XW(rs) = 0 then 32 else VADL::clz(XW(rs))       as UDWord))
-  $XFormExCRInstr((("CNTTZW"; 0b10000'11010); if XW(rs) = 0 then 32 else VADL::ctz(XW(rs))(4..0) as UDWord)) // TODO: why does ctz return negative number?
-  //$XFormExCRInstr((("CNTTZW"; 0b10000'11010); if XW(rs) = 0 then 32 else VADL::ctz(XW(rs))       as UDWord))
+//   $XFormExCRInstr((("CNTTZW"; 0b10000'11010); if XW(rs) = 0 then 32 else VADL::ctz(XW(rs))(4..0) as UDWord)) // TODO: why does ctz return negative number?
+  $XFormExCRInstr((("CNTTZW"; 0b10000'11010); if XW(rs) = 0 then 32 else VADL::ctz(XW(rs))       as UDWord))
 
   $SCFormSysCallInstr(("SC" ; 0b10); SysCall(lev)   )
   $SCFormSysCallInstr(("SCV"; 0b01); SysCallVectored)

--- a/vadl/main/vadl/iss/passes/IssNormalizationPass.java
+++ b/vadl/main/vadl/iss/passes/IssNormalizationPass.java
@@ -703,7 +703,7 @@ class IssNormalizer implements VadlBuiltInNoStatusDispatcher<BuiltInCall> {
 
   @Override
   public void handleCLZ(BuiltInCall input) {
-    var val = input.arguments().get(0);
+    var val = input.arguments().getFirst();
     var valT = val.type().asDataType();
     if (valT.bitWidth() == targetSize) {
       return;
@@ -763,8 +763,10 @@ class IssNormalizer implements VadlBuiltInNoStatusDispatcher<BuiltInCall> {
 
   @Override
   public void handleCTZ(BuiltInCall input) {
-    throw graphError(input, "Normalization not yet implemented for this built-in");
-
+    // do nothing, because a trailing zeros result is the same if it is done on a
+    // target size > input size.
+    // An exception is the input being 0, however, our QEMU's ctz is defined as
+    // input != 0 ? ctz(input) : input.size
   }
 
   @Override

--- a/vadl/main/vadl/utils/VadlBuiltInNoStatusDispatcher.java
+++ b/vadl/main/vadl/utils/VadlBuiltInNoStatusDispatcher.java
@@ -110,9 +110,9 @@ public interface VadlBuiltInNoStatusDispatcher<T> {
     } else if (builtIn == BuiltInTable.CLS) {
       handleCLS(input);
     } else if (builtIn == BuiltInTable.CTZ) {
-      handleCLZ(input);
+      handleCTZ(input);
     } else if (builtIn == BuiltInTable.CTO) {
-      handleCLO(input);
+      handleCTO(input);
     } else if (builtIn == BuiltInTable.CONCATENATE_BITS) {
       handleConcat(input);
     } else {


### PR DESCRIPTION
The built-in status dispatcher wrongly called the CLZ normalization handler instead of the CTZ one.

Closes #603.