### PR TITLE
frontend: Fix missing expand for forall-expr

### DIFF
--- a/vadl/main/vadl/ast/MacroExpander.java
+++ b/vadl/main/vadl/ast/MacroExpander.java
@@ -489,7 +489,11 @@ class MacroExpander
         (IsId) expandExpr(index.identifier()),
         index.typeLiteral == null ? null : (TypeLiteral) expandExpr(index.typeLiteral),
         expandExpr(index.domain)));
-    return new ForallExpr(indices, expr.operation, expr.foldOperator, expandExpr(expr.body),
+    return new ForallExpr(
+        indices,
+        expr.operation,
+        expr.foldOperator != null ? (IsBinOp) expandNode((Node) expr.foldOperator) : null,
+        expandExpr(expr.body),
         copyLoc(expr.loc));
   }
 


### PR DESCRIPTION
I forgot to addapt the MacroExpander in the original PR which means it would fail for higher order macros, which are quite extensively used in `sve.vadl`.

@AndreasKrall when `sve.vadl` is somewhat stable we should definitly add add it to the testcases because it's a great stress test for the macro system.

Closes: #665