### PR TITLE
asm: Fix asm parser builtin implementation

### DIFF
--- a/sys/v-risc/ABI_no_suffix.vadl
+++ b/sys/v-risc/ABI_no_suffix.vadl
@@ -159,25 +159,22 @@ assembly description AD for ABI = {
       ShiftImmediateIds: "ASRI" | "LSRI" | "LSLI";
 
       ShiftImmediateInstruction :
-        var mnemonicTmp = ShiftImmediateIds
-        var rdTmp = Reg @operand
-        ( // normal version of instruction
+          // normal version of instruction
           // e.g. LSRI r1, r2, 0x1
-          ?(LaIdEq(1,","))
-          a = (  
-            mnemonic = mnemonicTmp @operand
-            rd = rdTmp
+          ?(LaIdEq(4,","))
+          a = (
+            mnemonic = ShiftImmediateIds @operand
+            rd = Register @operand ","
             rs1 = Register @operand ","
             imm = ImmediateOperand
           ) @instruction
         | // short version of instruction with _S suffix
           // e.g. LSRI_S r1, 0x1
           b = (
-            mnemonic = s_suffix< mnemonicTmp > @operand
-            rd = rdTmp
+            mnemonic = s_suffix< ShiftImmediateIds > @operand
+            rd = Register @operand ","
             imm = ImmediateOperand
           ) @instruction
-        )
       ;
 
 

--- a/vadl/main/resources/templates/lcb/llvm/lib/Target/AsmParser/AsmRecursiveDescentParser.cpp
+++ b/vadl/main/resources/templates/lcb/llvm/lib/Target/AsmParser/AsmRecursiveDescentParser.cpp
@@ -61,24 +61,53 @@ namespace llvm {
   }
 
   bool [(${namespace})]AsmRecursiveDescentParser::VADL_asmparser_laidin(uint64_t lookahead, const std::vector<std::string>& compareStrings) {
-    std::vector<AsmToken> tokens(lookahead);
-    MutableArrayRef<AsmToken> Buf(tokens.data(), lookahead);
-    size_t ReadCount = Lexer.peekTokens(Buf, true);
+    std::optional<AsmToken> tok = VADL_asmparser_lookahead_token(lookahead);
+    if (!tok.has_value()) {
+      return false;
+    }
 
-    for (size_t i = 0; i < compareStrings.size(); i++) {
-      if (tokens[lookahead-1].getString().[(${compareFunction})](compareStrings[i])) {
-          return true;
+    StringRef s = tok->getString();
+    for (size_t i = 0; i < compareStrings.size(); ++i) {
+      if (s.[(${compareFunction})](compareStrings[i])) {
+        return true;
       }
     }
     return false;
   }
 
   bool [(${namespace})]AsmRecursiveDescentParser::VADL_asmparser_laideq(uint64_t lookahead, const std::string compareString) {
-      std::vector<AsmToken> tokens(lookahead);
-      MutableArrayRef<AsmToken> Buf(tokens.data() ,lookahead);
-      size_t ReadCount = Lexer.peekTokens(Buf, true);
+    std::optional<AsmToken> tok = VADL_asmparser_lookahead_token(lookahead);
+    if (!tok.has_value()) {
+      return false;
+    }
 
-      return tokens[lookahead-1].getString().[(${compareFunction})](compareString);
+    return tok->getString().[(${compareFunction})](compareString);
+  }
+
+  std::optional<AsmToken> [(${namespace})]AsmRecursiveDescentParser::VADL_asmparser_lookahead_token(uint64_t lookahead) {
+    if (lookahead == 0) {
+      return Lexer.getTok();
+    }
+
+    AsmToken current = Lexer.getTok();
+    AsmToken firstLookahead = Lexer.Lex();
+
+    std::optional<AsmToken> result;
+    if (lookahead == 1) {
+      result = firstLookahead;
+    } else {
+      std::vector<AsmToken> rest(lookahead - 1);
+      MutableArrayRef<AsmToken> buf(rest.data(), lookahead - 1);
+      size_t readCount = Lexer.peekTokens(buf, true);
+
+      size_t idx = lookahead - 2;
+      if (readCount > idx) {
+        result = rest[idx];
+      }
+    }
+
+    Lexer.UnLex(current);
+    return result;
   }
 
 [(${grammarRules})]

--- a/vadl/main/resources/templates/lcb/llvm/lib/Target/AsmParser/AsmRecursiveDescentParser.h
+++ b/vadl/main/resources/templates/lcb/llvm/lib/Target/AsmParser/AsmRecursiveDescentParser.h
@@ -75,6 +75,7 @@ private:
 
     bool VADL_asmparser_laidin(uint64_t lookahead, const std::vector<std::string>& compareStrings);
     bool VADL_asmparser_laideq(uint64_t lookahead, const std::string compareString);
+    std::optional<AsmToken> VADL_asmparser_lookahead_token(uint64_t lookahead);
 
 public:
     [(${namespace})]AsmRecursiveDescentParser(MCAsmLexer &lexer, MCAsmParser &parser, OperandVector& operands)

--- a/vadl/main/vadl/lcb/codegen/assembly/AssemblyParserCodeGenerator.java
+++ b/vadl/main/vadl/lcb/codegen/assembly/AssemblyParserCodeGenerator.java
@@ -507,7 +507,8 @@ public class AssemblyParserCodeGenerator {
         token -> token.getStringLiteral() != null
             ? "'" + token.getStringLiteral() + "'"
             : token.getRuleName()
-    ).collect(Collectors.joining(", "));
+    ).distinct().collect(Collectors.joining(", "));
+    // Use distinct() because tokens can overlap if alternatives have semantic predicates
     return "No alternative matched. Expected one of {" + expectedTokens + "}.";
   }
 


### PR DESCRIPTION
Fix the case where an asm parser builtin is called in an instruction rule before any other token is parsed like `?(LaIdEq(4,","))` in this example:
```c
ShiftImmediateInstruction :
  // normal version of instruction
  // e.g. LSRI r1, r2, 0x1
  ?(LaIdEq(4,","))
   a = (
     mnemonic = ShiftImmediateIds @operand
     rd = Register @operand ","
     rs1 = Register @operand ","
     imm = ImmediateOperand
   ) @instruction
 | // short version of instruction with _S suffix
   // e.g. LSRI_S r1, 0x1
   b = (
     mnemonic = s_suffix< ShiftImmediateIds > @operand
     rd = Register @operand ","
     imm = ImmediateOperand
   ) @instruction
;
```
Before this would not work because the `AsmParser` unlexes the first token (=mnemonic) of an instruction before calling the `RecursiveDescentParser`. This would break the previous implementation of `LaIdEq` and `LaIdIn` as these methods use `Lexer.peekTokens()` which is not aware of the unlexed token: 

https://github.com/OpenVADL/openvadl/blob/bc05c5c67573fcded9d7ef2858bb571af2f5f25b/vadl/main/resources/templates/lcb/llvm/lib/Target/AsmParser/AsmParser.cpp#L203-L207