### PR TITLE
ci: Run ISS tests only on x06

### DIFF
--- a/.github/workflows/openvadl-ci.yml
+++ b/.github/workflows/openvadl-ci.yml
@@ -43,7 +43,14 @@ jobs:
       matrix:
         task: [ test-lcb, test-common, test-iss, test-rtl ]
         include:
-          - runner: self-hosted
+          - task: test-lcb
+            runner: self-hosted
+          - task: test-common
+            runner: self-hosted
+          - task: test-iss
+            runner: self-hosted-arm64
+          - task: test-rtl
+            runner: self-hosted
     with:
       test-task: ${{ matrix.task }}
       runner: ${{ matrix.runner }}

--- a/vadl/test/vadl/iss/ppc64/CosimPpc64InstrTest.java
+++ b/vadl/test/vadl/iss/ppc64/CosimPpc64InstrTest.java
@@ -34,7 +34,6 @@ import org.junit.jupiter.api.TestMethodOrder;
  */
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-@Disabled
 public class CosimPpc64InstrTest extends AbstractCosimPpc64InstrTest {
 
   private static final long BASE_ADDRESS_LOAD_STORE = 0x1000L;
@@ -1073,7 +1072,8 @@ public class CosimPpc64InstrTest extends AbstractCosimPpc64InstrTest {
       var regSrc2 = update ? b.anyRegExceptZero().sample() : b.anyReg().sample();
       b.fillReg(regSrc1);
       b.fillReg(regSrc2, b.getImmU(15));
-      b.add("%s %s, %s(%s)", instruction, regSrc1, b.getImmUFrom(15, BigInteger.valueOf(BASE_ADDRESS_LOAD_STORE)), regSrc2);
+      b.add("%s %s, %s(%s)", instruction, regSrc1,
+          b.getImmUFrom(15, BigInteger.valueOf(BASE_ADDRESS_LOAD_STORE)), regSrc2);
       return b.toTestCase();
     });
   }


### PR DESCRIPTION
This resolves the currently flaky PPC ISS tests that are only failing on the h0 runner.

This is temporary until we resolve the issue @Giftzwerg02 @kbschlosser, see #728.