### PR TITLE
iss: Parallelize ppc64/main.py testing script

### DIFF
--- a/vadl-cosim/cosim-lib/src/ipc/cstructs.rs
+++ b/vadl-cosim/cosim-lib/src/ipc/cstructs.rs
@@ -557,7 +557,7 @@ impl<const SIZE: usize> BrokerSHMRingBuffer<SIZE> {
     // Once end_read is called, the reference is no longer valid, therefore the value needs to
     // already be used or cloned once `end_read` is called.
     pub const fn read_previous(&self) -> &BrokerSHMData {
-        let idx = self.ring_idx(self.read_idx - 1);
+        let idx = self.ring_idx(self.read_idx.wrapping_sub(1));
         &self.data[idx]
     }
 

--- a/vadl-cosim/cosim-lib/src/ipc/mod.rs
+++ b/vadl-cosim/cosim-lib/src/ipc/mod.rs
@@ -39,7 +39,7 @@ macro_rules! bail_on_libc_err {
         let res = $expr;
         if res != 0 {
             let s = stringify!($expr);
-            bail!(get_last_error(&format!("{s} failed")))
+            bail!(get_last_error(&format!("{s} failed (with return: {res:?})")))
         }
         res
     }};
@@ -47,7 +47,7 @@ macro_rules! bail_on_libc_err {
         let res = $expr;
         if res == $errcode {
             let s = stringify!($expr);
-            bail!(get_last_error(&format!("{s} failed")))
+            bail!(get_last_error(&format!("{s} failed (with return: {res:?})")))
         }
         res
     }};
