### PR TITLE
frontend: Migrate to virtual file system

### DIFF
--- a/vadl-cli/main/vadl/cli/BaseCommand.java
+++ b/vadl-cli/main/vadl/cli/BaseCommand.java
@@ -57,6 +57,7 @@ import vadl.error.DiagnosticPrinter;
 import vadl.pass.PassManager;
 import vadl.pass.PassOrder;
 import vadl.pass.exception.DuplicatedPassKeyException;
+import vadl.utils.DiskVirtualFileSystem;
 import vadl.utils.EditorUtils;
 import vadl.utils.SourceLocation;
 import vadl.viam.Specification;
@@ -172,7 +173,8 @@ public abstract class BaseCommand implements Callable<Integer> {
    */
   private Ast parseToAst() {
     try {
-      Ast ast = VadlParser.parse(input, Objects.requireNonNullElseGet(modelOverrides, Map::of));
+      Ast ast = VadlParser.parse(input, new DiskVirtualFileSystem(),
+          Objects.requireNonNullElseGet(modelOverrides, Map::of));
       new Ungrouper().ungroup(ast);
       new ModelRemover().removeModels(ast);
       return ast;
@@ -349,13 +351,13 @@ public abstract class BaseCommand implements Callable<Integer> {
       // Re-throw to let Picoli handle it
       throw e;
     } catch (Diagnostic d) {
-      System.out.println(new DiagnosticPrinter().toString(d));
+      System.out.println(new DiagnosticPrinter(new DiskVirtualFileSystem()).toString(d));
       if (showStacktrace) {
         System.out.println(getStackTrace(d));
       }
       returnVal = 1;
     } catch (DiagnosticList d) {
-      System.out.println(new DiagnosticPrinter().toString(d));
+      System.out.println(new DiagnosticPrinter(new DiskVirtualFileSystem()).toString(d));
       if (showStacktrace) {
         System.out.println(getStackTrace(d));
       }
@@ -389,7 +391,8 @@ public abstract class BaseCommand implements Callable<Integer> {
     }
 
     if (!DeferredDiagnosticStore.isEmpty()) {
-      System.out.println(new DiagnosticPrinter().toString(DeferredDiagnosticStore.getAll()));
+      System.out.println(new DiagnosticPrinter(new DiskVirtualFileSystem()).toString(
+          DeferredDiagnosticStore.getAll()));
 
       // Only exit abnormally if any diagnostic message is an error.
       if (DeferredDiagnosticStore.getAll().stream()

--- a/vadl-lsp/main/vadl/lsp/VadlTextDocumentService.java
+++ b/vadl-lsp/main/vadl/lsp/VadlTextDocumentService.java
@@ -17,10 +17,13 @@
 package vadl.lsp;
 
 import java.net.URI;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
@@ -48,6 +51,7 @@ import vadl.ast.Ungrouper;
 import vadl.ast.VadlParser;
 import vadl.error.Diagnostic.MsgType;
 import vadl.error.DiagnosticList;
+import vadl.utils.DiskVirtualFileSystem;
 import vadl.utils.SourceLocation;
 
 /**
@@ -61,12 +65,6 @@ class VadlTextDocumentService implements TextDocumentService {
    * developer is typing.
    */
   private static final int DIAGNOSTICS_DELAY_MS = 500;
-
-  /**
-   * The URI the Vadl Parser assigns to the String we give it for parsing. With this we can check
-   * if a location refers to this "file" or some other file that the Parser included along the way.
-   */
-  private static final URI PRIMARY_FILE = URI.create("memory://internal");
 
   private static final Logger log = LoggerFactory.getLogger(VadlTextDocumentService.class);
 
@@ -184,8 +182,9 @@ class VadlTextDocumentService implements TextDocumentService {
       }
 
       List<Diagnostic> lspItems = new ArrayList<>();
+      Path path = Paths.get(URI.create(document.getUri()));
       try {
-        Ast ast = VadlParser.parse(text, URI.create(document.getUri()));
+        Ast ast = VadlParser.parse(text, new DiskVirtualFileSystem(), Map.of(), path);
         new Ungrouper().ungroup(ast);
         new ModelRemover().removeModels(ast);
         new TypeChecker().verify(ast);
@@ -196,7 +195,7 @@ class VadlTextDocumentService implements TextDocumentService {
           // TODO Look into secondary locations too? Maybe as relatedInformation? Or to put a
           //      diagnostic message there as well?
           SourceLocation location = item.multiLocation.primaryLocation().location();
-          if (!location.uri().equals(PRIMARY_FILE)) {
+          if (!Objects.equals(location.path(), path)) {
             // Ignore errors for other files
             // TODO this means that errors in included files are not reported unless that file is
             //      opened in the client, even though the Parser gives us diagnostics for them

--- a/vadl/main/vadl/ast/Ast.java
+++ b/vadl/main/vadl/ast/Ast.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -16,7 +16,7 @@
 
 package vadl.ast;
 
-import java.net.URI;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -30,7 +30,10 @@ import vadl.utils.WithLocation;
  */
 public class Ast {
   List<Definition> definitions = new ArrayList<>();
-  URI fileUri = SourceLocation.INVALID_SOURCE_LOCATION.uri();
+
+  @Nullable
+  Path filePath = null;
+
   public List<PassTimings> passTimings = new ArrayList<>();
 
 
@@ -107,7 +110,7 @@ abstract class Node implements WithLocation {
     if (symbolTable == null) {
       throw new IllegalStateException(
           "Node `%s` should have received a symbol table in a previous pass, found at: %s"
-              .formatted(toString(), location().toIDEString()));
+              .formatted(toString(), location().toConciseString()));
     }
     return symbolTable;
   }

--- a/vadl/main/vadl/ast/MacroExpander.java
+++ b/vadl/main/vadl/ast/MacroExpander.java
@@ -1376,10 +1376,10 @@ class MacroExpander
     }
 
     if (loc.expandedFrom() == null) {
-      return new SourceLocation(loc.uri(), loc.begin(), loc.end(), expandingFrom);
+      return new SourceLocation(loc.path(), loc.begin(), loc.end(), expandingFrom);
     }
 
-    return new SourceLocation(loc.uri(), loc.begin(), loc.end(), copyLoc(loc.expandedFrom()));
+    return new SourceLocation(loc.path(), loc.begin(), loc.end(), copyLoc(loc.expandedFrom()));
   }
 
   static class MacroExpansionException extends Exception {

--- a/vadl/main/vadl/ast/Parser.frame
+++ b/vadl/main/vadl/ast/Parser.frame
@@ -28,10 +28,16 @@ Coco/R itself) does not fall under the GNU General Public License.
 -->begin
 import java.util.ArrayList;
 import vadl.utils.SourceLocation;
+import vadl.utils.VirtualFileSystem;
 import vadl.error.Diagnostic;
 import static vadl.error.Diagnostic.error;
 
 public class Parser {
+
+  /**
+  * The file abstraction used to load imported files
+  */
+  VirtualFileSystem fileSystem = null;
 
   /**
   * All the errors the parser has encountered.

--- a/vadl/main/vadl/ast/ParserUtils.java
+++ b/vadl/main/vadl/ast/ParserUtils.java
@@ -18,13 +18,9 @@ package vadl.ast;
 
 import static vadl.error.Diagnostic.error;
 
-import java.io.File;
 import java.io.IOException;
 import java.math.BigInteger;
-import java.net.URI;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -716,8 +712,8 @@ class ParserUtils {
                                   List<List<Identifier>> importedSymbols,
                                   List<StringLiteral> args, SourceLocation loc) {
     var modulePath = filePath == null
-        ? resolveUri(parser, Objects.requireNonNull(fileId))
-        : resolveUri(parser, filePath.value, filePath);
+        ? resolveImportPath(parser, Objects.requireNonNull(fileId))
+        : resolveImportPath(parser, filePath.value, filePath);
     if (modulePath != null) {
       var macroOverrides = new HashMap<String, String>();
       for (StringLiteral arg : args) {
@@ -731,7 +727,7 @@ class ParserUtils {
         macroOverrides.put(keyValue[0], keyValue[1]);
       }
       try {
-        var ast = VadlParser.parse(modulePath, macroOverrides);
+        var ast = VadlParser.parse(modulePath, parser.fileSystem, macroOverrides);
         parser.macroTable.importFrom(ast, importedSymbols);
         return new ImportDefinition(ast, importedSymbols, fileId, filePath, args, loc);
       } catch (DiagnosticList | Diagnostic e) {
@@ -746,20 +742,28 @@ class ParserUtils {
     return DUMMY_DEF;
   }
 
-  static @Nullable Path resolveUri(Parser parser, Identifier importPath) {
-    return resolveUri(parser, importPath.name, importPath);
+  static @Nullable Path resolveImportPath(Parser parser, Identifier importPath) {
+    return resolveImportPath(parser, importPath.name, importPath);
   }
 
-  static @Nullable Path resolveUri(Parser parser, String name, WithLocation location) {
-    var resolutionUri = Objects.requireNonNullElse(parser.resolutionUri, parser.sourceFile);
-    var relativeToSpec = Paths.get(resolutionUri.resolve(name));
-    if (Files.isRegularFile(relativeToSpec)) {
+  /**
+   * Resolves a usable path of the file to import.
+   * Since files are always imported relative to the caller this takes into account the path of the
+   * currently open file.
+   *
+   * @param parser      of the current file.
+   * @param name        to resolve, might be a path.
+   * @param location    of the import statement, used for errors.
+   * @return            a path to import.
+   */
+  static @Nullable Path resolveImportPath(Parser parser, String name, WithLocation location) {
+    var resolutionPath = Objects.requireNonNullElse(parser.resolutionPath, parser.sourceFile);
+    var relativeToSpec = resolutionPath.resolveSibling(name);
+    if (parser.fileSystem.exists(relativeToSpec)) {
       return relativeToSpec;
     }
-    var withAppendedExtension = relativeToSpec.resolveSibling(
-        relativeToSpec.getFileName() + VADL_EXTENSION
-    );
-    if (Files.isRegularFile(withAppendedExtension)) {
+    var withAppendedExtension = resolutionPath.resolveSibling(name + VADL_EXTENSION);
+    if (parser.fileSystem.exists(withAppendedExtension)) {
       return withAppendedExtension;
     }
     parser.diagnostics.add(Diagnostic.error("Import Error", location)
@@ -769,14 +773,14 @@ class ParserUtils {
   }
 
   /**
-   * Return the basename of a uri.
+   * Return the basename of a path.
    * Example: /home/flo/abc.txt -> abc
    *
-   * @param uri to extract the files basename
+   * @param path to extract the files basename
    * @return the basename
    */
-  static String baseName(URI uri) {
-    var name = new File(uri.getPath()).getName();
+  static String baseName(Path path) {
+    var name = path.getFileName().toString();
     return name.contains(".") ? name.substring(0, name.lastIndexOf('.')) : name;
   }
 

--- a/vadl/main/vadl/ast/TypeChecker.java
+++ b/vadl/main/vadl/ast/TypeChecker.java
@@ -309,7 +309,7 @@ public class TypeChecker
   private void throwUnimplemented(Node node) {
     throw new RuntimeException(
         "The typechecker doesn't know how to handle `%s` yet, found in %s".formatted(
-            node.getClass().getSimpleName(), node.location().toIDEString()));
+            node.getClass().getSimpleName(), node.location().toConciseString()));
   }
 
   /**
@@ -340,7 +340,7 @@ public class TypeChecker
   private IllegalStateException buildIllegalStateException(Node node, String message) {
     return new IllegalStateException(
         "The typechecker encountered an invalid state in `%s` at %s: %s".formatted(
-            node.getClass().getSimpleName(), node.location().toIDEString(), message));
+            node.getClass().getSimpleName(), node.location().toConciseString(), message));
   }
 
   private void throwInvalidAsmCast(AsmType from, AsmType to, WithLocation location) {
@@ -1432,7 +1432,7 @@ public class TypeChecker
         // FIXME: Support relational alias types on registers
         throw new IllegalStateException(
             "Relational alias types are not yet supported, found at: %s".formatted(
-                definition.loc.toIDEString()));
+                definition.loc.toConciseString()));
       }
 
       // we have to check the CallIndexExpr "manually" as the normal check cannot handle
@@ -1547,7 +1547,7 @@ public class TypeChecker
 
     throw new IllegalStateException(
         "Kind %s not yet implemented, found at: %s".formatted(definition.kind,
-            definition.loc.toIDEString()));
+            definition.loc.toConciseString()));
   }
 
   private Type setInnerMostType(Type type, BitsType innerType) {
@@ -2728,7 +2728,7 @@ public class TypeChecker
 
     throw new IllegalStateException(
         "Cannot find symbol `%s` found at: %s (The symbol resolver should already have caught that)"
-            .formatted(fullName, expr.location().toIDEString()));
+            .formatted(fullName, expr.location().toConciseString()));
   }
 
   @Override

--- a/vadl/main/vadl/ast/VadlParser.java
+++ b/vadl/main/vadl/ast/VadlParser.java
@@ -18,10 +18,9 @@ package vadl.ast;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.net.URI;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -29,7 +28,10 @@ import java.util.Map;
 import javax.annotation.Nullable;
 import vadl.error.Diagnostic;
 import vadl.error.DiagnosticList;
+import vadl.utils.DiskVirtualFileSystem;
+import vadl.utils.EmptyVirtualFileSystem;
 import vadl.utils.SourceLocation;
+import vadl.utils.VirtualFileSystem;
 
 /**
  * A parser for the VADL language, generated using Coco.
@@ -40,62 +42,89 @@ public class VadlParser {
    * Parses the VADL source program at the specified path into an AST.
    */
   public static Ast parse(Path path) throws IOException {
-    return parse(path, Collections.emptyMap());
+    return parse(path, new DiskVirtualFileSystem(), Collections.emptyMap());
   }
 
   /**
    * Parses the VADL source program at the specified path into an AST.
-   * Works just like {@link VadlParser#parse(String, Map, URI)},
+   */
+  public static Ast parse(Path path, VirtualFileSystem fileSystem) throws IOException {
+    return parse(path, fileSystem, Collections.emptyMap());
+  }
+
+  /**
+   * Parses the VADL source program at the specified path into an AST.
+   * Works just like {@link VadlParser#parse(String, Map, Path)},
    * except errors will have the proper file locations set.
    */
-  public static Ast parse(Path path, Map<String, String> macroOverrides) throws IOException {
+  public static Ast parse(Path path, VirtualFileSystem fileSystem,
+                          Map<String, String> macroOverrides) throws IOException {
     final var startTime = System.nanoTime();
-    var scanner = new Scanner(Files.newInputStream(path));
+    var scanner = new Scanner(fileSystem.getInputStream(path));
     var parser = new Parser(scanner);
-    parser.sourceFile = path.toUri();
+    parser.sourceFile = fileSystem.toAbsolutePath(path);
+    parser.fileSystem = fileSystem;
     macroOverrides.forEach((key, value) -> parser.macroOverrides.put(key,
         new Identifier(value, SourceLocation.INVALID_SOURCE_LOCATION)));
     var ast = parse(parser);
-    ast.fileUri = path.toUri();
+    ast.filePath = fileSystem.toAbsolutePath(path);
     ast.passTimings.add(
         new Ast.PassTimings("Parsing", (System.nanoTime() - startTime) / 1_000_000));
-
-
     return ast;
   }
 
   /**
-   * Convenience overload for {@link VadlParser#parse(String, Map, URI)} without any overrides.
+   * Convenience overload for {@link VadlParser#parse(String, Map, Path)} without any overrides.
    */
   public static Ast parse(String program) {
-    return parse(program, Map.of(), null);
+    return parse(program, Map.of(), Paths.get("memory"));
   }
 
   /**
-   * Convenience overload for {@link VadlParser#parse(String, Map, URI)} without any overrides.
+   * Convenience overload for {@link VadlParser#parse(String, Map, Path)} without any overrides.
    */
-  public static Ast parse(String program, URI resolutionUri) {
-    return parse(program, Map.of(), resolutionUri);
+  public static Ast parse(String program, Path resolutionPath) {
+    return parse(program, Map.of(), resolutionPath);
   }
 
   /**
    * Parses a source program into an AST.
    *
-   * @param program        a source code file to parse
-   * @param macroOverrides The overrides to perform in the macro evaluation
-   * @return The parsed syntax tree.
+   * @param program         a source code file to parse
+   * @param macroOverrides  The overrides to perform in the macro evaluation
+   * @return                The parsed syntax tree.
    * @throws DiagnosticList if there are any parsing errors.
    */
   public static Ast parse(String program, Map<String, String> macroOverrides,
-                          @Nullable URI resolutionUri) {
+                          @Nullable Path resolutionPath) {
+    return parse(program, new EmptyVirtualFileSystem(), macroOverrides, resolutionPath);
+  }
+
+
+  /**
+   * Parses a source program into an AST.
+   *
+   *
+   * @param program         a source code file to parse
+   * @param fileSystem      an abstraction layer over the filesystem
+   * @param macroOverrides  The overrides to perform in the macro evaluation
+   * @param resolutionPath  The path from which imports should be started
+   * @return                The parsed syntax tree.
+   * @throws DiagnosticList if there are any parsing errors.
+   */
+  public static Ast parse(String program, VirtualFileSystem fileSystem,
+                          Map<String, String> macroOverrides,
+                          @Nullable Path resolutionPath) {
     var scanner = new Scanner(new ByteArrayInputStream(program.getBytes(StandardCharsets.UTF_8)));
     var parser = new Parser(scanner);
-    parser.resolutionUri = resolutionUri;
-    parser.sourceFile = URI.create("memory://internal");
+    parser.resolutionPath = resolutionPath;
+    parser.sourceFile = resolutionPath;
+    parser.fileSystem = fileSystem;
     macroOverrides.forEach((key, value) -> parser.macroOverrides.put(key,
         new Identifier(value, SourceLocation.INVALID_SOURCE_LOCATION)));
     return parse(parser);
   }
+
 
   private static Ast parse(Parser parser) {
     List<Diagnostic> errors = new ArrayList<>();

--- a/vadl/main/vadl/ast/ViamLowering.java
+++ b/vadl/main/vadl/ast/ViamLowering.java
@@ -157,8 +157,9 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
   @SuppressWarnings("VariableDeclarationUsageDistance")
   public Specification generate(Ast ast) {
     var startTime = System.nanoTime();
+    var name = ast.filePath != null ? ParserUtils.baseName(ast.filePath) : "unknown";
     var spec = new Specification(
-        new vadl.viam.Identifier(ParserUtils.baseName(ast.fileUri),
+        new vadl.viam.Identifier(name,
             SourceLocation.INVALID_SOURCE_LOCATION));
     this.currentSpecification = spec;
 

--- a/vadl/main/vadl/ast/vadl.ATG
+++ b/vadl/main/vadl/ast/vadl.ATG
@@ -15,8 +15,8 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 $package=vadl.ast
+import java.nio.file.Path;
 import java.util.ArrayDeque;
-
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
@@ -31,8 +31,8 @@ import static vadl.ast.CounterDefinition.CounterKind.PROGRAM;
 import static vadl.ast.ParserUtils.*;
 
 COMPILER vadl
-  java.net.URI sourceFile = SourceLocation.INVALID_SOURCE_LOCATION.uri();
-  @Nullable java.net.URI resolutionUri;
+  @Nullable Path sourceFile = null;
+  @Nullable Path resolutionPath;
   Deque<List<MacroParam>> macroContext = new ArrayDeque<>();
   Ast ast = new Ast();
   SymbolTable macroTable = new SymbolTable();

--- a/vadl/main/vadl/error/DiagnosticPrinter.java
+++ b/vadl/main/vadl/error/DiagnosticPrinter.java
@@ -16,18 +16,16 @@
 
 package vadl.error;
 
-import java.io.File;
 import java.io.IOException;
-import java.net.URI;
-import java.nio.charset.Charset;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.StringJoiner;
 import vadl.utils.SourceLocation;
+import vadl.utils.VirtualFileSystem;
 
 /**
  * A human focused command line printer for vadl diagnostics.
@@ -38,15 +36,16 @@ public class DiagnosticPrinter {
   public boolean forceUnixPaths = false;
   private final PrinterColors colors;
   private final Map<Path, List<String>> fileLineCache = new HashMap<>();
+  VirtualFileSystem fileSystem;
 
-  public DiagnosticPrinter() {
-    this(true);
+  public DiagnosticPrinter(VirtualFileSystem fileSystem) {
+    this(fileSystem, true);
   }
 
-  public DiagnosticPrinter(boolean enableColors) {
+  public DiagnosticPrinter(VirtualFileSystem fileSystem, boolean enableColors) {
     colors = enableColors ? new AnsiColors() : new NoColors();
+    this.fileSystem = fileSystem;
   }
-
 
   /**
    * Prints a list of diagnostics into a string.
@@ -123,8 +122,11 @@ public class DiagnosticPrinter {
     // Print preview header
     builder.append("     %s╭──[%s]\n".formatted(colors.cyan(),
         diagnostic.multiLocation.primaryLocation().location().toIDEString(
-            forceRelativePaths ? SourceLocation.IDEDetectionMode.RELATIVE :
-                SourceLocation.IDEDetectionMode.AUTO, forceUnixPaths)));
+            fileSystem,
+            forceRelativePaths
+                ? SourceLocation.IDEDetectionMode.RELATIVE
+                : SourceLocation.IDEDetectionMode.AUTO,
+            forceUnixPaths)));
     builder.append("     │\n");
 
     // TODO: Sort them accordig to their line number in the future
@@ -158,12 +160,16 @@ public class DiagnosticPrinter {
    */
   private String sourceDelimiter(SourceLocation previous,
                                  SourceLocation next) {
-    if (!previous.uri().equals(next.uri())) {
+    if (!Objects.equals(previous.path(), next.path())) {
       // This is so unusual that we print the location everytime
       var message = "     %s⋮\n".formatted(colors.cyan());
       message += "     ╭─ %s\n".formatted(
-          next.toIDEString(forceRelativePaths ? SourceLocation.IDEDetectionMode.RELATIVE :
-              SourceLocation.IDEDetectionMode.AUTO, forceUnixPaths));
+          next.toIDEString(
+              fileSystem,
+              forceRelativePaths
+                  ? SourceLocation.IDEDetectionMode.RELATIVE
+                  : SourceLocation.IDEDetectionMode.AUTO,
+              forceUnixPaths));
       return message;
     } else if (next.begin().line() == previous.end().line() + 1) {
       return "     %s│\n".formatted(colors.cyan());
@@ -214,10 +220,13 @@ public class DiagnosticPrinter {
                                   StringBuilder builder) {
     List<String> lines;
     try {
-      lines = getFileLines(location.location().uri());
+      if (location.location().path() == null) {
+        throw new IllegalStateException();
+      }
+      lines = getFileLines(location.location().path());
     } catch (IOException | IllegalArgumentException e) {
       var previewError = "No Preview available: Could not find the file '%s'".formatted(
-          location.location().uri()
+          location.location().path()
       );
       var prefix = "     %s│%s    ".formatted(colors.cyan(), colors.reset());
       var text = "%s%s%s\n%s".formatted(colors.yellow(), previewError, colors.reset(),
@@ -396,17 +405,16 @@ public class DiagnosticPrinter {
   /**
    * Get all lines fo a file.
    *
-   * @param uri of the file to load
+   * @param path of the file to load
    * @return list of lines.
    * @throws IOException if the file doesn't exist.
    */
-  private List<String> getFileLines(URI uri) throws IOException {
-    var path = new File(uri).toPath();
+  private List<String> getFileLines(Path path) throws IOException {
     if (fileLineCache.containsKey(path)) {
       return fileLineCache.get(path);
     }
 
-    var lines = Files.readAllLines(new File(uri).toPath(), Charset.defaultCharset());
+    var lines = fileSystem.readLines(path).toList();
     fileLineCache.put(path, lines);
     return lines;
   }

--- a/vadl/main/vadl/utils/DiskVirtualFileSystem.java
+++ b/vadl/main/vadl/utils/DiskVirtualFileSystem.java
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText : © 2026 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.utils;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * A abstraction layer to inject behavior into file loading.
+ * Some tests and the LSP might want to hide or inject files into the parser. For example the
+ * LSP has to work on files that are open in the editor but not yet saved, so it can overwrite
+ * this implementation.
+ */
+public class DiskVirtualFileSystem implements VirtualFileSystem {
+  @Override
+  public boolean exists(Path path) {
+    var file = new File(path.toUri());
+    return file.exists();
+  }
+
+  @Override
+  public InputStream getInputStream(Path path) throws IOException {
+    var file = new File(path.toUri());
+    return new FileInputStream(file);
+  }
+
+  @Override
+  public Path toAbsolutePath(Path path) {
+    var file = new File(path.toUri());
+    return file.toPath();
+  }
+
+  @Override
+  public Path toRelativePath(Path path) {
+    var currentWorkingDir = Paths.get(System.getProperty("user.dir"));
+    return currentWorkingDir.relativize(path);
+  }
+}

--- a/vadl/main/vadl/utils/EmptyVirtualFileSystem.java
+++ b/vadl/main/vadl/utils/EmptyVirtualFileSystem.java
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText : © 2026 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.utils;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+
+/**
+ * An empty virtual file system that pretends that no file exists.
+ */
+public class EmptyVirtualFileSystem implements VirtualFileSystem {
+  @Override
+  public boolean exists(Path path) {
+    return false;
+  }
+
+  @Override
+  public InputStream getInputStream(Path path) throws IOException {
+    throw new FileNotFoundException();
+  }
+
+  @Override
+  public Path toAbsolutePath(Path path) {
+    return path;
+  }
+
+  @Override
+  public Path toRelativePath(Path path) {
+    return path;
+  }
+}

--- a/vadl/main/vadl/utils/SourceLocation.java
+++ b/vadl/main/vadl/utils/SourceLocation.java
@@ -16,14 +16,13 @@
 
 package vadl.utils;
 
+import static java.util.Objects.requireNonNull;
 import static vadl.utils.EditorUtils.isIntelliJIDE;
 
 import com.google.common.collect.Streams;
 import java.io.IOException;
-import java.net.URI;
 import java.nio.file.FileSystems;
-import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -38,7 +37,7 @@ import org.slf4j.LoggerFactory;
 /**
  * References a location span in source.
  *
- * @param uri          uri to concrete source file
+ * @param path         path to concrete source file
  * @param begin        the span begin with line and column
  * @param end          the span end with line and column (this is inclusive)
  * @param expandedFrom pointing to the location of a macro instantiation from which the current ast
@@ -46,7 +45,7 @@ import org.slf4j.LoggerFactory;
  *                     the invocation. Is null for location that weren't expanded.
  */
 public record SourceLocation(
-    URI uri,
+    @Nullable Path path,
     Position begin,
     Position end,
     @Nullable SourceLocation expandedFrom
@@ -54,29 +53,28 @@ public record SourceLocation(
 
   private static final Logger logger = LoggerFactory.getLogger(SourceLocation.class);
 
-  private static final URI INVALID_MEMORY = URI.create("memory://unknown");
 
   public static final SourceLocation INVALID_SOURCE_LOCATION =
-      new SourceLocation(INVALID_MEMORY, 0);
+      new SourceLocation(null, 0);
 
-  public SourceLocation(URI uri, Position begin, Position end) {
-    this(uri, begin, end, null);
+  public SourceLocation(@Nullable Path path, Position begin, Position end) {
+    this(path, begin, end, null);
   }
 
-  public SourceLocation(URI uri, Position begin) {
-    this(uri, begin, begin);
+  public SourceLocation(@Nullable Path path, Position begin) {
+    this(path, begin, begin);
   }
 
-  public SourceLocation(URI uri, int lineBegin, int lineEnd) {
-    this(uri, new Position(lineBegin), new Position(lineEnd));
+  public SourceLocation(@Nullable Path path, int lineBegin, int lineEnd) {
+    this(path, new Position(lineBegin), new Position(lineEnd));
   }
 
-  public SourceLocation(URI uri, int line) {
-    this(uri, line, line);
+  public SourceLocation(@Nullable Path path, int line) {
+    this(path, line, line);
   }
 
   public boolean isValid() {
-    return !this.uri.equals(INVALID_MEMORY);
+    return this.path != null;
   }
 
   public SourceLocation orDefault(SourceLocation defaultLocation) {
@@ -144,7 +142,7 @@ public record SourceLocation(
     var firstLocation = locationPair.left();
     var secondLocation = locationPair.right();
 
-    if (!firstLocation.uri.equals(secondLocation.uri)) {
+    if (!Objects.equals(firstLocation.path, secondLocation.path)) {
       throw new IllegalArgumentException(
           "Cannot join source locations from different files.");
     }
@@ -157,7 +155,7 @@ public record SourceLocation(
         Objects.equals(firstLocation.expandedFrom, secondLocation.expandedFrom)
             ? firstLocation.expandedFrom : null;
 
-    return new SourceLocation(firstLocation.uri, begin, end, expanedFrom);
+    return new SourceLocation(firstLocation.path, begin, end, expanedFrom);
   }
 
 
@@ -179,7 +177,7 @@ public record SourceLocation(
       return INVALID_SOURCE_LOCATION;
     }
 
-    if (!this.uri.equals(other.uri)) {
+    if (!Objects.equals(this.path, other.path)) {
       throw new IllegalArgumentException(
           "Cannot intersect source locations that point to different files.");
     }
@@ -194,7 +192,7 @@ public record SourceLocation(
         Objects.equals(this.expandedFrom, other.expandedFrom)
             ? this.expandedFrom : null;
 
-    return new SourceLocation(this.uri, begin, end, expanedFrom);
+    return new SourceLocation(this.path, begin, end, expanedFrom);
   }
 
   /**
@@ -208,46 +206,23 @@ public record SourceLocation(
    * Produces version that is easily understandable for IDE's.
    *
    * <p>E.g.: {@code SourceLocation("relative/path/to/file.vadl", (1, 3), (2, 4))}
-   * becomes  {@code "relative/path/to/file.vadl:1:3"}
+   * becomes  {@code "relative/path/to/file.vadl:1:3"} for most Editors
+   * becomes  {@code "file:///absolut/path/to/file.vadl:1:3"} for IntelliJ
    * </p>
    */
-  public String toIDEString() {
-    return toIDEString(IDEDetectionMode.AUTO);
-  }
-
-  /**
-   * Produces version that is easily understandable for IDE's.
-   *
-   * <p>E.g.: {@code SourceLocation("relative/path/to/file.vadl", (1, 3), (2, 4))}
-   * becomes  {@code "relative/path/to/file.vadl:1:3"}
-   * </p>
-   */
-  public String toIDEString(IDEDetectionMode mode) {
-    return toIDEString(mode, false);
-  }
-
-  /**
-   * Produces version that is easily understandable for IDE's.
-   *
-   * <p>E.g.: {@code SourceLocation("relative/path/to/file.vadl", (1, 3), (2, 4))}
-   * becomes  {@code "relative/path/to/file.vadl:1:3"}
-   * </p>
-   */
-  public String toIDEString(IDEDetectionMode mode, boolean forceUnixPaths) {
+  public String toIDEString(VirtualFileSystem fileSystem, IDEDetectionMode mode,
+                            boolean forceUnixPaths) {
     if (!this.isValid()) {
       return "Source Location was lost";
     }
 
     String printablePath;
 
-    if (mode == IDEDetectionMode.ABSOLUTE || (mode == IDEDetectionMode.AUTO && (isIntelliJIDE()
-        || this.uri.getScheme().equals("memory")))) {
+    if (mode == IDEDetectionMode.ABSOLUTE || (mode == IDEDetectionMode.AUTO && isIntelliJIDE())) {
       // IntelliJ integrated terminal needs special treatment
-      printablePath = this.uri.toString();
+      printablePath = "file://" + fileSystem.toAbsolutePath(requireNonNull(path));
     } else {
-      var filePath = Paths.get(this.uri);
-      var currentWorkingDir = Paths.get(System.getProperty("user.dir"));
-      printablePath = currentWorkingDir.relativize(filePath).toFile().getPath();
+      printablePath = fileSystem.toRelativePath(requireNonNull(path)).toString();
     }
     if (forceUnixPaths) {
       printablePath = printablePath.replace(FileSystems.getDefault().getSeparator(), "/");
@@ -266,7 +241,7 @@ public record SourceLocation(
    * </p>
    */
   public String toConciseString() {
-    var uriAsString = this.uri.toString();
+    var uriAsString = this.path != null ? "file://" + this.path : "memory://invalid";
     var indexOfLastSlash = uriAsString.lastIndexOf('/');
     return uriAsString.substring(indexOfLastSlash + 1)
         + ":"
@@ -279,12 +254,12 @@ public record SourceLocation(
    * Reads the content of the source file at this location and
    * returns it as String.
    */
-  public String toSourceString() {
+  public String toSourceString(VirtualFileSystem fileSystem) {
     if (!this.isValid()) {
       return "Invalid source location: " + this;
     }
 
-    try (Stream<String> lines = Files.lines(Paths.get(uri))) {
+    try (Stream<String> lines = fileSystem.readLines(requireNonNull(this.path))) {
       if (begin.line <= 0) {
         return "Invalid source location: " + this;
       }
@@ -321,12 +296,15 @@ public record SourceLocation(
    * becomes "file:///path/file.vadl:1:3 .. 2:4"
    */
   public String toUriString() {
-    return uri.toString() + ":" + begin + " .. " + end;
+    if (path == null) {
+      return "memory://invalid";
+    }
+    return "file://" + path.toString() + ":" + begin + " .. " + end;
   }
 
   @Override
   public String toString() {
-    var printPath = !uri.getPath().isEmpty() ? uri.getPath() : "unknown";
+    var printPath = path != null ? path.toString() : "unknown";
     printPath += ":" + begin + ".." + end;
     return printPath;
   }
@@ -340,7 +318,7 @@ public record SourceLocation(
       return false;
     }
     SourceLocation that = (SourceLocation) o;
-    return Objects.equals(uri, that.uri)
+    return Objects.equals(path, that.path)
         && Objects.equals(begin, that.begin)
         && Objects.equals(end, that.end)
         && Objects.equals(expandedFrom, that.expandedFrom);
@@ -348,7 +326,7 @@ public record SourceLocation(
 
   @Override
   public int hashCode() {
-    return Objects.hash(uri, begin, end, expandedFrom);
+    return Objects.hash(path, begin, end, expandedFrom);
   }
 
   @Override

--- a/vadl/main/vadl/utils/VirtualFileSystem.java
+++ b/vadl/main/vadl/utils/VirtualFileSystem.java
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText : © 2026 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.utils;
+
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+/**
+ * An abstraction layer over the file system, which allows the caller to "lie" to the frontend
+ * about the state of the filesystem.
+ * This is especially important for the LSP who wants to run the compiler on files that might not
+ * yet exist on disk but only in the editor of the user.
+ */
+public interface VirtualFileSystem {
+
+  /**
+   * Checks whether a file exists.
+   * The provided path might point to a directory in which it still would return null.
+   *
+   * @param path  to check for.
+   * @return      true if the file exists, false otherwise.
+   */
+  boolean exists(Path path);
+
+  /**
+   * Open a stream to read from the provided file.
+   *
+   * @param path          of the file to be read.
+   * @return              an input stream to read from the file.
+   * @throws IOException  if the file cannot be opened.
+   */
+  InputStream getInputStream(Path path) throws IOException;
+
+
+  /**
+   * Convert a potential relative path to an absolute one.
+   *
+   * @param path  to be converted.
+   * @return      the absolute version.
+   */
+  Path toAbsolutePath(Path path);
+
+  /**
+   * Convert a potential absolut path to a relative one (relative to the current working directory).
+   *
+   * @param path  to be converted.
+   * @return      the relative version.
+   */
+  Path toRelativePath(Path path);
+
+  /**
+   * Read the file from the provided path line by line.
+   *
+   * @param path          to read from.
+   * @return              a stream of the lines from the file.
+   * @throws IOException  if the file cannot be read.
+   */
+  default Stream<String> readLines(Path path) throws IOException {
+    return new BufferedReader(new InputStreamReader(getInputStream(path), StandardCharsets.UTF_8))
+        .lines();
+  }
+}

--- a/vadl/main/vadl/viam/ViamError.java
+++ b/vadl/main/vadl/viam/ViamError.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -29,6 +29,7 @@ import javax.annotation.Nullable;
 import org.jetbrains.annotations.Contract;
 import vadl.error.Diagnostic;
 import vadl.error.DiagnosticBuilder;
+import vadl.utils.DiskVirtualFileSystem;
 import vadl.utils.SourceLocation;
 
 /**
@@ -115,7 +116,8 @@ public class ViamError extends RuntimeException {
         .map("\n\twith %s"::formatted)
         .collect(Collectors.joining())
         + "\n\twith location:\t%s".formatted(location)
-        + "\n\twith source:\t%s".formatted(location.toSourceString());
+        // FIMXE: Introduce some global structure to get the current VFS instead of hardcoding it.
+        + "\n\twith source:\t%s".formatted(location.toSourceString(new DiskVirtualFileSystem()));
   }
 
 

--- a/vadl/test/vadl/OpenVadlTestFrontend.java
+++ b/vadl/test/vadl/OpenVadlTestFrontend.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -29,6 +29,7 @@ import vadl.ast.VadlParser;
 import vadl.ast.ViamLowering;
 import vadl.error.Diagnostic;
 import vadl.error.DiagnosticPrinter;
+import vadl.utils.DiskVirtualFileSystem;
 import vadl.viam.Specification;
 
 class OpenVadlTestFrontend implements TestFrontend {
@@ -54,7 +55,7 @@ class OpenVadlTestFrontend implements TestFrontend {
     } catch (Diagnostic e) {
       // FIXME: Proper print to string
       var stringWriter = new StringWriter();
-      stringWriter.append(new DiagnosticPrinter(false).toString(e));
+      stringWriter.append(new DiagnosticPrinter(new DiskVirtualFileSystem(), false).toString(e));
       stringWriter.append("\n");
       e.printStackTrace(new PrintWriter(stringWriter));
       logs = e.getMessage() + "\n" + stringWriter;

--- a/vadl/test/vadl/ast/AstDumpTests.java
+++ b/vadl/test/vadl/ast/AstDumpTests.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DynamicTest;
@@ -59,7 +58,7 @@ public class AstDumpTests {
   }
 
   private void assertDumpEquality(Path vadlPath, Path expectedDumpPath) throws IOException {
-    var ast = VadlParser.parse(vadlPath.toAbsolutePath(), Map.of());
+    var ast = VadlParser.parse(vadlPath.toAbsolutePath());
     ModelRemover remover = new ModelRemover();
     remover.removeModels(ast);
     Ungrouper ungrouper = new Ungrouper();

--- a/vadl/test/vadl/ast/AstMacroTests.java
+++ b/vadl/test/vadl/ast/AstMacroTests.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -29,6 +29,7 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.TestFactory;
+import vadl.utils.DiskVirtualFileSystem;
 
 public class AstMacroTests {
 
@@ -65,7 +66,7 @@ public class AstMacroTests {
 
   private void assertAstEquality(Path vadlPath) throws IOException {
     var replacements = parseMacroReplacements(vadlPath.toAbsolutePath());
-    var ast = VadlParser.parse(vadlPath.toAbsolutePath(), replacements);
+    var ast = VadlParser.parse(vadlPath.toAbsolutePath(), new DiskVirtualFileSystem(), replacements);
     verifyPrettifiedAst(ast);
 
     var actualExpandedAst = ast.prettyPrintToString();

--- a/vadl/test/vadl/ast/AstTestUtils.java
+++ b/vadl/test/vadl/ast/AstTestUtils.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -34,7 +34,7 @@ public class AstTestUtils {
     MODEL_REMOVER.removeModels(ast);
     UNGROUPER.ungroup(ast);
     var progPretty = ast.prettyPrintToString();
-    var astPretty = Assertions.assertDoesNotThrow(() -> VadlParser.parse(progPretty, ast.fileUri),
+    var astPretty = Assertions.assertDoesNotThrow(() -> VadlParser.parse(progPretty, ast.filePath),
         "Cannot parse prettified input \n" + progPretty);
     UNGROUPER.ungroup(astPretty);
     assertAstEquality(astPretty, ast);

--- a/vadl/test/vadl/ast/DiagnosticsTest.java
+++ b/vadl/test/vadl/ast/DiagnosticsTest.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.TestFactory;
 import vadl.error.Diagnostic;
 import vadl.error.DiagnosticList;
 import vadl.error.DiagnosticPrinter;
+import vadl.utils.DiskVirtualFileSystem;
 import vadl.viam.passes.verification.ViamVerifier;
 
 /// Runs all files in the test/resources/diagnostics directory.
@@ -91,7 +92,7 @@ public class DiagnosticsTest {
 
     // Force relative and slashified paths because the tests must always produce the same and the
     // absolute path and file separator will differ on different machines.
-    DiagnosticPrinter printer = new DiagnosticPrinter(false);
+    DiagnosticPrinter printer = new DiagnosticPrinter(new DiskVirtualFileSystem(), false);
     printer.forceRelativePaths = true;
     printer.forceUnixPaths = true;
     var output = "Reported Diagnostics:\n\n";

--- a/vadl/test/vadl/ast/MacroTests.java
+++ b/vadl/test/vadl/ast/MacroTests.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -19,7 +19,7 @@ package vadl.ast;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static vadl.ast.AstTestUtils.assertAstEquality;
 
-import java.net.URI;
+import java.nio.file.Paths;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -309,7 +309,7 @@ public class MacroTests {
         """;
 
     var exception = Assertions.assertThrows(DiagnosticList.class,
-        () -> VadlParser.parse(prog, URI.create("memory://hardcoded")));
+        () -> VadlParser.parse(prog, Paths.get("hardcoded")));
     var location = exception.items.get(0).multiLocation.primaryLocation().location();
     Assertions.assertNotNull(location.expandedFrom());
     Assertions.assertEquals(5, location.expandedFrom().begin().line());

--- a/vadl/test/vadl/ast/VirtualFileSystemTest.java
+++ b/vadl/test/vadl/ast/VirtualFileSystemTest.java
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText : © 2026 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.ast;
+
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import vadl.utils.VirtualFileSystem;
+
+public class VirtualFileSystemTest {
+
+
+  @Test
+  void testMockedVFS() throws IOException {
+    // Let's parse a file that doesn't exist on disk but is only injected into the compiler via
+    // the virtual filesystem (VFS).
+    // The file also imports another pseudo file that only exists in the VFS.
+    VadlParser.parse(Paths.get("firstPseudoFile.vadl"), new TestVFS());
+  }
+
+  private static class TestVFS implements VirtualFileSystem {
+    private final Map<String, String> files = Map.of(
+        "firstPseudoFile.vadl", "import secondPseudoFile::magicNumber \nconstant flo = $magicNumber()",
+        "secondPseudoFile.vadl", "model magicNumber(): Ex = {\n"
+            + "  42\n"
+            + "}\n"
+    );
+
+    @Override
+    public boolean exists(Path path) {
+      return files.containsKey(path.toString());
+    }
+
+    @Override
+    public InputStream getInputStream(Path path) throws IOException {
+      return new ByteArrayInputStream(files.get(path.toString()).toString().getBytes(
+          StandardCharsets.UTF_8));
+    }
+
+    @Override
+    public Path toAbsolutePath(Path path) {
+      return path;
+    }
+
+    @Override
+    public Path toRelativePath(Path path) {
+      return path;
+    }
+  }
+
+}

--- a/vadl/test/vadl/utils/SourceLocationTest.java
+++ b/vadl/test/vadl/utils/SourceLocationTest.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -16,14 +16,15 @@
 
 package vadl.utils;
 
+import static java.util.Objects.requireNonNull;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Objects;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -32,62 +33,62 @@ import org.junit.jupiter.api.Test;
  */
 public class SourceLocationTest {
 
-  private static URI miniVadlUri;
+  private static Path miniVadlPath;
 
   @BeforeAll
   public static void setup() throws URISyntaxException {
-    miniVadlUri =
-        Objects.requireNonNull(SourceLocationTest.class.getResource("/testFiles/mini.vadl"))
-            .toURI();
+    miniVadlPath =
+        Paths.get(
+            requireNonNull(SourceLocationTest.class.getResource("/testFiles/mini.vadl")).getPath());
   }
 
 
   @Test
   public void testToSourceString_singleLine() {
-    SourceLocation location = new SourceLocation(miniVadlUri, 12);
+    SourceLocation location = new SourceLocation(miniVadlPath, 12);
     String expected =
         "  constant MLen   = $ArchSize()           // MLen = 32 or 64 depending on ArchSize";
-    assertEquals(expected, location.toSourceString());
+    assertEquals(expected, location.toSourceString(new DiskVirtualFileSystem()));
   }
 
   @Test
   public void testToSourceString_multipleLines() {
-    SourceLocation location = new SourceLocation(miniVadlUri, 14, 16);
+    SourceLocation location = new SourceLocation(miniVadlPath, 14, 16);
     String expected = "  using Inst     = Bits<32>               // instruction word is 32 bit\n"
         + "  using Regs     = Bits<MLen>             // untyped register word type\n"
         + "  using Bits3    = Bits< 3>               // 3 bit type";
-    assertEquals(expected, location.toSourceString());
+    assertEquals(expected, location.toSourceString(new DiskVirtualFileSystem()));
   }
 
   @Test
   public void testToSourceString_withColumn() {
     SourceLocation.Position start = new SourceLocation.Position(23, 10);
     SourceLocation.Position end = new SourceLocation.Position(23, 15);
-    SourceLocation location = new SourceLocation(miniVadlUri, start, end);
+    SourceLocation location = new SourceLocation(miniVadlPath, start, end);
     String expected = "Rtype";
-    assertEquals(expected, location.toSourceString());
+    assertEquals(expected, location.toSourceString(new DiskVirtualFileSystem()));
   }
 
   @Test
   public void testToSourceString_multipleLinesWithColumn() {
     SourceLocation.Position start = new SourceLocation.Position(33, 3);
     SourceLocation.Position end = new SourceLocation.Position(34, 61);
-    SourceLocation location = new SourceLocation(miniVadlUri, start, end);
+    SourceLocation location = new SourceLocation(miniVadlPath, start, end);
     String expected =
         "instruction ADD : Rtype =               // 3 register operand instructions\n"
             + "      X(rd) := ((X(rs1) as Bits) + (X(rs2) as Bits)) as Regs";
-    assertEquals(expected, location.toSourceString());
+    assertEquals(expected, location.toSourceString(new DiskVirtualFileSystem()));
   }
 
   @Test
   public void testToSourceString_whenBeginLineIsZero() {
-    SourceLocation location = new SourceLocation(miniVadlUri, 0);
-    assert (location.toSourceString().contains("Invalid source location"));
+    SourceLocation location = new SourceLocation(miniVadlPath, 0);
+    assert (location.toSourceString(new DiskVirtualFileSystem()).contains("Invalid source location"));
   }
 
   @Test
   public void testToUriString() {
-    SourceLocation location = new SourceLocation(miniVadlUri, new SourceLocation.Position(1, 5));
+    SourceLocation location = new SourceLocation(miniVadlPath, new SourceLocation.Position(1, 5));
     assertThat(location.toUriString(), startsWith("file:/"));
     assertThat(location.toUriString(), endsWith("mini.vadl:1:5 .. 1:5"));
   }


### PR DESCRIPTION
Some tooling needs a custom abstraction layer over files. For example the LSP needs to inject unsaved edits into files for the compiler.
Now all reads in the frontend should be determined through VFS abstraction.