### PR TITLE
typechecker: Fix crash on division by zero

### DIFF
--- a/vadl/main/vadl/ast/ConstantEvaluator.java
+++ b/vadl/main/vadl/ast/ConstantEvaluator.java
@@ -97,6 +97,10 @@ class ConstantEvaluator implements ExprVisitor<ConstantValue> {
     if (args.size() == 2) {
       var leftVal = args.getFirst();
       var rightVal = args.getLast();
+
+      // Some general checks that cannot be evaluated
+      checkDivisionByZero(builtin, leftVal, rightVal, loc);
+
       if (BuiltInTable.logicalComparisons.contains(builtin)
           || (BuiltInTable.SHIFTING_BUILT_INS.contains(builtin) && args.getFirst()
           .type() instanceof ConstantType)
@@ -141,6 +145,26 @@ class ConstantEvaluator implements ExprVisitor<ConstantValue> {
     }
 
     return new ConstantValue(finalVal.integer(), type);
+  }
+
+  @SuppressWarnings("UnusedVariable")
+  private void checkDivisionByZero(BuiltInTable.BuiltIn builtIn, ConstantValue leftVal,
+                                   ConstantValue rightVal, WithLocation loc) {
+    var divisionFunctions = List.of(
+        BuiltInTable.SDIV,
+        BuiltInTable.SDIVS,
+        BuiltInTable.SMOD,
+        BuiltInTable.SMODS,
+        BuiltInTable.UDIV,
+        BuiltInTable.UDIVS,
+        BuiltInTable.UMOD,
+        BuiltInTable.UMODS
+    );
+    if (rightVal.value().equals(BigInteger.ZERO) && divisionFunctions.contains(builtIn)
+    ) {
+      throw new EvaluationError("Division by zero cannot be computed.", loc);
+    }
+
   }
 
   private ConstantValue visitIdentifiable(Expr expr) {

--- a/vadl/test/resources/diagnostics/typechecker/invalidEvalDivisionByZero.vadl
+++ b/vadl/test/resources/diagnostics/typechecker/invalidEvalDivisionByZero.vadl
@@ -1,0 +1,86 @@
+constant a = 10 / 0
+constant b = 10 % 0
+constant c = VADL::sdiv(10, 0)
+constant d = VADL::udiv(10, 0)
+constant e = VADL::sdivs(10, 0)
+constant f = VADL::udivs(10, 0)
+constant g = VADL::smod(10, 0)
+constant h = VADL::umod(10, 0)
+constant i = VADL::smods(10, 0)
+constant j = VADL::umods(10, 0)
+
+
+//  Reported Diagnostics:
+//
+//  error: Constant value required
+//       ╭──[test/resources/diagnostics/typechecker/invalidEvalDivisionByZero.vadl:1:14]
+//       │
+//     1 │ constant a = 10 / 0
+//       │              ^^^^^^ Division by zero cannot be computed.
+//       │
+//
+//  error: Constant value required
+//       ╭──[test/resources/diagnostics/typechecker/invalidEvalDivisionByZero.vadl:2:14]
+//       │
+//     2 │ constant b = 10 % 0
+//       │              ^^^^^^ Division by zero cannot be computed.
+//       │
+//
+//  error: Constant value required
+//       ╭──[test/resources/diagnostics/typechecker/invalidEvalDivisionByZero.vadl:3:14]
+//       │
+//     3 │ constant c = VADL::sdiv(10, 0)
+//       │              ^^^^^^^^^^^^^^^^^ Division by zero cannot be computed.
+//       │
+//
+//  error: Constant value required
+//       ╭──[test/resources/diagnostics/typechecker/invalidEvalDivisionByZero.vadl:4:14]
+//       │
+//     4 │ constant d = VADL::udiv(10, 0)
+//       │              ^^^^^^^^^^^^^^^^^ Division by zero cannot be computed.
+//       │
+//
+//  error: Constant value required
+//       ╭──[test/resources/diagnostics/typechecker/invalidEvalDivisionByZero.vadl:5:14]
+//       │
+//     5 │ constant e = VADL::sdivs(10, 0)
+//       │              ^^^^^^^^^^^^^^^^^^ Division by zero cannot be computed.
+//       │
+//
+//  error: Constant value required
+//       ╭──[test/resources/diagnostics/typechecker/invalidEvalDivisionByZero.vadl:6:14]
+//       │
+//     6 │ constant f = VADL::udivs(10, 0)
+//       │              ^^^^^^^^^^^^^^^^^^ Division by zero cannot be computed.
+//       │
+//
+//  error: Constant value required
+//       ╭──[test/resources/diagnostics/typechecker/invalidEvalDivisionByZero.vadl:7:14]
+//       │
+//     7 │ constant g = VADL::smod(10, 0)
+//       │              ^^^^^^^^^^^^^^^^^ Division by zero cannot be computed.
+//       │
+//
+//  error: Constant value required
+//       ╭──[test/resources/diagnostics/typechecker/invalidEvalDivisionByZero.vadl:8:14]
+//       │
+//     8 │ constant h = VADL::umod(10, 0)
+//       │              ^^^^^^^^^^^^^^^^^ Division by zero cannot be computed.
+//       │
+//
+//  error: Constant value required
+//       ╭──[test/resources/diagnostics/typechecker/invalidEvalDivisionByZero.vadl:9:14]
+//       │
+//     9 │ constant i = VADL::smods(10, 0)
+//       │              ^^^^^^^^^^^^^^^^^^ Division by zero cannot be computed.
+//       │
+//
+//  error: Constant value required
+//       ╭──[test/resources/diagnostics/typechecker/invalidEvalDivisionByZero.vadl:10:14]
+//       │
+//    10 │ constant j = VADL::umods(10, 0)
+//       │              ^^^^^^^^^^^^^^^^^^ Division by zero cannot be computed.
+//       │
+//
+//
+// Part of the class vadl.ast.DiagnosticsTest


### PR DESCRIPTION
The constant evaluator previously didn't have any checks for division by zero.