### PR TITLE
frontend: diagnosticprinter - catch additional exception

### DIFF
--- a/vadl/main/vadl/error/DiagnosticPrinter.java
+++ b/vadl/main/vadl/error/DiagnosticPrinter.java
@@ -221,10 +221,14 @@ public class DiagnosticPrinter {
         throw new IllegalStateException();
       }
       lines = getFileLines(location.location().path());
-    } catch (IOException | IllegalArgumentException e) {
-      var previewError = "No Preview available: Could not find the file '%s'".formatted(
-          location.location().path()
-      );
+    } catch (IOException | IllegalArgumentException | IllegalStateException e) {
+      var locationPath = location.location().path();
+      var previewError = "No Preview available: No source location found";
+      if (locationPath != null) {
+        previewError = "No Preview available: Could not find the file '%s'".formatted(
+                  location.location().path());
+      }
+
       var prefix = "     %s│%s    ".formatted(colors.cyan(), colors.reset());
       var text = "%s%s%s\n%s".formatted(colors.yellow(), previewError, colors.reset(),
           messageBlock(location));


### PR DESCRIPTION
- Add `IllegalStateException` to the surrounding try-catch block.
- Adapt error-preview-message depending on if a source-location is available

Closes #794 