### PR TITLE
typechecker: Fix missing typechecking of multiplier in CallIndexExpr

### DIFF
--- a/vadl/main/vadl/ast/Expr.java
+++ b/vadl/main/vadl/ast/Expr.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -1638,9 +1638,11 @@ final class SymbolExpr extends Expr implements IsSymExpr {
   @Override
   public void prettyPrintExpr(int indent, StringBuilder builder, Precedence parentPrec) {
     path.prettyPrint(indent, builder);
-    builder.append("< ");
+    var prefix = size instanceof BinaryExpr ? "<( " : "< ";
+    var suffix = size instanceof BinaryExpr ? " )>" : " >";
+    builder.append(prefix);
     size.prettyPrintExpr(indent, builder, Precedence.NoPrecedence);
-    builder.append(" >");
+    builder.append(suffix);
   }
 
   @Override

--- a/vadl/main/vadl/ast/TypeChecker.java
+++ b/vadl/main/vadl/ast/TypeChecker.java
@@ -3647,7 +3647,9 @@ public class TypeChecker
                 expr.typeBeforeSlice())
             .build());
       }
+
       // handle the targetSize expression if defined
+      check(targetSizeExpr);
       int multiplier = constantEvaluator.eval(targetSizeExpr).value().intValueExact();
 
       if (callTarget instanceof MemoryDefinition) {

--- a/vadl/test/resources/diagnostics/typechecker/multiplierWithConstantBinaryExpression.vadl
+++ b/vadl/test/resources/diagnostics/typechecker/multiplierWithConstantBinaryExpression.vadl
@@ -1,0 +1,91 @@
+// INCLUDE-AST-DUMP
+
+// Previously there was a bug where this program would crash, because one expression wasn't typechecked before it was
+// evaluated.
+// https://github.com/OpenVADL/openvadl/issues/714
+
+instruction set architecture Test = {
+  memory   MEM : Bits<64> -> Bits<8>
+  register Reg : Bits<8><64>
+
+  format Inst: Bits<4> = {op : Bits<4>}
+
+  instruction t : Inst = Reg(7) := MEM<(1 << 3)>(Reg(0))
+  //                                    ^^^^^^ This expression crashed
+  encoding t = {op = 0}
+  assembly t = ("load")
+}
+
+
+//  Reported Diagnostics:
+//
+//  No diagnostics were reported, the input was correctly parsed, typechecked and lowered.
+//
+//
+//  Dumped AST:
+//
+//    InstructionSetDefinition name: "Test"
+//    . MemoryDefinition name: "MEM"
+//    . : TypeLiteral type: Bits<64>
+//    . : ' Identifier name: "Bits" type: null
+//    . : ' IntegerLiteral literal: 64 (64) type: Const<64>
+//    . : TypeLiteral type: Bits<8>
+//    . : ' Identifier name: "Bits" type: null
+//    . : ' IntegerLiteral literal: 8 (8) type: Const<8>
+//    . RegisterDefinition name: "Reg"
+//    . : TypeLiteral type: Bits<8><64>
+//    . : ' Identifier name: "Bits" type: null
+//    . : ' IntegerLiteral literal: 8 (8) type: Const<8>
+//    . : ' IntegerLiteral literal: 64 (64) type: Const<64>
+//    . FormatDefinition name: "Inst"
+//    . : TypeLiteral type: Bits<4>
+//    . : ' Identifier name: "Bits" type: null
+//    . : ' IntegerLiteral literal: 4 (4) type: Const<4>
+//    . : TypedFormatField name: "op"
+//    . : ' TypeLiteral type: Bits<4>
+//    . : ' | Identifier name: "Bits" type: null
+//    . : ' | IntegerLiteral literal: 4 (4) type: Const<4>
+//    . InstructionDefinition name: "t"
+//    . : Identifier name: "Inst" type: null
+//    . : AssignmentStatement
+//    . : ' CallIndexExpr type: Bits<64>
+//    . : ' | Identifier name: "Reg" type: null
+//    . : ' | ArgsIndices
+//    . : ' | . CastExpr type: Bits<3>
+//    . : ' | . : IntegerLiteral literal: 7 (7) type: Const<7>
+//    . : ' | . : TypeLiteral type: Bits<3>
+//    . : ' | . : ' Identifier name: "Bits" type: null
+//    . : ' | . : ' IntegerLiteral literal: 3 (3) type: null
+//    . : ' CallIndexExpr type: Bits<64>
+//    . : ' | SymbolExpr type: null
+//    . : ' | . Identifier name: "MEM" type: null
+//    . : ' | . BinaryExpr operator: << type: Const<8>
+//    . : ' | . : IntegerLiteral literal: 1 (1) type: Const<1>
+//    . : ' | . : CastExpr type: UInt<2>
+//    . : ' | . : ' IntegerLiteral literal: 3 (3) type: Const<3>
+//    . : ' | . : ' TypeLiteral type: UInt<2>
+//    . : ' | . : ' | Identifier name: "UInt" type: null
+//    . : ' | . : ' | IntegerLiteral literal: 2 (2) type: null
+//    . : ' | ArgsIndices
+//    . : ' | . CallIndexExpr type: Bits<64>
+//    . : ' | . : Identifier name: "Reg" type: null
+//    . : ' | . : ArgsIndices
+//    . : ' | . : ' CastExpr type: Bits<3>
+//    . : ' | . : ' | IntegerLiteral literal: 0 (0) type: Const<0>
+//    . : ' | . : ' | TypeLiteral type: Bits<3>
+//    . : ' | . : ' | . Identifier name: "Bits" type: null
+//    . : ' | . : ' | . IntegerLiteral literal: 3 (3) type: null
+//    . EncodingDefinition
+//    . : Identifier name: "t" type: null
+//    . : Identifier name: "op" type: null
+//    . : CastExpr type: Bits<4>
+//    . : ' IntegerLiteral literal: 0 (0) type: Const<0>
+//    . : ' TypeLiteral type: Bits<4>
+//    . : ' | Identifier name: "Bits" type: null
+//    . : ' | IntegerLiteral literal: 4 (4) type: null
+//    . AssemblyDefinition
+//    . : GroupedExpr type: String
+//    . : ' StringLiteral literal: "load" ("load") type: String
+//
+//
+// Part of the class vadl.ast.DiagnosticsTest


### PR DESCRIPTION
Closes: #714