### PR TITLE
asm: Remove unnecessary casts in assembly grammars

### DIFF
--- a/sys/risc-v/rv32im.vadl
+++ b/sys/risc-v/rv32im.vadl
@@ -155,15 +155,14 @@ assembly description ASM for ABI = {
         ) @operand
     ;
 
-    // FIXME: Fix constant types in typechecker to allow just '1' instead of '1 as Bits<1>'
     JalrInstruction @instruction:
       var rdTmp = null @operand
       var rs1Tmp = null @operand
       var immTmp = null @operand
       mnemonic = "JALR" @operand
-      ( ?(LaIdEq(1 as Bits<1>, ",") )
+      ( ?(LaIdEq(1, ","))
           rdTmp = Register@operand ","
-          ( ?(LaIdEq(1 as Bits<1>, ",") )         // jalr rd, rs, imm
+          ( ?(LaIdEq(1, ","))                     // jalr rd, rs, imm
               rs1Tmp = Register@operand ","
               immTmp = JalrImmediateOperand
             |

--- a/sys/risc-v/rv32imAsmGen.vadl
+++ b/sys/risc-v/rv32imAsmGen.vadl
@@ -123,15 +123,14 @@ assembly description ASM for ABI = {
         ) @operand
     ;
 
-    // FIXME: Fix constant types in typechecker to allow just '1' instead of '1 as Bits<1>'
     JalrInstruction @instruction:
       var rdTmp = null @operand
       var rs1Tmp = null @operand
       var immTmp = null @operand
       mnemonic = "JALR" @operand
-      ( ?(LaIdEq(1 as Bits<1>, ",") )
+      ( ?(LaIdEq(1, ","))
           rdTmp = Register@operand ","
-          ( ?(LaIdEq(1 as Bits<1>, ",") )         // jalr rd, rs, imm
+          ( ?(LaIdEq(1, ","))                     // jalr rd, rs, imm
               rs1Tmp = Register@operand ","
               immTmp = ImmediateOperand
             |

--- a/sys/v-risc/ABI_no_suffix.vadl
+++ b/sys/v-risc/ABI_no_suffix.vadl
@@ -99,7 +99,7 @@ assembly description AD for ABI = {
 
       RTypeInstruction :
         var mnemonicTmp = RTypeIds
-        ( ?(LaIdEq(3 as Bits<2>,","))
+        ( ?(LaIdEq(3,","))
           a = (
             mnemonic = mnemonicTmp @operand
             rd = Register @operand ","
@@ -121,7 +121,7 @@ assembly description AD for ABI = {
         var mnemonicTmp = ITypeIds
         var rdTmp = Reg @operand
         inst = (
-          ?(LaIdEq(1 as Bits<1>,","))
+          ?(LaIdEq(1,","))
           (
             var rs1Tmp = Reg @operand
 
@@ -163,7 +163,7 @@ assembly description AD for ABI = {
         var rdTmp = Reg @operand
         ( // normal version of instruction
           // e.g. LSRI r1, r2, 0x1
-          ?(LaIdEq(1 as Bits<1>,","))
+          ?(LaIdEq(1,","))
           a = (  
             mnemonic = mnemonicTmp @operand
             rd = rdTmp
@@ -255,7 +255,7 @@ assembly description AD for ABI = {
         var rdTmp = Reg @operand
         ( // normal version of instruction
           // e.g. SGTI r1, r2, 0x1
-          ?(LaIdEq(1 as Bits<1>,","))
+          ?(LaIdEq(1,","))
           a = (  
             mnemonic = mnemonicTmp @operand
             rd = rdTmp


### PR DESCRIPTION
Remove VADL type casts from assembly grammars, as they are no longer necessary following the fixes in #810.