### PR TITLE
lcb: add upcast access to annotation to RISCV Wshft instructions

### DIFF
--- a/sys/risc-v/rv3264im.vadl
+++ b/sys/risc-v/rv3264im.vadl
@@ -144,6 +144,7 @@ instruction set architecture RV3264Base = {
     }
 
   model WShftInstr (name : Id, op : BinOp, funct3 : Bin, funct7 : Bin, lhsTy : Id) : IsaDefs = {
+    [ upcast access to : shamt, MLen ]
     instruction $name : Rtype =                        // shift immediate instructions word
       X(rd) := (((X(rs1) as $lhsTy) $op shamt) as SInt) as SIntR
     encoding $name = {opcode = 0b001'1011, funct3 = $funct3, funct7 = $funct7}

--- a/vadl/test/resources/snapshots/rv64im/InstrInfoTableGen.td
+++ b/vadl/test/resources/snapshots/rv64im/InstrInfoTableGen.td
@@ -493,9 +493,9 @@ class RV3264Base_SLLIW_shamt<ValueType ty> : Operand<ty>
   let DecoderMethod = "RV3264Base_SLLIW_shamt_decode_wrapper";
 }
 
-def RV3264Base_SLLIW_shamtAsInt8
-    : RV3264Base_SLLIW_shamt<i8>
-    , ImmLeaf<i8, [{ return RV3264Base_SLLIW_shamt_predicate(Imm); }]>;
+def RV3264Base_SLLIW_shamtAsInt64
+    : RV3264Base_SLLIW_shamt<i64>
+    , ImmLeaf<i64, [{ return RV3264Base_SLLIW_shamt_predicate(Imm); }]>;
 
 def RV3264Base_SLLIW_shamtAsLabel : RV3264Base_SLLIW_shamt<OtherVT>;
 
@@ -541,9 +541,9 @@ class RV3264Base_SRAIW_shamt<ValueType ty> : Operand<ty>
   let DecoderMethod = "RV3264Base_SRAIW_shamt_decode_wrapper";
 }
 
-def RV3264Base_SRAIW_shamtAsInt8
-    : RV3264Base_SRAIW_shamt<i8>
-    , ImmLeaf<i8, [{ return RV3264Base_SRAIW_shamt_predicate(Imm); }]>;
+def RV3264Base_SRAIW_shamtAsInt64
+    : RV3264Base_SRAIW_shamt<i64>
+    , ImmLeaf<i64, [{ return RV3264Base_SRAIW_shamt_predicate(Imm); }]>;
 
 def RV3264Base_SRAIW_shamtAsLabel : RV3264Base_SRAIW_shamt<OtherVT>;
 
@@ -565,9 +565,9 @@ class RV3264Base_SRLIW_shamt<ValueType ty> : Operand<ty>
   let DecoderMethod = "RV3264Base_SRLIW_shamt_decode_wrapper";
 }
 
-def RV3264Base_SRLIW_shamtAsInt8
-    : RV3264Base_SRLIW_shamt<i8>
-    , ImmLeaf<i8, [{ return RV3264Base_SRLIW_shamt_predicate(Imm); }]>;
+def RV3264Base_SRLIW_shamtAsInt64
+    : RV3264Base_SRLIW_shamt<i64>
+    , ImmLeaf<i64, [{ return RV3264Base_SRLIW_shamt_predicate(Imm); }]>;
 
 def RV3264Base_SRLIW_shamtAsLabel : RV3264Base_SRLIW_shamt<OtherVT>;
 
@@ -3037,7 +3037,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs X:$rd );
-let InOperandList = ( ins X:$rs1, RV3264Base_SLLIW_shamtAsInt8:$shamt );
+let InOperandList = ( ins X:$rs1, RV3264Base_SLLIW_shamtAsInt64:$shamt );
 
 field bits<32> Inst;
 
@@ -3459,7 +3459,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs X:$rd );
-let InOperandList = ( ins X:$rs1, RV3264Base_SRAIW_shamtAsInt8:$shamt );
+let InOperandList = ( ins X:$rs1, RV3264Base_SRAIW_shamtAsInt64:$shamt );
 
 field bits<32> Inst;
 
@@ -3673,7 +3673,7 @@ let Size = 4;
 let CodeSize = 4;
 
 let OutOperandList = ( outs X:$rd );
-let InOperandList = ( ins X:$rs1, RV3264Base_SRLIW_shamtAsInt8:$shamt );
+let InOperandList = ( ins X:$rs1, RV3264Base_SRLIW_shamtAsInt64:$shamt );
 
 field bits<32> Inst;
 


### PR DESCRIPTION
Add the new `upcast access to` annotation to WShftInstrs. This does not yet lead to better instruction selection but should fix any type issues regarding these instructions.