### PR TITLE
typechecker: Fix crash when constant evaluator runs out of options

### DIFF
--- a/vadl/main/vadl/ast/ConstantEvaluator.java
+++ b/vadl/main/vadl/ast/ConstantEvaluator.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -260,7 +260,9 @@ class ConstantEvaluator implements ExprVisitor<ConstantValue> {
 
   @Override
   public ConstantValue visit(WildcardLiteral expr) {
-    throw new UnsupportedOperationException("Not yet implemented");
+    throw new EvaluationError(
+        "The constant evaluator cannot evaluate %s.".formatted(expr.getClass().getSimpleName()),
+        expr);
   }
 
   @Override
@@ -292,8 +294,9 @@ class ConstantEvaluator implements ExprVisitor<ConstantValue> {
 
   @Override
   public ConstantValue visit(RangeExpr expr) {
-    throw new RuntimeException(
-        "Constant evaluator cannot evaluate %s yet.".formatted(expr.getClass().getSimpleName()));
+    throw new EvaluationError(
+        "The constant evaluator cannot evaluate %s.".formatted(expr.getClass().getSimpleName()),
+        expr);
   }
 
   @Override
@@ -358,9 +361,9 @@ class ConstantEvaluator implements ExprVisitor<ConstantValue> {
         var fakeBinExpr = AstUtils.getBuiltinBinOp(expr, builtin);
         result = eval(fakeBinExpr);
       } else {
-        throw new RuntimeException(
+        throw new EvaluationError(
             "At the moment the constant evaluator can only evaluate builtins that are also binary "
-                + "or unary operators.");
+                + "or unary operators.", expr);
       }
     }
 
@@ -415,8 +418,9 @@ class ConstantEvaluator implements ExprVisitor<ConstantValue> {
 
   @Override
   public ConstantValue visit(SymbolExpr expr) {
-    throw new RuntimeException(
-        "Constant evaluator cannot evaluate %s yet.".formatted(expr.getClass().getSimpleName()));
+    throw new EvaluationError(
+        "The constant evaluator cannot evaluate %s.".formatted(expr.getClass().getSimpleName()),
+        expr);
 
   }
 
@@ -456,43 +460,49 @@ class ConstantEvaluator implements ExprVisitor<ConstantValue> {
 
   @Override
   public ConstantValue visit(ExistsInExpr expr) {
-    throw new RuntimeException(
-        "Constant evaluator cannot evaluate %s yet.".formatted(expr.getClass().getSimpleName()));
+    throw new EvaluationError(
+        "The constant evaluator cannot evaluate %s.".formatted(expr.getClass().getSimpleName()),
+        expr);
 
   }
 
   @Override
   public ConstantValue visit(ExistsInThenExpr expr) {
-    throw new RuntimeException(
-        "Constant evaluator cannot evaluate %s yet.".formatted(expr.getClass().getSimpleName()));
+    throw new EvaluationError(
+        "The constant evaluator cannot evaluate %s.".formatted(expr.getClass().getSimpleName()),
+        expr);
 
   }
 
 
   @Override
   public ConstantValue visit(ForallExpr expr) {
-    throw new RuntimeException(
-        "Constant evaluator cannot evaluate %s yet.".formatted(expr.getClass().getSimpleName()));
+    throw new EvaluationError(
+        "The constant evaluator cannot evaluate %s.".formatted(expr.getClass().getSimpleName()),
+        expr);
 
   }
 
   @Override
   public ConstantValue visit(SequenceCallExpr expr) {
-    throw new RuntimeException(
-        "Constant evaluator cannot evaluate %s yet.".formatted(expr.getClass().getSimpleName()));
+    throw new EvaluationError(
+        "The constant evaluator cannot evaluate %s.".formatted(expr.getClass().getSimpleName()),
+        expr);
 
   }
 
   @Override
   public ConstantValue visit(ExpandedSequenceCallExpr expr) {
-    throw new RuntimeException(
-        "Constant evaluator cannot evaluate %s yet.".formatted(expr.getClass().getSimpleName()));
+    throw new EvaluationError(
+        "The constant evaluator cannot evaluate %s.".formatted(expr.getClass().getSimpleName()),
+        expr);
   }
 
   @Override
   public ConstantValue visit(ExpandedAliasDefSequenceCallExpr expr) {
-    throw new RuntimeException(
-        "Constant evaluator cannot evaluate %s yet.".formatted(expr.getClass().getSimpleName()));
+    throw new EvaluationError(
+        "The constant evaluator cannot evaluate %s.".formatted(expr.getClass().getSimpleName()),
+        expr);
   }
 
   @Override

--- a/vadl/main/vadl/ast/TypeChecker.java
+++ b/vadl/main/vadl/ast/TypeChecker.java
@@ -165,6 +165,16 @@ public class TypeChecker
         expr.type = new InternalErrorType();
       }
       throw signal;
+    } catch (EvaluationError error) {
+      errors.add(
+          error("Constant value required", error.location)
+              .locationDescription(error.location, "%s", requireNonNull(error.getMessage()))
+              .build()
+      );
+      if (expr.type == null) {
+        expr.type = new InternalErrorType();
+      }
+      throw new StopPartialCheckingSignal();
     } finally {
       currentlyVisiting.pop();
     }
@@ -3167,10 +3177,8 @@ public class TypeChecker
         check(indexExpr);
 
         @Nullable Integer staticIndex = null;
-        try {
+        if (constantEvaluator.isConstant(indexExpr)) {
           staticIndex = constantEvaluator.eval(indexExpr).value().intValueExact();
-        } catch (EvaluationError e) {
-          // This is a dynamic slice, that's also fine
         }
 
         currType = currTensoType.pop();
@@ -3846,23 +3854,12 @@ public class TypeChecker
 
       // Check as expression
       if (index.domain instanceof RangeExpr rangeExpr) {
-        try {
-          index.computedFrom = constantEvaluator.eval(rangeExpr.from).value().intValueExact();
-          index.computedTo = constantEvaluator.eval(rangeExpr.to).value().intValueExact();
-        } catch (EvaluationError e) {
-          addErrorAndStopChecking(error("Constant value required", e.location)
-              .locationDescription(e.location, "%s", requireNonNull(e.getMessage()))
-              .build());
-        }
+        index.computedFrom = constantEvaluator.eval(rangeExpr.from).value().intValueExact();
+        index.computedTo = constantEvaluator.eval(rangeExpr.to).value().intValueExact();
+
       } else {
-        try {
-          index.computedFrom = constantEvaluator.eval(index.domain).value().intValueExact();
-          index.computedTo = index.computedFrom;
-        } catch (EvaluationError e) {
-          addErrorAndStopChecking(error("Constant value required", e.location)
-              .locationDescription(e.location, "%s", requireNonNull(e.getMessage()))
-              .build());
-        }
+        index.computedFrom = constantEvaluator.eval(index.domain).value().intValueExact();
+        index.computedTo = index.computedFrom;
       }
     });
 
