### PR TITLE
frontend: Add initial VIAM snapshot test framework

### DIFF
--- a/vadl/test/resources/viam-snapshots/instructionEncodingAssembly.vadl
+++ b/vadl/test/resources/viam-snapshots/instructionEncodingAssembly.vadl
@@ -1,0 +1,280 @@
+// INCLUDE-VIAM-DUMP
+
+instruction set architecture Mini = {
+
+  using Inst     = Bits<32>               // instruction word is 32 bit
+  using Regs     = Bits<32>               // untyped register word type
+
+  register    X : Bits<5>   -> Regs  // integer register with 32 registers of 32 bits
+  register    V : Bits<5> -> Bits<1024>
+  alias register VL : Bits<32><32><32> = V
+  [ zero : XC(11) ]
+  alias register XC: Bits<32><12> = X(*)(11..0)
+
+  format Rtype : Inst =                   // Rtype register 3 operand instruction format
+    { funct7 : Bits<7>                    // [31..25] 7 bit function code
+    , rs2    : Bits<5>                    // [24..20] 2nd source register index / shamt
+    , rs1    : Bits<5>                    // [19..15] 1st source register index
+    , funct3 : Bits<3>                    // [14..12] 3 bit function code
+    , rd     : Bits<5>                    // [11..7]  destination register index
+    , opcode : Bits<7>                    // [6..0]   7 bit operation code
+    }
+
+  instruction ADD : Rtype = X(rd) := (X(rs1) + X(rs2)) as Regs
+  encoding ADD = {opcode = 0b011'0011, funct3 = 0b000, funct7 = 0b000'0000}
+  assembly ADD = (mnemonic, " ", register(rd), ",", register(rs1), ",", register(rs2))
+}
+
+
+//  Dumped VIAM:
+//
+//    Specification name: "spec"
+//    . Definitions: 1
+//    . InstructionSetArchitecture name: "Mini"
+//    . : PC: -
+//    . : InstructionCount: 1
+//    . : PseudoInstructionCount: 0
+//    . : FormatCount: 1
+//    . : FunctionCount: 0
+//    . : ExceptionCount: 0
+//    . : RelocationCount: 0
+//    . : RegisterCount: 2
+//    . : MemoryCount: 0
+//    . : ArtificialResourceCount: 2
+//    . : Format name: "Rtype"
+//    . : ' Type: b32
+//    . : ' FieldCount: 6
+//    . : ' FieldAccessCount: 0
+//    . : ' FieldEncodingCount: 0
+//    . : ' Field name: "funct7"
+//    . : ' | Type: b7
+//    . : ' | BitSlice: [31..25]
+//    . : ' | RefFormat: -
+//    . : ' Field name: "rs2"
+//    . : ' | Type: b5
+//    . : ' | BitSlice: [24..20]
+//    . : ' | RefFormat: -
+//    . : ' Field name: "rs1"
+//    . : ' | Type: b5
+//    . : ' | BitSlice: [19..15]
+//    . : ' | RefFormat: -
+//    . : ' Field name: "funct3"
+//    . : ' | Type: b3
+//    . : ' | BitSlice: [14..12]
+//    . : ' | RefFormat: -
+//    . : ' Field name: "rd"
+//    . : ' | Type: b5
+//    . : ' | BitSlice: [11..7]
+//    . : ' | RefFormat: -
+//    . : ' Field name: "opcode"
+//    . : ' | Type: b7
+//    . : ' | BitSlice: [6..0]
+//    . : ' | RefFormat: -
+//    . : RegisterTensor name: "X"
+//    . : ' Type: b32
+//    . : ' Dimensions: [0:b5x32, 1:b5x32]
+//    . : ' ConstraintCount: 0
+//    . : RegisterTensor name: "V"
+//    . : ' Type: b1024
+//    . : ' Dimensions: [0:b5x32, 1:b10x1024]
+//    . : ' ConstraintCount: 0
+//    . : ArtificialResource name: "VL"
+//    . : ' Kind: REGISTER
+//    . : ' InnerResource: V
+//    . : ' ReadFunction: read
+//    . : ' WriteProcedure: write
+//    . : ' AliasSlice: null
+//    . : ' Semantics:
+//    . : ' | BaseTensor: V
+//    . : ' | FixedIndices: []
+//    . : ' | DynamicDimensions: [0:b5x32, 1:b5x32]
+//    . : ' | AliasSlice: null
+//    . : ' | OverwriteMode: MERGE
+//    . : ' | ZeroConstraint: -
+//    . : ' Function name: "read"
+//    . : ' | Type: (Bits<5>,Bits<5>)->Bits<32>
+//    . : ' | Signature: (Bits<5>, Bits<5>) -> Bits<32>
+//    . : ' | Parameters: [index:b5, index:b5]
+//    . : ' | Behavior Graph:
+//    . : ' | . n0  FuncParam           in: ()         succ: ()      type: b5      param: index   index: 0
+//    . : ' | . n1  ReadsRegisterTensor in: (n0)       succ: ()      type: b1024   reg: V
+//    . : ' | . n2  Constant            in: ()         succ: ()      type: b11     const: 0x0: Bits<11>
+//    . : ' | . n3  FuncParam           in: ()         succ: ()      type: b5      param: index   index: 0
+//    . : ' | . n4  ZeroExtend          in: (n3)       succ: ()      type: b11     fromWidth: 5
+//    . : ' | . n5  Constant            in: ()         succ: ()      type: b11     const: 0x20: Bits<11>
+//    . : ' | . n6  BuiltInCall         in: (n4 n5)    succ: ()      type: b11     builtin: VADL::mul   operator: *
+//    . : ' | . n7  BuiltInCall         in: (n2 n6)    succ: ()      type: b11     builtin: VADL::add   operator: +
+//    . : ' | . n8  Constant            in: ()         succ: ()      type: b11     const: 0x1f: Bits<11>
+//    . : ' | . n9  BuiltInCall         in: (n7 n8)    succ: ()      type: b11     builtin: VADL::add   operator: +
+//    . : ' | . n10 DynSlice            in: (n1 n9 n7) succ: ()      type: b32     slice: dynamic
+//    . : ' | . n11 Return              in: (n10)      succ: ()      retType: b32
+//    . : ' | . n12 Start               in: ()         succ: (n11)   next: set
+//    . : ' | Parameter name: "index"
+//    . : ' | . Index: 0
+//    . : ' | . Type: b5
+//    . : ' | Parameter name: "index"
+//    . : ' | . Index: 0
+//    . : ' | . Type: b5
+//    . : ' Procedure name: "write"
+//    . : ' | Parameters: [index:b5, index:b5, value:b32]
+//    . : ' | ReadResources: [V]
+//    . : ' | WrittenResources: [V]
+//    . : ' | Behavior Graph:
+//    . : ' | . n0  FuncParam            in: ()        succ: ()      type: b5      param: index   index: 0
+//    . : ' | . n1  ReadsRegisterTensor  in: (n0)      succ: ()      type: b1024   reg: V
+//    . : ' | . n2  Constant             in: ()        succ: ()      type: b1024   const: 0x1: Bits<1024>
+//    . : ' | . n3  Constant             in: ()        succ: ()      type: b11     const: 0x0: Bits<11>
+//    . : ' | . n4  FuncParam            in: ()        succ: ()      type: b5      param: index   index: 0
+//    . : ' | . n5  ZeroExtend           in: (n4)      succ: ()      type: b11     fromWidth: 5
+//    . : ' | . n6  Constant             in: ()        succ: ()      type: b11     const: 0x20: Bits<11>
+//    . : ' | . n7  BuiltInCall          in: (n5 n6)   succ: ()      type: b11     builtin: VADL::mul   operator: *
+//    . : ' | . n8  BuiltInCall          in: (n3 n7)   succ: ()      type: b11     builtin: VADL::add   operator: +
+//    . : ' | . n9  Constant             in: ()        succ: ()      type: b11     const: 0x1f: Bits<11>
+//    . : ' | . n10 BuiltInCall          in: (n8 n9)   succ: ()      type: b11     builtin: VADL::add   operator: +
+//    . : ' | . n11 ZeroExtend           in: (n10)     succ: ()      type: b1024   fromWidth: 11
+//    . : ' | . n12 ZeroExtend           in: (n8)      succ: ()      type: b1024   fromWidth: 11
+//    . : ' | . n13 BuiltInCall          in: (n11 n12) succ: ()      type: b1024   builtin: VADL::sub   operator: -
+//    . : ' | . n14 BuiltInCall          in: (n13 n2)  succ: ()      type: b1024   builtin: VADL::add   operator: +
+//    . : ' | . n15 BuiltInCall          in: (n2 n14)  succ: ()      type: b1024   builtin: VADL::lsl   operator: <<
+//    . : ' | . n16 BuiltInCall          in: (n15 n2)  succ: ()      type: b1024   builtin: VADL::sub   operator: -
+//    . : ' | . n17 BuiltInCall          in: (n16 n12) succ: ()      type: b1024   builtin: VADL::lsl   operator: <<
+//    . : ' | . n18 Constant             in: ()        succ: ()      type: b1024   const: 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff: Bits<1024>
+//    . : ' | . n19 BuiltInCall          in: (n17 n18) succ: ()      type: b1024   builtin: VADL::xor   operator: ^
+//    . : ' | . n20 BuiltInCall          in: (n1 n19)  succ: ()      type: b1024   builtin: VADL::and   operator: &
+//    . : ' | . n21 FuncParam            in: ()        succ: ()      type: b32     param: value   index: 1
+//    . : ' | . n22 ZeroExtend           in: (n21)     succ: ()      type: b1024   fromWidth: 32
+//    . : ' | . n23 BuiltInCall          in: (n22 n12) succ: ()      type: b1024   builtin: VADL::lsl   operator: <<
+//    . : ' | . n24 BuiltInCall          in: (n20 n23) succ: ()      type: b1024   builtin: VADL::or    operator: |
+//    . : ' | . n25 WritesRegisterTensor in: (n0 n24)  succ: ()      reg: V
+//    . : ' | . n26 ProcEnd              in: (n25)     succ: ()      effects: 1
+//    . : ' | . n27 Start                in: ()        succ: (n26)   next: set
+//    . : ' | Parameter name: "index"
+//    . : ' | . Index: 0
+//    . : ' | . Type: b5
+//    . : ' | Parameter name: "index"
+//    . : ' | . Index: 0
+//    . : ' | . Type: b5
+//    . : ' | Parameter name: "value"
+//    . : ' | . Index: 1
+//    . : ' | . Type: b32
+//    . : ArtificialResource name: "XC"
+//    . : ' Kind: REGISTER
+//    . : ' InnerResource: X
+//    . : ' ReadFunction: read
+//    . : ' WriteProcedure: write
+//    . : ' AliasSlice: [11..0]
+//    . : ' Semantics:
+//    . : ' | BaseTensor: X
+//    . : ' | FixedIndices: []
+//    . : ' | DynamicDimensions: [0:b5x32]
+//    . : ' | AliasSlice: [11..0]
+//    . : ' | OverwriteMode: MERGE
+//    . : ' | ZeroConstraint: [0xb: Bits<5>]
+//    . : ' Function name: "read"
+//    . : ' | Type: (Bits<5>)->Bits<12>
+//    . : ' | Signature: (Bits<5>) -> Bits<12>
+//    . : ' | Parameters: [index:b5]
+//    . : ' | Behavior Graph:
+//    . : ' | . n0 FuncParam           in: ()         succ: ()     type: b5     param: index   index: 0
+//    . : ' | . n1 Constant            in: ()         succ: ()     type: b5     const: 0xb: Bits<5>
+//    . : ' | . n2 BuiltInCall         in: (n0 n1)    succ: ()     type: bool   builtin: VADL::neq   operator: !=
+//    . : ' | . n3 ReadsRegisterTensor in: (n0)       succ: ()     type: b32    reg: X
+//    . : ' | . n4 Constant            in: ()         succ: ()     type: b32    const: 0x0: Bits<32>
+//    . : ' | . n5 Select              in: (n2 n3 n4) succ: ()     type: b32
+//    . : ' | . n6 Slice               in: (n5)       succ: ()     type: b12    slice: [11..0]
+//    . : ' | . n7 Return              in: (n6)       succ: ()     retType: b12
+//    . : ' | . n8 Start               in: ()         succ: (n7)   next: set
+//    . : ' | Parameter name: "index"
+//    . : ' | . Index: 0
+//    . : ' | . Type: b5
+//    . : ' Procedure name: "write"
+//    . : ' | Parameters: [index:b5, value:b12]
+//    . : ' | ReadResources: [X]
+//    . : ' | WrittenResources: [X]
+//    . : ' | Behavior Graph:
+//    . : ' | . n0  ProcEnd              in: ()        succ: ()          effects: 0
+//    . : ' | . n1  FuncParam            in: ()        succ: ()          type: b5     param: index   index: 0
+//    . : ' | . n2  ReadsRegisterTensor  in: (n1)      succ: ()          type: b32    reg: X
+//    . : ' | . n3  Constant             in: ()        succ: ()          type: b32    const: 0xfffff000: Bits<32>
+//    . : ' | . n4  BuiltInCall          in: (n2 n3)   succ: ()          type: b32    builtin: VADL::and   operator: &
+//    . : ' | . n5  FuncParam            in: ()        succ: ()          type: b12    param: value   index: 1
+//    . : ' | . n6  Truncate             in: (n5)      succ: ()          type: b12    fromWidth: 12
+//    . : ' | . n7  ZeroExtend           in: (n6)      succ: ()          type: b32    fromWidth: 12
+//    . : ' | . n8  BuiltInCall          in: (n4 n7)   succ: ()          type: b32    builtin: VADL::or    operator: |
+//    . : ' | . n9  WritesRegisterTensor in: (n1 n8)   succ: ()          reg: X
+//    . : ' | . n10 BranchEnd            in: (n9)      succ: ()          effects: 1
+//    . : ' | . n11 BranchBegin          in: ()        succ: (n10)       next: set
+//    . : ' | . n12 BranchEnd            in: ()        succ: ()          effects: 0
+//    . : ' | . n13 BranchBegin          in: ()        succ: (n12)       next: set
+//    . : ' | . n14 Constant             in: ()        succ: ()          type: b5     const: 0xb: Bits<5>
+//    . : ' | . n15 BuiltInCall          in: (n1 n14)  succ: ()          type: bool   builtin: VADL::neq   operator: !=
+//    . : ' | . n16 If                   in: (n15)     succ: (n11 n13)   branches: 2
+//    . : ' | . n17 Merge                in: (n10 n12) succ: (n0)        branchEnds: 2
+//    . : ' | . n18 Start                in: ()        succ: (n16)       next: set
+//    . : ' | Parameter name: "index"
+//    . : ' | . Index: 0
+//    . : ' | . Type: b5
+//    . : ' | Parameter name: "value"
+//    . : ' | . Index: 1
+//    . : ' | . Type: b12
+//    . : Instruction name: "ADD" format: "Rtype"
+//    . : ' Inputs: rs1, rs2
+//    . : ' Outputs: rd
+//    . : ' Encoding: encoding
+//    . : ' Assembly: Mini::ADD::assembly
+//    . : ' Behavior Graph:
+//    . : ' | n0 FieldRef             in: ()      succ: ()     type: b5    field: rd    format: Rtype
+//    . : ' | n1 FieldRef             in: ()      succ: ()     type: b5    field: rs1   format: Rtype
+//    . : ' | n2 ReadsRegisterTensor  in: (n1)    succ: ()     type: b32   reg: X
+//    . : ' | n3 FieldRef             in: ()      succ: ()     type: b5    field: rs2   format: Rtype
+//    . : ' | n4 ReadsRegisterTensor  in: (n3)    succ: ()     type: b32   reg: X
+//    . : ' | n5 BuiltInCall          in: (n2 n4) succ: ()     type: b32   builtin: VADL::add   operator: +
+//    . : ' | n6 WritesRegisterTensor in: (n0 n5) succ: ()     reg: X
+//    . : ' | n7 InstrEnd             in: (n6)    succ: ()     effects: 1
+//    . : ' | n8 Start                in: ()      succ: (n7)   next: set
+//    . : ' Assembly name: "Mini::ADD::assembly"
+//    . : ' | Function: Mini::ADD::assembly::func
+//    . : ' | FieldAccesses: []
+//    . : ' | Function name: "Mini::ADD::assembly::func"
+//    . : ' | . Type: ()->String
+//    . : ' | . Signature: () -> String
+//    . : ' | . Parameters: []
+//    . : ' | . Behavior Graph:
+//    . : ' | . : n0  BuiltInCall in: ()        succ: ()      type: String   builtin: mnemonic
+//    . : ' | . : n1  Constant    in: ()        succ: ()      type: String   const: " "
+//    . : ' | . : n2  BuiltInCall in: (n0 n1)   succ: ()      type: String   builtin: VADL::concat_str
+//    . : ' | . : n3  FieldRef    in: ()        succ: ()      type: b5       field: rd    format: Rtype
+//    . : ' | . : n4  BuiltInCall in: (n3)      succ: ()      type: String   builtin: register
+//    . : ' | . : n5  BuiltInCall in: (n2 n4)   succ: ()      type: String   builtin: VADL::concat_str
+//    . : ' | . : n6  Constant    in: ()        succ: ()      type: String   const: ","
+//    . : ' | . : n7  BuiltInCall in: (n5 n6)   succ: ()      type: String   builtin: VADL::concat_str
+//    . : ' | . : n8  FieldRef    in: ()        succ: ()      type: b5       field: rs1   format: Rtype
+//    . : ' | . : n9  BuiltInCall in: (n8)      succ: ()      type: String   builtin: register
+//    . : ' | . : n10 BuiltInCall in: (n7 n9)   succ: ()      type: String   builtin: VADL::concat_str
+//    . : ' | . : n11 BuiltInCall in: (n10 n6)  succ: ()      type: String   builtin: VADL::concat_str
+//    . : ' | . : n12 FieldRef    in: ()        succ: ()      type: b5       field: rs2   format: Rtype
+//    . : ' | . : n13 BuiltInCall in: (n12)     succ: ()      type: String   builtin: register
+//    . : ' | . : n14 BuiltInCall in: (n11 n13) succ: ()      type: String   builtin: VADL::concat_str
+//    . : ' | . : n15 Return      in: (n14)     succ: ()      retType: String
+//    . : ' | . : n16 Start       in: ()        succ: (n15)   next: set
+//    . : ' Encoding name: "encoding"
+//    . : ' | Type: b32
+//    . : ' | Format: Rtype
+//    . : ' | FieldEncodings: 3
+//    . : ' | NonEncodedFields: [rs2, rs1, rd]
+//    . : ' | HasConstraint: false
+//    . : ' | Field name: "opcode"
+//    . : ' | . Field: opcode
+//    . : ' | . Type: b7
+//    . : ' | . Constant: 0x33: Bits<7>
+//    . : ' | Field name: "funct3"
+//    . : ' | . Field: funct3
+//    . : ' | . Type: b3
+//    . : ' | . Constant: 0x0: Bits<3>
+//    . : ' | Field name: "funct7"
+//    . : ' | . Field: funct7
+//    . : ' | . Type: b7
+//    . : ' | . Constant: 0x0: Bits<7>
+//
+//
+// Part of the class vadl.viam.ViamSnapshotTest

