### PR TITLE
frontend: Add operation definition

### DIFF
--- a/vadl/main/vadl/ast/AnnotationTable.java
+++ b/vadl/main/vadl/ast/AnnotationTable.java
@@ -185,6 +185,17 @@ public class AnnotationTable {
         })
         .build();
 
+    annotationOn(InstructionDefinition.class, "operation",
+        () -> new IdentifersAnnotation(OperationDefinition.class))
+        .check((def, annotation, lowering) -> {
+          // Add the definition to the operation defined
+          annotation.identifiers.forEach(identifier -> {
+            var operation = (OperationDefinition) requireNonNull(identifier.target());
+            operation.instructions.add(def);
+          });
+        })
+        .build();
+
     annotationOn(AliasDefinition.class, "overwrite source",
         () -> new EnumAnnotation(List.of("zero", "sign")))
         .check((def, annotation, lowering) -> {
@@ -1265,6 +1276,125 @@ class EnumAnnotation extends Annotation {
     return "[ " + name + " : " + options + " ]";
   }
 }
+
+/**
+ * A simple annotation that stores a single Identifier.
+ *
+ * <p>Examples for such annotations:
+ * <pre>
+ * [ relatedInstr : ADDI ]
+ * </pre>
+ */
+class IdentiferAnnotation extends Annotation {
+  @LazyInit
+  Identifier identifier;
+
+  @Nullable
+  final Class<? extends Definition> targetClass;
+
+  public IdentiferAnnotation() {
+    super();
+    targetClass = null;
+  }
+
+  public IdentiferAnnotation(Class<? extends Definition> targetClass) {
+    super();
+    this.targetClass = targetClass;
+  }
+
+  @Override
+  void resolveName(AnnotationDefinition definition, SymbolTable.SymbolResolver resolver) {
+    verifyValuesCnt(definition, 1);
+    var firstValue = definition.values.getFirst();
+
+    if (!(firstValue instanceof Identifier identifier)) {
+      throw error("Invalid Annotation Argument", firstValue)
+          .locationDescription(firstValue, "Expected an identifier but got %s",
+              firstValue.getClass().getSimpleName())
+          .build();
+    }
+    this.identifier = identifier;
+
+    if (targetClass != null) {
+      definition.symbolTable().requireAs(identifier, targetClass);
+    } else {
+      definition.symbolTable().requireAs(identifier, Node.class);
+    }
+  }
+
+  @Override
+  void typeCheck(AnnotationDefinition definition, TypeChecker typeChecker) {
+    // Only typecheck expressions
+    if (targetClass != null && Expr.class.isAssignableFrom(targetClass)) {
+      typeChecker.check(identifier);
+    }
+  }
+
+  @Override
+  public String usageString() {
+    return "[ " + name + " : <Id> ]";
+  }
+}
+
+/**
+ * A simple annotation that stores a one or more Identifiers.
+ *
+ * <p>Examples for such annotations:
+ * <pre>
+ * [ relatedInstr : ADDI ADDU ]
+ * </pre>
+ */
+class IdentifersAnnotation extends Annotation {
+  List<Identifier> identifiers = new ArrayList<>();
+
+  @Nullable
+  final Class<? extends Definition> targetClass;
+
+  public IdentifersAnnotation() {
+    super();
+    targetClass = null;
+  }
+
+  public IdentifersAnnotation(Class<? extends Definition> targetClass) {
+    super();
+    this.targetClass = targetClass;
+  }
+
+  @Override
+  void resolveName(AnnotationDefinition definition, SymbolTable.SymbolResolver resolver) {
+    verifyValuesNonEmpty(definition);
+
+    for (var value : definition.values) {
+      if (!(value instanceof Identifier identifier)) {
+        throw error("Invalid Annotation Argument", value)
+            .locationDescription(value, "Expected an identifier but got %s",
+                value.getClass().getSimpleName())
+            .build();
+      }
+      identifiers.add(identifier);
+
+      if (targetClass != null) {
+        definition.symbolTable().requireAs(identifier, targetClass);
+      } else {
+        definition.symbolTable().requireAs(identifier, Node.class);
+      }
+    }
+  }
+
+  @Override
+  void typeCheck(AnnotationDefinition definition, TypeChecker typeChecker) {
+    // Only typecheck expressions
+    if (targetClass != null && Expr.class.isAssignableFrom(targetClass)) {
+      identifiers.forEach(typeChecker::check);
+    }
+  }
+
+  @Override
+  public String usageString() {
+    return "[ " + name + " : <Id>... ]";
+  }
+}
+
 
 /**
  * A annotation that holds a single expression. Used for more complex annotations.

--- a/vadl/main/vadl/ast/AnnotationTable.java
+++ b/vadl/main/vadl/ast/AnnotationTable.java
@@ -301,12 +301,14 @@ public class AnnotationTable {
           }
         }).build();
 
-    annotationOn(InstructionDefinition.class, "add operands", DefinitionRefAnnotation::new)
+    annotationOn(InstructionDefinition.class, "add operands",
+        () -> new IdentifersAnnotation(Definition.class))
         .applyViam((def, annotation, lowering) -> {
           var fields =
-              annotation.def.stream()
-                  .map(x -> (Format.Field) ensurePresent(lowering.fetch((FormatField) x),
-                      () -> Diagnostic.error("Cannot find field", x.location()))).toList();
+              annotation.identifiers.stream()
+                  .map(x -> (Format.Field) ensurePresent(
+                      lowering.fetch((FormatField) requireNonNull(x.target())),
+                      () -> error("Cannot find field", x.location()))).toList();
 
           def.addAnnotation(new DefineOperandAnnotation(fields));
         }).build();
@@ -1014,6 +1016,8 @@ abstract class Annotation implements AnnotationDeclaration, WithLocation {
   }
 }
 
+// ---------- GENERAL ANNOTATION CLASSES ----------
+
 /**
  * A simple annotation that just stores a boolean value, true by default but an optional argument
  * can be provided.
@@ -1059,57 +1063,6 @@ class EnableAnnotation extends Annotation {
   @Override
   public String usageString() {
     return "[ " + name + " ]";
-  }
-}
-
-/**
- * Provides the annotation {@code [ upcast access to : <ident>, <ex> ]} on an instruction that
- * treats the field access of {@code <ident>} as being of type {@code <ex>}. {@code <ex>} has to
- * evaluate to a positive integer.
- * This is useful when there is a type mismatch between the field access and an LLVM type.
- */
-class UpcastAnnotation extends Annotation {
-
-  @LazyInit
-  ConstantValue bitSize;
-
-  @LazyInit
-  Definition targetDef;
-
-  public UpcastAnnotation() {
-    super();
-  }
-
-  @Override
-  void resolveName(AnnotationDefinition definition, SymbolTable.SymbolResolver resolver) {
-    verifyValuesCnt(definition, 2);
-    for (var val : definition.values) {
-      val.accept(resolver);
-    }
-  }
-
-  @Override
-  void typeCheck(AnnotationDefinition definition, TypeChecker typeChecker) {
-
-    var def = definition.values.getFirst();
-    Diagnostic.ensure(def instanceof Identifier, () -> error("Invalid annotation value", def)
-        .description("A single identifier was expected.")
-    );
-    var target = ((Identifier) def).target();
-    Diagnostic.ensure(target instanceof Definition, () -> error("Invalid annotation value", def)
-        .description("The identifier must reference a definition."));
-    targetDef = ((Definition) target);
-
-    var valueExpr = definition.values.get(1);
-    typeChecker.check(valueExpr);
-    bitSize = typeChecker.constantEvaluator.eval(valueExpr);
-    Diagnostic.ensure(bitSize.value().signum() > 0,
-        () -> error("Bit size of type has to be bigger than zero", valueExpr));
-  }
-
-  @Override
-  public String usageString() {
-    return "[ " + name + " : <ident>, <int> ]";
   }
 }
 
@@ -1278,66 +1231,9 @@ class EnumAnnotation extends Annotation {
 }
 
 /**
- * A simple annotation that stores a single Identifier.
- *
- * <p>Examples for such annotations:
- * <pre>
- * [ relatedInstr : ADDI ]
- * </pre>
- */
-class IdentiferAnnotation extends Annotation {
-  @LazyInit
-  Identifier identifier;
-
-  @Nullable
-  final Class<? extends Definition> targetClass;
-
-  public IdentiferAnnotation() {
-    super();
-    targetClass = null;
-  }
-
-  public IdentiferAnnotation(Class<? extends Definition> targetClass) {
-    super();
-    this.targetClass = targetClass;
-  }
-
-  @Override
-  void resolveName(AnnotationDefinition definition, SymbolTable.SymbolResolver resolver) {
-    verifyValuesCnt(definition, 1);
-    var firstValue = definition.values.getFirst();
-
-    if (!(firstValue instanceof Identifier identifier)) {
-      throw error("Invalid Annotation Argument", firstValue)
-          .locationDescription(firstValue, "Expected an identifier but got %s",
-              firstValue.getClass().getSimpleName())
-          .build();
-    }
-    this.identifier = identifier;
-
-    if (targetClass != null) {
-      definition.symbolTable().requireAs(identifier, targetClass);
-    } else {
-      definition.symbolTable().requireAs(identifier, Node.class);
-    }
-  }
-
-  @Override
-  void typeCheck(AnnotationDefinition definition, TypeChecker typeChecker) {
-    // Only typecheck expressions
-    if (targetClass != null && Expr.class.isAssignableFrom(targetClass)) {
-      typeChecker.check(identifier);
-    }
-  }
-
-  @Override
-  public String usageString() {
-    return "[ " + name + " : <Id> ]";
-  }
-}
-
-/**
  * A simple annotation that stores a one or more Identifiers.
+ * The creator can also specify the node class to which the identifiers have to point.
+ * The identifiers have to point to some node in the AST and will be resolved.
  *
  * <p>Examples for such annotations:
  * <pre>
@@ -1345,6 +1241,12 @@ class IdentiferAnnotation extends Annotation {
  * </pre>
  */
 class IdentifersAnnotation extends Annotation {
+
+  /**
+   * If set to true, the annotation only allows one argument.
+   */
+  private boolean singleMode = false;
+
   List<Identifier> identifiers = new ArrayList<>();
 
   @Nullable
@@ -1360,9 +1262,31 @@ class IdentifersAnnotation extends Annotation {
     this.targetClass = targetClass;
   }
 
+  /**
+   * Creates an IdentifersAnnotation that only allows one argument.
+   */
+  public static IdentifersAnnotation single() {
+    var annotation = new IdentifersAnnotation();
+    annotation.singleMode = true;
+    return annotation;
+  }
+
+  /**
+   * Creates an IdentifersAnnotation that only allows one argument.
+   */
+  public static IdentifersAnnotation single(Class<? extends Definition> targetClass) {
+    var annotation = new IdentifersAnnotation(targetClass);
+    annotation.singleMode = true;
+    return annotation;
+  }
+
   @Override
   void resolveName(AnnotationDefinition definition, SymbolTable.SymbolResolver resolver) {
-    verifyValuesNonEmpty(definition);
+    if (singleMode) {
+      verifyValuesCnt(definition, 1);
+    } else {
+      verifyValuesNonEmpty(definition);
+    }
 
     for (var value : definition.values) {
       if (!(value instanceof Identifier identifier)) {
@@ -1391,6 +1315,9 @@ class IdentifersAnnotation extends Annotation {
 
   @Override
   public String usageString() {
+    if (singleMode) {
+      return "[ " + name + " : <Id>]";
+    }
     return "[ " + name + " : <Id>... ]";
   }
 }
@@ -1436,6 +1363,8 @@ class ExprAnnotation extends Annotation {
         .locationDescription(expr, "Expression must be a %s", type));
   }
 }
+
+// ---------- SPECIFIC ANNOTATION CLASSES ----------
 
 /**
  * The {@code [ zero : <register>(<expr>) ]} annotation.
@@ -1522,49 +1451,53 @@ class InstructionUndefinedAnnotation extends ExprAnnotation {
   }
 }
 
-class DefinitionRefAnnotation extends Annotation {
-  List<Definition> def = new ArrayList<>();
+/**
+ * Provides the annotation {@code [ upcast access to : <ident>, <ex> ]} on an instruction that
+ * treats the field access of {@code <ident>} as being of type {@code <ex>}. {@code <ex>} has to
+ * evaluate to a positive integer.
+ * This is useful when there is a type mismatch between the field access and an LLVM type.
+ */
+class UpcastAnnotation extends Annotation {
 
-  private Expr firstVal() {
-    return definition.values.getFirst();
+  @LazyInit
+  ConstantValue bitSize;
+
+  @LazyInit
+  Definition targetDef;
+
+  public UpcastAnnotation() {
+    super();
   }
 
   @Override
   void resolveName(AnnotationDefinition definition, SymbolTable.SymbolResolver resolver) {
-    // resolve the symbol of the value
-    for (var v : definition.values) {
-      v.accept(resolver);
+    verifyValuesCnt(definition, 2);
+    for (var val : definition.values) {
+      val.accept(resolver);
     }
   }
 
   @Override
   void typeCheck(AnnotationDefinition definition, TypeChecker typeChecker) {
-    for (var v : definition.values) {
-      Diagnostic.ensure(v instanceof Identifier, () -> error("Invalid annotation value", v)
-          .description("A single identifier was expected.")
-      );
-      var target = ((Identifier) v).target();
-      Diagnostic.ensure(target instanceof Definition, () -> error("Invalid annotation value", v)
-          .description("The identifier must reference a definition."));
-      def.add((Definition) target);
-    }
+
+    var def = definition.values.getFirst();
+    Diagnostic.ensure(def instanceof Identifier, () -> error("Invalid annotation value", def)
+        .description("A single identifier was expected.")
+    );
+    var target = ((Identifier) def).target();
+    Diagnostic.ensure(target instanceof Definition, () -> error("Invalid annotation value", def)
+        .description("The identifier must reference a definition."));
+    targetDef = ((Definition) target);
+
+    var valueExpr = definition.values.get(1);
+    typeChecker.check(valueExpr);
+    bitSize = typeChecker.constantEvaluator.eval(valueExpr);
+    Diagnostic.ensure(bitSize.value().signum() > 0,
+        () -> error("Bit size of type has to be bigger than zero", valueExpr));
   }
 
   @Override
   public String usageString() {
-    return "[ " + name + " : <ident> ]";
-  }
-
-  /**
-   * Utility method to check if the referenced definition is of this definition type.
-   *
-   * @return the casted definition.
-   */
-  public <T extends Definition> T verifyDefinitionType(Class<T> defClass) {
-    Diagnostic.ensure(defClass.isInstance(def), () -> error("Invalid annotation value", firstVal())
-        .locationDescription(firstVal(), "The identifier must reference a %s, but was %s",
-            defClass.getSimpleName(),
-            def));
-    return defClass.cast(def);
+    return "[ " + name + " : <ident>, <int> ]";
   }
 }

--- a/vadl/main/vadl/ast/Definition.java
+++ b/vadl/main/vadl/ast/Definition.java
@@ -3237,7 +3237,17 @@ class ProcessDefinition extends Definition implements IdentifiableNode {
 
 class OperationDefinition extends Definition implements IdentifiableNode {
   IdentifierOrPlaceholder name;
+
+  @Child
   List<IsId> resources;
+
+  /**
+   * This is the actual set of instructions this operation set contains.
+   * The resources might contain other operations, however here they are expaned.
+   * Populated by the Typechecker.
+   */
+  Set<InstructionDefinition> instructions = new HashSet<>();
+
   SourceLocation loc;
 
   OperationDefinition(IdentifierOrPlaceholder name, List<IsId> resources, SourceLocation loc) {

--- a/vadl/main/vadl/ast/SymbolTable.java
+++ b/vadl/main/vadl/ast/SymbolTable.java
@@ -282,7 +282,7 @@ class SymbolTable {
    * @return the resolved node, or null if it could not be resolved with the given type
    */
   // FIXME: I don't like how it's called require but still returns null
-  private <T extends Node> @Nullable T requireAs(IsId usage, Class<T> type) {
+  <T extends Node> @Nullable T requireAs(IsId usage, Class<T> type) {
     var origin = findAs(usage, type);
     if (origin != null) {
       return origin;
@@ -302,18 +302,6 @@ class SymbolTable {
     var suggestions = Levenshtein.suggestions(usage.pathToString(), allSymbolNamesOf(type));
     reportUnkownError(definitionName, usage.pathToString(), usage, suggestions);
     return null;
-  }
-
-  /**
-   * Finds the node for the given Id and throws the error provided by the error builder
-   * if the node could not be found.
-   */
-  Node require(IsId name, Supplier<DiagnosticBuilder> errorBuilder) {
-    var node = requireAs(name, Node.class);
-    if (node == null) {
-      throw errorBuilder.get().build();
-    }
-    return node;
   }
 
   /**

--- a/vadl/main/vadl/ast/TypeChecker.java
+++ b/vadl/main/vadl/ast/TypeChecker.java
@@ -1786,7 +1786,24 @@ public class TypeChecker
 
   @Override
   public Void visit(OperationDefinition operationDefinition) {
-    throwUnimplemented(operationDefinition);
+    operationDefinition.resources.forEach(resource -> {
+      switch (requireNonNull(resource.target())) {
+        case InstructionDefinition instr -> operationDefinition.instructions.add(instr);
+        case OperationDefinition op -> {
+          // Add all other operations
+          check(op);
+          operationDefinition.instructions.addAll(op.instructions);
+        }
+
+        // We don't need to stop checking we can continue after an error.
+        default -> errors.add(
+            error("Invalid Operation Member", resource)
+                .locationNote(resource, "Operation members must be instructions but this was '%s'",
+                    requireNonNull(resource.target()).getClass().getSimpleName())
+                .build());
+      }
+    });
+
     return null;
   }
 

--- a/vadl/main/vadl/ast/ViamLowering.java
+++ b/vadl/main/vadl/ast/ViamLowering.java
@@ -73,6 +73,7 @@ import vadl.viam.Logic;
 import vadl.viam.Memory;
 import vadl.viam.MemoryRegion;
 import vadl.viam.MicroArchitecture;
+import vadl.viam.Operation;
 import vadl.viam.PrintableInstruction;
 import vadl.viam.Procedure;
 import vadl.viam.Processor;
@@ -1539,6 +1540,7 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
             .toList();
     var formats = filterAndCastToInstance(allDefinitions, Format.class);
     var functions = filterAndCastToInstance(allDefinitions, Function.class);
+    var operations = filterAndCastToInstance(allDefinitions, Operation.class);
     var relocations = filterAndCastToInstance(allDefinitions, Relocation.class);
     // TODO: @flofriday include anonymous exceptions as definitions
     var exceptions = filterAndCastToInstance(allDefinitions, ExceptionDef.class);
@@ -1564,6 +1566,7 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
         currentSpecification,
         formats,
         functions,
+        operations,
         exceptions,
         relocations,
         instructions,
@@ -1641,6 +1644,7 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
     var registers = filterAndCastToInstance(children, RegisterTensor.class);
     var memories = filterAndCastToInstance(children, Memory.class);
     var functions = filterAndCastToInstance(children, Function.class);
+    var operations = filterAndCastToInstance(children, Operation.class);
 
     return Optional.of(new MicroArchitecture(
             identifier,
@@ -1650,7 +1654,8 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
             signals,
             registers,
             memories,
-            functions
+            functions,
+            operations
         )
     );
   }
@@ -1723,8 +1728,12 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
 
   @Override
   public Optional<vadl.viam.Definition> visit(OperationDefinition definition) {
-    throw new RuntimeException("The ViamGenerator does not support `%s` yet".formatted(
-        definition.getClass().getSimpleName()));
+    return Optional.of(new vadl.viam.Operation(
+        generateIdentifier(definition.identifier().name, definition.identifier()),
+        definition.instructions.stream()
+            .map(def -> (Instruction) fetch(def).get())
+            .collect(Collectors.toSet())
+    ));
   }
 
   @Override

--- a/vadl/main/vadl/dump/entities/DefinitionEntity.java
+++ b/vadl/main/vadl/dump/entities/DefinitionEntity.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -30,6 +30,7 @@ import vadl.viam.ExceptionDef;
 import vadl.viam.Format;
 import vadl.viam.Instruction;
 import vadl.viam.InstructionSetArchitecture;
+import vadl.viam.Operation;
 import vadl.viam.PseudoInstruction;
 import vadl.viam.Relocation;
 import vadl.viam.Resource;
@@ -133,6 +134,7 @@ public class DefinitionEntity extends DumpEntity {
       is(Instruction.class),
       is(PseudoInstruction.class),
       is(Relocation.class),
+      is(Operation.class),
       isAndISALevel(vadl.viam.Function.class),
       is(Encoding.class),
       is(Format.FieldAccess.class)

--- a/vadl/main/vadl/dump/entitySuppliers/ViamEntitySupplier.java
+++ b/vadl/main/vadl/dump/entitySuppliers/ViamEntitySupplier.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -29,6 +29,8 @@ import vadl.viam.DefinitionVisitor;
 import vadl.viam.Encoding;
 import vadl.viam.Format;
 import vadl.viam.InstructionSetArchitecture;
+import vadl.viam.MicroArchitecture;
+import vadl.viam.Operation;
 import vadl.viam.Parameter;
 import vadl.viam.Specification;
 import vadl.viam.asm.AsmDirectiveMapping;
@@ -144,6 +146,18 @@ public class ViamEntitySupplier extends DefinitionVisitor.Empty
     replaceAsSubEntityOfParent(encodingField);
   }
 
+
+  @Override
+  public void visit(Operation operation) {
+    // Operations should be displayed in the TOC if they are at ISA level
+    // or at MicroArchitecture level.
+    var entity = entityOf(operation);
+    Objects.requireNonNull(entity.parent());
+    if (!(entity.parent().origin() instanceof InstructionSetArchitecture)
+        && !(entity.parent().origin() instanceof MicroArchitecture)) {
+      replaceAsSubEntityOfParent(operation);
+    }
+  }
 
   @Override
   public void visit(Format.FieldAccess fieldAccess) {

--- a/vadl/main/vadl/dump/infoEnrichers/ViamEnricherCollection.java
+++ b/vadl/main/vadl/dump/infoEnrichers/ViamEnricherCollection.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -35,6 +35,8 @@ import vadl.viam.Encoding;
 import vadl.viam.Format;
 import vadl.viam.Function;
 import vadl.viam.Instruction;
+import vadl.viam.MicroArchitecture;
+import vadl.viam.Operation;
 import vadl.viam.Parameter;
 import vadl.viam.Stage;
 import vadl.viam.ViamError;
@@ -338,6 +340,59 @@ public class ViamEnricherCollection {
       });
 
   /**
+   * A {@link InfoEnricher} that adds an expandable table to {@link Operation} definitions
+   * listing all instructions it contains with links to their definitions.
+   */
+  public static InfoEnricher OPERATION_INSTRUCTIONS_SUPPLIER_EXPANDABLE =
+      forType(DefinitionEntity.class, (entity, passResult) -> {
+        if (entity.origin() instanceof Operation operation) {
+          var instructions = operation.getInstructions().stream()
+              .map(instr -> "<a href=\"#" + DefinitionEntity.cssIdFor(instr) + "\">"
+                  + instr.simpleName() + "</a>")
+              .sorted()
+              .toList();
+
+          if (instructions.isEmpty()) {
+            return;
+          }
+
+          var info = InfoUtils.createTableExpandable(
+              "Instructions",
+              List.of(instructions)
+          );
+          entity.addInfo(info);
+        }
+      });
+
+  /**
+   * A {@link InfoEnricher} that adds a {@link vadl.dump.Info.Tag} to instructions
+   * if they are part of an {@link Operation}, providing a link to that operation.
+   */
+  public static InfoEnricher INSTRUCTION_OPERATION_SUPPLIER_TAG =
+      forType(DefinitionEntity.class, (entity, passResult) -> {
+        if (entity.origin() instanceof Instruction instruction) {
+          var isa = instruction.parentArchitecture();
+          if (isa != null) {
+            for (var op : isa.ownOperations()) {
+              if (op.getInstructions().contains(instruction)) {
+                entity.addInfo(Info.Tag.of("Operation", op.simpleName(),
+                    "#" + DefinitionEntity.cssIdFor(op)));
+              }
+            }
+          }
+
+          if (instruction.behavior().parentDefinition() instanceof MicroArchitecture mia) {
+            for (var op : mia.ownOperations()) {
+              if (op.getInstructions().contains(instruction)) {
+                entity.addInfo(Info.Tag.of("Operation", op.simpleName(),
+                    "#" + DefinitionEntity.cssIdFor(op)));
+              }
+            }
+          }
+        }
+      });
+
+  /**
    * A list of all info enrichers for the default VIAM specification.
    */
   public static List<InfoEnricher> all = List.of(
@@ -351,7 +406,9 @@ public class ViamEnricherCollection {
       SOURCE_CODE_SUPPLIER_EXPANDABLE,
       RESOURCE_ACCESS_SUPPLIER_EXPANDABLE,
       BEHAVIOR_NO_LOCATION_EXPANDABLE,
-      STAGE_ORDER_SUPPLIER
+      STAGE_ORDER_SUPPLIER,
+      OPERATION_INSTRUCTIONS_SUPPLIER_EXPANDABLE,
+      INSTRUCTION_OPERATION_SUPPLIER_TAG
   );
 
 }

--- a/vadl/main/vadl/viam/DefinitionVisitor.java
+++ b/vadl/main/vadl/viam/DefinitionVisitor.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -39,6 +39,8 @@ public interface DefinitionVisitor {
   void visit(Encoding encoding);
 
   void visit(Encoding.Field encodingField);
+
+  void visit(Operation operation);
 
   void visit(Format format);
 
@@ -127,6 +129,7 @@ public interface DefinitionVisitor {
       // do not visit PC as it is included as register in registers()
       isa.ownFormats().forEach(e -> e.accept(this));
       isa.ownFunctions().forEach(e -> e.accept(this));
+      isa.ownOperations().forEach(e -> e.accept(this));
       isa.exceptions().forEach(e -> e.accept(this));
       isa.ownRelocations().forEach(e -> e.accept(this));
       isa.registerTensors().forEach(e -> e.accept(this));
@@ -175,6 +178,12 @@ public interface DefinitionVisitor {
     public void visit(Encoding.Field encodingField) {
       beforeTraversal(encodingField);
       afterTraversal(encodingField);
+    }
+
+    @Override
+    public void visit(Operation operation) {
+      beforeTraversal(operation);
+      afterTraversal(operation);
     }
 
     @Override
@@ -314,6 +323,7 @@ public interface DefinitionVisitor {
       microArchitecture.ownRegisters().forEach(register -> register.accept(this));
       microArchitecture.ownMemories().forEach(memory -> memory.accept(this));
       microArchitecture.ownFunctions().forEach(function -> function.accept(this));
+      microArchitecture.ownOperations().forEach(operation -> operation.accept(this));
       microArchitecture.isa().accept(this);
       afterTraversal(microArchitecture);
     }
@@ -448,6 +458,11 @@ public interface DefinitionVisitor {
 
     @Override
     public void visit(Encoding.Field encodingField) {
+
+    }
+
+    @Override
+    public void visit(Operation operation) {
 
     }
 

--- a/vadl/main/vadl/viam/InstructionSetArchitecture.java
+++ b/vadl/main/vadl/viam/InstructionSetArchitecture.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -36,6 +36,8 @@ public class InstructionSetArchitecture extends Definition {
 
   private final List<Format> formats;
   private final List<Function> functions;
+  private final List<Operation> operations;
+
   // contains declared and anonymous exceptions
   private final List<ExceptionDef> exceptions;
   private final List<Relocation> relocations;
@@ -58,6 +60,7 @@ public class InstructionSetArchitecture extends Definition {
                                     Specification specification,
                                     List<Format> formats,
                                     List<Function> functions,
+                                    List<Operation> operations,
                                     List<ExceptionDef> exceptions,
                                     List<Relocation> relocations,
                                     List<Instruction> instructions,
@@ -71,6 +74,7 @@ public class InstructionSetArchitecture extends Definition {
     this.specification = specification;
     this.formats = formats;
     this.functions = functions;
+    this.operations = operations;
     this.exceptions = exceptions;
     this.relocations = relocations;
     this.registers = registers;
@@ -114,6 +118,15 @@ public class InstructionSetArchitecture extends Definition {
   public List<Function> ownFunctions() {
     return functions;
   }
+
+  /**
+   * Returns the {@link Operation}s <b>owned</b> by this ISA.
+   * So it might not include definitions accessible through the super ISA.
+   */
+  public List<Operation> ownOperations() {
+    return operations;
+  }
+
 
   public List<ExceptionDef> exceptions() {
     return exceptions;

--- a/vadl/main/vadl/viam/MicroArchitecture.java
+++ b/vadl/main/vadl/viam/MicroArchitecture.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -38,6 +38,7 @@ public class MicroArchitecture extends Definition {
   private final List<Memory> memories;
 
   private final List<Function> functions;
+  private final List<Operation> operations;
 
   /**
    * Create a micro architecture definition.
@@ -52,8 +53,7 @@ public class MicroArchitecture extends Definition {
                            List<Stage> stages,
                            List<Logic> logic) {
     this(identifier, instructionSetArchitecture, stages, logic, new ArrayList<>(),
-        new ArrayList<>(),
-        new ArrayList<>(), new ArrayList<>());
+        new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
   }
 
   /**
@@ -67,12 +67,14 @@ public class MicroArchitecture extends Definition {
    * @param registers                  list of registers (tensors)
    * @param memories                   list of memories
    * @param functions                  list of functions
+   * @param operations                 list of operations
    */
   public MicroArchitecture(Identifier identifier,
                            InstructionSetArchitecture instructionSetArchitecture,
                            List<Stage> stages,
                            List<Logic> logic, List<Signal> signals, List<RegisterTensor> registers,
-                           List<Memory> memories, List<Function> functions) {
+                           List<Memory> memories, List<Function> functions,
+                           List<Operation> operations) {
     super(identifier);
     this.instructionSetArchitecture = instructionSetArchitecture;
     this.stages = stages;
@@ -81,6 +83,7 @@ public class MicroArchitecture extends Definition {
     this.registers = registers;
     this.memories = memories;
     this.functions = functions;
+    this.operations = operations;
 
     for (Stage stage : stages) {
       stage.setMia(this);
@@ -134,6 +137,10 @@ public class MicroArchitecture extends Definition {
 
   public List<Function> ownFunctions() {
     return functions;
+  }
+
+  public List<Operation> ownOperations() {
+    return operations;
   }
 
   @Override

--- a/vadl/main/vadl/viam/Operation.java
+++ b/vadl/main/vadl/viam/Operation.java
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText : © 2026 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.viam;
+
+import java.util.Set;
+
+/**
+ * Represents a VADL operation, which is a named collection of instructions.
+ */
+public class Operation extends Definition {
+
+  private final Set<Instruction> instructions;
+
+  public Operation(Identifier identifier, Set<Instruction> instructions) {
+    super(identifier);
+    this.instructions = instructions;
+  }
+
+  public Set<Instruction> getInstructions() {
+    return instructions;
+  }
+
+  @Override
+  public void accept(DefinitionVisitor visitor) {
+    visitor.visit(this);
+  }
+}

--- a/vadl/test/resources/frontend-snapshots/annotation/invalidOperationAnnotationInvalidTarget.vadl
+++ b/vadl/test/resources/frontend-snapshots/annotation/invalidOperationAnnotationInvalidTarget.vadl
@@ -1,0 +1,32 @@
+// Every operation must have a target, they are not implicitly defined
+
+instruction set architecture ISA = {
+  program counter PC : Bits<32>                 // program counter
+
+  format B_Type : Bits<32> =                    // branch format
+    { offset : SInt<24>                         // PC relative offset
+    , opcode : Bits<8>                          // operation code
+    }
+
+  [operation: BranchOp]
+  instruction Branch : B_Type =                 // PC relative branch
+    PC := PC + offset as SInt<32> << 2          // set new PC relative to the old value
+  encoding Branch = {opcode = 0}
+  assembly Branch = ""
+
+  // WITHOUT THIS THE CODE IS WRONG
+  // operation BranchOp   = {}                // empty branch set, elements added by annotation
+}
+
+
+//  Reported Diagnostics:
+//
+//  error: Unknown OperationDefinition: "BranchOp"
+//       ╭──[test/resources/frontend-snapshots/annotation/invalidOperationAnnotationInvalidTarget.vadl:11:15]
+//       │
+//    11 │   [operation: BranchOp]
+//       │               ^^^^^^^^ No operationdefinition with this name exists.
+//       │
+//
+//
+// Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl/test/resources/frontend-snapshots/lowering/aliasConstantRegister.vadl
+++ b/vadl/test/resources/frontend-snapshots/lowering/aliasConstantRegister.vadl
@@ -48,6 +48,7 @@ assembly Test = ""
 //    . : PseudoInstructionCount: 0
 //    . : FormatCount: 1
 //    . : FunctionCount: 1
+//    . : OperationCount: 0
 //    . : ExceptionCount: 0
 //    . : RelocationCount: 0
 //    . : RegisterCount: 4

--- a/vadl/test/resources/frontend-snapshots/lowering/aliasRegisters.vadl
+++ b/vadl/test/resources/frontend-snapshots/lowering/aliasRegisters.vadl
@@ -32,6 +32,7 @@ instruction set architecture ISA = {
 //    . : PseudoInstructionCount: 0
 //    . : FormatCount: 1
 //    . : FunctionCount: 0
+//    . : OperationCount: 0
 //    . : ExceptionCount: 0
 //    . : RelocationCount: 0
 //    . : RegisterCount: 1

--- a/vadl/test/resources/frontend-snapshots/lowering/complexFoldOperatorFromMacro.vadl
+++ b/vadl/test/resources/frontend-snapshots/lowering/complexFoldOperatorFromMacro.vadl
@@ -38,6 +38,7 @@ instruction set architecture ISA = {
 //    . : PseudoInstructionCount: 0
 //    . : FormatCount: 1
 //    . : FunctionCount: 0
+//    . : OperationCount: 0
 //    . : ExceptionCount: 0
 //    . : RelocationCount: 0
 //    . : RegisterCount: 1

--- a/vadl/test/resources/frontend-snapshots/lowering/dynamicIndexingForAllDo.vadl
+++ b/vadl/test/resources/frontend-snapshots/lowering/dynamicIndexingForAllDo.vadl
@@ -30,6 +30,7 @@ instruction set architecture Tensor = {
 //    . : PseudoInstructionCount: 0
 //    . : FormatCount: 1
 //    . : FunctionCount: 0
+//    . : OperationCount: 0
 //    . : ExceptionCount: 0
 //    . : RelocationCount: 0
 //    . : RegisterCount: 1

--- a/vadl/test/resources/frontend-snapshots/lowering/dynamicTensorSlicingForAllDo.vadl
+++ b/vadl/test/resources/frontend-snapshots/lowering/dynamicTensorSlicingForAllDo.vadl
@@ -25,6 +25,7 @@ instruction set architecture Tensor = {
 //    . : PseudoInstructionCount: 0
 //    . : FormatCount: 1
 //    . : FunctionCount: 0
+//    . : OperationCount: 0
 //    . : ExceptionCount: 0
 //    . : RelocationCount: 0
 //    . : RegisterCount: 1

--- a/vadl/test/resources/frontend-snapshots/lowering/dynamicTensorSlicingForAllTensor.vadl
+++ b/vadl/test/resources/frontend-snapshots/lowering/dynamicTensorSlicingForAllTensor.vadl
@@ -31,6 +31,7 @@ instruction set architecture Tensor = {
 //    . : PseudoInstructionCount: 0
 //    . : FormatCount: 1
 //    . : FunctionCount: 0
+//    . : OperationCount: 0
 //    . : ExceptionCount: 0
 //    . : RelocationCount: 0
 //    . : RegisterCount: 1

--- a/vadl/test/resources/frontend-snapshots/lowering/exceptionWithConstantValue.vadl
+++ b/vadl/test/resources/frontend-snapshots/lowering/exceptionWithConstantValue.vadl
@@ -27,6 +27,7 @@ instruction set architecture ISA = {
 //    . : PseudoInstructionCount: 0
 //    . : FormatCount: 0
 //    . : FunctionCount: 0
+//    . : OperationCount: 0
 //    . : ExceptionCount: 1
 //    . : RelocationCount: 0
 //    . : RegisterCount: 1

--- a/vadl/test/resources/frontend-snapshots/lowering/fiveStageMicroarchitecture.vadl
+++ b/vadl/test/resources/frontend-snapshots/lowering/fiveStageMicroarchitecture.vadl
@@ -75,6 +75,7 @@ micro architecture SingleStage implements ISA = {
 //    . : RegisterCount: 0
 //    . : MemoryCount: 0
 //    . : FunctionCount: 0
+//    . : OperationCount: 0
 //    . : Stage name: "FETCH"
 //    . : ' Outputs: [fr]
 //    . : ' Signals: []
@@ -175,6 +176,7 @@ micro architecture SingleStage implements ISA = {
 //    . : ' PseudoInstructionCount: 0
 //    . : ' FormatCount: 0
 //    . : ' FunctionCount: 0
+//    . : ' OperationCount: 0
 //    . : ' ExceptionCount: 0
 //    . : ' RelocationCount: 0
 //    . : ' RegisterCount: 3

--- a/vadl/test/resources/frontend-snapshots/lowering/operation.vadl
+++ b/vadl/test/resources/frontend-snapshots/lowering/operation.vadl
@@ -1,0 +1,103 @@
+// INCLUDE-VIAM-DUMP
+// This example is from the VADL documentation.
+
+instruction set architecture ISA = {
+  program counter PC : Bits<32>                 // program counter
+
+  format B_Type : Bits<32> =                    // branch format
+    { offset : SInt<24>                         // PC relative offset
+    , opcode : Bits<8>                          // operation code
+    }
+
+  instruction Branch : B_Type =                 // PC relative branch
+    PC := PC + offset as SInt<32> << 2          // set new PC relative to the old value
+  encoding Branch = {opcode = 0}
+  assembly Branch = ""
+
+  operation BranchOp   = {Branch}                     // empty branch set, elements added by annotation
+}
+
+
+//  Reported Diagnostics:
+//
+//  No diagnostics were reported, the input was correctly parsed, typechecked and lowered.
+//
+//
+//  VIAM Dump:
+//
+//    Specification name: "operation"
+//    . Definitions: 1
+//    . InstructionSetArchitecture name: "ISA"
+//    . : PC: PC
+//    . : InstructionCount: 1
+//    . : PseudoInstructionCount: 0
+//    . : FormatCount: 1
+//    . : FunctionCount: 0
+//    . : OperationCount: 1
+//    . : ExceptionCount: 0
+//    . : RelocationCount: 0
+//    . : RegisterCount: 1
+//    . : MemoryCount: 0
+//    . : ArtificialResourceCount: 0
+//    . : Format name: "B_Type"
+//    . : ' Type: b32
+//    . : ' FieldCount: 2
+//    . : ' FieldAccessCount: 0
+//    . : ' FieldEncodingCount: 0
+//    . : ' Field name: "offset"
+//    . : ' | Type: i24
+//    . : ' | BitSlice: [31..8]
+//    . : ' | RefFormat: -
+//    . : ' Field name: "opcode"
+//    . : ' | Type: b8
+//    . : ' | BitSlice: [7..0]
+//    . : ' | RefFormat: -
+//    . : Operation name: "BranchOp"
+//    . : ' Instructions: [Branch]
+//    . : RegisterTensor name: "PC"
+//    . : ' Type: b32
+//    . : ' Dimensions: [0:b5x32]
+//    . : ' ConstraintCount: 0
+//    . : Instruction name: "Branch" format: "B_Type"
+//    . : ' Inputs: PC
+//    . : ' Outputs: PC
+//    . : ' Encoding: encoding
+//    . : ' Assembly: ISA::Branch::assembly
+//    . : ' Behavior Graph:
+//    . : ' | n0 ReadsRegisterTensor  in: ()      succ: ()     type: b32   reg: PC
+//    . : ' | n1 FieldRef             in: ()      succ: ()     type: i24   field: offset   format: B_Type
+//    . : ' | n2 SignExtend           in: (n1)    succ: ()     type: i32   fromWidth: 24
+//    . : ' | n3 BuiltInCall          in: (n0 n2) succ: ()     type: i32   builtin: VADL::add   operator: +
+//    . : ' | n4 Constant             in: ()      succ: ()     type: u2    const: 0x2: UInt<2>
+//    . : ' | n5 BuiltInCall          in: (n3 n4) succ: ()     type: b32   builtin: VADL::lsl   operator: <<
+//    . : ' | n6 WritesRegisterTensor in: (n5)    succ: ()     reg: PC
+//    . : ' | n7 InstrEnd             in: (n6)    succ: ()     effects: 1
+//    . : ' | n8 Start                in: ()      succ: (n7)   next: set
+//    . : ' Assembly name: "ISA::Branch::assembly"
+//    . : ' | Function: ISA::Branch::assembly::func
+//    . : ' | FieldAccesses: []
+//    . : ' | Function name: "ISA::Branch::assembly::func"
+//    . : ' | . Type: ()->String
+//    . : ' | . Signature: () -> String
+//    . : ' | . Parameters: []
+//    . : ' | . Behavior Graph:
+//    . : ' | . : n0 Constant in: ()   succ: ()     type: String   const: ""
+//    . : ' | . : n1 Return   in: (n0) succ: ()     retType: String
+//    . : ' | . : n2 Start    in: ()   succ: (n1)   next: set
+//    . : ' Encoding name: "encoding"
+//    . : ' | Type: b32
+//    . : ' | Format: B_Type
+//    . : ' | FieldEncodings: 1
+//    . : ' | NonEncodedFields: [offset]
+//    . : ' | HasConstraint: false
+//    . : ' | Field name: "opcode"
+//    . : ' | . Field: opcode
+//    . : ' | . Type: b8
+//    . : ' | . Constant: 0x0: Bits<8>
+//    . : Counter name: "PC"
+//    . : ' RegisterTensor: PC
+//    . : ' Indices: []
+//    . : ' ResultType: b32
+//
+//
+// Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl/test/resources/frontend-snapshots/lowering/operationContainingOperation.vadl
+++ b/vadl/test/resources/frontend-snapshots/lowering/operationContainingOperation.vadl
@@ -1,0 +1,177 @@
+// INCLUDE-VIAM-DUMP
+// When operations contain other operations, they are expanded in the VIAM.
+
+instruction set architecture ISA = {
+  program counter PC : Bits<32>                 // program counter
+
+  format Instr : Bits<32> =                    // branch format
+    { offset : SInt<24>                         // PC relative offset
+    , opcode : Bits<8>                          // operation code
+    }
+
+  instruction A : Instr =
+    PC := 1
+  encoding A = {opcode = 0}
+  assembly A = "A"
+
+  instruction B : Instr =
+    PC := 2
+  encoding B = {opcode = 1}
+  assembly B = "B"
+
+  instruction C : Instr =
+    PC := 3
+  encoding C = {opcode = 2}
+  assembly C = "C"
+
+
+  operation all = {double, C}
+  operation double = {single, B}
+  operation single = {A}
+}
+
+
+//  Reported Diagnostics:
+//
+//  No diagnostics were reported, the input was correctly parsed, typechecked and lowered.
+//
+//
+//  VIAM Dump:
+//
+//    Specification name: "operationContainingOperation"
+//    . Definitions: 1
+//    . InstructionSetArchitecture name: "ISA"
+//    . : PC: PC
+//    . : InstructionCount: 3
+//    . : PseudoInstructionCount: 0
+//    . : FormatCount: 1
+//    . : FunctionCount: 0
+//    . : OperationCount: 3
+//    . : ExceptionCount: 0
+//    . : RelocationCount: 0
+//    . : RegisterCount: 1
+//    . : MemoryCount: 0
+//    . : ArtificialResourceCount: 0
+//    . : Format name: "Instr"
+//    . : ' Type: b32
+//    . : ' FieldCount: 2
+//    . : ' FieldAccessCount: 0
+//    . : ' FieldEncodingCount: 0
+//    . : ' Field name: "offset"
+//    . : ' | Type: i24
+//    . : ' | BitSlice: [31..8]
+//    . : ' | RefFormat: -
+//    . : ' Field name: "opcode"
+//    . : ' | Type: b8
+//    . : ' | BitSlice: [7..0]
+//    . : ' | RefFormat: -
+//    . : Operation name: "all"
+//    . : ' Instructions: [A, B, C]
+//    . : Operation name: "double"
+//    . : ' Instructions: [A, B]
+//    . : Operation name: "single"
+//    . : ' Instructions: [A]
+//    . : RegisterTensor name: "PC"
+//    . : ' Type: b32
+//    . : ' Dimensions: [0:b5x32]
+//    . : ' ConstraintCount: 0
+//    . : Instruction name: "A" format: "Instr"
+//    . : ' Inputs: -
+//    . : ' Outputs: PC
+//    . : ' Encoding: encoding
+//    . : ' Assembly: ISA::A::assembly
+//    . : ' Behavior Graph:
+//    . : ' | n0 Constant             in: ()   succ: ()     type: b32   const: 0x1: Bits<32>
+//    . : ' | n1 WritesRegisterTensor in: (n0) succ: ()     reg: PC
+//    . : ' | n2 InstrEnd             in: (n1) succ: ()     effects: 1
+//    . : ' | n3 Start                in: ()   succ: (n2)   next: set
+//    . : ' Assembly name: "ISA::A::assembly"
+//    . : ' | Function: ISA::A::assembly::func
+//    . : ' | FieldAccesses: []
+//    . : ' | Function name: "ISA::A::assembly::func"
+//    . : ' | . Type: ()->String
+//    . : ' | . Signature: () -> String
+//    . : ' | . Parameters: []
+//    . : ' | . Behavior Graph:
+//    . : ' | . : n0 Constant in: ()   succ: ()     type: String   const: "A"
+//    . : ' | . : n1 Return   in: (n0) succ: ()     retType: String
+//    . : ' | . : n2 Start    in: ()   succ: (n1)   next: set
+//    . : ' Encoding name: "encoding"
+//    . : ' | Type: b32
+//    . : ' | Format: Instr
+//    . : ' | FieldEncodings: 1
+//    . : ' | NonEncodedFields: [offset]
+//    . : ' | HasConstraint: false
+//    . : ' | Field name: "opcode"
+//    . : ' | . Field: opcode
+//    . : ' | . Type: b8
+//    . : ' | . Constant: 0x0: Bits<8>
+//    . : Instruction name: "B" format: "Instr"
+//    . : ' Inputs: -
+//    . : ' Outputs: PC
+//    . : ' Encoding: encoding
+//    . : ' Assembly: ISA::B::assembly
+//    . : ' Behavior Graph:
+//    . : ' | n0 Constant             in: ()   succ: ()     type: b32   const: 0x2: Bits<32>
+//    . : ' | n1 WritesRegisterTensor in: (n0) succ: ()     reg: PC
+//    . : ' | n2 InstrEnd             in: (n1) succ: ()     effects: 1
+//    . : ' | n3 Start                in: ()   succ: (n2)   next: set
+//    . : ' Assembly name: "ISA::B::assembly"
+//    . : ' | Function: ISA::B::assembly::func
+//    . : ' | FieldAccesses: []
+//    . : ' | Function name: "ISA::B::assembly::func"
+//    . : ' | . Type: ()->String
+//    . : ' | . Signature: () -> String
+//    . : ' | . Parameters: []
+//    . : ' | . Behavior Graph:
+//    . : ' | . : n0 Constant in: ()   succ: ()     type: String   const: "B"
+//    . : ' | . : n1 Return   in: (n0) succ: ()     retType: String
+//    . : ' | . : n2 Start    in: ()   succ: (n1)   next: set
+//    . : ' Encoding name: "encoding"
+//    . : ' | Type: b32
+//    . : ' | Format: Instr
+//    . : ' | FieldEncodings: 1
+//    . : ' | NonEncodedFields: [offset]
+//    . : ' | HasConstraint: false
+//    . : ' | Field name: "opcode"
+//    . : ' | . Field: opcode
+//    . : ' | . Type: b8
+//    . : ' | . Constant: 0x1: Bits<8>
+//    . : Instruction name: "C" format: "Instr"
+//    . : ' Inputs: -
+//    . : ' Outputs: PC
+//    . : ' Encoding: encoding
+//    . : ' Assembly: ISA::C::assembly
+//    . : ' Behavior Graph:
+//    . : ' | n0 Constant             in: ()   succ: ()     type: b32   const: 0x3: Bits<32>
+//    . : ' | n1 WritesRegisterTensor in: (n0) succ: ()     reg: PC
+//    . : ' | n2 InstrEnd             in: (n1) succ: ()     effects: 1
+//    . : ' | n3 Start                in: ()   succ: (n2)   next: set
+//    . : ' Assembly name: "ISA::C::assembly"
+//    . : ' | Function: ISA::C::assembly::func
+//    . : ' | FieldAccesses: []
+//    . : ' | Function name: "ISA::C::assembly::func"
+//    . : ' | . Type: ()->String
+//    . : ' | . Signature: () -> String
+//    . : ' | . Parameters: []
+//    . : ' | . Behavior Graph:
+//    . : ' | . : n0 Constant in: ()   succ: ()     type: String   const: "C"
+//    . : ' | . : n1 Return   in: (n0) succ: ()     retType: String
+//    . : ' | . : n2 Start    in: ()   succ: (n1)   next: set
+//    . : ' Encoding name: "encoding"
+//    . : ' | Type: b32
+//    . : ' | Format: Instr
+//    . : ' | FieldEncodings: 1
+//    . : ' | NonEncodedFields: [offset]
+//    . : ' | HasConstraint: false
+//    . : ' | Field name: "opcode"
+//    . : ' | . Field: opcode
+//    . : ' | . Type: b8
+//    . : ' | . Constant: 0x2: Bits<8>
+//    . : Counter name: "PC"
+//    . : ' RegisterTensor: PC
+//    . : ' Indices: []
+//    . : ' ResultType: b32
+//
+//
+// Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl/test/resources/frontend-snapshots/lowering/operationInMia.vadl
+++ b/vadl/test/resources/frontend-snapshots/lowering/operationInMia.vadl
@@ -1,0 +1,114 @@
+// INCLUDE-VIAM-DUMP
+
+instruction set architecture ISA = {
+  program counter PC : Bits<32>                 // program counter
+
+  format B_Type : Bits<32> =                    // branch format
+    { offset : SInt<24>                         // PC relative offset
+    , opcode : Bits<8>                          // operation code
+    }
+
+  instruction Branch : B_Type =                 // PC relative branch
+    PC := PC + offset as SInt<32> << 2          // set new PC relative to the old value
+  encoding Branch = {opcode = 0}
+  assembly Branch = ""
+}
+
+micro architecture MIA implements ISA = {
+  // Define the operation here and not in the ISA.
+  operation BranchOp   = {Branch}                // empty branch set, elements added by annotation
+}
+
+
+//  Reported Diagnostics:
+//
+//  No diagnostics were reported, the input was correctly parsed, typechecked and lowered.
+//
+//
+//  VIAM Dump:
+//
+//    Specification name: "operationInMia"
+//    . Definitions: 1
+//    . MicroArchitecture name: "MIA"
+//    . : ISA: ISA
+//    . : StageCount: 0
+//    . : LogicCount: 0
+//    . : SignalCount: 0
+//    . : RegisterCount: 0
+//    . : MemoryCount: 0
+//    . : FunctionCount: 0
+//    . : OperationCount: 1
+//    . : Operation name: "BranchOp"
+//    . : ' Instructions: [Branch]
+//    . : InstructionSetArchitecture name: "ISA"
+//    . : ' PC: PC
+//    . : ' InstructionCount: 1
+//    . : ' PseudoInstructionCount: 0
+//    . : ' FormatCount: 1
+//    . : ' FunctionCount: 0
+//    . : ' OperationCount: 0
+//    . : ' ExceptionCount: 0
+//    . : ' RelocationCount: 0
+//    . : ' RegisterCount: 1
+//    . : ' MemoryCount: 0
+//    . : ' ArtificialResourceCount: 0
+//    . : ' Format name: "B_Type"
+//    . : ' | Type: b32
+//    . : ' | FieldCount: 2
+//    . : ' | FieldAccessCount: 0
+//    . : ' | FieldEncodingCount: 0
+//    . : ' | Field name: "offset"
+//    . : ' | . Type: i24
+//    . : ' | . BitSlice: [31..8]
+//    . : ' | . RefFormat: -
+//    . : ' | Field name: "opcode"
+//    . : ' | . Type: b8
+//    . : ' | . BitSlice: [7..0]
+//    . : ' | . RefFormat: -
+//    . : ' RegisterTensor name: "PC"
+//    . : ' | Type: b32
+//    . : ' | Dimensions: [0:b5x32]
+//    . : ' | ConstraintCount: 0
+//    . : ' Instruction name: "Branch" format: "B_Type"
+//    . : ' | Inputs: PC
+//    . : ' | Outputs: PC
+//    . : ' | Encoding: encoding
+//    . : ' | Assembly: ISA::Branch::assembly
+//    . : ' | Behavior Graph:
+//    . : ' | . n0 ReadsRegisterTensor  in: ()      succ: ()     type: b32   reg: PC
+//    . : ' | . n1 FieldRef             in: ()      succ: ()     type: i24   field: offset   format: B_Type
+//    . : ' | . n2 SignExtend           in: (n1)    succ: ()     type: i32   fromWidth: 24
+//    . : ' | . n3 BuiltInCall          in: (n0 n2) succ: ()     type: i32   builtin: VADL::add   operator: +
+//    . : ' | . n4 Constant             in: ()      succ: ()     type: u2    const: 0x2: UInt<2>
+//    . : ' | . n5 BuiltInCall          in: (n3 n4) succ: ()     type: b32   builtin: VADL::lsl   operator: <<
+//    . : ' | . n6 WritesRegisterTensor in: (n5)    succ: ()     reg: PC
+//    . : ' | . n7 InstrEnd             in: (n6)    succ: ()     effects: 1
+//    . : ' | . n8 Start                in: ()      succ: (n7)   next: set
+//    . : ' | Assembly name: "ISA::Branch::assembly"
+//    . : ' | . Function: ISA::Branch::assembly::func
+//    . : ' | . FieldAccesses: []
+//    . : ' | . Function name: "ISA::Branch::assembly::func"
+//    . : ' | . : Type: ()->String
+//    . : ' | . : Signature: () -> String
+//    . : ' | . : Parameters: []
+//    . : ' | . : Behavior Graph:
+//    . : ' | . : ' n0 Constant in: ()   succ: ()     type: String   const: ""
+//    . : ' | . : ' n1 Return   in: (n0) succ: ()     retType: String
+//    . : ' | . : ' n2 Start    in: ()   succ: (n1)   next: set
+//    . : ' | Encoding name: "encoding"
+//    . : ' | . Type: b32
+//    . : ' | . Format: B_Type
+//    . : ' | . FieldEncodings: 1
+//    . : ' | . NonEncodedFields: [offset]
+//    . : ' | . HasConstraint: false
+//    . : ' | . Field name: "opcode"
+//    . : ' | . : Field: opcode
+//    . : ' | . : Type: b8
+//    . : ' | . : Constant: 0x0: Bits<8>
+//    . : ' Counter name: "PC"
+//    . : ' | RegisterTensor: PC
+//    . : ' | Indices: []
+//    . : ' | ResultType: b32
+//
+//
+// Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl/test/resources/frontend-snapshots/lowering/operationViaAnnotation.vadl
+++ b/vadl/test/resources/frontend-snapshots/lowering/operationViaAnnotation.vadl
@@ -1,0 +1,106 @@
+// INCLUDE-VIAM-DUMP
+
+instruction set architecture ISA = {
+  program counter PC : Bits<32>                 // program counter
+
+  format B_Type : Bits<32> =                    // branch format
+    { offset : SInt<24>                         // PC relative offset
+    , opcode : Bits<8>                          // operation code
+    }
+
+  [operation: BranchOp, OtherOp]
+  instruction Branch : B_Type =                 // PC relative branch
+    PC := PC + offset as SInt<32> << 2          // set new PC relative to the old value
+  encoding Branch = {opcode = 0}
+  assembly Branch = ""
+
+  operation BranchOp   = {}                // empty branch set, elements added by annotation
+  operation OtherOp    = {}                // empty branch set, elements added by annotation
+}
+
+
+//  Reported Diagnostics:
+//
+//  No diagnostics were reported, the input was correctly parsed, typechecked and lowered.
+//
+//
+//  VIAM Dump:
+//
+//    Specification name: "operationViaAnnotation"
+//    . Definitions: 1
+//    . InstructionSetArchitecture name: "ISA"
+//    . : PC: PC
+//    . : InstructionCount: 1
+//    . : PseudoInstructionCount: 0
+//    . : FormatCount: 1
+//    . : FunctionCount: 0
+//    . : OperationCount: 2
+//    . : ExceptionCount: 0
+//    . : RelocationCount: 0
+//    . : RegisterCount: 1
+//    . : MemoryCount: 0
+//    . : ArtificialResourceCount: 0
+//    . : Format name: "B_Type"
+//    . : ' Type: b32
+//    . : ' FieldCount: 2
+//    . : ' FieldAccessCount: 0
+//    . : ' FieldEncodingCount: 0
+//    . : ' Field name: "offset"
+//    . : ' | Type: i24
+//    . : ' | BitSlice: [31..8]
+//    . : ' | RefFormat: -
+//    . : ' Field name: "opcode"
+//    . : ' | Type: b8
+//    . : ' | BitSlice: [7..0]
+//    . : ' | RefFormat: -
+//    . : Operation name: "BranchOp"
+//    . : ' Instructions: [Branch]
+//    . : Operation name: "OtherOp"
+//    . : ' Instructions: [Branch]
+//    . : RegisterTensor name: "PC"
+//    . : ' Type: b32
+//    . : ' Dimensions: [0:b5x32]
+//    . : ' ConstraintCount: 0
+//    . : Instruction name: "Branch" format: "B_Type"
+//    . : ' Inputs: PC
+//    . : ' Outputs: PC
+//    . : ' Encoding: encoding
+//    . : ' Assembly: ISA::Branch::assembly
+//    . : ' Behavior Graph:
+//    . : ' | n0 ReadsRegisterTensor  in: ()      succ: ()     type: b32   reg: PC
+//    . : ' | n1 FieldRef             in: ()      succ: ()     type: i24   field: offset   format: B_Type
+//    . : ' | n2 SignExtend           in: (n1)    succ: ()     type: i32   fromWidth: 24
+//    . : ' | n3 BuiltInCall          in: (n0 n2) succ: ()     type: i32   builtin: VADL::add   operator: +
+//    . : ' | n4 Constant             in: ()      succ: ()     type: u2    const: 0x2: UInt<2>
+//    . : ' | n5 BuiltInCall          in: (n3 n4) succ: ()     type: b32   builtin: VADL::lsl   operator: <<
+//    . : ' | n6 WritesRegisterTensor in: (n5)    succ: ()     reg: PC
+//    . : ' | n7 InstrEnd             in: (n6)    succ: ()     effects: 1
+//    . : ' | n8 Start                in: ()      succ: (n7)   next: set
+//    . : ' Assembly name: "ISA::Branch::assembly"
+//    . : ' | Function: ISA::Branch::assembly::func
+//    . : ' | FieldAccesses: []
+//    . : ' | Function name: "ISA::Branch::assembly::func"
+//    . : ' | . Type: ()->String
+//    . : ' | . Signature: () -> String
+//    . : ' | . Parameters: []
+//    . : ' | . Behavior Graph:
+//    . : ' | . : n0 Constant in: ()   succ: ()     type: String   const: ""
+//    . : ' | . : n1 Return   in: (n0) succ: ()     retType: String
+//    . : ' | . : n2 Start    in: ()   succ: (n1)   next: set
+//    . : ' Encoding name: "encoding"
+//    . : ' | Type: b32
+//    . : ' | Format: B_Type
+//    . : ' | FieldEncodings: 1
+//    . : ' | NonEncodedFields: [offset]
+//    . : ' | HasConstraint: false
+//    . : ' | Field name: "opcode"
+//    . : ' | . Field: opcode
+//    . : ' | . Type: b8
+//    . : ' | . Constant: 0x0: Bits<8>
+//    . : Counter name: "PC"
+//    . : ' RegisterTensor: PC
+//    . : ' Indices: []
+//    . : ' ResultType: b32
+//
+//
+// Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl/test/resources/frontend-snapshots/lowering/singleStageMicroarchitecture.vadl
+++ b/vadl/test/resources/frontend-snapshots/lowering/singleStageMicroarchitecture.vadl
@@ -32,6 +32,7 @@ micro architecture SingleStage implements ISA = {
 //    . : RegisterCount: 0
 //    . : MemoryCount: 0
 //    . : FunctionCount: 0
+//    . : OperationCount: 0
 //    . : Stage name: "FETCH"
 //    . : ' Outputs: [ir]
 //    . : ' Signals: []
@@ -55,6 +56,7 @@ micro architecture SingleStage implements ISA = {
 //    . : ' PseudoInstructionCount: 0
 //    . : ' FormatCount: 0
 //    . : ' FunctionCount: 0
+//    . : ' OperationCount: 0
 //    . : ' ExceptionCount: 0
 //    . : ' RelocationCount: 0
 //    . : ' RegisterCount: 1

--- a/vadl/test/resources/frontend-snapshots/lowering/threeStageMicroarchitecture.vadl
+++ b/vadl/test/resources/frontend-snapshots/lowering/threeStageMicroarchitecture.vadl
@@ -53,6 +53,7 @@ micro architecture SingleStage implements ISA = {
 //    . : RegisterCount: 0
 //    . : MemoryCount: 0
 //    . : FunctionCount: 0
+//    . : OperationCount: 0
 //    . : Stage name: "IF"
 //    . : ' Outputs: [fr]
 //    . : ' Signals: []
@@ -118,6 +119,7 @@ micro architecture SingleStage implements ISA = {
 //    . : ' PseudoInstructionCount: 0
 //    . : ' FormatCount: 0
 //    . : ' FunctionCount: 0
+//    . : ' OperationCount: 0
 //    . : ' ExceptionCount: 0
 //    . : ' RelocationCount: 0
 //    . : ' RegisterCount: 1

--- a/vadl/test/resources/frontend-snapshots/typechecker/invalidOperationTargetIsNoInstruction.vadl
+++ b/vadl/test/resources/frontend-snapshots/typechecker/invalidOperationTargetIsNoInstruction.vadl
@@ -1,0 +1,17 @@
+instruction set architecture ISA = {
+  program counter PC : Bits<32>                 // program counter
+  operation BranchOp   = {PC}                   // empty branch set, elements added by annotation
+}
+
+
+//  Reported Diagnostics:
+//
+//  error: Invalid Operation Member
+//       ╭──[test/resources/frontend-snapshots/typechecker/invalidOperationTargetIsNoInstruction.vadl:3:27]
+//       │
+//     3 │   operation BranchOp   = {PC}                   // empty branch set, elements added by annotation
+//       │                           ^^ note: Operation members must be instructions but this was 'CounterDefinition'
+//       │
+//
+//
+// Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl/test/resources/viam-snapshots/instructionEncodingAssembly.vadl
+++ b/vadl/test/resources/viam-snapshots/instructionEncodingAssembly.vadl
@@ -36,6 +36,7 @@ instruction set architecture Mini = {
 //    . : PseudoInstructionCount: 0
 //    . : FormatCount: 1
 //    . : FunctionCount: 0
+//    . : OperationCount: 0
 //    . : ExceptionCount: 0
 //    . : RelocationCount: 0
 //    . : RegisterCount: 2

--- a/vadl/test/vadl/viam/ViamSnapshotDumper.java
+++ b/vadl/test/vadl/viam/ViamSnapshotDumper.java
@@ -159,11 +159,21 @@ public class ViamSnapshotDumper extends DefinitionVisitor.Empty {
       lineAt(atIndent, "PseudoInstructionCount: %d".formatted(isa.ownPseudoInstructions().size()));
       lineAt(atIndent, "FormatCount: %d".formatted(isa.ownFormats().size()));
       lineAt(atIndent, "FunctionCount: %d".formatted(isa.ownFunctions().size()));
+      lineAt(atIndent, "OperationCount: %d".formatted(isa.ownOperations().size()));
       lineAt(atIndent, "ExceptionCount: %d".formatted(isa.exceptions().size()));
       lineAt(atIndent, "RelocationCount: %d".formatted(isa.ownRelocations().size()));
       lineAt(atIndent, "RegisterCount: %d".formatted(isa.registerTensors().size()));
       lineAt(atIndent, "MemoryCount: %d".formatted(isa.ownMemories().size()));
       lineAt(atIndent, "ArtificialResourceCount: %d".formatted(isa.artificialResources().size()));
+    }
+
+    @Override
+    public void visit(Operation operation) {
+      lineAt(atIndent, "Instructions: %s".formatted(
+          operation.getInstructions().stream()
+              .map(Instruction::simpleName)
+              .sorted()
+              .toList()));
     }
 
     @Override
@@ -344,6 +354,7 @@ public class ViamSnapshotDumper extends DefinitionVisitor.Empty {
       lineAt(atIndent, "RegisterCount: %d".formatted(microArchitecture.ownRegisters().size()));
       lineAt(atIndent, "MemoryCount: %d".formatted(microArchitecture.ownMemories().size()));
       lineAt(atIndent, "FunctionCount: %d".formatted(microArchitecture.ownFunctions().size()));
+      lineAt(atIndent, "OperationCount: %d".formatted(microArchitecture.ownOperations().size()));
     }
 
     @Override

--- a/vadl/test/vadl/viam/passes/constant_propagation/CanonicalizationPassTest.java
+++ b/vadl/test/vadl/viam/passes/constant_propagation/CanonicalizationPassTest.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -80,6 +80,7 @@ class CanonicalizationPassTest extends AbstractTest {
     var isa = new InstructionSetArchitecture(
         Identifier.noLocation("isaIdentifierValue"),
         viam,
+        List.of(),
         List.of(),
         List.of(),
         Collections.emptyList(),


### PR DESCRIPTION
The definition previously was already parsable but not included in the typechecker, lowering or VIAM.

Operations can be defined in the ISA or MIA and either explicitly or via the annotation.