@@ -4219,23 +4216,11 @@ public class TypeChecker
 
       // Check as expression
       if (index.domain instanceof RangeExpr rangeExpr) {
-        try {
-          index.computedFrom = constantEvaluator.eval(rangeExpr.from).value().intValueExact();
-          index.computedTo = constantEvaluator.eval(rangeExpr.to).value().intValueExact();
-        } catch (EvaluationError e) {
-          addErrorAndStopChecking(error("Constant value required", e.location)
-              .locationDescription(e.location, "%s", requireNonNull(e.getMessage()))
-              .build());
-        }
+        index.computedFrom = constantEvaluator.eval(rangeExpr.from).value().intValueExact();
+        index.computedTo = constantEvaluator.eval(rangeExpr.to).value().intValueExact();
       } else {
-        try {
-          index.computedFrom = constantEvaluator.eval(index.domain).value().intValueExact();
-          index.computedTo = index.computedFrom;
-        } catch (EvaluationError e) {
-          addErrorAndStopChecking(error("Constant value required", e.location)
-              .locationDescription(e.location, "%s", requireNonNull(e.getMessage()))
-              .build());
-        }
+        index.computedFrom = constantEvaluator.eval(index.domain).value().intValueExact();
+        index.computedTo = index.computedFrom;
       }
     });
 

--- a/vadl/test/resources/diagnostics/typechecker/invalidConstNotEvaluatable.vadl
+++ b/vadl/test/resources/diagnostics/typechecker/invalidConstNotEvaluatable.vadl
@@ -1,0 +1,37 @@
+constant a = "kuchen"
+constant b = forall i: Bits<2> in 0..3 fold + with (4 as Bits<32>)
+
+function f(a1: Bits<32>) -> Bits<32> = a1 + 1
+
+constant c = f(9)
+
+
+//  Reported Diagnostics:
+//
+//  error: Invalid constant value
+//       ╭──[test/resources/diagnostics/typechecker/invalidConstNotEvaluatable.vadl:1:14]
+//       │
+//     1 │ constant a = "kuchen"
+//       │              ^^^^^^^^ Cannot evaluate strings (yet).
+//       │
+//       All constants must be able to be evaluated
+//  error: Invalid constant value
+//       ╭──[test/resources/diagnostics/typechecker/invalidConstNotEvaluatable.vadl:2:14]
+//       │
+//     2 │ constant b = forall i: Bits<2> in 0..3 fold + with (4 as Bits<32>)
+//       │              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The constant evaluator cannot evaluate ForallExpr.
+//       │
+//       All constants must be able to be evaluated
+//  error: Invalid constant value
+//       ╭──[test/resources/diagnostics/typechecker/invalidConstNotEvaluatable.vadl:6:14]
+//       │
+//     4 │ function f(a1: Bits<32>) -> Bits<32> = a1 + 1
+//       │                                        -- Cannot evaluate identifier with origin of vadl.ast.Parameter
+//       ⋮
+//     6 │ constant c = f(9)
+//       │              ^^^^
+//       │
+//       All constants must be able to be evaluated
+//
+//
+// Part of the class vadl.ast.DiagnosticsTest


### PR DESCRIPTION
The constant evaluator is deeply integrated into the typechecking. However, there are situations where it runs out of options and returns an error. All such errors are now reported to the user instead of crashing the compiler.

Related but not closing: https://github.com/OpenVADL/openvadl/issues/687