--- a/vadl/test/vadl/viam/ViamSnapshotDumper.java
+++ b/vadl/test/vadl/viam/ViamSnapshotDumper.java
@@ -1,0 +1,908 @@
+// SPDX-FileCopyrightText : © 2026 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.viam;
+
+import java.util.Comparator;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import vadl.javaannotations.DispatchFor;
+import vadl.javaannotations.Handler;
+import vadl.types.BitsType;
+import vadl.types.BoolType;
+import vadl.types.SIntType;
+import vadl.types.Type;
+import vadl.types.UIntType;
+import vadl.viam.asm.AsmDirectiveMapping;
+import vadl.viam.asm.AsmModifier;
+import vadl.viam.asm.rules.AsmBuiltinRule;
+import vadl.viam.asm.rules.AsmGrammarRule;
+import vadl.viam.asm.rules.AsmNonTerminalRule;
+import vadl.viam.asm.rules.AsmTerminalRule;
+import vadl.viam.graph.Graph;
+import vadl.viam.graph.HasRegisterTensor;
+import vadl.viam.graph.Node;
+import vadl.viam.graph.ReadsRegisterTensor;
+import vadl.viam.graph.WritesRegisterTensor;
+import vadl.viam.graph.control.AbstractEndNode;
+import vadl.viam.graph.control.BranchEndNode;
+import vadl.viam.graph.control.ControlSplitNode;
+import vadl.viam.graph.control.DirectionalNode;
+import vadl.viam.graph.control.ForallNode;
+import vadl.viam.graph.control.IfNode;
+import vadl.viam.graph.control.InstrCallNode;
+import vadl.viam.graph.control.MergeNode;
+import vadl.viam.graph.control.NewLabelNode;
+import vadl.viam.graph.control.ReturnNode;
+import vadl.viam.graph.dependency.AsmBuiltInCall;
+import vadl.viam.graph.dependency.BuiltInCall;
+import vadl.viam.graph.dependency.ConstantNode;
+import vadl.viam.graph.dependency.DynSliceNode;
+import vadl.viam.graph.dependency.ExpressionNode;
+import vadl.viam.graph.dependency.FieldAccessRefNode;
+import vadl.viam.graph.dependency.FieldRefNode;
+import vadl.viam.graph.dependency.FoldNode;
+import vadl.viam.graph.dependency.ForIdxNode;
+import vadl.viam.graph.dependency.FuncCallNode;
+import vadl.viam.graph.dependency.FuncParamNode;
+import vadl.viam.graph.dependency.LabelNode;
+import vadl.viam.graph.dependency.LetNode;
+import vadl.viam.graph.dependency.MiaBuiltInCall;
+import vadl.viam.graph.dependency.ProcCallNode;
+import vadl.viam.graph.dependency.ReadArtificialResNode;
+import vadl.viam.graph.dependency.ReadMemNode;
+import vadl.viam.graph.dependency.ReadRegTensorNode;
+import vadl.viam.graph.dependency.ReadSignalNode;
+import vadl.viam.graph.dependency.ReadStageOutputNode;
+import vadl.viam.graph.dependency.SelectNode;
+import vadl.viam.graph.dependency.SideEffectNode;
+import vadl.viam.graph.dependency.SignExtendNode;
+import vadl.viam.graph.dependency.SliceNode;
+import vadl.viam.graph.dependency.TensorNode;
+import vadl.viam.graph.dependency.TruncateNode;
+import vadl.viam.graph.dependency.TupleGetFieldNode;
+import vadl.viam.graph.dependency.WriteArtificialResNode;
+import vadl.viam.graph.dependency.WriteMemNode;
+import vadl.viam.graph.dependency.WriteRegTensorNode;
+import vadl.viam.graph.dependency.WriteSignalNode;
+import vadl.viam.graph.dependency.WriteStageOutputNode;
+import vadl.viam.graph.dependency.ZeroExtendNode;
+
+/**
+ * Produces a deterministic text snapshot of the VIAM for testing.
+ */
+public class ViamSnapshotDumper extends DefinitionVisitor.Empty {
+
+  private static final int INDENT_BY = 2;
+  private static final String INDENT_CHARACTERS = ". : ' | ";
+  private final StringBuilder builder = new StringBuilder();
+  private int indent;
+
+  /**
+   * Dumps VIAM definitions and behavior graphs in a textual snapshot format.
+   */
+  public String dump(Specification specification) {
+    builder.setLength(0);
+    indent = 0;
+    new DefinitionVisitor.Recursive() {
+      @Override
+      public void beforeTraversal(Definition definition) {
+        dumpDefinition(definition);
+        indent++;
+      }
+
+      @Override
+      public void afterTraversal(Definition definition) {
+        indent--;
+      }
+    }.visit(specification);
+
+    return builder.toString();
+  }
+
+  private void dumpDefinition(Definition definition) {
+    if (definition instanceof Specification specification) {
+      line("Specification name: \"%s\"".formatted(specification.simpleName()));
+      lineAt(indent + 1, "Definitions: %d".formatted(specification.definitions().count()));
+      return;
+    }
+
+    if (definition instanceof Instruction instruction) {
+      line("Instruction name: \"%s\" format: \"%s\"".formatted(
+          instruction.simpleName(), instruction.format().simpleName()));
+      lineAt(indent + 1, "Inputs: %s".formatted(joinOrDash(instructionInputNames(instruction))));
+      lineAt(indent + 1, "Outputs: %s".formatted(joinOrDash(instructionOutputNames(instruction))));
+      lineAt(indent + 1, "Encoding: %s".formatted(instruction.encoding().simpleName()));
+      lineAt(indent + 1, "Assembly: %s".formatted(instruction.assembly().simpleName()));
+      dumpBehaviors(List.of(instruction.behavior()), indent + 1);
+      return;
+    }
+
+    line("%s name: \"%s\"".formatted(definition.getClass().getSimpleName(),
+        definition.simpleName()));
+    new DefinitionInfoPrinter(indent + 1).print(definition);
+    if (definition instanceof DefProp.WithBehavior withBehavior) {
+      dumpBehaviors(withBehavior.behaviors(), indent + 1);
+    }
+  }
+
+  private class DefinitionInfoPrinter extends DefinitionVisitor.Empty {
+    private final int atIndent;
+
+    DefinitionInfoPrinter(int atIndent) {
+      this.atIndent = atIndent;
+    }
+
+    void print(Definition definition) {
+      definition.accept(this);
+    }
+
+    @Override
+    public void visit(InstructionSetArchitecture isa) {
+      lineAt(atIndent, "PC: %s".formatted(isa.pc() != null ? isa.pc().simpleName() : "-"));
+      lineAt(atIndent, "InstructionCount: %d".formatted(isa.ownInstructions().size()));
+      lineAt(atIndent, "PseudoInstructionCount: %d".formatted(isa.ownPseudoInstructions().size()));
+      lineAt(atIndent, "FormatCount: %d".formatted(isa.ownFormats().size()));
+      lineAt(atIndent, "FunctionCount: %d".formatted(isa.ownFunctions().size()));
+      lineAt(atIndent, "ExceptionCount: %d".formatted(isa.exceptions().size()));
+      lineAt(atIndent, "RelocationCount: %d".formatted(isa.ownRelocations().size()));
+      lineAt(atIndent, "RegisterCount: %d".formatted(isa.registerTensors().size()));
+      lineAt(atIndent, "MemoryCount: %d".formatted(isa.ownMemories().size()));
+      lineAt(atIndent, "ArtificialResourceCount: %d".formatted(isa.artificialResources().size()));
+    }
+
+    @Override
+    public void visit(Format format) {
+      lineAt(atIndent, "Type: %s".formatted(compactType(format.type())));
+      lineAt(atIndent, "FieldCount: %d".formatted(format.fields().length));
+      lineAt(atIndent, "FieldAccessCount: %d".formatted(format.fieldAccesses().size()));
+      lineAt(atIndent, "FieldEncodingCount: %d".formatted(format.fieldEncodings().size()));
+    }
+
+    @Override
+    public void visit(Format.Field field) {
+      lineAt(atIndent, "Type: %s".formatted(compactType(field.type())));
+      lineAt(atIndent, "BitSlice: %s".formatted(field.bitSlice()));
+      lineAt(atIndent, "RefFormat: %s".formatted(field.refFormat() != null
+          ? field.refFormat().simpleName() : "-"));
+    }
+
+    @Override
+    public void visit(Format.FieldAccess fieldAccess) {
+      lineAt(atIndent, "Type: %s".formatted(compactType(fieldAccess.type())));
+      lineAt(atIndent, "FieldRefs: %s".formatted(
+          fieldAccess.fieldRefs().stream().map(Format.Field::simpleName).toList()));
+      lineAt(atIndent, "AccessFunction: %s".formatted(fieldAccess.accessFunction().simpleName()));
+      lineAt(atIndent, "Predicate: %s".formatted(fieldAccess.predicate() != null
+          ? fieldAccess.predicate().simpleName() : "-"));
+    }
+
+    @Override
+    public void visit(RegisterTensor registerTensor) {
+      lineAt(atIndent, "Type: %s".formatted(compactType(registerTensor.type())));
+      lineAt(atIndent, "Dimensions: %s".formatted(
+          registerTensor.dimensions().stream()
+              .map(dim -> "%d:%sx%d".formatted(dim.index(),
+                  compactType(dim.indexType()), dim.size()))
+              .toList()));
+      lineAt(atIndent, "ConstraintCount: %d".formatted(registerTensor.constraints().size()));
+    }
+
+    @Override
+    public void visit(Memory memory) {
+      lineAt(atIndent, "AddressType: %s".formatted(compactType(memory.addressType())));
+      lineAt(atIndent, "ResultType: %s".formatted(compactType(memory.resultType())));
+      lineAt(atIndent, "WordSize: %d".formatted(memory.wordSize()));
+    }
+
+    @Override
+    public void visit(Counter counter) {
+      lineAt(atIndent, "RegisterTensor: %s".formatted(counter.registerTensor().simpleName()));
+      lineAt(atIndent, "Indices: %s".formatted(counter.indices()));
+      lineAt(atIndent, "ResultType: %s".formatted(compactType(counter.resultType())));
+    }
+
+    @Override
+    public void visit(ArtificialResource artificialResource) {
+      lineAt(atIndent, "Kind: %s".formatted(artificialResource.kind()));
+      lineAt(atIndent,
+          "InnerResource: %s".formatted(artificialResource.innerResourceRef().simpleName()));
+      lineAt(atIndent,
+          "ReadFunction: %s".formatted(artificialResource.readFunction().simpleName()));
+      lineAt(atIndent,
+          "WriteProcedure: %s".formatted(artificialResource.writeProcedure().simpleName()));
+      lineAt(atIndent, "AliasSlice: %s".formatted(artificialResource.aliasSlice()));
+      var semantics = artificialResource.semantics();
+      lineAt(atIndent, "Semantics:");
+      lineAt(atIndent + 1, "BaseTensor: %s".formatted(semantics.baseTensor().simpleName()));
+      lineAt(atIndent + 1, "FixedIndices: %s".formatted(semantics.fixedIndices()));
+      lineAt(atIndent + 1, "DynamicDimensions: %s".formatted(
+          semantics.dynamicDimensions().stream()
+              .map(dim -> "%d:%sx%d".formatted(dim.index(), compactType(dim.indexType()),
+                  dim.size()))
+              .toList()));
+      lineAt(atIndent + 1, "AliasSlice: %s".formatted(semantics.aliasSlice()));
+      lineAt(atIndent + 1, "OverwriteMode: %s".formatted(semantics.overwriteMode()));
+      lineAt(atIndent + 1, "ZeroConstraint: %s".formatted(
+          semantics.zeroConstraint() != null ? semantics.zeroConstraint().indices() : "-"));
+    }
+
+    @Override
+    public void visit(Encoding encoding) {
+      lineAt(atIndent, "Type: %s".formatted(compactType(encoding.type())));
+      lineAt(atIndent, "Format: %s".formatted(encoding.format().simpleName()));
+      lineAt(atIndent, "FieldEncodings: %d".formatted(encoding.fieldEncodings().length));
+      lineAt(atIndent, "NonEncodedFields: %s".formatted(
+          java.util.Arrays.stream(encoding.nonEncodedFormatFields())
+              .map(Format.Field::simpleName).toList()));
+      lineAt(atIndent, "HasConstraint: %s".formatted(encoding.constraint() != null));
+    }
+
+    @Override
+    public void visit(Encoding.Field field) {
+      lineAt(atIndent, "Field: %s".formatted(field.formatField().simpleName()));
+      lineAt(atIndent, "Type: %s".formatted(compactType(field.type())));
+      lineAt(atIndent, "Constant: %s".formatted(formatConstant(field.constant())));
+    }
+
+    @Override
+    public void visit(Function function) {
+      lineAt(atIndent, "Type: %s".formatted(compactType(function.type())));
+      lineAt(atIndent, "Signature: %s".formatted(function.signature()));
+      lineAt(atIndent, "Parameters: %s".formatted(
+          java.util.Arrays.stream(function.parameters())
+              .map(p -> p.simpleName() + ":" + compactType(p.type())).toList()));
+    }
+
+    @Override
+    public void visit(Procedure procedure) {
+      lineAt(atIndent, "Parameters: %s".formatted(
+          java.util.Arrays.stream(procedure.parameters())
+              .map(p -> p.simpleName() + ":" + compactType(p.type())).toList()));
+      lineAt(atIndent, "ReadResources: %s".formatted(
+          procedure.readResources().stream().map(Resource::simpleName).distinct().toList()));
+      lineAt(atIndent, "WrittenResources: %s".formatted(
+          procedure.writtenResources().stream().map(Resource::simpleName).distinct().toList()));
+    }
+
+    @Override
+    public void visit(ExceptionDef exception) {
+      lineAt(atIndent, "Kind: %s".formatted(exception.kind()));
+      lineAt(atIndent, "Parameters: %d".formatted(exception.parameters().length));
+    }
+
+    @Override
+    public void visit(Relocation relocation) {
+      lineAt(atIndent, "Kind: %s".formatted(relocation.kind()));
+      lineAt(atIndent, "Type: %s".formatted(compactType(relocation.type())));
+      lineAt(atIndent, "Parameters: %s".formatted(
+          java.util.Arrays.stream(relocation.parameters())
+              .map(p -> p.simpleName() + ":" + compactType(p.type())).toList()));
+    }
+
+    @Override
+    public void visit(PseudoInstruction pseudoInstruction) {
+      lineAt(atIndent, "Parameters: %s".formatted(
+          java.util.Arrays.stream(pseudoInstruction.parameters())
+              .map(p -> p.simpleName() + ":" + compactType(p.type())).toList()));
+      lineAt(atIndent, "Assembly: %s".formatted(pseudoInstruction.assembly().simpleName()));
+    }
+
+    @Override
+    public void visit(CompilerInstruction compilerInstruction) {
+      lineAt(atIndent, "Parameters: %s".formatted(
+          java.util.Arrays.stream(compilerInstruction.parameters())
+              .map(p -> p.simpleName() + ":" + compactType(p.type())).toList()));
+    }
+
+    @Override
+    public void visit(Assembly assembly) {
+      lineAt(atIndent, "Function: %s".formatted(assembly.function().simpleName()));
+      lineAt(atIndent, "FieldAccesses: %s".formatted(
+          assembly.fieldAccesses().stream().map(Format.FieldAccess::simpleName).toList()));
+    }
+
+    @Override
+    public void visit(Parameter parameter) {
+      lineAt(atIndent, "Index: %d".formatted(parameter.index()));
+      lineAt(atIndent, "Type: %s".formatted(compactType(parameter.type())));
+    }
+
+    @Override
+    public void visit(Processor processor) {
+      lineAt(atIndent, "TargetName: %s".formatted(processor.targetName()));
+      lineAt(atIndent, "ISA: %s".formatted(processor.isa().simpleName()));
+      lineAt(atIndent, "ABI: %s".formatted(
+          processor.abiNullable() != null ? processor.abiNullable().simpleName() : "-"));
+      lineAt(atIndent, "Reset: %s".formatted(processor.reset().simpleName()));
+      lineAt(atIndent,
+          "Stop: %s".formatted(processor.stop() != null ? processor.stop().simpleName() : "-"));
+      lineAt(atIndent, "MemoryRegions: %d".formatted(processor.memoryRegions().size()));
+    }
+
+    @Override
+    public void visit(MicroArchitecture microArchitecture) {
+      lineAt(atIndent, "ISA: %s".formatted(microArchitecture.isa().simpleName()));
+      lineAt(atIndent, "StageCount: %d".formatted(microArchitecture.stages().size()));
+      lineAt(atIndent, "LogicCount: %d".formatted(microArchitecture.logic().size()));
+      lineAt(atIndent, "SignalCount: %d".formatted(microArchitecture.signals().size()));
+      lineAt(atIndent, "RegisterCount: %d".formatted(microArchitecture.ownRegisters().size()));
+      lineAt(atIndent, "MemoryCount: %d".formatted(microArchitecture.ownMemories().size()));
+      lineAt(atIndent, "FunctionCount: %d".formatted(microArchitecture.ownFunctions().size()));
+    }
+
+    @Override
+    public void visit(Logic logic) {
+      lineAt(atIndent, "LogicClass: %s".formatted(logic.getClass().getSimpleName()));
+      lineAt(atIndent, "Signals: %s".formatted(
+          logic.signals().stream().map(Signal::simpleName).toList()));
+      lineAt(atIndent, "Registers: %s".formatted(
+          logic.registers().stream().map(RegisterTensor::simpleName).toList()));
+    }
+
+    @Override
+    public void visit(Stage stage) {
+      lineAt(atIndent,
+          "Outputs: %s".formatted(stage.outputs().stream().map(StageOutput::simpleName).toList()));
+      lineAt(atIndent,
+          "Signals: %s".formatted(stage.signals().stream().map(Signal::simpleName).toList()));
+      lineAt(atIndent, "Registers: %s".formatted(
+          stage.registers().stream().map(RegisterTensor::simpleName).toList()));
+      lineAt(atIndent,
+          "Prev: %s".formatted(stage.prev() != null ? stage.prev().simpleName() : "-"));
+      lineAt(atIndent, "Next: %s".formatted(
+          stage.next() != null ? stage.next().stream().map(Stage::simpleName).toList() :
+              List.of()));
+    }
+
+    @Override
+    public void visit(StageOutput stageOutput) {
+      lineAt(atIndent, "Type: %s".formatted(compactType(stageOutput.type())));
+    }
+
+    @Override
+    public void visit(Signal signal) {
+      lineAt(atIndent, "Type: %s".formatted(compactType(signal.resultType())));
+    }
+
+    @Override
+    public void visit(Abi abi) {
+      lineAt(atIndent, "ReturnAddress: %s".formatted(abi.returnAddress().render()));
+      lineAt(atIndent, "StackPointer: %s".formatted(abi.stackPointer().render()));
+      lineAt(atIndent, "FramePointer: %s".formatted(abi.framePointer().render()));
+      lineAt(atIndent, "CallerSavedCount: %d".formatted(abi.callerSaved().size()));
+      lineAt(atIndent, "CalleeSavedCount: %d".formatted(abi.calleeSaved().size()));
+      lineAt(atIndent, "ArgumentRegistersCount: %d".formatted(abi.argumentRegisters().size()));
+      lineAt(atIndent, "ReturnRegisterGroups: %d".formatted(abi.returnRegisters().size()));
+      lineAt(atIndent, "StackAlignment: %d".formatted(abi.stackAlignment().bitAlignment()));
+      lineAt(atIndent, "TransientStackAlignment: %d".formatted(
+          abi.transientStackAlignment().bitAlignment()));
+      lineAt(atIndent, "ConstantSequenceCount: %d".formatted(abi.constantSequences().size()));
+      lineAt(atIndent, "RegisterAdjustmentSequenceCount: %d".formatted(
+          abi.registerAdjustmentSequences().size()));
+      lineAt(atIndent, "ClangTypeCount: %d".formatted(abi.clangTypes().size()));
+    }
+
+    @Override
+    public void visit(Abi.AbstractClangType.NumericClangType numericClangType) {
+      lineAt(atIndent, "TypeName: %s".formatted(numericClangType.typeNameAsString()));
+      lineAt(atIndent, "Value: %s".formatted(numericClangType.value()));
+    }
+
+    @Override
+    public void visit(Abi.AbstractClangType.ClangType clangType) {
+      lineAt(atIndent, "TypeName: %s".formatted(clangType.typeNameAsString()));
+      lineAt(atIndent, "Value: %s".formatted(clangType.value()));
+    }
+
+    @Override
+    public void visit(AssemblyDescription assemblyDescription) {
+      lineAt(atIndent, "DirectiveCount: %d".formatted(assemblyDescription.directives().size()));
+      lineAt(atIndent, "ModifierCount: %d".formatted(assemblyDescription.modifiers().size()));
+      lineAt(atIndent, "RuleCount: %d".formatted(assemblyDescription.rules().size()));
+      lineAt(atIndent, "CommonDefinitionCount: %d".formatted(
+          assemblyDescription.commonDefinitions().size()));
+    }
+
+    @Override
+    public void visit(AsmDirectiveMapping directive) {
+      lineAt(atIndent, "Alias: %s".formatted(directive.getAlias()));
+      lineAt(atIndent, "Target: %s".formatted(directive.getTarget()));
+      lineAt(atIndent, "AlignmentIsInBytes: %s".formatted(directive.getAlignmentIsInBytes()));
+    }
+
+    @Override
+    public void visit(AsmModifier modifier) {
+      lineAt(atIndent, "Relocation: %s".formatted(modifier.getRelocation().simpleName()));
+    }
+
+    @Override
+    public void visit(AsmBuiltinRule builtinRule) {
+      lineAt(atIndent, "AsmType: %s".formatted(compactAsmType(builtinRule)));
+    }
+
+    @Override
+    public void visit(AsmTerminalRule terminalRule) {
+      lineAt(atIndent, "AsmType: %s".formatted(compactAsmType(terminalRule)));
+      lineAt(atIndent, "Value: %s".formatted(terminalRule.getValue()));
+    }
+
+    @Override
+    public void visit(AsmNonTerminalRule nonTerminalRule) {
+      lineAt(atIndent, "AsmType: %s".formatted(compactAsmType(nonTerminalRule)));
+      lineAt(atIndent, "Alternatives: %s".formatted(nonTerminalRule.getAlternatives()));
+    }
+  }
+
+  private void dumpBehaviors(List<Graph> behaviors, int baseIndent) {
+    for (int i = 0; i < behaviors.size(); i++) {
+      if (behaviors.size() == 1) {
+        lineAt(baseIndent, "Behavior Graph:");
+      } else {
+        lineAt(baseIndent, "Behavior Graph #%d:".formatted(i));
+      }
+      dumpGraph(behaviors.get(i), baseIndent + 1);
+    }
+  }
+
+  private void dumpGraph(Graph graph, int graphIndent) {
+    var nodes = graph.getNodes(Node.class)
+        .sorted(Comparator.comparingInt(n -> n.id().numericId()))
+        .toList();
+
+    var stableIds = new IdentityHashMap<Node, String>();
+    for (int i = 0; i < nodes.size(); i++) {
+      stableIds.put(nodes.get(i), "n" + i);
+    }
+
+    var nodeDumps = nodes.stream().map(n -> toNodeDump(n, stableIds)).toList();
+
+    var inWidth = nodeDumps.stream().mapToInt(n -> n.in().length()).max().orElse(2);
+    var succWidth = nodeDumps.stream().mapToInt(n -> n.succ().length()).max().orElse(2);
+    var opWidth = nodeDumps.stream().mapToInt(n -> n.op().length()).max().orElse(1);
+    var attrValWidths = new LinkedHashMap<String, Integer>();
+    for (var nodeDump : nodeDumps) {
+      for (var attr : nodeDump.attrs().entrySet()) {
+        attrValWidths.merge(attr.getKey(), attr.getValue().length(), Math::max);
+      }
+    }
+    var idWidth = nodeDumps.stream().mapToInt(n -> n.id().length()).max().orElse(2);
+
+    for (var node : nodeDumps) {
+      var line = new StringBuilder()
+          .append(pad(node.id(), idWidth))
+          .append(" ")
+          .append(pad(node.op(), opWidth))
+          .append(" in: ")
+          .append(pad(node.in(), inWidth))
+          .append(" succ: ")
+          .append(pad(node.succ(), succWidth));
+
+      for (var attr : node.attrs().entrySet()) {
+        var valueWidth = attrValWidths.getOrDefault(attr.getKey(), attr.getValue().length());
+        line.append("   ")
+            .append(attr.getKey())
+            .append(":")
+            .append(" ")
+            .append(pad(attr.getValue(), valueWidth));
+      }
+      lineAt(graphIndent, line.toString());
+    }
+  }
+
+  private NodeDump toNodeDump(Node node, Map<Node, String> ids) {
+    var attrs = new LinkedHashMap<String, String>();
+
+    if (node instanceof ExpressionNode expressionNode) {
+      attrs.put("type", compactType(expressionNode.type()));
+    }
+
+    if (node instanceof HasRegisterTensor withRegister) {
+      attrs.put("reg", withRegister.registerTensor().simpleName());
+    }
+
+    if (node instanceof ConstantNode constantNode) {
+      attrs.put("const", formatConstant(constantNode.constant()));
+    }
+
+    var dispatchCtx = new NodeAttrContext(attrs, ids);
+    NodeAttrCollectorDispatcher.dispatch(nodeAttrCollector, dispatchCtx, node);
+
+    return new NodeDump(
+        ids.get(node),
+        formatNodeRefList(node.inputs().map(ids::get).toList()),
+        formatNodeRefList(node.successors().map(ids::get).toList()),
+        opName(node),
+        attrs
+    );
+  }
+
+  private static String opName(Node node) {
+    if (node instanceof ReadsRegisterTensor) {
+      return "ReadsRegisterTensor";
+    }
+    if (node instanceof WritesRegisterTensor) {
+      return "WritesRegisterTensor";
+    }
+    return node.nodeName();
+  }
+
+  private static String formatNodeRefList(List<String> nodeIds) {
+    if (nodeIds.isEmpty()) {
+      return "()";
+    }
+    return "(" + String.join(" ", nodeIds) + ")";
+  }
+
+  private static String compactType(Type type) {
+    if (type instanceof SIntType sint) {
+      return "i" + sint.bitWidth();
+    }
+    if (type instanceof UIntType uint) {
+      return "u" + uint.bitWidth();
+    }
+    if (type instanceof BoolType) {
+      return "bool";
+    }
+    if (type instanceof BitsType bits) {
+      return "b" + bits.bitWidth();
+    }
+    return type.name().replaceAll("\\s+", "");
+  }
+
+  private static String compactAsmType(AsmGrammarRule rule) {
+    return rule.getAsmType().name().replaceAll("\\s+", "");
+  }
+
+  private static String formatConstant(Constant constant) {
+    if (constant instanceof Constant.Str str) {
+      return "\"" + escapeString(str.value()) + "\"";
+    }
+    return constant.toString();
+  }
+
+  private static String escapeString(String value) {
+    return value
+        .replace("\\", "\\\\")
+        .replace("\"", "\\\"")
+        .replace("\n", "\\n")
+        .replace("\t", "\\t")
+        .replace("\r", "\\r");
+  }
+
+  private static String pad(String value, int width) {
+    if (value.length() >= width) {
+      return value;
+    }
+    return value + " ".repeat(width - value.length());
+  }
+
+  private static String joinOrDash(List<String> values) {
+    if (values.isEmpty()) {
+      return "-";
+    }
+    return String.join(", ", values);
+  }
+
+  private static List<String> instructionInputNames(Instruction instruction) {
+    return instruction.behavior().getNodes(ReadsRegisterTensor.class)
+        .map(ViamSnapshotDumper::operandName)
+        .distinct()
+        .sorted()
+        .toList();
+  }
+
+  private static List<String> instructionOutputNames(Instruction instruction) {
+    return instruction.behavior().getNodes(WritesRegisterTensor.class)
+        .map(ViamSnapshotDumper::operandName)
+        .distinct()
+        .sorted()
+        .toList();
+  }
+
+  private static String operandName(HasRegisterTensor access) {
+    if (!access.indices().isEmpty() && access.indices()
+        .get(0) instanceof FieldRefNode fieldRefNode) {
+      return fieldRefNode.formatField().simpleName();
+    }
+    return access.registerTensor().simpleName();
+  }
+
+  private String indentString(int indentLevel) {
+    var indentLength = indentLevel * INDENT_BY;
+    return INDENT_CHARACTERS.repeat(indentLength / INDENT_CHARACTERS.length())
+        + INDENT_CHARACTERS.substring(0, indentLength % INDENT_CHARACTERS.length());
+  }
+
+  private void lineAt(int indentLevel, String line) {
+    builder.append(indentString(indentLevel)).append(line.stripTrailing()).append('\n');
+  }
+
+  private void line(String line) {
+    lineAt(indent, line);
+  }
+
+  private record NodeDump(
+      String id,
+      String in,
+      String succ,
+      String op,
+      LinkedHashMap<String, String> attrs
+  ) {
+  }
+
+  private final NodeAttrCollector nodeAttrCollector = new NodeAttrCollector();
+
+  static record NodeAttrContext(LinkedHashMap<String, String> attrs, Map<Node, String> ids) {
+    void put(String key, String value) {
+      if (value == null || value.isBlank()) {
+        return;
+      }
+      attrs.putIfAbsent(key, value);
+    }
+
+    String idOf(Node node) {
+      return ids.get(node);
+    }
+  }
+
+  @DispatchFor(
+      value = Node.class,
+      include = {"vadl.viam"},
+      context = NodeAttrContext.class
+  )
+  static class NodeAttrCollector {
+    @Handler
+    void handle(NodeAttrContext ctx, Node node) {
+      // fallback
+    }
+
+    @Handler
+    void handle(NodeAttrContext ctx, BuiltInCall node) {
+      ctx.put("builtin", node.builtIn().name());
+      if (node.builtIn().operator() != null) {
+        ctx.put("operator", node.builtIn().operator());
+      }
+    }
+
+    @Handler
+    void handle(NodeAttrContext ctx, AsmBuiltInCall node) {
+      ctx.put("builtin", node.asmBuiltIn().name());
+      if (node.asmBuiltIn().operator() != null) {
+        ctx.put("operator", node.asmBuiltIn().operator());
+      }
+    }
+
+    @Handler
+    void handle(NodeAttrContext ctx, MiaBuiltInCall node) {
+      ctx.put("resources", node.resources().stream().map(Resource::simpleName).toList().toString());
+      ctx.put("logic", node.logic().stream().map(Logic::simpleName).toList().toString());
+    }
+
+    @Handler
+    void handle(NodeAttrContext ctx, FieldRefNode node) {
+      ctx.put("field", node.formatField().simpleName());
+      ctx.put("format", node.formatField().format().simpleName());
+    }
+
+    @Handler
+    void handle(NodeAttrContext ctx, FieldAccessRefNode node) {
+      ctx.put("fieldAccess", node.fieldAccess().simpleName());
+      ctx.put("fieldRefs", node.fieldAccess().fieldRefs().stream()
+          .map(Format.Field::simpleName).toList().toString());
+    }
+
+    @Handler
+    void handle(NodeAttrContext ctx, ReadMemNode node) {
+      ctx.put("memory", node.memory().simpleName());
+      ctx.put("words", Integer.toString(node.words()));
+    }
+
+    @Handler
+    void handle(NodeAttrContext ctx, WriteMemNode node) {
+      ctx.put("memory", node.memory().simpleName());
+      ctx.put("words", Integer.toString(node.words()));
+    }
+
+    @Handler
+    void handle(NodeAttrContext ctx, ReadRegTensorNode node) {
+      ctx.put("counter", node.staticCounterAccess() != null
+          ? node.staticCounterAccess().simpleName() : null);
+    }
+
+    @Handler
+    void handle(NodeAttrContext ctx, WriteRegTensorNode node) {
+      ctx.put("counter", node.staticCounterAccess() != null
+          ? node.staticCounterAccess().simpleName() : null);
+    }
+
+    @Handler
+    void handle(NodeAttrContext ctx, ReadArtificialResNode node) {
+      ctx.put("resource", node.resourceDefinition().simpleName());
+      ctx.put("baseReg", node.getBaseTensor().simpleName());
+    }
+
+    @Handler
+    void handle(NodeAttrContext ctx, WriteArtificialResNode node) {
+      ctx.put("resource", node.resourceDefinition().simpleName());
+    }
+
+    @Handler
+    void handle(NodeAttrContext ctx, ReadSignalNode node) {
+      ctx.put("signal", node.signal().simpleName());
+    }
+
+    @Handler
+    void handle(NodeAttrContext ctx, WriteSignalNode node) {
+      ctx.put("signal", node.signal().simpleName());
+    }
+
+    @Handler
+    void handle(NodeAttrContext ctx, ReadStageOutputNode node) {
+      ctx.put("stageOutput", node.stageOutput().simpleName());
+    }
+
+    @Handler
+    void handle(NodeAttrContext ctx, WriteStageOutputNode node) {
+      ctx.put("stageOutput", node.stageOutput() != null ? node.stageOutput().simpleName() : "-");
+    }
+
+    @Handler
+    void handle(NodeAttrContext ctx, FuncCallNode node) {
+      ctx.put("func", node.function().simpleName());
+    }
+
+    @Handler
+    void handle(NodeAttrContext ctx, ProcCallNode node) {
+      ctx.put("proc", node.procedure().simpleName());
+      ctx.put("raise", Boolean.toString(node.exceptionRaise()));
+    }
+
+    @Handler
+    void handle(NodeAttrContext ctx, InstrCallNode node) {
+      ctx.put("instruction", node.target().simpleName());
+      ctx.put("params", node.getParamFieldsOrAccesses().stream()
+          .map(param -> param.isLeft()
+              ? "field:" + param.left().simpleName()
+              : "access:" + param.right().simpleName())
+          .toList().toString());
+    }
+
+    @Handler
+    void handle(NodeAttrContext ctx, FuncParamNode node) {
+      ctx.put("param", node.parameter().simpleName());
+      ctx.put("index", Integer.toString(node.parameter().index()));
+    }
+
+    @Handler
+    void handle(NodeAttrContext ctx, ForIdxNode node) {
+      ctx.put("from", Integer.toString(node.fromIdx()));
+      ctx.put("to", Integer.toString(node.toIdx()));
+    }
+
+    @Handler
+    void handle(NodeAttrContext ctx, FoldNode node) {
+      ctx.put("combiner", node.combiner().simpleName());
+    }
+
+    @Handler
+    void handle(NodeAttrContext ctx, LetNode node) {
+      ctx.put("name", node.letName().name());
+    }
+
+    @Handler
+    void handle(NodeAttrContext ctx, SliceNode node) {
+      ctx.put("slice", node.bitSlice().toString());
+    }
+
+    @Handler
+    void handle(NodeAttrContext ctx, DynSliceNode node) {
+      ctx.put("slice", "dynamic");
+    }
+
+    @Handler
+    void handle(NodeAttrContext ctx, TupleGetFieldNode node) {
+      ctx.put("index", Integer.toString(node.index()));
+    }
+
+    @Handler
+    void handle(NodeAttrContext ctx, TensorNode node) {
+      // nothing to add
+    }
+
+    @Handler
+    void handle(NodeAttrContext ctx, SelectNode node) {
+      // nothing to add
+    }
+
+    @Handler
+    void handle(NodeAttrContext ctx, ZeroExtendNode node) {
+      ctx.put("fromWidth", Integer.toString(node.fromBitWidth()));
+    }
+
+    @Handler
+    void handle(NodeAttrContext ctx, SignExtendNode node) {
+      ctx.put("fromWidth", Integer.toString(node.fromBitWidth()));
+    }
+
+    @Handler
+    void handle(NodeAttrContext ctx, TruncateNode node) {
+      ctx.put("fromWidth", Integer.toString(node.value().type().asDataType().bitWidth()));
+    }
+
+    @Handler
+    void handle(NodeAttrContext ctx, LabelNode node) {
+      ctx.put("labelType", compactType(node.type()));
+    }
+
+    @Handler
+    void handle(NodeAttrContext ctx, NewLabelNode node) {
+      // nothing to add
+    }
+
+    @Handler
+    void handle(NodeAttrContext ctx, IfNode node) {
+      ctx.put("branches", Integer.toString(node.branches().size()));
+    }
+
+    @Handler
+    void handle(NodeAttrContext ctx, ControlSplitNode node) {
+      ctx.put("branches", Integer.toString(node.branches().size()));
+    }
+
+    @Handler
+    void handle(NodeAttrContext ctx, MergeNode node) {
+      ctx.put("branchEnds", Long.toString(node.inputs().count()));
+    }
+
+    @Handler
+    void handle(NodeAttrContext ctx, ForallNode node) {
+      ctx.put("range", node.idx().fromIdx() + ".." + node.idx().toIdx());
+    }
+
+    @Handler
+    void handle(NodeAttrContext ctx, BranchEndNode node) {
+      ctx.put("effects", Integer.toString(node.sideEffects().size()));
+    }
+
+    @Handler
+    void handle(NodeAttrContext ctx, AbstractEndNode node) {
+      ctx.put("effects", Integer.toString(node.sideEffects().size()));
+    }
+
+    @Handler
+    void handle(NodeAttrContext ctx, DirectionalNode node) {
+      ctx.put("next", node.successors().findAny().isPresent() ? "set" : "-");
+    }
+
+    @Handler
+    void handle(NodeAttrContext ctx, ReturnNode node) {
+      ctx.put("retType", compactType(node.returnType()));
+    }
+
+    @Handler
+    void handle(NodeAttrContext ctx, SideEffectNode node) {
+      if (node.nullableCondition() == null) {
+        ctx.put("cond", "-");
+      } else {
+        var id = ctx.idOf(node.nullableCondition());
+        ctx.put("cond", id != null ? id : "<ext>");
+      }
+    }
+  }
+}

