### PR TITLE
sys/aarch64: Fix SMADDL instruction

### DIFF
--- a/sys/aarch64/aarch64.vadl
+++ b/sys/aarch64/aarch64.vadl
@@ -475,7 +475,7 @@ instruction set architecture AArch64Base = {
 
   model MulAddSubLongInstr (i: InstrWithFunct, type: Id): IsaDefs = {
     instruction $i.id: MulAddSubFormat =
-      X(rd) := VADL::$i.funct (X(ra), $WXReg(WSize)(rn) *# $WXReg(WSize)(rm))
+      X(rd) := VADL::$i.funct (X(ra), $WXReg(WSize)(rn) as $type *# $WXReg(WSize)(rm) as $type)
     encoding $i.id = { op = $i.opcode, sf = SF::XSize }
     assembly $i.id = ($i.mnemo, ' ', XSize(rd), ', ', WSize(rn), ', ', WSize(rm), ', ', XSize(ra))
     }

--- a/vadl/test/resources/embench/build_virt-iss-a64.sh
+++ b/vadl/test/resources/embench/build_virt-iss-a64.sh
@@ -5,5 +5,4 @@ cd $(realpath $(dirname "$0"))
 CFLAGS="-march=armv8-a -g -mstrict-align"
 # benchmarks that use floating point types must be excluded
 FLOATEXCL="cubic,nbody,minver,st,statemate,ud,wikisort"
-NOTWORKING=",edn"
-./build_all.py --cc aarch64-none-elf-gcc --arch aarch64 --chip generic --board virt-iss --clean --cflags "$CFLAGS" --exclude "$FLOATEXCL$NOTWORKING" "$@"
+./build_all.py --cc aarch64-none-elf-gcc --arch aarch64 --chip generic --board virt-iss --clean --cflags "$CFLAGS" --exclude "$FLOATEXCL" "$@"


### PR DESCRIPTION
The `SMADDL` instruction in AArch64 was wrong.
The `type` argument of the `MulAddSubLongInstr` was never used and therefore, the instruction used a `usmull` instead of `smull`. 

Closes #460.