### PR TITLE
iss: Disable cosim test for powerpc

### DIFF
--- a/vadl/test/vadl/iss/ppc64/CosimPpc64InstrTest.java
+++ b/vadl/test/vadl/iss/ppc64/CosimPpc64InstrTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.TestMethodOrder;
  */
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@Disabled
 public class CosimPpc64InstrTest extends AbstractCosimPpc64InstrTest {
 
   private static final long BASE_ADDRESS_LOAD_STORE = 0x1000L;


### PR DESCRIPTION
The test is flaky and needs to be investigated. For now, we disable the test to enable the rest of the team again.

fyi @Giftzwerg02 