--- a/vadl/test/vadl/viam/ViamSnapshotTest.java
+++ b/vadl/test/vadl/viam/ViamSnapshotTest.java
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText : © 2026 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.viam;
+
+import static vadl.TestUtils.assertEqualsFileLines;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+import vadl.TestUtils;
+
+/**
+ * Snapshot tests for VIAM dumps.
+ *
+ * <p>To update snapshots:
+ * {@code UPDATE_SNAPSHOTS=true ./gradlew test --tests vadl.viam.ViamSnapshotTest}</p>
+ */
+class ViamSnapshotTest {
+  private static final Pattern DUMP_TAIL_PATTERN =
+      Pattern.compile("//  Dumped VIAM:.*$", Pattern.DOTALL);
+  private static final Pattern INCLUDE_VIAM_DUMP_PATTERN =
+      Pattern.compile("^// *INCLUDE-VIAM-DUMP *$", Pattern.MULTILINE);
+
+  @TestFactory
+  Stream<DynamicTest> snapshotTests() throws IOException {
+    return Files.walk(Paths.get("test/resources/viam-snapshots"))
+        .filter(path -> path.toString().endsWith(".vadl"))
+        .map(path -> DynamicTest.dynamicTest(path.toString(), () -> runSnapshotTest(path)));
+  }
+
+  private void runSnapshotTest(Path path) throws IOException {
+    var input = Files.readString(path);
+    if (!INCLUDE_VIAM_DUMP_PATTERN.matcher(input).find()) {
+      throw new IllegalStateException(
+          "Snapshot fixture must include // INCLUDE-VIAM-DUMP: " + path);
+    }
+
+    var spec = TestUtils.compileToViam(input);
+    var dump = new ViamSnapshotDumper().dump(spec);
+
+    var output = "Dumped VIAM:\n\n" + dump.indent(2);
+    output = "//  "
+        + output.strip().replaceAll("\n", "\n//  ").replaceAll("// +\n", "//\n")
+        + "\n//\n//\n// Part of the %s".formatted(this.getClass());
+
+    var stripped = DUMP_TAIL_PATTERN.matcher(input).replaceAll("").strip();
+    var actual = stripped + "\n\n\n" + output;
+
+    if (System.getenv("UPDATE_SNAPSHOTS") != null) {
+      Files.writeString(path, actual);
+      return;
+    }
+
+    assertEqualsFileLines(path, actual);
+  }
+}


### PR DESCRIPTION
Currently, there are no snapshot tests for the VIAM-lowering. 
This makes it very difficult to see what changed that causes a failing test.
This PR adds a VIAM dumper that produces a text representation of the VIAM (including graphs) in a similar way as it is done for the AST. 

The test framework works the same way as for Diagnostics. 