### PR TITLE
typechecker: Fix crash with function call in type literal

### DIFF
--- a/vadl/main/vadl/ast/TypeChecker.java
+++ b/vadl/main/vadl/ast/TypeChecker.java
@@ -2741,10 +2741,8 @@ public class TypeChecker
       check(functionDefinition);
 
       if (!functionDefinition.params.isEmpty()) {
-        // We can still continue after the error here, no need to stop checking. We simply assume
-        // it returns the type of the function. This is only possible because we don't have
-        // function overloading.
-        errors.add(error("Invalid Function Call", expr)
+        // We cannot continue here because it might get evaluated and confused.
+        addErrorAndStopChecking(error("Invalid Function Call", expr)
             .description("Expected `%s` arguments but got `%s`.", functionDefinition.params.size(),
                 0)
             .build());

--- a/vadl/test/resources/frontend-snapshots/typechecker/invalidFunctionCallTooFewArgsInTypeLiteral.vadl
+++ b/vadl/test/resources/frontend-snapshots/typechecker/invalidFunctionCallTooFewArgsInTypeLiteral.vadl
@@ -1,0 +1,21 @@
+// Previously this would have crashed in the constant evaluator because the typechecker created an error but could
+// still reason that the expression would return Bits<8> and so the expression would enter the constant evaluator who
+// would get confused and crash
+
+constant abc = 7 as Bits<flo>
+
+function flo(x: Bits<8>) -> Bits<8> = x + 1
+
+
+//  Reported Diagnostics:
+//
+//  error: Invalid Function Call
+//       ╭──[test/resources/frontend-snapshots/typechecker/invalidFunctionCallTooFewArgsInTypeLiteral.vadl:5:26]
+//       │
+//     5 │ constant abc = 7 as Bits<flo>
+//       │                          ^^^
+//       │
+//       Expected `1` arguments but got `0`.
+//
+//
+// Part of the class vadl.ast.FrontendSnapshotTests


### PR DESCRIPTION
This fixes the issue we talked about today.