### PR TITLE
frontend: Add internal api for potentially broken ASTs

### DIFF
--- a/vadl-cli/main/vadl/cli/BaseCommand.java
+++ b/vadl-cli/main/vadl/cli/BaseCommand.java
@@ -178,17 +178,11 @@ public abstract class BaseCommand implements Callable<Integer> {
    * @return the AST.
    */
   private Ast parseToAst() {
-    try {
-      Ast ast = VadlParser.parse(input, new DiskVirtualFileSystem(),
-          Objects.requireNonNullElseGet(modelOverrides, Map::of));
-      new Ungrouper().ungroup(ast);
-      new ModelRemover().removeModels(ast);
-      return ast;
-    } catch (IOException e) {
-      throw Diagnostic.error("Cannot open file", SourceLocation.INVALID_SOURCE_LOCATION)
-          .description("%s", Objects.requireNonNullElse(e.getMessage(), ""))
-          .build();
-    }
+    Ast ast = VadlParser.parse(input, new DiskVirtualFileSystem(),
+        Objects.requireNonNullElseGet(modelOverrides, Map::of));
+    new Ungrouper().ungroup(ast);
+    new ModelRemover().removeModels(ast);
+    return ast;
   }
 
   /**

--- a/vadl-lsp/main/vadl/lsp/LspSnapshotFileSystem.java
+++ b/vadl-lsp/main/vadl/lsp/LspSnapshotFileSystem.java
@@ -77,7 +77,7 @@ class LspSnapshotFileSystem implements VirtualFileSystem {
   }
 
   @Override
-  public InputStream getInputStream(Path path) throws IOException {
+  public InputStream getInputStream(Path path) {
     String uri = toUri(path);
     readFiles.add(uri);
 

--- a/vadl-lsp/main/vadl/lsp/VadlTextDocumentService.java
+++ b/vadl-lsp/main/vadl/lsp/VadlTextDocumentService.java
@@ -19,7 +19,6 @@ package vadl.lsp;
 import static vadl.lsp.LspUtils.toPath;
 import static vadl.lsp.LspUtils.toUri;
 
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -184,9 +183,6 @@ public class VadlTextDocumentService implements TextDocumentService {
       try {
         ast = VadlParser.parse(toPath(uri), snapshots);
 
-      } catch (IOException e) {
-        log.error("Unexpected Exception occurred when parsing {}", uri, e);
-        return definitionResult(null);
       } catch (DiagnosticList dl) {
         log.debug("UNABLE definition: Parser produced diagnostics instead of AST for {}", uri);
         return definitionResult(null);
@@ -274,9 +270,6 @@ public class VadlTextDocumentService implements TextDocumentService {
       Path path = document.getPath();
       try {
         Frontend.compileToAst(path, snapshots);
-      } catch (IOException e) {
-        log.error("Unexpected Exception occurred when parsing {}", document.uri, e);
-
       } catch (DiagnosticList dl) {
         log.debug("Raw diagnostics ({}): {}", document.uri, dl.getMessage());
         List<String> importedFileErrors = new ArrayList<>();

--- a/vadl/main/vadl/ast/Frontend.java
+++ b/vadl/main/vadl/ast/Frontend.java
@@ -16,8 +16,12 @@
 
 package vadl.ast;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.IOException;
 import java.nio.file.Path;
+import javax.annotation.Nullable;
+import vadl.error.DiagnosticList;
 import vadl.utils.Pair;
 import vadl.utils.SingleFileVirtualFileSystem;
 import vadl.utils.VirtualFileSystem;
@@ -66,14 +70,11 @@ public class Frontend {
    */
   public static Ast compileToAst(Path path, VirtualFileSystem fileSystem) throws
       IOException {
-    var ast = VadlParser.parse(path, fileSystem);
-    var remover = new ModelRemover();
-    remover.removeModels(ast);
-    var ungrouper = new Ungrouper();
-    ungrouper.ungroup(ast);
-    var typechecker = new TypeChecker();
-    typechecker.verify(ast);
-    return ast;
+    var result = compileToPotentiallyBrokenAst(path, fileSystem);
+    if (result.diagnostics != null) {
+      throw result.diagnostics;
+    }
+    return requireNonNull(result.ast);
   }
 
   /**
@@ -123,5 +124,53 @@ public class Frontend {
     var lowering = new ViamLowering();
     var spec = lowering.generate(ast);
     return Pair.of(ast, spec);
+  }
+
+
+  enum CompilationStage {
+    PARSING, REMOVAL, UNGROUPING, TYPE_CHECKING, VIAM_LOWERING
+  }
+
+  record PotentiallyBrokenAst(
+      @Nullable Ast ast,
+      @Nullable DiagnosticList diagnostics,
+      @Nullable CompilationStage failedIn) { }
+
+  /**
+   * USE WITH CAUTION!
+   * Compile a program from a provided path to an potentially broken AST.
+   *
+   * <p>This method is mostly intended for the LSP which might want to (carefully) do some
+   * processing on an AST well knowingly that it might be broken.
+   *
+   * @param path
+   * @param fileSystem
+   * @return
+   * @throws IOException
+   */
+  public static PotentiallyBrokenAst compileToPotentiallyBrokenAst(Path path, VirtualFileSystem fileSystem) throws IOException {
+    Ast ast = null;
+    CompilationStage failedIn = null;
+    try {
+      failedIn = CompilationStage.PARSING;
+      ast = VadlParser.parse(path, fileSystem);
+
+      failedIn = CompilationStage.REMOVAL;
+      var remover = new ModelRemover();
+      remover.removeModels(ast);
+
+      failedIn = CompilationStage.UNGROUPING;
+      var ungrouper = new Ungrouper();
+      ungrouper.ungroup(ast);
+
+      failedIn = CompilationStage.TYPE_CHECKING;
+      var typechecker = new TypeChecker();
+      typechecker.verify(ast);
+
+      return new PotentiallyBrokenAst(ast, null, null);
+    } catch (DiagnosticList diagnostics) {
+      return new PotentiallyBrokenAst(ast, diagnostics, failedIn);
+    }
+
   }
 }

