### PR TITLE
chore: Prevent LSP `run` and `installDist` tasks on root `run/installDist`

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ For example, you can create the ISS (Instruction Set Simulator) for a minimal ri
 
 To get a description of the complete usage, you can run: `./gradlew run --args="--help"`
 
+### Running the LSP
+
+The LSP (Language Server Protocol) can be started with `./gradlew vadl-lsp:run`.
+
 ### Building
 
 You can build and run in two steps with

--- a/vadl-lsp/build.gradle.kts
+++ b/vadl-lsp/build.gradle.kts
@@ -24,6 +24,16 @@ application {
     mainClass.set("vadl.lsp.Main")
 }
 
+// Tasks that should only be executed if the concrete path was specified (using the vadl-lsp: prefix)
+var pathSpecificTasks = with(tasks) {
+    setOf(run, installDist)
+}.map { it.name }
+tasks.filter { it.name in pathSpecificTasks }.forEach { it ->
+    it.onlyIf {
+        gradle.startParameter.taskNames.any { it.contains("vadl-lsp:") }
+    }
+}
+
 tasks.test {
     useJUnitPlatform()
 }


### PR DESCRIPTION
Closes #629 by preventing that Gradle executes `vadl-lsp:run` when executing `./gradlew run`.
The same applies to `installDist`.