### PR TITLE
diagnostic: Fix order of snippets in DiagnosticPrinter

### DIFF
--- a/vadl/main/vadl/error/DiagnosticPrinter.java
+++ b/vadl/main/vadl/error/DiagnosticPrinter.java
@@ -129,9 +129,10 @@ public class DiagnosticPrinter {
             forceUnixPaths)));
     builder.append("     │\n");
 
-    // TODO: Sort them accordig to their line number in the future
-    var allSnippets = new ArrayList<>(diagnostic.multiLocation.secondaryLocations());
+    // TODO: Sort them according to their line number in the future
+    var allSnippets = new ArrayList<Diagnostic.LabeledLocation>();
     allSnippets.add(diagnostic.multiLocation.primaryLocation());
+    allSnippets.addAll(diagnostic.multiLocation.secondaryLocations());
 
     for (int i = 0; i < allSnippets.size(); i++) {
       var snippet = allSnippets.get(i);

--- a/vadl/test/resources/diagnostics/annotation/invalidZeroAnnoationInvalidTarget2.vadl
+++ b/vadl/test/resources/diagnostics/annotation/invalidZeroAnnoationInvalidTarget2.vadl
@@ -12,11 +12,11 @@ instruction set architecture TEST =
 //  error: Invalid zero annotation
 //       ╭──[test/resources/diagnostics/annotation/invalidZeroAnnoationInvalidTarget2.vadl:5:12]
 //       │
-//     6 │   register X : Bits<5> -> Bits<32>
-//       │   -------------------------------- note: This is the register to target.
-//       ⋮
 //     5 │   [ zero : Y(1)]
 //       │            ^ Zero annotation target must be the annotated register.
+//       │
+//     6 │   register X : Bits<5> -> Bits<32>
+//       │   -------------------------------- note: This is the register to target.
 //       │
 //
 //

--- a/vadl/test/resources/diagnostics/annotation/invalidZeroAnnotationInvalidArgument.vadl
+++ b/vadl/test/resources/diagnostics/annotation/invalidZeroAnnotationInvalidArgument.vadl
@@ -12,11 +12,11 @@ instruction set architecture TEST =
 //  error: Invalid zero annotation
 //       ╭──[test/resources/diagnostics/annotation/invalidZeroAnnotationInvalidArgument.vadl:5:14]
 //       │
-//     6 │   register X : Bits<5> -> Bits<32>
-//       │   -------------------------------- note: Cannot evaluate identifier with origin of vadl.ast.RegisterDefinition
-//       ⋮
 //     5 │   [ zero : X(Y) ]
 //       │              ^ Index must be a constant expression.
+//       │
+//     6 │   register X : Bits<5> -> Bits<32>
+//       │   -------------------------------- note: Cannot evaluate identifier with origin of vadl.ast.RegisterDefinition
 //       │
 //
 //

--- a/vadl/test/resources/diagnostics/annotation/invalidZeroAnnotationInvalidTarget1.vadl
+++ b/vadl/test/resources/diagnostics/annotation/invalidZeroAnnotationInvalidTarget1.vadl
@@ -12,11 +12,11 @@ instruction set architecture TEST =
 //  error: Invalid zero annotation
 //       ╭──[test/resources/diagnostics/annotation/invalidZeroAnnotationInvalidTarget1.vadl:5:12]
 //       │
-//     6 │   register X : Bits<5> -> Bits<32>
-//       │   -------------------------------- note: This is the register to target.
-//       ⋮
 //     5 │   [ zero : M(1)]
 //       │            ^ Zero annotation target must be the annotated register.
+//       │
+//     6 │   register X : Bits<5> -> Bits<32>
+//       │   -------------------------------- note: This is the register to target.
 //       │
 //
 //

--- a/vadl/test/resources/diagnostics/imports/invalidImportAndRedeclareModel.vadl
+++ b/vadl/test/resources/diagnostics/imports/invalidImportAndRedeclareModel.vadl
@@ -12,12 +12,12 @@ model magicNumber(): Ex = {
 //  error: Macro name already used: magicNumber
 //       ╭──[test/resources/diagnostics/imports/invalidImportAndRedeclareModel.vadl:5:7]
 //       │
-//     1 │ model magicNumber(): Ex = {
-//       │       ----------- First defined here.
-//       ⋮
-//       ╭─ test/resources/diagnostics/imports/invalidImportAndRedeclareModel.vadl:5:7
 //     5 │ model magicNumber(): Ex = {
 //       │       ^^^^^^^^^^^ Second definition here.
+//       ⋮
+//       ╭─ test/resources/diagnostics/imports/base.vadl:1:7
+//     1 │ model magicNumber(): Ex = {
+//       │       ----------- First defined here.
 //       │
 //       note: All macros must have a unique name.
 //

--- a/vadl/test/resources/diagnostics/nameresolution/invalidResolveTwoOverlappingConstant.vadl
+++ b/vadl/test/resources/diagnostics/nameresolution/invalidResolveTwoOverlappingConstant.vadl
@@ -7,11 +7,11 @@ constant a = 13
 //  error: Symbol name already used: a
 //       ╭──[test/resources/diagnostics/nameresolution/invalidResolveTwoOverlappingConstant.vadl:2:10]
 //       │
-//     1 │ constant a = 13
-//       │          - First defined here.
-//       │
 //     2 │ constant a = 13
 //       │          ^ Second definition here.
+//       ⋮
+//     1 │ constant a = 13
+//       │          - First defined here.
 //       │
 //       note: All symbols must have a unique name.
 //

--- a/vadl/test/resources/diagnostics/nameresolution/invalidResolveTwoOverlappingMemoryDefinitions.vadl
+++ b/vadl/test/resources/diagnostics/nameresolution/invalidResolveTwoOverlappingMemoryDefinitions.vadl
@@ -9,11 +9,11 @@ instruction set architecture FLO = {
 //  error: Symbol name already used: MEM
 //       ╭──[test/resources/diagnostics/nameresolution/invalidResolveTwoOverlappingMemoryDefinitions.vadl:3:10]
 //       │
-//     2 │   memory MEM: Bits<32> -> Bits<8>
-//       │          --- First defined here.
-//       │
 //     3 │   memory MEM: Bits<6> -> Bits<2>
 //       │          ^^^ Second definition here.
+//       ⋮
+//     2 │   memory MEM: Bits<32> -> Bits<8>
+//       │          --- First defined here.
 //       │
 //       note: All symbols must have a unique name.
 //

--- a/vadl/test/resources/diagnostics/nameresolution/invalidResolveTwoOverlappingRegisterDefinitions.vadl
+++ b/vadl/test/resources/diagnostics/nameresolution/invalidResolveTwoOverlappingRegisterDefinitions.vadl
@@ -9,11 +9,11 @@ instruction set architecture FLO = {
 //  error: Symbol name already used: X
 //       ╭──[test/resources/diagnostics/nameresolution/invalidResolveTwoOverlappingRegisterDefinitions.vadl:3:12]
 //       │
-//     2 │   register X : Bits<5>
-//       │            - First defined here.
-//       │
 //     3 │   register X : Bits<2>
 //       │            ^ Second definition here.
+//       ⋮
+//     2 │   register X : Bits<5>
+//       │            - First defined here.
 //       │
 //       note: All symbols must have a unique name.
 //

--- a/vadl/test/resources/diagnostics/nameresolution/invalidResolveTwoOverlappingRegisterFileDefinitions.vadl
+++ b/vadl/test/resources/diagnostics/nameresolution/invalidResolveTwoOverlappingRegisterFileDefinitions.vadl
@@ -9,11 +9,11 @@ instruction set architecture FLO = {
 //  error: Symbol name already used: X
 //       ╭──[test/resources/diagnostics/nameresolution/invalidResolveTwoOverlappingRegisterFileDefinitions.vadl:3:12]
 //       │
-//     2 │   register X : Bits<5> -> Bits<32>
-//       │            - First defined here.
-//       │
 //     3 │   register X : Bits<2> -> Bits<4>
 //       │            ^ Second definition here.
+//       ⋮
+//     2 │   register X : Bits<5> -> Bits<32>
+//       │            - First defined here.
 //       │
 //       note: All symbols must have a unique name.
 //

--- a/vadl/test/resources/diagnostics/typechecker/invalidFunctionDefinitionWrongReturnType.vadl
+++ b/vadl/test/resources/diagnostics/typechecker/invalidFunctionDefinitionWrongReturnType.vadl
@@ -7,10 +7,10 @@ function addOne(n: SInt<8>) -> SInt<8> = false
 //       ╭──[test/resources/diagnostics/typechecker/invalidFunctionDefinitionWrongReturnType.vadl:1:42]
 //       │
 //     1 │ function addOne(n: SInt<8>) -> SInt<8> = false
-//       │                                ------- Return type defined here as `SInt<8>`
+//       │                                          ^^^^^ Expected `SInt<8>` but got `Bool`
 //       ⋮
 //     1 │ function addOne(n: SInt<8>) -> SInt<8> = false
-//       │                                          ^^^^^ Expected `SInt<8>` but got `Bool`
+//       │                                ------- Return type defined here as `SInt<8>`
 //       │
 //
 //


### PR DESCRIPTION
This `Diagnostic` I introduced in #758 references two snippets in the VADL source code when thrown (more precisely: the snippet of `instruction.assembly()` and the snippet where `conflictingRule` is defined):
https://github.com/OpenVADL/openvadl/blob/a112795c178c7600f80b6953828a8e7218610c99/vadl/main/vadl/lcb/passes/asm/AsmGrammarRuleGenerationPass.java#L201-L211

When testing this warning I noticed that for both snippets the same source location was printed in the console:
<img width="984" height="464" alt="warning_wrong" src="https://github.com/user-attachments/assets/f364cf9e-65a2-4241-a29b-803682c7fc45" />

I think the bug is in the `DiagnosticPrinter`, where the snippet of the `primaryLocation` is added _after_ all `secondaryLocations`, when it should be added _first_. Applying the suggested change prints the warning with correct source locations:
<img width="986" height="455" alt="warning_right" src="https://github.com/user-attachments/assets/04c57303-cec0-4190-8a2e-cb1d032e201c" />

Finally, regarding the affected snapshot tests:

- As this PR changes the order of printed snippets, tests containing multiple snippets must be adjusted to fit the printed order.
- The test `invalidImportAndRedeclareModel` actually captures the bug this PR tries to fix. It includes an error with snippets from two different VADL files, but currently expects only one location to be printed. With this PR the test is fixed and now expects the two different locations to be printed.