### PR TITLE
viam: Add min max builtin functions

### DIFF
--- a/vadl/main/vadl/ast/ConstantEvaluator.java
+++ b/vadl/main/vadl/ast/ConstantEvaluator.java
@@ -326,6 +326,10 @@ class ConstantEvaluator implements ExprVisitor<ConstantValue> {
     BinOpFuncs.put(BuiltInTable.SMULL, BigInteger::multiply);
     BinOpFuncs.put(BuiltInTable.UMULL, BigInteger::multiply);
     BinOpFuncs.put(BuiltInTable.SUMULL, BigInteger::multiply);
+    BinOpFuncs.put(BuiltInTable.SMIN, BigInteger::min);
+    BinOpFuncs.put(BuiltInTable.UMIN, BigInteger::min);
+    BinOpFuncs.put(BuiltInTable.SMAX, BigInteger::max);
+    BinOpFuncs.put(BuiltInTable.UMAX, BigInteger::max);
   }
 
   @Override

--- a/vadl/main/vadl/ast/Expr.java
+++ b/vadl/main/vadl/ast/Expr.java
@@ -1603,6 +1603,10 @@ final class IdentifierPath extends Expr implements IsId {
     return visitor.visit(this);
   }
 
+  @Override
+  public String toString() {
+    return "%s name: \"%s\"".formatted(this.getClass().getSimpleName(), pathToString());
+  }
 
   @Override
   public boolean equals(Object o) {

--- a/vadl/main/vadl/ast/TypeChecker.java
+++ b/vadl/main/vadl/ast/TypeChecker.java
@@ -736,7 +736,7 @@ public class TypeChecker
       // Shifts and rotates require that the right type is uint and the left can be anything.
       var requireRightUInt =
           List.of("<<", ">>", "<<>", "<>>");
-      if (requireRightUInt.contains(builtIn.operator())) {
+      if (builtIn.operator() != null && requireRightUInt.contains(builtIn.operator())) {
 
         Type closestUIntType;
         if (right.type() instanceof BitsType bitsRightType) {

--- a/vadl/main/vadl/types/BuiltInTable.java
+++ b/vadl/main/vadl/types/BuiltInTable.java
@@ -511,6 +511,47 @@ public class BuiltInTable {
           .returnsFirstBitWidthAndStatus(UIntType.class)
           .build();
 
+  /**
+   * {@code function smin ( a : SInt<N>, b : SInt<N> ) -> SInt<N>}
+   */
+  public static final BuiltIn SMIN =
+      func("VADL::smin", null, Type.relation(SIntType.class, SIntType.class, SIntType.class))
+          .compute((Constant.Value a, Constant.Value b) -> a.min(b, true))
+          .takesAllWithSameBitWidths()
+          .returnsFirstBitWidth(SIntType.class)
+          .build();
+
+  /**
+   * {@code function umin ( a : UInt<N>, b : UInt<N> ) -> UInt<N>}
+   */
+  public static final BuiltIn UMIN =
+      func("VADL::umin", null, Type.relation(UIntType.class, UIntType.class, UIntType.class))
+          .compute((Constant.Value a, Constant.Value b) -> a.min(b, false))
+          .takesAllWithSameBitWidths()
+          .returnsFirstBitWidth(SIntType.class)
+          .build();
+
+
+  /**
+   * {@code function smax ( a : SInt<N>, b : SInt<N> ) -> SInt<N>}
+   */
+  public static final BuiltIn SMAX =
+      func("VADL::smax", null, Type.relation(SIntType.class, SIntType.class, SIntType.class))
+          .compute((Constant.Value a, Constant.Value b) -> a.max(b, true))
+          .takesAllWithSameBitWidths()
+          .returnsFirstBitWidth(SIntType.class)
+          .build();
+
+  /**
+   * {@code function umax( a : UInt<N>, b : UInt<N> ) -> UInt<N>}
+   */
+  public static final BuiltIn UMAX =
+      func("VADL::umax", null, Type.relation(UIntType.class, UIntType.class, UIntType.class))
+          .compute((Constant.Value a, Constant.Value b) -> a.max(b, false))
+          .takesAllWithSameBitWidths()
+          .returnsFirstBitWidth(SIntType.class)
+          .build();
+
 
   ///// LOGICAL //////
 
@@ -1293,7 +1334,12 @@ public class BuiltInTable {
       SDIV,
       UDIV,
       SDIVS,
-      UDIVS
+      UDIVS,
+
+      SMIN,
+      UMIN,
+      SMAX,
+      UMAX
   );
 
   public static final List<BuiltIn> LOGICAL_BUILT_INS = List.of(
@@ -1399,6 +1445,8 @@ public class BuiltInTable {
       SDIV, UDIV,
       SMOD, UMOD,
       SMULL, UMULL, SUMULL,
+      SMIN, UMIN,
+      SMAX, UMAX,
       CONCATENATE_STRINGS
   );
 

--- a/vadl/main/vadl/viam/Constant.java
+++ b/vadl/main/vadl/viam/Constant.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -509,6 +509,28 @@ public abstract class Constant {
       var newIntegerValue = a.integer()
           .mod(b.integer());
       return fromInteger(newIntegerValue, divType);
+    }
+
+    /**
+     * Return the min value. If both are equal, the first will be returned.
+     */
+    public Constant.Value min(Constant.Value other, boolean signed) {
+      ensure(type().isTrivialCastTo(other.type()),
+          "Min must be of same type, but other was %s",
+          other.type());
+
+      return this.leq(other, signed).bool() ? this : other;
+    }
+
+    /**
+     * Return the max value. If both are equal, the first will be returned.
+     */
+    public Constant.Value max(Constant.Value other, boolean signed) {
+      ensure(type().isTrivialCastTo(other.type()),
+          "Max must be of same type, but other was %s",
+          other.type());
+
+      return this.geq(other, signed).bool() ? this : other;
     }
 
     /**

--- a/vadl/test/resources/frontend-snapshots/parser/letStatementWithMultipleVariables.vadl
+++ b/vadl/test/resources/frontend-snapshots/parser/letStatementWithMultipleVariables.vadl
@@ -42,7 +42,7 @@ instruction set architecture ISA = {
 //    . : ' | Identifier name: "next" type: Bits<32>
 //    . : ' | Identifier name: "status" type: Status
 //    . : ' | CallIndexExpr type: Tuple<Bits<32>, Status>
-//    . : ' | . IdentifierPath type: null
+//    . : ' | . IdentifierPath name: "VADL::adds" type: null
 //    . : ' | . ArgsIndices
 //    . : ' | . : Identifier name: "PC" type: Bits<32>
 //    . : ' | . : CastExpr type: Bits<32>

--- a/vadl/test/resources/frontend-snapshots/typechecker/builtinOnConstantTypes.vadl
+++ b/vadl/test/resources/frontend-snapshots/typechecker/builtinOnConstantTypes.vadl
@@ -38,61 +38,61 @@ constant v = VADL::czb(0b110110)      // 2
 //    . IntegerLiteral literal: 42 (42) type: Const<42>
 //    ConstantDefinition name: "e" evaluatedValue: 59
 //    . CallIndexExpr type: Const<59>
-//    . : IdentifierPath type: null
+//    . : IdentifierPath name: "VADL::or" type: null
 //    . : ArgsIndices
 //    . : ' Identifier name: "a" type: Const<51>
 //    . : ' Identifier name: "b" type: Const<42>
 //    ConstantDefinition name: "f" evaluatedValue: 34
 //    . CallIndexExpr type: Const<34>
-//    . : IdentifierPath type: null
+//    . : IdentifierPath name: "VADL::and" type: null
 //    . : ArgsIndices
 //    . : ' Identifier name: "a" type: Const<51>
 //    . : ' Identifier name: "b" type: Const<42>
 //    ConstantDefinition name: "g" evaluatedValue: 25
 //    . CallIndexExpr type: Const<25>
-//    . : IdentifierPath type: null
+//    . : IdentifierPath name: "VADL::xor" type: null
 //    . : ArgsIndices
 //    . : ' Identifier name: "a" type: Const<51>
 //    . : ' Identifier name: "b" type: Const<42>
 //    ConstantDefinition name: "h" evaluatedValue: 0
 //    . CallIndexExpr type: Bool
-//    . : IdentifierPath type: null
+//    . : IdentifierPath name: "VADL::equ" type: null
 //    . : ArgsIndices
 //    . : ' Identifier name: "a" type: Const<51>
 //    . : ' Identifier name: "b" type: Const<42>
 //    ConstantDefinition name: "i" evaluatedValue: 1
 //    . CallIndexExpr type: Bool
-//    . : IdentifierPath type: null
+//    . : IdentifierPath name: "VADL::neq" type: null
 //    . : ArgsIndices
 //    . : ' Identifier name: "a" type: Const<51>
 //    . : ' Identifier name: "b" type: Const<42>
 //    ConstantDefinition name: "j" evaluatedValue: 1
 //    . CallIndexExpr type: Bool
-//    . : IdentifierPath type: null
+//    . : IdentifierPath name: "VADL::sgeq" type: null
 //    . : ArgsIndices
 //    . : ' Identifier name: "a" type: Const<51>
 //    . : ' Identifier name: "b" type: Const<42>
 //    ConstantDefinition name: "k" evaluatedValue: 1
 //    . CallIndexExpr type: Bool
-//    . : IdentifierPath type: null
+//    . : IdentifierPath name: "VADL::sgth" type: null
 //    . : ArgsIndices
 //    . : ' Identifier name: "a" type: Const<51>
 //    . : ' Identifier name: "b" type: Const<42>
 //    ConstantDefinition name: "l" evaluatedValue: 0
 //    . CallIndexExpr type: Bool
-//    . : IdentifierPath type: null
+//    . : IdentifierPath name: "VADL::slth" type: null
 //    . : ArgsIndices
 //    . : ' Identifier name: "a" type: Const<51>
 //    . : ' Identifier name: "b" type: Const<42>
 //    ConstantDefinition name: "m" evaluatedValue: 0
 //    . CallIndexExpr type: Bool
-//    . : IdentifierPath type: null
+//    . : IdentifierPath name: "VADL::sleq" type: null
 //    . : ArgsIndices
 //    . : ' Identifier name: "a" type: Const<51>
 //    . : ' Identifier name: "b" type: Const<42>
 //    ConstantDefinition name: "n" evaluatedValue: 168
 //    . CallIndexExpr type: Const<168>
-//    . : IdentifierPath type: null
+//    . : IdentifierPath name: "VADL::lsl" type: null
 //    . : ArgsIndices
 //    . : ' Identifier name: "b" type: Const<42>
 //    . : ' CastExpr type: UInt<2>
@@ -102,7 +102,7 @@ constant v = VADL::czb(0b110110)      // 2
 //    . : ' | . IntegerLiteral literal: 2 (2) type: null
 //    ConstantDefinition name: "o" evaluatedValue: 10
 //    . CallIndexExpr type: Const<10>
-//    . : IdentifierPath type: null
+//    . : IdentifierPath name: "VADL::lsr" type: null
 //    . : ArgsIndices
 //    . : ' Identifier name: "b" type: Const<42>
 //    . : ' CastExpr type: UInt<2>
@@ -112,42 +112,42 @@ constant v = VADL::czb(0b110110)      // 2
 //    . : ' | . IntegerLiteral literal: 2 (2) type: null
 //    ConstantDefinition name: "p" evaluatedValue: 93
 //    . CallIndexExpr type: Const<93>
-//    . : IdentifierPath type: null
+//    . : IdentifierPath name: "VADL::add" type: null
 //    . : ArgsIndices
 //    . : ' Identifier name: "a" type: Const<51>
 //    . : ' Identifier name: "b" type: Const<42>
 //    ConstantDefinition name: "q" evaluatedValue: 9
 //    . CallIndexExpr type: Const<9>
-//    . : IdentifierPath type: null
+//    . : IdentifierPath name: "VADL::sub" type: null
 //    . : ArgsIndices
 //    . : ' Identifier name: "a" type: Const<51>
 //    . : ' Identifier name: "b" type: Const<42>
 //    ConstantDefinition name: "r" evaluatedValue: 2142
 //    . CallIndexExpr type: Const<2142>
-//    . : IdentifierPath type: null
+//    . : IdentifierPath name: "VADL::mul" type: null
 //    . : ArgsIndices
 //    . : ' Identifier name: "a" type: Const<51>
 //    . : ' Identifier name: "b" type: Const<42>
 //    ConstantDefinition name: "s" evaluatedValue: 10
 //    . CallIndexExpr type: Const<10>
-//    . : IdentifierPath type: null
+//    . : IdentifierPath name: "VADL::div" type: null
 //    . : ArgsIndices
 //    . : ' Identifier name: "a" type: Const<51>
 //    . : ' IntegerLiteral literal: 5 (5) type: Const<5>
 //    ConstantDefinition name: "t" evaluatedValue: 2
 //    . CallIndexExpr type: Const<2>
-//    . : IdentifierPath type: null
+//    . : IdentifierPath name: "VADL::mod" type: null
 //    . : ArgsIndices
 //    . : ' Identifier name: "b" type: Const<42>
 //    . : ' IntegerLiteral literal: 20 (20) type: Const<20>
 //    ConstantDefinition name: "u" evaluatedValue: 4
 //    . CallIndexExpr type: Const<4>
-//    . : IdentifierPath type: null
+//    . : IdentifierPath name: "VADL::cob" type: null
 //    . : ArgsIndices
 //    . : ' BinaryLiteral literal: 0b110110 (54) type: Const<54>
 //    ConstantDefinition name: "v" evaluatedValue: 2
 //    . CallIndexExpr type: Const<2>
-//    . : IdentifierPath type: null
+//    . : IdentifierPath name: "VADL::czb" type: null
 //    . : ArgsIndices
 //    . : ' BinaryLiteral literal: 0b110110 (54) type: Const<54>
 //

--- a/vadl/test/resources/frontend-snapshots/typechecker/builtinOnConstantTypes.vadl
+++ b/vadl/test/resources/frontend-snapshots/typechecker/builtinOnConstantTypes.vadl
@@ -23,6 +23,10 @@ constant s = VADL::div(a, 5)          // 5
 constant t = VADL::mod(b, 20)         // 2
 constant u = VADL::cob(0b110110)      // 4
 constant v = VADL::czb(0b110110)      // 2
+constant w = VADL::smin(a, b)         // 42
+constant x = VADL::umin(a, b)         // 42
+constant y = VADL::smax(a, b)         // 51
+constant z = VADL::umax(a, b)         // 51
 
 
 //  Reported Diagnostics:
@@ -150,6 +154,30 @@ constant v = VADL::czb(0b110110)      // 2
 //    . : IdentifierPath name: "VADL::czb" type: null
 //    . : ArgsIndices
 //    . : ' BinaryLiteral literal: 0b110110 (54) type: Const<54>
+//    ConstantDefinition name: "w" evaluatedValue: 42
+//    . CallIndexExpr type: Const<42>
+//    . : IdentifierPath name: "VADL::smin" type: null
+//    . : ArgsIndices
+//    . : ' Identifier name: "a" type: Const<51>
+//    . : ' Identifier name: "b" type: Const<42>
+//    ConstantDefinition name: "x" evaluatedValue: 42
+//    . CallIndexExpr type: Const<42>
+//    . : IdentifierPath name: "VADL::umin" type: null
+//    . : ArgsIndices
+//    . : ' Identifier name: "a" type: Const<51>
+//    . : ' Identifier name: "b" type: Const<42>
+//    ConstantDefinition name: "y" evaluatedValue: 51
+//    . CallIndexExpr type: Const<51>
+//    . : IdentifierPath name: "VADL::smax" type: null
+//    . : ArgsIndices
+//    . : ' Identifier name: "a" type: Const<51>
+//    . : ' Identifier name: "b" type: Const<42>
+//    ConstantDefinition name: "z" evaluatedValue: 51
+//    . CallIndexExpr type: Const<51>
+//    . : IdentifierPath name: "VADL::umax" type: null
+//    . : ArgsIndices
+//    . : ' Identifier name: "a" type: Const<51>
+//    . : ' Identifier name: "b" type: Const<42>
 //
 //
 // Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl/test/resources/frontend-snapshots/typechecker/enumEntryReferenceBeforeDefinition.vadl
+++ b/vadl/test/resources/frontend-snapshots/typechecker/enumEntryReferenceBeforeDefinition.vadl
@@ -20,12 +20,12 @@ enumeration Nums : Bits<4> =
 //    ConstantDefinition name: "friday" evaluatedValue: 5
 //    . TypeLiteral type: Bits<11>
 //    . : Identifier name: "Bits" type: null
-//    . : IdentifierPath type: Bits<4>
+//    . : IdentifierPath name: "Nums::second" type: Bits<4>
 //    . CastExpr type: Bits<11>
 //    . : IntegerLiteral literal: 5 (5) type: Const<5>
 //    . : TypeLiteral type: Bits<11>
 //    . : ' Identifier name: "Bits" type: null
-//    . : ' IdentifierPath type: Bits<4>
+//    . : ' IdentifierPath name: "Nums::second" type: Bits<4>
 //    EnumerationDefinition name: "Nums"
 //    . Identifier name: "first" type: null
 //    . CastExpr type: Bits<4>

--- a/vadl/test/vadl/viam/ConstantTests.java
+++ b/vadl/test/vadl/viam/ConstantTests.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -515,6 +515,45 @@ public class ConstantTests {
     );
   }
 
+  @ParameterizedTest
+  @MethodSource("minTestSource")
+  void constantMin_shouldYieldCorrectValue(Constant.Value a, Constant.Value b,
+                                              Constant.Value expected) {
+    var actual = a.min(b, a.type().isSigned());
+    assertEquals(expected, actual);
+  }
+
+  static Stream<Arguments> minTestSource() {
+    return Stream.of(
+        Arguments.of(intU(1, 32), intU(2, 32), intU(1, 32)),
+        Arguments.of(intS(1, 32), intS(2, 32), intS(1, 32)),
+
+        Arguments.of(intS(-1, 32), intS(-2, 32), intS(-2, 32)),
+        Arguments.of(intS(-1, 32), intS(2, 32), intS(-1, 32)),
+
+        Arguments.of(intU(0, 32), intU(0xFFFFFFFFL, 32), intU(0, 32))
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("maxTestSource")
+  void constantMax_shouldYieldCorrectValue(Constant.Value a, Constant.Value b,
+                                           Constant.Value expected) {
+    var actual = a.max(b, a.type().isSigned());
+    assertEquals(expected, actual);
+  }
+
+  static Stream<Arguments> maxTestSource() {
+    return Stream.of(
+        Arguments.of(intU(1, 32), intU(2, 32), intU(2, 32)),
+        Arguments.of(intS(1, 32), intS(2, 32), intS(2, 32)),
+
+        Arguments.of(intS(-1, 32), intS(-2, 32), intS(-1, 32)),
+        Arguments.of(intS(-1, 32), intS(2, 32), intS(2, 32)),
+
+        Arguments.of(intU(0, 32), intU(0xFFFFFFFFL, 32), intU(0xFFFFFFFFL, 32))
+    );
+  }
 
   @ParameterizedTest
   @MethodSource("truncateFailTestSource")


### PR DESCRIPTION
This PR also fixes a issue in the dumps, because identifierpaths previously didn't print the value they were holding.

Related issue: #660 