### PR TITLE
viam: Fix invalid SMULL optimization #602

### DIFF
--- a/sys/ppc64/ppc64.vadl
+++ b/sys/ppc64/ppc64.vadl
@@ -1230,7 +1230,7 @@ instruction set architecture PPC64SFS = {
       let prod = VADL::$r.x.op(XW(ra), XW(rb)) in
         let result = $r.res as UDWord in {
           X(rs) := result
-          //$SetXERAndCRWithOV($oe; false; $rc; true)
+          $SetXERAndCRWithOV($oe; false; $rc; true)
         }
     encoding $eid = {opcd = 0b011111, oe = $oe, extopcd = $r.x.ext, rc = $rc}
     assembly $eid = ($r.x.asm, $rStr($rc), " ", decimal(rs), ",", decimal(ra), ",", decimal(rb)) // oStr not necessary

--- a/vadl/main/vadl/viam/passes/behaviorRewrite/rules/impl/MergeSMullAndTruncateToMulSimplificationRule.java
+++ b/vadl/main/vadl/viam/passes/behaviorRewrite/rules/impl/MergeSMullAndTruncateToMulSimplificationRule.java
@@ -46,6 +46,11 @@ public class MergeSMullAndTruncateToMulSimplificationRule
       for (var matching : matchings) {
         var casted = (TruncateNode) matching;
         var builtin = (BuiltInCall) casted.value();
+        if (builtin.usageCount() != 1) {
+          // if the built-in is also used by other (maybe non-truncate) nodes, we can't
+          // do this replacement
+          continue;
+        }
         builtin.setBuiltIn(BuiltInTable.MUL);
         builtin.setType(casted.type());
 


### PR DESCRIPTION
A BehaviorRewritePass optimization that turns SMULL <- Trunc sequences into MUL operations didn't take care of cases where the SMULL result is used by others than the Trunc node.

Closes #602.

The PR does not enable the MULW tests, as they are still failing, however, due to some other reason.