@@ -56,15 +56,17 @@ macro_rules! bail_on_libc_err {
 #[macro_export]
 macro_rules! eprintln_on_libc_err {
     ($expr:expr) => {
-        if $expr != 0 {
+        let res = $expr;
+        if res != 0 {
             let s = stringify!($expr);
-            eprintln!("{}", get_last_error(&format!("{s} failed")))
+            eprintln!("{}", get_last_error(&format!("{s} failed (with return: {res:?})")))
         }
     };
     ($expr:expr, $errcode:expr) => {
-        if $expr == $errcode {
+        let res = $expr;
+        if res == $errcode {
             let s = stringify!($expr);
-            eprintln!("{}", get_last_error(&format!("{s} failed")))
+            eprintln!("{}", get_last_error(&format!("{s} failed (with return: {res:?})")))
         }
     };
 }

--- a/vadl-cosim/cosim-lib/src/ipc/shm.rs
+++ b/vadl-cosim/cosim-lib/src/ipc/shm.rs
@@ -2,7 +2,7 @@ use std::{ffi::CString, marker::PhantomData, ptr};
 
 use color_eyre::{eyre::{Context, bail}, Result};
 use libc::{
-    close, ftruncate, mmap, munmap, shm_open, shm_unlink, MAP_FAILED, MAP_SHARED, O_CREAT, O_EXCL, O_RDWR, PROT_READ, PROT_WRITE
+    MAP_FAILED, MAP_SHARED, O_CREAT, O_EXCL, O_RDWR, PROT_READ, PROT_WRITE, close, mmap, munmap, posix_fallocate, shm_open, shm_unlink
 };
 
 use crate::{
@@ -59,7 +59,7 @@ impl<T: Sized> SharedMemory<T> {
             )
         };
 
-        unsafe { bail_on_libc_err!(ftruncate(fd, size as i64)) };
+        unsafe { bail_on_libc_err!(posix_fallocate(fd, 0, size as i64)) };
 
         let addr = unsafe {
             bail_on_libc_err!(

--- a/vadl-test/resources/cosim_scripts/ppc64/compiler.py
+++ b/vadl-test/resources/cosim_scripts/ppc64/compiler.py
@@ -1,5 +1,5 @@
-import asyncio
 import os
+import subprocess
 from pathlib import Path
 
 AS_BE = "powerpc64-unknown-elf-as"
@@ -9,21 +9,21 @@ AS_LE = "powerpc64le-unknown-elf-as"
 LD_LE = "powerpc64le-unknown-elf-ld"
 OBJDUMP_LE = "powerpc64le-unknown-elf-objdump"
 
-async def compile(id: str, asm: str, debug: bool = True) -> dict:
-  asm_path = await build_assembly(id, asm)
-  linker_path = await build_linker_script(id)
+def compile(id: str, asm: str, debug: bool = True) -> dict:
+  asm_path = build_assembly(id, asm)
+  linker_path = build_linker_script(id)
 
   # big-endian
   obj_be = _tmp_file(id, f"obj-{id}-be.o")
   elf_be = _tmp_file(id, f"elf-{id}-be")
-  await assemble(AS_BE, asm_path, obj_be)
-  await link(LD_BE, linker_path, obj_be, elf_be)
+  assemble(AS_BE, asm_path, obj_be)
+  link(LD_BE, linker_path, obj_be, elf_be)
 
   # little-endian
   obj_le = _tmp_file(id, f"obj-{id}-le.o")
   elf_le = _tmp_file(id, f"elf-{id}-le")
-  await assemble(AS_LE, asm_path, obj_le)
-  await link(LD_LE, linker_path, obj_le, elf_le)
+  assemble(AS_LE, asm_path, obj_le)
+  link(LD_LE, linker_path, obj_le, elf_le)
 
   result = {
     "asm": asm_path,
@@ -37,8 +37,8 @@ async def compile(id: str, asm: str, debug: bool = True) -> dict:
   if debug:
     objdump_be = _tmp_file(id, f"elf-{id}-be.dump")
     objdump_le = _tmp_file(id, f"elf-{id}-le.dump")
-    await objdump(OBJDUMP_BE, elf_be, objdump_be)
-    await objdump(OBJDUMP_BE, elf_le, objdump_le)
+    objdump(OBJDUMP_BE, elf_be, objdump_be)
+    objdump(OBJDUMP_BE, elf_le, objdump_le)
     result.update({
         "objdump_be": objdump_be,
         "objdump_le": objdump_le,
@@ -47,27 +47,21 @@ async def compile(id: str, asm: str, debug: bool = True) -> dict:
   return result
 
 
-async def assemble(as_cmd: str, asm_path: Path, obj_out: Path) -> None:
-    proc = await asyncio.create_subprocess_exec(
-        as_cmd, "-o", str(obj_out), str(asm_path),
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
+def assemble(as_cmd: str, asm_path: Path, obj_out: Path) -> None:
+    proc = subprocess.run([
+        as_cmd, "-o", str(obj_out), str(asm_path)],
     )
-    _, stderr = await proc.communicate()
     if proc.returncode != 0:
-        raise RuntimeError(f"Assembly failed ({as_cmd}): {stderr.decode()}")
+        raise RuntimeError(f"Assembly failed ({as_cmd}): {proc.stderr.decode()}")
 
-async def link(ld_cmd: str, linker_script: Path, obj_in: Path, elf_out: Path) -> None:
-    proc = await asyncio.create_subprocess_exec(
-        ld_cmd, "-T", str(linker_script), "-o", str(elf_out), str(obj_in),
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
+def link(ld_cmd: str, linker_script: Path, obj_in: Path, elf_out: Path) -> None:
+    proc = subprocess.run([
+        ld_cmd, "-T", str(linker_script), "-o", str(elf_out), str(obj_in)],
     )
-    _, stderr = await proc.communicate()
     if proc.returncode != 0:
-        raise RuntimeError(f"Linking failed ({ld_cmd}): {stderr.decode()}")
+        raise RuntimeError(f"Linking failed ({ld_cmd}): {proc.stderr.decode()}")
 
-async def build_assembly(id: str, core: str) -> Path:
+def build_assembly(id: str, core: str) -> Path:
   asm_out = _tmp_file(id, f"asm-{id}.s")
 
   content = f"""
@@ -86,7 +80,7 @@ async def build_assembly(id: str, core: str) -> Path:
   return asm_out
 
 
-async def build_linker_script(id: str) -> Path:
+def build_linker_script(id: str) -> Path:
   linker_out = _tmp_file(id, f"linker-{id}.ld")
 
   content = """
@@ -103,17 +97,14 @@ async def build_linker_script(id: str) -> Path:
     f.write(content)
   return linker_out
 
-async def objdump(objdump_bin: str, obj_file: Path, out_file: Path):
+def objdump(objdump_bin: str, obj_file: Path, out_file: Path):
     with out_file.open("wb") as f:
-      proc = await asyncio.create_subprocess_exec(
-        objdump_bin, "-D", str(obj_file),
+      proc = subprocess.run(
+        [objdump_bin, "-D", str(obj_file)],
         stdout=f,
-      stderr=asyncio.subprocess.PIPE,
       )
-      _, stderr = await proc.communicate()
-
     if proc.returncode != 0:
-      raise RuntimeError(stderr.decode())
+      raise RuntimeError(proc.stderr.decode())
 
 def _tmp_file(id: str, name: str) -> Path:
   build_dir = f"/tmp/build-{id}/"

--- a/vadl-test/resources/cosim_scripts/ppc64/main.py
+++ b/vadl-test/resources/cosim_scripts/ppc64/main.py
@@ -1,9 +1,9 @@
 import argparse
 from pathlib import Path
-import asyncio
+import subprocess
+from concurrent.futures import ProcessPoolExecutor
 import yaml
 import os
-import sys
 import compiler
 import shutil
 
@@ -17,43 +17,53 @@ def dump_debug_info(tid: str, results: Path, comp: dict):
     shutil.copy(comp["objdump_be"], debug_dir)
     shutil.copy(comp["objdump_le"], debug_dir)
 
-async def run_cosim(le: str, be: str, out: Path, cosim_config: Path):
+def run_cosim(le: str, be: str, out: Path, cosim_config: Path):
     e = os.environ.copy()
     e["RUST_BACKTRACE"] = "1"
-    proc = await asyncio.create_subprocess_exec(
+    subprocess.run([
         "vadl-cosim-broker",
         "--config", cosim_config,
         "--test-exec", le,
         "--test-exec", be,
-        "--output-file", str(out),
-        env=e
+        "--output-file", str(out)
+        ],
+        env=e,
     )
-    await proc.wait()
 
-async def run_test(t: dict, results: Path, cosim_config: Path):
+def compile_test(t: dict, results: Path) -> dict:
     tid = str(t["id"])
-    try:
-        debug = t["debug"]
-        comp = await compiler.compile(tid, str(t["asm_core"]), debug)
-        if debug:
-          dump_debug_info(tid, results, comp)
-        await run_cosim(str(comp["elf_le"]), str(comp["elf_be"]), results / f"result-{tid}", cosim_config)
-    except Exception as e:
-        print(f"error for test=\"{tid}\": ", e)
+    debug = t["debug"]
+    comp = compiler.compile(tid, str(t["asm_core"]), debug)
+    if debug:
+        dump_debug_info(tid, results, comp)
+    return comp
 
-async def main(testsuite_path: Path):
+def run_test(t: dict, results: Path, cosim_config: Path):
+        tid = t["id"]
+        comp = compile_test(t, results)
+        try:
+            run_cosim(str(comp["elf_le"]), str(comp["elf_be"]), results / f"result-{tid}", cosim_config)
+        except Exception as e:
+            print(f"error for test=\"{tid}\": ", e)
+
+def main(testsuite_path: Path):
     config = yaml.safe_load(testsuite_path.read_text())
     results = Path(config.get("result_dir", "/work/results"))
     results.mkdir(parents=True, exist_ok=True)
 
-    cosim_config = config.get("cosim_config", "/cosim_config/ppc64_config.toml")
-    #tasks = [run_test(t, results) for t in config.get("tests", [])]
-    tasks = []; [await run_test(t, results, cosim_config) for t in config.get("tests", [])]
+    num_cores = os.cpu_count()
+    if num_cores is None:
+        num_cores = 1 # safe fallback
 
-    await asyncio.gather(*tasks)
+    cosim_config = config.get("cosim_config", "/cosim_config/ppc64_config.toml")
+
+    with ProcessPoolExecutor(num_cores) as executor:
+        for t in config.get("tests", []):
+            executor.submit(run_test, t, results, cosim_config)
+    executor.shutdown(wait=True)
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("config")
     args = parser.parse_args()
-    asyncio.run(main(Path(args.config)))
+    main(Path(args.config))


### PR DESCRIPTION
After some further testing, I believe that the reason for the seemingly random test-failures when running the tests in parallel, was due to `asyncio` spawning too many instances at once - causing and out-of-memory issue.

Simply limiting the number of concurrent cosim-spawns not only solves this issue but also seems to get the best performance when setting this number to the number of cores of the machine.

This PR does exactly that, also swapping `asyncio` with the `ProcessPoolExecutor` which gave better results w.r.t. performance.  