### PR TITLE
lcb: Setup intrinsic attributes

### DIFF
--- a/vadl/main/vadl/gcb/passes/DetermineIntrinsicAttributesPass.java
+++ b/vadl/main/vadl/gcb/passes/DetermineIntrinsicAttributesPass.java
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.gcb.passes;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import javax.annotation.Nullable;
+import vadl.configuration.GcbConfiguration;
+import vadl.pass.Pass;
+import vadl.pass.PassName;
+import vadl.pass.PassResults;
+import vadl.viam.Instruction;
+import vadl.viam.Specification;
+import vadl.viam.graph.Graph;
+import vadl.viam.graph.WritesRegisterTensor;
+import vadl.viam.graph.dependency.ProcCallNode;
+import vadl.viam.graph.dependency.ReadMemNode;
+import vadl.viam.graph.dependency.WriteMemNode;
+import vadl.viam.passes.SnapshotInstructionBehaviorPass;
+
+/**
+ * Compute the intrinsic attributes for a {@link Instruction}.
+ */
+public class DetermineIntrinsicAttributesPass extends Pass {
+  public DetermineIntrinsicAttributesPass(GcbConfiguration gcbConfiguration) {
+    super(gcbConfiguration);
+  }
+
+  @Override
+  public PassName getName() {
+    return new PassName("DetermineIntrinsicAttributesPass");
+  }
+
+  @Nullable
+  @Override
+  public Object execute(PassResults passResults, Specification viam) throws IOException {
+    var snapshots =
+        (Map<Instruction, Graph>) passResults.lastResultOf(SnapshotInstructionBehaviorPass.class);
+    IdentityHashMap<Instruction, List<InstructionIntrinsicAttributesCtx.Attribute>> map =
+        new IdentityHashMap<>();
+
+    for (var instruction : viam.isa().orElseThrow().ownInstructions()) {
+      var snapshot = Objects.requireNonNull(snapshots.get(instruction));
+      var isNoMem = isNoMem(snapshot);
+      var willReturn = willReturn(snapshot);
+      var speculatable = speculatable(snapshot);
+
+      var attributes = new ArrayList<InstructionIntrinsicAttributesCtx.Attribute>();
+      if (isNoMem) {
+        attributes.add(InstructionIntrinsicAttributesCtx.Attribute.NoMem);
+      }
+      if (willReturn) {
+        attributes.add(InstructionIntrinsicAttributesCtx.Attribute.WillReturn);
+      } else {
+        attributes.add(InstructionIntrinsicAttributesCtx.Attribute.NoReturn);
+      }
+      if (speculatable) {
+        attributes.add(InstructionIntrinsicAttributesCtx.Attribute.Speculatable);
+      }
+
+      map.put(instruction, attributes);
+      instruction.attachExtension(new InstructionIntrinsicAttributesCtx(attributes));
+    }
+
+    return map;
+  }
+
+  private boolean isMem(Graph snapshot) {
+    return !snapshot.getNodes(WriteMemNode.class).toList().isEmpty()
+        || !snapshot.getNodes(ReadMemNode.class).toList().isEmpty();
+  }
+
+  private boolean isNoMem(Graph snapshot) {
+    return !isMem(snapshot);
+  }
+
+  private boolean willReturn(Graph snapshot) {
+    return !snapshot.getNodes(WritesRegisterTensor.class).toList().isEmpty();
+  }
+
+  /**
+   * Compute a special attribute for LLVM.
+   * The following conditions must hold:
+   * x) No side effects
+   * x) Does not write memory
+   * x) Does not perform I/O
+   * x) Does not change global state
+   * x) Cannot trap or fault
+   * x) No division-by-zero traps
+   */
+  private boolean speculatable(Graph snapshot) {
+    return isNoMem(snapshot) && snapshot.getNodes(ProcCallNode.class).toList().isEmpty();
+  }
+}

--- a/vadl/main/vadl/gcb/passes/InstructionIntrinsicAttributesCtx.java
+++ b/vadl/main/vadl/gcb/passes/InstructionIntrinsicAttributesCtx.java
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.gcb.passes;
+
+import java.util.List;
+import vadl.viam.Definition;
+import vadl.viam.DefinitionExtension;
+import vadl.viam.Instruction;
+
+/**
+ * An extension for the {@link Instruction}. It will be used to indicate what the attributes for the
+ * intrinsic of the {@link Instruction} are.
+ */
+public class InstructionIntrinsicAttributesCtx extends DefinitionExtension<Instruction> {
+  /**
+   * Attributes for the intrinsic.
+   */
+  public enum Attribute {
+    NoMem,
+    WillReturn,
+    NoReturn,
+    Speculatable
+  }
+
+  private final List<Attribute> attributes;
+
+  public InstructionIntrinsicAttributesCtx(List<Attribute> attributes) {
+    this.attributes = attributes;
+  }
+
+  public List<Attribute> getAttributes() {
+    return attributes;
+  }
+
+  @Override
+  public Class<? extends Definition> extendsDefClass() {
+    return Definition.class;
+  }
+}

