### PR TITLE
cosim: Fix build issue with disabled test

### DIFF
--- a/vadl/test/vadl/iss/ppc64/CosimPpc64InstrTest.java
+++ b/vadl/test/vadl/iss/ppc64/CosimPpc64InstrTest.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.util.Objects;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;


### PR DESCRIPTION
I think #725 missed to import the Disabled annotation which causes the build issues.