### PR TITLE
frontend: Add internal broken parser api

### DIFF
--- a/vadl/main/vadl/ast/VadlParser.java
+++ b/vadl/main/vadl/ast/VadlParser.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nullable;
 import vadl.error.Diagnostic;
 import vadl.error.DiagnosticList;
 import vadl.utils.DiskVirtualFileSystem;
@@ -37,6 +36,11 @@ public class VadlParser {
 
   /**
    * Parses the VADL source program at the specified path into an AST.
+   * The returned AST is already macro expanded and all symbols are resolved.
+   * This method loads the file always from disk.
+   *
+   * @param path to load the file from.
+   * @throws DiagnosticList if the file cannot be loaded or not correctly parsed.
    */
   public static Ast parse(Path path) {
     return parse(path, new DiskVirtualFileSystem(), Collections.emptyMap());
@@ -44,6 +48,12 @@ public class VadlParser {
 
   /**
    * Parses the VADL source program at the specified path into an AST.
+   * The returned AST is already macro expanded and all symbols are resolved.
+   * The file will be loaded from the specified filesystem.
+   *
+   * @param path to load the file from.
+   * @param fileSystem to load the file from.
+   * @throws DiagnosticList if the file cannot be loaded or not correctly parsed.
    */
   public static Ast parse(Path path, VirtualFileSystem fileSystem) {
     return parse(path, fileSystem, Collections.emptyMap());
@@ -51,8 +61,27 @@ public class VadlParser {
 
   /**
    * Parses the VADL source program at the specified path into an AST.
-   * Works just like {@link VadlParser#parse(String, Map, Path)},
-   * except errors will have the proper file locations set.
+   * The returned AST is already macro expanded and all symbols are resolved.
+   * This method is most useful for testing.
+   *
+   * @param program to parse.
+   * @throws DiagnosticList if the file cannot be loaded or not correctly parsed.
+   */
+  public static Ast parse(String program) {
+    var path = Paths.get("memory");
+    var fileSystem = new SingleFileVirtualFileSystem(program, path);
+    return parse(path, fileSystem);
+  }
+
+  /**
+   * Parses the VADL source program at the specified path into an AST.
+   * The returned AST is already macro expanded and all symbols are resolved.
+   * The file will be loaded from the specified filesystem.
+   *
+   * @param path to load the file from.
+   * @param fileSystem to load the file from.
+   * @param macroOverrides which are either specified from an import or the CLI.
+   * @throws DiagnosticList if the file cannot be loaded or not correctly parsed.
    */
   public static Ast parse(Path path, VirtualFileSystem fileSystem,
                           Map<String, String> macroOverrides) {
@@ -66,36 +95,6 @@ public class VadlParser {
     ast.filePath = fileSystem.toAbsolutePath(path);
     return ast;
   }
-
-  /**
-   * Convenience overload for {@link VadlParser#parse(String, Map, Path)} without any overrides.
-   */
-  public static Ast parse(String program) {
-    return parse(program, Map.of(), Paths.get("memory"));
-  }
-
-  /**
-   * Convenience overload for {@link VadlParser#parse(String, Map, Path)} without any overrides.
-   */
-  public static Ast parse(String program, Path resolutionPath) {
-    return parse(program, Map.of(), resolutionPath);
-  }
-
-  /**
-   * Parses a source program into an AST.
-   *
-   * @param program         a source code file to parse
-   * @param macroOverrides  The overrides to perform in the macro evaluation
-   * @return                The parsed syntax tree.
-   * @throws DiagnosticList if there are any parsing errors.
-   */
-  public static Ast parse(String program, Map<String, String> macroOverrides,
-                          @Nullable Path resolutionPath) {
-    var path = Paths.get("virtualFile.vadl");
-    var fileSystem = new SingleFileVirtualFileSystem(program, path);
-    return parse(path, fileSystem, macroOverrides);
-  }
-
 
   private static Ast parse(Parser parser) {
     List<Diagnostic> errors = new ArrayList<>();

--- a/vadl/main/vadl/ast/VadlParser.java
+++ b/vadl/main/vadl/ast/VadlParser.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import vadl.error.Diagnostic;
 import vadl.error.DiagnosticList;
 import vadl.utils.DiskVirtualFileSystem;
@@ -129,4 +130,79 @@ public class VadlParser {
     return ast;
   }
 
+  /**
+   * A structure to hold an ast and the errors that might have been produced during its creation.
+   *
+   * @param ast that was parsed.
+   * @param diagnostics null if everything went ok, otherwise a non-empty list.
+   */
+  record PotentiallyBrokenAst(
+      Ast ast,
+      @Nullable DiagnosticList diagnostics) {
+    public boolean isBroken() {
+      return diagnostics != null;
+    }
+  }
+
+  /**
+   * Parses the VADL source program at the specified path into an AST that might not have succeeded
+   * parsing. Even if parsing fails all symbols tried to be resolved. The errors returned are from
+   * the first stage that fails to avoid follow-up errors.
+   *
+   * <p>USE WITH EXTREME CAUTION! There are no guarantees about the state in which the AST might
+   * be in. This includes, but is not limited to, dummy statements that don't appear in the input
+   * but are inserted as placeholders and still contained as macro expansion has gone wrong, only
+   * halfway parsed inputs as faulty macro invocation prevents the parser from continuing.
+   *
+   * @param path           to load the file from.
+   * @param fileSystem     to load the file from.
+   * @param macroOverrides which are either specified from an import or the CLI.
+   */
+  public static PotentiallyBrokenAst unsafeParseToPotentiallyBrokenAst(
+      // FIXME: This is really similar to the normal parse method and so in the future if this
+      // stays that similar we can reabse them on a common core.
+      // https://github.com/OpenVADL/openvadl/pull/867#discussion_r3037098145
+      Path path,
+      VirtualFileSystem fileSystem, Map<String, String> macroOverrides) {
+
+    var scanner = new Scanner(fileSystem.getInputStream(path));
+    var parser = new Parser(scanner);
+    parser.sourceFile = fileSystem.toAbsolutePath(path);
+    parser.fileSystem = fileSystem;
+    macroOverrides.forEach((key, value) -> parser.macroOverrides.put(key,
+        new Identifier(value, SourceLocation.INVALID_SOURCE_LOCATION)));
+    var potentialBrokenAst =
+        parser.ast.withPassTiming("Parsing", () -> unsafeParseToPotentiallyBrokenAst(parser));
+    potentialBrokenAst.ast.filePath = fileSystem.toAbsolutePath(path);
+    return potentialBrokenAst;
+  }
+
+  private static PotentiallyBrokenAst unsafeParseToPotentiallyBrokenAst(Parser parser) {
+    List<Diagnostic> errors = new ArrayList<>();
+
+    try {
+      parser.Parse();
+    } catch (Diagnostic e) {
+      errors.add(e);
+    } catch (DiagnosticList e) {
+      errors.addAll(e.items);
+    }
+
+    errors.addAll(parser.diagnostics);
+
+
+    // during parsing there might be errors in the macro table (e.g. conflicting macro definitions)
+    if (errors.isEmpty()) {
+      errors = parser.macroTable.errors.stream().distinct().toList();
+    }
+
+    var ast = parser.ast;
+
+    var symbolErrors = SymbolTable.collectAndResolveSymbols(ast);
+    if (errors.isEmpty()) {
+      errors = symbolErrors;
+    }
+
+    return new PotentiallyBrokenAst(ast, !errors.isEmpty() ? new DiagnosticList(errors) : null);
+  }
 }

--- a/vadl/test/vadl/ast/AstTestUtils.java
+++ b/vadl/test/vadl/ast/AstTestUtils.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
+import vadl.utils.EmptyVirtualFileSystem;
 import vadl.utils.OverlayVirtualFileSystem;
 import vadl.utils.SingleFileVirtualFileSystem;
 import vadl.utils.VirtualFileSystem;
@@ -32,13 +33,7 @@ public class AstTestUtils {
 
 
   static void verifyPrettifiedAst(Ast ast) {
-    ModelRemover.removeModels(ast);
-    Ungrouper.ungroup(ast);
-    var progPretty = ast.prettyPrintToString();
-    var astPretty = Assertions.assertDoesNotThrow(() -> VadlParser.parse(progPretty, ast.filePath),
-        "Cannot parse prettified input \n" + progPretty);
-    Ungrouper.ungroup(astPretty);
-    assertAstEquality(astPretty, ast);
+    verifyPrettifiedAst(ast, new EmptyVirtualFileSystem());
   }
 
   static void verifyPrettifiedAst(Ast ast, VirtualFileSystem fileSystem) {

--- a/vadl/test/vadl/ast/MacroTests.java
+++ b/vadl/test/vadl/ast/MacroTests.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import vadl.error.Diagnostic;
 import vadl.error.DiagnosticList;
+import vadl.utils.SingleFileVirtualFileSystem;
 
 public class MacroTests {
 
@@ -308,8 +309,10 @@ public class MacroTests {
         constant a = $x()
         """;
 
+    var path = Paths.get("hardcoded");
+    var fileSystem = new SingleFileVirtualFileSystem(prog, path);
     var exception = Assertions.assertThrows(DiagnosticList.class,
-        () -> VadlParser.parse(prog, Paths.get("hardcoded")));
+        () -> VadlParser.parse(path, fileSystem));
     var location = exception.items.get(0).multiLocation.primaryLocation().location();
     Assertions.assertNotNull(location.expandedFrom());
     Assertions.assertEquals(5, location.expandedFrom().begin().line());


### PR DESCRIPTION
This API is mostly for the LSP, @jaraonthe-dot-net can you verify that this would be helpful for you?

There is also a commit in here that cleans up the parser API and removes a couple of barely used functions.

This PR is the successor to #838