--- a/vadl/main/vadl/pass/PassOrders.java
+++ b/vadl/main/vadl/pass/PassOrders.java
@@ -32,6 +32,7 @@ import vadl.configuration.LcbConfiguration;
 import vadl.configuration.RtlConfiguration;
 import vadl.dump.CollectBehaviorDotGraphPass;
 import vadl.dump.HtmlDumpPass;
+import vadl.gcb.passes.DetermineIntrinsicAttributesPass;
 import vadl.gcb.passes.DetermineRegisterUsesAndDefsPass;
 import vadl.gcb.passes.DetermineRelocationTypeForFieldPass;
 import vadl.gcb.passes.GenerateCompilerRegistersPass;
@@ -259,6 +260,7 @@ public class PassOrders {
     order.add(new DetermineRegisterUsesAndDefsPass(gcbConfiguration));
     order.add(new GenerateInstructionOperandsPass(gcbConfiguration));
     order.add(new InstructionPatternPruningPass(gcbConfiguration));
+    order.add(new DetermineIntrinsicAttributesPass(gcbConfiguration));
 
     addHtmlDump(order, gcbConfiguration, "gcbProcessing",
         "Now the gcb produced all necessary encoding function for field accesses "

--- a/vadl/test/vadl/gcb/riscv/riscv64/passes/DetermineIntrinsicAttributesPassTest.java
+++ b/vadl/test/vadl/gcb/riscv/riscv64/passes/DetermineIntrinsicAttributesPassTest.java
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.gcb.riscv.riscv64.passes;
+
+import static vadl.gcb.passes.InstructionIntrinsicAttributesCtx.Attribute.NoMem;
+import static vadl.gcb.passes.InstructionIntrinsicAttributesCtx.Attribute.Speculatable;
+import static vadl.gcb.passes.InstructionIntrinsicAttributesCtx.Attribute.WillReturn;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import vadl.gcb.AbstractGcbTest;
+import vadl.gcb.passes.DetermineIntrinsicAttributesPass;
+import vadl.gcb.passes.InstructionIntrinsicAttributesCtx;
+import vadl.pass.PassKey;
+import vadl.pass.exception.DuplicatedPassKeyException;
+import vadl.viam.Instruction;
+
+public class DetermineIntrinsicAttributesPassTest extends AbstractGcbTest {
+  public static Stream<Arguments> expected() {
+    return Stream.of(
+        Arguments.of("ADD", List.of(NoMem, WillReturn, Speculatable)),
+        Arguments.of("SUB", List.of(NoMem, WillReturn, Speculatable)),
+        Arguments.of("MUL", List.of(NoMem, WillReturn, Speculatable))
+    );
+  }
+
+  @MethodSource(value = "expected")
+  @ParameterizedTest
+  void shouldDetect(String instructionName,
+                    List<InstructionIntrinsicAttributesCtx.Attribute> attrs)
+      throws DuplicatedPassKeyException, IOException {
+    // Given
+    var setup = runGcb(getConfiguration(false), "sys/risc-v/rv64im.vadl",
+        new PassKey(DetermineIntrinsicAttributesPassTest.class.getName()));
+    var passManager = setup.passManager();
+
+    // When
+    var result =
+        ((Map<Instruction, List<InstructionIntrinsicAttributesCtx.Attribute>>) passManager.getPassResults()
+            .lastResultOf(DetermineIntrinsicAttributesPass.class)).entrySet().stream().collect(
+            Collectors.toMap(x -> x.getKey().simpleName(), Map.Entry::getValue));
+
+    // Then
+    Assertions.assertNotNull(result);
+    Assertions.assertNotNull(result.get(instructionName));
+    Assertions.assertEquals(result.get(instructionName), attrs);
+  }
+}


### PR DESCRIPTION
Setup a pass to compute intrinsic attributes. For more information [see](https://github.com/10x-Engineers/clang-builtin-tutorial?tab=readme-ov-file#step-5---adding-intrinsic-definiton-in-middle-end). The current implementation only supports three attributes. An extension would be to support memory instructions which is important for vectorization.