### PR TITLE
cosim: Fixed incorrect order of data to clients in diff output

### DIFF
--- a/vadl-cosim/cosim-lib/src/cosim/mod.rs
+++ b/vadl-cosim/cosim-lib/src/cosim/mod.rs
@@ -191,7 +191,7 @@ impl Broker {
             crate::config::ProtocolLayer::Insn => loop {
                 let c1name = self.clients[0].name_or_id();
                 let c2name = self.clients[1].name_or_id();
-                let mut reads = self.clients.iter_mut().rev().map(|client| {
+                let mut reads = self.clients.iter_mut().map(|client| {
                     let res = client
                         .shm
                         .read_buffer()


### PR DESCRIPTION
I think I forgot to remove the call to `rev()` after a debugging-session, but the bug only occurred once I had to move the `c1name` and `c2name` above the reads call.

Nevertheless, `rev()` can be safely removed, fixing #617  