--- a/vadl/main/vadl/ast/Frontend.java
+++ b/vadl/main/vadl/ast/Frontend.java
@@ -18,7 +18,6 @@ package vadl.ast;
 
 import static java.util.Objects.requireNonNull;
 
-import java.io.IOException;
 import java.nio.file.Path;
 import javax.annotation.Nullable;
 import vadl.error.DiagnosticList;
@@ -51,12 +50,8 @@ public class Frontend {
    * @throws vadl.error.DiagnosticList  if the program isn't valid.
    */
   public static Ast compileToAst(String program) {
-    try {
-      return compileToAst(SingleFileVirtualFileSystem.DEFAULT_PATH,
-          new SingleFileVirtualFileSystem(program));
-    } catch (IOException e) {
-      throw new RuntimeException("This can never happen as the filesystem always succeeds here.");
-    }
+    return compileToAst(SingleFileVirtualFileSystem.DEFAULT_PATH,
+        new SingleFileVirtualFileSystem(program));
   }
 
   /**
@@ -68,8 +63,7 @@ public class Frontend {
    * @return  the parsed and checked AST.
    * @throws vadl.error.DiagnosticList  if the program isn't valid.
    */
-  public static Ast compileToAst(Path path, VirtualFileSystem fileSystem) throws
-      IOException {
+  public static Ast compileToAst(Path path, VirtualFileSystem fileSystem) {
     var result = compileToPotentiallyBrokenAst(path, fileSystem);
     if (result.diagnostics != null) {
       throw result.diagnostics;
@@ -85,12 +79,8 @@ public class Frontend {
    * @throws vadl.error.DiagnosticList  if the program isn't valid.
    */
   public static Specification compileToViam(String program) {
-    try {
-      return compileToViam(SingleFileVirtualFileSystem.DEFAULT_PATH,
-          new SingleFileVirtualFileSystem(program));
-    } catch (IOException e) {
-      throw new RuntimeException("This can never happen as the filesystem always succeeds here.");
-    }
+    return compileToViam(SingleFileVirtualFileSystem.DEFAULT_PATH,
+        new SingleFileVirtualFileSystem(program));
   }
 
   /**
@@ -101,8 +91,7 @@ public class Frontend {
    * @return  the parsed and checked VIAM spec.
    * @throws vadl.error.DiagnosticList  if the program isn't valid.
    */
-  public static Specification compileToViam(Path path, VirtualFileSystem fileSystem) throws
-      IOException {
+  public static Specification compileToViam(Path path, VirtualFileSystem fileSystem) {
     var ast = compileToAst(path, fileSystem);
     var lowering = new ViamLowering();
     return lowering.generate(ast);
@@ -118,8 +107,7 @@ public class Frontend {
    * @throws vadl.error.DiagnosticList  if the program isn't valid.
    */
   public static Pair<Ast, Specification> compileToAstAndViam(Path path,
-                                                             VirtualFileSystem fileSystem) throws
-      IOException {
+                                                             VirtualFileSystem fileSystem) {
     var ast = compileToAst(path, fileSystem);
     var lowering = new ViamLowering();
     var spec = lowering.generate(ast);
@@ -146,9 +134,8 @@ public class Frontend {
    * @param path
    * @param fileSystem
    * @return
-   * @throws IOException
    */
-  public static PotentiallyBrokenAst compileToPotentiallyBrokenAst(Path path, VirtualFileSystem fileSystem) throws IOException {
+  public static PotentiallyBrokenAst compileToPotentiallyBrokenAst(Path path, VirtualFileSystem fileSystem) {
     Ast ast = null;
     CompilationStage failedIn = null;
     try {

--- a/vadl/main/vadl/ast/ParserUtils.java
+++ b/vadl/main/vadl/ast/ParserUtils.java
@@ -19,7 +19,6 @@ package vadl.ast;
 import static java.util.Objects.requireNonNull;
 import static vadl.error.Diagnostic.error;
 
-import java.io.IOException;
 import java.math.BigInteger;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -763,11 +762,6 @@ class ParserUtils {
       return new ImportDefinition(ast, importedSymbols, fileId, filePath, args, loc);
     } catch (DiagnosticList | Diagnostic e) {
       throw e;
-    } catch (IOException e) {
-      throw error("Import Failed", loc)
-          .description("The following error occurred: %s",
-              e.getMessage() != null ? e.getMessage() : e)
-          .build();
     }
   }
 

--- a/vadl/main/vadl/ast/VadlParser.java
+++ b/vadl/main/vadl/ast/VadlParser.java
@@ -17,7 +17,6 @@
 package vadl.ast;
 
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -41,14 +40,14 @@ public class VadlParser {
   /**
    * Parses the VADL source program at the specified path into an AST.
    */
-  public static Ast parse(Path path) throws IOException {
+  public static Ast parse(Path path) {
     return parse(path, new DiskVirtualFileSystem(), Collections.emptyMap());
   }
 
   /**
    * Parses the VADL source program at the specified path into an AST.
    */
-  public static Ast parse(Path path, VirtualFileSystem fileSystem) throws IOException {
+  public static Ast parse(Path path, VirtualFileSystem fileSystem) {
     return parse(path, fileSystem, Collections.emptyMap());
   }
 
@@ -58,7 +57,7 @@ public class VadlParser {
    * except errors will have the proper file locations set.
    */
   public static Ast parse(Path path, VirtualFileSystem fileSystem,
-                          Map<String, String> macroOverrides) throws IOException {
+                          Map<String, String> macroOverrides) {
     final var startTime = System.nanoTime();
     var scanner = new Scanner(fileSystem.getInputStream(path));
     var parser = new Parser(scanner);

--- a/vadl/main/vadl/utils/DiskVirtualFileSystem.java
+++ b/vadl/main/vadl/utils/DiskVirtualFileSystem.java
@@ -16,6 +16,8 @@
 
 package vadl.utils;
 
+import static vadl.error.Diagnostic.error;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -39,9 +41,13 @@ public class DiskVirtualFileSystem implements VirtualFileSystem {
   }
 
   @Override
-  public InputStream getInputStream(Path path) throws IOException {
+  public InputStream getInputStream(Path path) {
     var file = new File(path.toUri());
-    return new FileInputStream(file);
+    try {
+      return new FileInputStream(file);
+    } catch (IOException e) {
+      throw error("File not found: " + path, SourceLocation.INVALID_SOURCE_LOCATION).build();
+    }
   }
 
   @Override

--- a/vadl/main/vadl/utils/EmptyVirtualFileSystem.java
+++ b/vadl/main/vadl/utils/EmptyVirtualFileSystem.java
@@ -16,8 +16,8 @@
 
 package vadl.utils;
 
-import java.io.FileNotFoundException;
-import java.io.IOException;
+import static vadl.error.Diagnostic.error;
+
 import java.io.InputStream;
 import java.nio.file.Path;
 
@@ -31,8 +31,8 @@ public class EmptyVirtualFileSystem implements VirtualFileSystem {
   }
 
   @Override
-  public InputStream getInputStream(Path path) throws IOException {
-    throw new FileNotFoundException();
+  public InputStream getInputStream(Path path) {
+    throw error("File not found: " + path, SourceLocation.INVALID_SOURCE_LOCATION).build();
   }
 
   @Override

--- a/vadl/main/vadl/utils/SingleFileVirtualFileSystem.java
+++ b/vadl/main/vadl/utils/SingleFileVirtualFileSystem.java
@@ -16,9 +16,9 @@
 
 package vadl.utils;
 
+import static vadl.error.Diagnostic.error;
+
 import java.io.ByteArrayInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
@@ -48,9 +48,9 @@ public class SingleFileVirtualFileSystem implements VirtualFileSystem {
   }
 
   @Override
-  public InputStream getInputStream(Path path) throws IOException {
+  public InputStream getInputStream(Path path) {
     if (!path.equals(this.path)) {
-      throw new FileNotFoundException("File not found: " + path);
+      throw error("File not found: " + path, SourceLocation.INVALID_SOURCE_LOCATION).build();
     }
     return new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
   }

--- a/vadl/main/vadl/utils/VirtualFileSystem.java
+++ b/vadl/main/vadl/utils/VirtualFileSystem.java
@@ -49,7 +49,7 @@ public interface VirtualFileSystem {
    * @return              an input stream to read from the file.
    * @throws IOException  if the file cannot be opened.
    */
-  InputStream getInputStream(Path path) throws IOException;
+  InputStream getInputStream(Path path);
 
 
   /**

--- a/vadl/test/vadl/ast/VirtualFileSystemTest.java
+++ b/vadl/test/vadl/ast/VirtualFileSystemTest.java
@@ -52,7 +52,7 @@ public class VirtualFileSystemTest {
     }
 
     @Override
-    public InputStream getInputStream(Path path) throws IOException {
+    public InputStream getInputStream(Path path) {
       return new ByteArrayInputStream(files.get(path.toString()).toString().getBytes(
           StandardCharsets.UTF_8));
     }


### PR DESCRIPTION
The LSP might want to access the AST even if the frontend produces errors.
In that case the AST might not be in any good state and the LSP has to dread lightly but might still benefit from it.

@jaraonthe-dot-net can you confirm that this API would help you with the LSP development?