### PR TITLE
frontend: Improve diagnostic printing of multi-location diagnostics

### DIFF
--- a/vadl/main/vadl/error/DiagnosticPrinter.java
+++ b/vadl/main/vadl/error/DiagnosticPrinter.java
@@ -19,6 +19,7 @@ package vadl.error;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -129,15 +130,11 @@ public class DiagnosticPrinter {
             forceUnixPaths)));
     builder.append("     │\n");
 
-    // TODO: Sort them accordig to their line number in the future
-    var allSnippets = new ArrayList<>(diagnostic.multiLocation.secondaryLocations());
-    allSnippets.add(diagnostic.multiLocation.primaryLocation());
+    var allSnippets = sortLabels(diagnostic.multiLocation.primaryLocation(),
+        diagnostic.multiLocation.secondaryLocations());
 
     for (int i = 0; i < allSnippets.size(); i++) {
       var snippet = allSnippets.get(i);
-
-      // FIXME: if the first location is not from the same file as the primary we don't currently
-      //        the file it is from.
 
       // Delimiter in multilocation
       if (i > 0) {
@@ -418,6 +415,55 @@ public class DiagnosticPrinter {
     fileLineCache.put(path, lines);
     return lines;
   }
+
+  /**
+   * Sort the labels (locations) within a multi-location diagnostic.
+   *
+   * <p><b>Algorithm:</b>
+   * The locations are first sorted into two buckets based on the file they originate from.
+   * The first bucket for the file from the primaryLocation and the second all other files.
+   * Inside the buckets all locations are sorted by their starting position of the location. Then
+   * the two buckets are merged into a single list, with the primary location first.
+   *
+   * <p>This ensures that the file of the primary location is always first even if the primary
+   * location might not be first and that in all files the locations are sorted, which closer
+   * resembles the order in the specification.
+   *
+   * <p>The algorithm might or might not have been rudely stolen from the Rust compiler and the
+   * excellent
+   * <a href="https://docs.rs/codespan-reporting/latest/codespan_reporting/files/index.html">
+   * code_span.</a> crate.
+   *
+   *
+   * @param primary     The primary label.
+   * @param secondary   All secondary label.
+   * @return            The sorted list of label.
+   */
+  private static List<Diagnostic.LabeledLocation> sortLabels(
+      Diagnostic.LabeledLocation primary,
+      List<Diagnostic.LabeledLocation> secondary
+  ) {
+    var primaryPath = primary.location().path();
+    var primaryLabels = new ArrayList<>(List.of(primary));
+    var otherLabels = new ArrayList<Diagnostic.LabeledLocation>();
+
+    secondary.forEach(l -> {
+      if (Objects.equals(l.location().path(), primaryPath)) {
+        primaryLabels.add(l);
+      } else {
+        otherLabels.add(l);
+      }
+    });
+
+    primaryLabels.sort(Comparator.comparing(Diagnostic.LabeledLocation::location));
+    otherLabels.sort(Comparator.comparing(Diagnostic.LabeledLocation::location));
+
+    var all = new ArrayList<Diagnostic.LabeledLocation>();
+    all.addAll(primaryLabels);
+    all.addAll(otherLabels);
+    return all;
+  }
+
 
   @SuppressWarnings("UnusedMethod")
   private interface PrinterColors {

--- a/vadl/main/vadl/utils/SourceLocation.java
+++ b/vadl/main/vadl/utils/SourceLocation.java
@@ -49,7 +49,7 @@ public record SourceLocation(
     Position begin,
     Position end,
     @Nullable SourceLocation expandedFrom
-) implements WithLocation {
+) implements WithLocation, Comparable<SourceLocation> {
 
   private static final Logger logger = LoggerFactory.getLogger(SourceLocation.class);
 
@@ -193,6 +193,21 @@ public record SourceLocation(
             ? this.expandedFrom : null;
 
     return new SourceLocation(this.path, begin, end, expanedFrom);
+  }
+
+  @Override
+  public int compareTo(@Nonnull SourceLocation o) {
+    if (Objects.equals(this.path, o.path)) {
+      return this.begin.compareTo(o.begin);
+    }
+
+    if (this.path == null) {
+      return -1;
+    }
+    if (o.path == null) {
+      return 1;
+    }
+    return this.path.compareTo(o.path);
   }
 
   /**

--- a/vadl/test/resources/diagnostics/annotation/invalidZeroAnnoationInvalidTarget2.vadl
+++ b/vadl/test/resources/diagnostics/annotation/invalidZeroAnnoationInvalidTarget2.vadl
@@ -12,11 +12,11 @@ instruction set architecture TEST =
 //  error: Invalid zero annotation
 //       ╭──[test/resources/diagnostics/annotation/invalidZeroAnnoationInvalidTarget2.vadl:5:12]
 //       │
-//     6 │   register X : Bits<5> -> Bits<32>
-//       │   -------------------------------- note: This is the register to target.
-//       ⋮
 //     5 │   [ zero : Y(1)]
 //       │            ^ Zero annotation target must be the annotated register.
+//       │
+//     6 │   register X : Bits<5> -> Bits<32>
+//       │   -------------------------------- note: This is the register to target.
 //       │
 //
 //

--- a/vadl/test/resources/diagnostics/annotation/invalidZeroAnnotationInvalidArgument.vadl
+++ b/vadl/test/resources/diagnostics/annotation/invalidZeroAnnotationInvalidArgument.vadl
@@ -12,11 +12,11 @@ instruction set architecture TEST =
 //  error: Invalid zero annotation
 //       ╭──[test/resources/diagnostics/annotation/invalidZeroAnnotationInvalidArgument.vadl:5:14]
 //       │
-//     6 │   register X : Bits<5> -> Bits<32>
-//       │   -------------------------------- note: Cannot evaluate identifier with origin of vadl.ast.RegisterDefinition
-//       ⋮
 //     5 │   [ zero : X(Y) ]
 //       │              ^ Index must be a constant expression.
+//       │
+//     6 │   register X : Bits<5> -> Bits<32>
+//       │   -------------------------------- note: Cannot evaluate identifier with origin of vadl.ast.RegisterDefinition
 //       │
 //
 //

--- a/vadl/test/resources/diagnostics/annotation/invalidZeroAnnotationInvalidTarget1.vadl
+++ b/vadl/test/resources/diagnostics/annotation/invalidZeroAnnotationInvalidTarget1.vadl
@@ -12,11 +12,11 @@ instruction set architecture TEST =
 //  error: Invalid zero annotation
 //       ╭──[test/resources/diagnostics/annotation/invalidZeroAnnotationInvalidTarget1.vadl:5:12]
 //       │
-//     6 │   register X : Bits<5> -> Bits<32>
-//       │   -------------------------------- note: This is the register to target.
-//       ⋮
 //     5 │   [ zero : M(1)]
 //       │            ^ Zero annotation target must be the annotated register.
+//       │
+//     6 │   register X : Bits<5> -> Bits<32>
+//       │   -------------------------------- note: This is the register to target.
 //       │
 //
 //

--- a/vadl/test/resources/diagnostics/imports/invalidImportAndRedeclareModel.vadl
+++ b/vadl/test/resources/diagnostics/imports/invalidImportAndRedeclareModel.vadl
@@ -1,5 +1,3 @@
-// FIXME: The diagnostics printing displays the wrong file for the first location.
-
 import base::magicNumber
 
 model magicNumber(): Ex = {
@@ -10,14 +8,14 @@ model magicNumber(): Ex = {
 //  Reported Diagnostics:
 //
 //  error: Macro name already used: magicNumber
-//       ╭──[test/resources/diagnostics/imports/invalidImportAndRedeclareModel.vadl:5:7]
+//       ╭──[test/resources/diagnostics/imports/invalidImportAndRedeclareModel.vadl:3:7]
 //       │
+//     3 │ model magicNumber(): Ex = {
+//       │       ^^^^^^^^^^^ Second definition here.
+//       ⋮
+//       ╭─ test/resources/diagnostics/imports/base.vadl:1:7
 //     1 │ model magicNumber(): Ex = {
 //       │       ----------- First defined here.
-//       ⋮
-//       ╭─ test/resources/diagnostics/imports/invalidImportAndRedeclareModel.vadl:5:7
-//     5 │ model magicNumber(): Ex = {
-//       │       ^^^^^^^^^^^ Second definition here.
 //       │
 //       note: All macros must have a unique name.
 //


### PR DESCRIPTION
This is an alternative to #780 with a more sophisticated location sorting inspired by the Rust and Gleam compiler.