### PR TITLE
diagnostic: Improve diagnostic rendering

### DIFF
--- a/vadl/main/vadl/error/DiagnosticPrinter.java
+++ b/vadl/main/vadl/error/DiagnosticPrinter.java
@@ -87,7 +87,10 @@ public class DiagnosticPrinter {
   private void toString(Diagnostic diagnostic, StringBuilder builder) {
     printHeader(diagnostic, builder);
     printMultiSourcePreview(diagnostic, builder);
-    builder.append(indentBy(messageBlock(diagnostic.messages), "     "));
+    if (!diagnostic.messages.isEmpty()) {
+      builder.append(indentBy(messageBlock(diagnostic.messages), "     "));
+      builder.append("\n");
+    }
     builder.append("\n");
   }
 
@@ -121,7 +124,7 @@ public class DiagnosticPrinter {
    */
   private void printMultiSourcePreview(Diagnostic diagnostic, StringBuilder builder) {
     // Print preview header
-    builder.append("     %s╭──[%s]\n".formatted(colors.cyan(),
+    builder.append("     %s╭── %s\n".formatted(colors.cyan(),
         diagnostic.multiLocation.primaryLocation().location().toIDEString(
             fileSystem,
             forceRelativePaths
@@ -289,7 +292,7 @@ public class DiagnosticPrinter {
     if (numLines < 8) {
       for (int i = location.location().begin().line(); i <= location.location().end().line(); i++) {
         // Print the line number, guard and actual line
-        builder.append("%s%4d".formatted(colors.reset(), i));
+        builder.append("%s%4d".formatted(colors.lightgrey(), i));
         builder.append(
             " %s│%s>%s ".formatted(colors.cyan(), isPrimary ? colors.red() : colors.lightblue(),
                 colors.reset()));
@@ -300,18 +303,18 @@ public class DiagnosticPrinter {
       for (int i = location.location().begin().line(); i <= location.location().begin().line() + 2;
            i++) {
         // Print the line number, guard and actual line
-        builder.append("%s%4d".formatted(colors.reset(), i));
+        builder.append("%s%4d".formatted(colors.lightgrey(), i));
         builder.append(" %s│%s>%s ".formatted(colors.cyan(), colors.red(), colors.reset()));
         builder.append(lines.get(i - 1));
         builder.append("\n");
       }
       builder.append(
-          "    %s⋮%s  %d lines omitted here...\n".formatted(colors.cyan(), colors.reset(),
-              numLines - 6));
+          "     %s⋮%s  %d lines omitted here...%s\n".formatted(colors.cyan(), colors.lightgrey(),
+              numLines - 6, colors.reset()));
       for (int i = location.location().end().line() - 2; i <= location.location().end().line();
            i++) {
         // Print the line number, guard and actual line
-        builder.append("%s%4d".formatted(colors.reset(), i));
+        builder.append("%s%4d".formatted(colors.lightgrey(), i));
         builder.append(" %s│%s>%s ".formatted(colors.cyan(), colors.red(), colors.reset()));
         builder.append(lines.get(i - 1));
         builder.append("\n");
@@ -335,7 +338,7 @@ public class DiagnosticPrinter {
                                       String markerColor) {
 
     // Print the line number, guard and actual line
-    builder.append("%s%4d".formatted(colors.reset(), location.location().begin().line()));
+    builder.append("%s%4d".formatted(colors.lightgrey(), location.location().begin().line()));
     builder.append(" %s│%s ".formatted(colors.cyan(), colors.reset()));
     builder.append(lines.get(location.location().begin().line() - 1));
     builder.append("\n");
@@ -377,7 +380,8 @@ public class DiagnosticPrinter {
       case HELP -> "help: ";
     };
 
-    return "%s%s%s%s".formatted(colors.bold(), label, colors.reset(), message.content());
+    return "%s%s%s%s".formatted(colors.bold(), label, colors.reset(),
+        renderMarkup(message.content()));
   }
 
   /**
@@ -401,6 +405,21 @@ public class DiagnosticPrinter {
    */
   private String indentBy(String text, String prefix) {
     return prefix + text.replaceAll("\n", "\n" + prefix);
+  }
+
+  /**
+   * Render markup in a string, such as code blocks.
+   *
+   * @param text to render markup in.
+   * @return the rendered string (text block).
+   */
+  private String renderMarkup(String text) {
+    // leave the backticks in if we aren't allowed to use colors.
+    if (colors instanceof NoColors) {
+      return text;
+    }
+    return text.replaceAll("`(.+?)`",
+        "%s%s$1%s".formatted(colors.purple(), colors.underline(), colors.reset()));
   }
 
   /**

--- a/vadl/test/resources/frontend-snapshots/annotation/invalidOperationAnnotationInvalidTarget.vadl
+++ b/vadl/test/resources/frontend-snapshots/annotation/invalidOperationAnnotationInvalidTarget.vadl
@@ -22,7 +22,7 @@ instruction set architecture ISA = {
 //  Reported Diagnostics:
 //
 //  error: Unknown OperationDefinition: "BranchOp"
-//       ╭──[test/resources/frontend-snapshots/annotation/invalidOperationAnnotationInvalidTarget.vadl:11:15]
+//       ╭── test/resources/frontend-snapshots/annotation/invalidOperationAnnotationInvalidTarget.vadl:11:15
 //       │
 //    11 │   [operation: BranchOp]
 //       │               ^^^^^^^^ No operationdefinition with this name exists.

--- a/vadl/test/resources/frontend-snapshots/annotation/invalidZeroAnnoationInvalidTarget2.vadl
+++ b/vadl/test/resources/frontend-snapshots/annotation/invalidZeroAnnoationInvalidTarget2.vadl
@@ -10,7 +10,7 @@ instruction set architecture TEST =
 //  Reported Diagnostics:
 //
 //  error: Invalid zero annotation
-//       ╭──[test/resources/frontend-snapshots/annotation/invalidZeroAnnoationInvalidTarget2.vadl:5:12]
+//       ╭── test/resources/frontend-snapshots/annotation/invalidZeroAnnoationInvalidTarget2.vadl:5:12
 //       │
 //     5 │   [ zero : Y(1)]
 //       │            ^ Zero annotation target must be the annotated register.

--- a/vadl/test/resources/frontend-snapshots/annotation/invalidZeroAnnotationInvalidArgument.vadl
+++ b/vadl/test/resources/frontend-snapshots/annotation/invalidZeroAnnotationInvalidArgument.vadl
@@ -10,7 +10,7 @@ instruction set architecture TEST =
 //  Reported Diagnostics:
 //
 //  error: Invalid zero annotation
-//       ╭──[test/resources/frontend-snapshots/annotation/invalidZeroAnnotationInvalidArgument.vadl:5:14]
+//       ╭── test/resources/frontend-snapshots/annotation/invalidZeroAnnotationInvalidArgument.vadl:5:14
 //       │
 //     5 │   [ zero : X(Y) ]
 //       │              ^ Index must be a constant expression.

--- a/vadl/test/resources/frontend-snapshots/annotation/invalidZeroAnnotationInvalidArgumentNumber.vadl
+++ b/vadl/test/resources/frontend-snapshots/annotation/invalidZeroAnnotationInvalidArgumentNumber.vadl
@@ -9,7 +9,7 @@ instruction set architecture TEST =
 //  Reported Diagnostics:
 //
 //  error: Invalid zero annotation
-//       ╭──[test/resources/frontend-snapshots/annotation/invalidZeroAnnotationInvalidArgumentNumber.vadl:4:12]
+//       ╭── test/resources/frontend-snapshots/annotation/invalidZeroAnnotationInvalidArgumentNumber.vadl:4:12
 //       │
 //     4 │   [ zero : X(1)(2) ]
 //       │            ^^^^^^^ Exactly one register index was expected, but 2 were provided.

--- a/vadl/test/resources/frontend-snapshots/annotation/invalidZeroAnnotationInvalidStructure.vadl
+++ b/vadl/test/resources/frontend-snapshots/annotation/invalidZeroAnnotationInvalidStructure.vadl
@@ -10,7 +10,7 @@ instruction set architecture TEST =
 //  Reported Diagnostics:
 //
 //  error: Invalid zero annotation
-//       ╭──[test/resources/frontend-snapshots/annotation/invalidZeroAnnotationInvalidStructure.vadl:5:3]
+//       ╭── test/resources/frontend-snapshots/annotation/invalidZeroAnnotationInvalidStructure.vadl:5:3
 //       │
 //     5 │   [ zero : 2 + 3 - 1]
 //       │   ^^^^^^^^^^^^^^^^^^^ Zero annotation must be of form [ zero : <register>( <expr> ) ].

--- a/vadl/test/resources/frontend-snapshots/annotation/invalidZeroAnnotationInvalidTarget1.vadl
+++ b/vadl/test/resources/frontend-snapshots/annotation/invalidZeroAnnotationInvalidTarget1.vadl
@@ -10,7 +10,7 @@ instruction set architecture TEST =
 //  Reported Diagnostics:
 //
 //  error: Invalid zero annotation
-//       ╭──[test/resources/frontend-snapshots/annotation/invalidZeroAnnotationInvalidTarget1.vadl:5:12]
+//       ╭── test/resources/frontend-snapshots/annotation/invalidZeroAnnotationInvalidTarget1.vadl:5:12
 //       │
 //     5 │   [ zero : M(1)]
 //       │            ^ Zero annotation target must be the annotated register.

--- a/vadl/test/resources/frontend-snapshots/imports/invalidImportAndRedeclareModel.vadl
+++ b/vadl/test/resources/frontend-snapshots/imports/invalidImportAndRedeclareModel.vadl
@@ -8,7 +8,7 @@ model magicNumber(): Ex = {
 //  Reported Diagnostics:
 //
 //  error: Macro name already used: magicNumber
-//       ╭──[test/resources/frontend-snapshots/imports/invalidImportAndRedeclareModel.vadl:3:7]
+//       ╭── test/resources/frontend-snapshots/imports/invalidImportAndRedeclareModel.vadl:3:7
 //       │
 //     3 │ model magicNumber(): Ex = {
 //       │       ^^^^^^^^^^^ Second definition here.

--- a/vadl/test/resources/frontend-snapshots/imports/invalidImportBareImport.vadl
+++ b/vadl/test/resources/frontend-snapshots/imports/invalidImportBareImport.vadl
@@ -8,7 +8,7 @@ constant flo = $magicNumber()
 //  Reported Diagnostics:
 //
 //  error: Invalid Import
-//       ╭──[test/resources/frontend-snapshots/imports/invalidImportBareImport.vadl:3:8]
+//       ╭── test/resources/frontend-snapshots/imports/invalidImportBareImport.vadl:3:8
 //       │
 //     3 │ import base
 //       │        ^^^^ The import only describes the file to import from but not what to import.

--- a/vadl/test/resources/frontend-snapshots/imports/invalidImportOverrideNonIdMacro.vadl
+++ b/vadl/test/resources/frontend-snapshots/imports/invalidImportOverrideNonIdMacro.vadl
@@ -5,14 +5,14 @@ import base::magicNumber with ("magicNumber=two")
 //  Reported Diagnostics:
 //
 //  error: Invalid Model Override
-//       ╭──[test/resources/frontend-snapshots/imports/base.vadl:1:1]
+//       ╭── test/resources/frontend-snapshots/imports/base.vadl:1:1
 //       │
 //     1 │ model magicNumber(): Ex = {
 //       │ ^^^^^^^^^^^^^^^^^^^^^^^ note: This model was overridden but only models returning `Id` can be overridden.
 //       │
 //
 //  error: Unknown Model `$num`
-//       ╭──[test/resources/frontend-snapshots/imports/base.vadl:11:3]
+//       ╭── test/resources/frontend-snapshots/imports/base.vadl:11:3
 //       │
 //    11 │   $num + 1
 //       │   ^^^^

--- a/vadl/test/resources/frontend-snapshots/imports/invalidImportWhereWithIsMacroOfWrongType.vadl
+++ b/vadl/test/resources/frontend-snapshots/imports/invalidImportWhereWithIsMacroOfWrongType.vadl
@@ -14,14 +14,14 @@ constant flo = $numPlusOne()
 //  Reported Diagnostics:
 //
 //  error: Invalid Import
-//       ╭──[Source Location was lost]
+//       ╭── Source Location was lost
 //       │
 //       │    No Preview available: No source location found
 //       │    Macro overrides must have the form `<macro-name>=<substitute>`.
 //       │
 //
 //  error: SyntaxType Mismatch
-//       ╭──[test/resources/frontend-snapshots/imports/invalidImportWhereWithIsMacroOfWrongType.vadl:4:3]
+//       ╭── test/resources/frontend-snapshots/imports/invalidImportWhereWithIsMacroOfWrongType.vadl:4:3
 //       │
 //     4 │   42
 //       │   ^^

--- a/vadl/test/resources/frontend-snapshots/imports/invalidImportsBadPaths.vadl
+++ b/vadl/test/resources/frontend-snapshots/imports/invalidImportsBadPaths.vadl
@@ -15,56 +15,63 @@ import "sys/does/not/exist"::{this, also, not}
 //  Reported Diagnostics:
 //
 //  error: Import Error
-//       ╭──[test/resources/frontend-snapshots/imports/invalidImportsBadPaths.vadl:4:8]
+//       ╭── test/resources/frontend-snapshots/imports/invalidImportsBadPaths.vadl:4:8
 //       │
 //     4 │ import doesnotexist::{alsoNotExisting}
 //       │        ^^^^^^^^^^^^
 //       │
 //       Could not resolve file path: "doesnotexist"
+//
 //  error: Import Error
-//       ╭──[test/resources/frontend-snapshots/imports/invalidImportsBadPaths.vadl:5:8]
+//       ╭── test/resources/frontend-snapshots/imports/invalidImportsBadPaths.vadl:5:8
 //       │
 //     5 │ import doesnotexist
 //       │        ^^^^^^^^^^^^
 //       │
 //       Could not resolve file path: "doesnotexist"
+//
 //  error: Import Error
-//       ╭──[test/resources/frontend-snapshots/imports/invalidImportsBadPaths.vadl:6:8]
+//       ╭── test/resources/frontend-snapshots/imports/invalidImportsBadPaths.vadl:6:8
 //       │
 //     6 │ import does::not::exist
 //       │        ^^^^
 //       │
 //       Could not resolve file path: "does"
+//
 //  error: Import Error
-//       ╭──[test/resources/frontend-snapshots/imports/invalidImportsBadPaths.vadl:7:8]
+//       ╭── test/resources/frontend-snapshots/imports/invalidImportsBadPaths.vadl:7:8
 //       │
 //     7 │ import sys::does::not::exist::{this, also, not}
 //       │        ^^^
 //       │
 //       Could not resolve file path: "sys"
+//
 //  error: Import Error
-//       ╭──[test/resources/frontend-snapshots/imports/invalidImportsBadPaths.vadl:9:8]
+//       ╭── test/resources/frontend-snapshots/imports/invalidImportsBadPaths.vadl:9:8
 //       │
 //     9 │ import "doesnotexist"::{alsoNotExisting}
 //       │        ^^^^^^^^^^^^^^
 //       │
 //       Could not resolve file path: "doesnotexist"
+//
 //  error: Import Error
-//       ╭──[test/resources/frontend-snapshots/imports/invalidImportsBadPaths.vadl:10:8]
+//       ╭── test/resources/frontend-snapshots/imports/invalidImportsBadPaths.vadl:10:8
 //       │
 //    10 │ import "doesnotexist"
 //       │        ^^^^^^^^^^^^^^
 //       │
 //       Could not resolve file path: "doesnotexist"
+//
 //  error: Import Error
-//       ╭──[test/resources/frontend-snapshots/imports/invalidImportsBadPaths.vadl:11:8]
+//       ╭── test/resources/frontend-snapshots/imports/invalidImportsBadPaths.vadl:11:8
 //       │
 //    11 │ import "does/not/exist"
 //       │        ^^^^^^^^^^^^^^^^
 //       │
 //       Could not resolve file path: "does/not/exist"
+//
 //  error: Import Error
-//       ╭──[test/resources/frontend-snapshots/imports/invalidImportsBadPaths.vadl:12:8]
+//       ╭── test/resources/frontend-snapshots/imports/invalidImportsBadPaths.vadl:12:8
 //       │
 //    12 │ import "sys/does/not/exist"::{this, also, not}
 //       │        ^^^^^^^^^^^^^^^^^^^^

--- a/vadl/test/resources/frontend-snapshots/imports/invalidImportwrongMacroOverrideFormat.vadl
+++ b/vadl/test/resources/frontend-snapshots/imports/invalidImportwrongMacroOverrideFormat.vadl
@@ -6,7 +6,7 @@ constant flo = $magicNumber()
 //  Reported Diagnostics:
 //
 //  error: Invalid Import
-//       ╭──[test/resources/frontend-snapshots/imports/invalidImportwrongMacroOverrideFormat.vadl:1:32]
+//       ╭── test/resources/frontend-snapshots/imports/invalidImportwrongMacroOverrideFormat.vadl:1:32
 //       │
 //     1 │ import base::magicNumber with ("magicNunberNoSpace")
 //       │                                ^^^^^^^^^^^^^^^^^^^^ Macro overrides must have the form `<macro-name>=<substitute>`.

--- a/vadl/test/resources/frontend-snapshots/lowering/invalidPseudoCallInstructionMissing.vadl
+++ b/vadl/test/resources/frontend-snapshots/lowering/invalidPseudoCallInstructionMissing.vadl
@@ -30,7 +30,7 @@ instruction set architecture ISA = {
 //  Reported Diagnostics:
 //
 //  error: Unknown Symbol: "DOESNOTEXIST"
-//       ╭──[test/resources/frontend-snapshots/lowering/invalidPseudoCallInstructionMissing.vadl:13:30]
+//       ╭── test/resources/frontend-snapshots/lowering/invalidPseudoCallInstructionMissing.vadl:13:30
 //       │
 //    13 │   special call instruction = DOESNOTEXIST
 //       │                              ^^^^^^^^^^^^ No symbol with this name exists.

--- a/vadl/test/resources/frontend-snapshots/lowering/invalidPseudoReturnInstructionMissing.vadl
+++ b/vadl/test/resources/frontend-snapshots/lowering/invalidPseudoReturnInstructionMissing.vadl
@@ -30,7 +30,7 @@ instruction set architecture ISA = {
 //  Reported Diagnostics:
 //
 //  error: Unknown Symbol: "DOESNOTEXIST"
-//       ╭──[test/resources/frontend-snapshots/lowering/invalidPseudoReturnInstructionMissing.vadl:12:36]
+//       ╭── test/resources/frontend-snapshots/lowering/invalidPseudoReturnInstructionMissing.vadl:12:36
 //       │
 //    12 │       special return instruction = DOESNOTEXIST
 //       │                                    ^^^^^^^^^^^^ No symbol with this name exists.

--- a/vadl/test/resources/frontend-snapshots/macro/invalidTopLevelMacroProducesIsaDef.vadl
+++ b/vadl/test/resources/frontend-snapshots/macro/invalidTopLevelMacroProducesIsaDef.vadl
@@ -10,7 +10,7 @@ $instr()
 //  Reported Diagnostics:
 //
 //  error: SyntaxType Mismatch
-//       ╭──[test/resources/frontend-snapshots/macro/invalidTopLevelMacroProducesIsaDef.vadl:4:3]
+//       ╭── test/resources/frontend-snapshots/macro/invalidTopLevelMacroProducesIsaDef.vadl:4:3
 //       │
 //     4 │   instruction ABC: X = { }
 //       │   ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/vadl/test/resources/frontend-snapshots/nameresolution/formatFieldsAvailableInInstruction.vadl
+++ b/vadl/test/resources/frontend-snapshots/nameresolution/formatFieldsAvailableInInstruction.vadl
@@ -13,7 +13,7 @@ instruction set architecture ISA = {
 //  Reported Diagnostics:
 //
 //  error: Missing Assembly
-//       ╭──[test/resources/frontend-snapshots/nameresolution/formatFieldsAvailableInInstruction.vadl:7:15]
+//       ╭── test/resources/frontend-snapshots/nameresolution/formatFieldsAvailableInInstruction.vadl:7:15
 //       │
 //     7 │   instruction BEQ : Btype = {
 //       │               ^^^

--- a/vadl/test/resources/frontend-snapshots/nameresolution/invalidResolveTwoOverlappingConstant.vadl
+++ b/vadl/test/resources/frontend-snapshots/nameresolution/invalidResolveTwoOverlappingConstant.vadl
@@ -5,7 +5,7 @@ constant a = 13
 //  Reported Diagnostics:
 //
 //  error: Symbol name already used: a
-//       ╭──[test/resources/frontend-snapshots/nameresolution/invalidResolveTwoOverlappingConstant.vadl:2:10]
+//       ╭── test/resources/frontend-snapshots/nameresolution/invalidResolveTwoOverlappingConstant.vadl:2:10
 //       │
 //     1 │ constant a = 13
 //       │          - First defined here.

--- a/vadl/test/resources/frontend-snapshots/nameresolution/invalidResolveTwoOverlappingMemoryDefinitions.vadl
+++ b/vadl/test/resources/frontend-snapshots/nameresolution/invalidResolveTwoOverlappingMemoryDefinitions.vadl
@@ -7,7 +7,7 @@ instruction set architecture FLO = {
 //  Reported Diagnostics:
 //
 //  error: Symbol name already used: MEM
-//       ╭──[test/resources/frontend-snapshots/nameresolution/invalidResolveTwoOverlappingMemoryDefinitions.vadl:3:10]
+//       ╭── test/resources/frontend-snapshots/nameresolution/invalidResolveTwoOverlappingMemoryDefinitions.vadl:3:10
 //       │
 //     2 │   memory MEM: Bits<32> -> Bits<8>
 //       │          --- First defined here.

--- a/vadl/test/resources/frontend-snapshots/nameresolution/invalidResolveTwoOverlappingRegisterDefinitions.vadl
+++ b/vadl/test/resources/frontend-snapshots/nameresolution/invalidResolveTwoOverlappingRegisterDefinitions.vadl
@@ -7,7 +7,7 @@ instruction set architecture FLO = {
 //  Reported Diagnostics:
 //
 //  error: Symbol name already used: X
-//       ╭──[test/resources/frontend-snapshots/nameresolution/invalidResolveTwoOverlappingRegisterDefinitions.vadl:3:12]
+//       ╭── test/resources/frontend-snapshots/nameresolution/invalidResolveTwoOverlappingRegisterDefinitions.vadl:3:12
 //       │
 //     2 │   register X : Bits<5>
 //       │            - First defined here.

--- a/vadl/test/resources/frontend-snapshots/nameresolution/invalidResolveTwoOverlappingRegisterFileDefinitions.vadl
+++ b/vadl/test/resources/frontend-snapshots/nameresolution/invalidResolveTwoOverlappingRegisterFileDefinitions.vadl
@@ -7,7 +7,7 @@ instruction set architecture FLO = {
 //  Reported Diagnostics:
 //
 //  error: Symbol name already used: X
-//       ╭──[test/resources/frontend-snapshots/nameresolution/invalidResolveTwoOverlappingRegisterFileDefinitions.vadl:3:12]
+//       ╭── test/resources/frontend-snapshots/nameresolution/invalidResolveTwoOverlappingRegisterFileDefinitions.vadl:3:12
 //       │
 //     2 │   register X : Bits<5> -> Bits<32>
 //       │            - First defined here.

--- a/vadl/test/resources/frontend-snapshots/nameresolution/invalidResolveUndefinedVariable.vadl
+++ b/vadl/test/resources/frontend-snapshots/nameresolution/invalidResolveUndefinedVariable.vadl
@@ -4,7 +4,7 @@ constant a = b
 //  Reported Diagnostics:
 //
 //  error: Unknown Symbol: "b"
-//       ╭──[test/resources/frontend-snapshots/nameresolution/invalidResolveUndefinedVariable.vadl:1:14]
+//       ╭── test/resources/frontend-snapshots/nameresolution/invalidResolveUndefinedVariable.vadl:1:14
 //       │
 //     1 │ constant a = b
 //       │              ^ No symbol with this name exists.

--- a/vadl/test/resources/frontend-snapshots/nameresolution/invalidTypeNameInUsing.vadl
+++ b/vadl/test/resources/frontend-snapshots/nameresolution/invalidTypeNameInUsing.vadl
@@ -6,7 +6,7 @@ instruction set architecture ISA = {
 //  Reported Diagnostics:
 //
 //  error: Unknown Symbol: "XSize"
-//       ╭──[test/resources/frontend-snapshots/nameresolution/invalidTypeNameInUsing.vadl:2:28]
+//       ╭── test/resources/frontend-snapshots/nameresolution/invalidTypeNameInUsing.vadl:2:28
 //       │
 //     2 │   using Word        = SInt<XSize>
 //       │                            ^^^^^ No symbol with this name exists.

--- a/vadl/test/resources/frontend-snapshots/nameresolution/invalidTypeSizeNameDoesNotExist.vadl
+++ b/vadl/test/resources/frontend-snapshots/nameresolution/invalidTypeSizeNameDoesNotExist.vadl
@@ -4,7 +4,7 @@ constant b: SInt<a> = 1
 //  Reported Diagnostics:
 //
 //  error: Unknown Symbol: "a"
-//       ╭──[test/resources/frontend-snapshots/nameresolution/invalidTypeSizeNameDoesNotExist.vadl:1:18]
+//       ╭── test/resources/frontend-snapshots/nameresolution/invalidTypeSizeNameDoesNotExist.vadl:1:18
 //       │
 //     1 │ constant b: SInt<a> = 1
 //       │                  ^ No symbol with this name exists.

--- a/vadl/test/resources/frontend-snapshots/nameresolution/invalidUnknownFieldInEcoding.vadl
+++ b/vadl/test/resources/frontend-snapshots/nameresolution/invalidUnknownFieldInEcoding.vadl
@@ -12,7 +12,7 @@ instruction set architecture ISA = {
 //  Reported Diagnostics:
 //
 //  error: Unknown Field: "bit"
-//       ╭──[test/resources/frontend-snapshots/nameresolution/invalidUnknownFieldInEcoding.vadl:8:20]
+//       ╭── test/resources/frontend-snapshots/nameresolution/invalidUnknownFieldInEcoding.vadl:8:20
 //       │
 //     8 │   encoding BEQ = { bit = 8 }
 //       │                    ^^^ No field with this name exists.

--- a/vadl/test/resources/frontend-snapshots/nameresolution/nestedFormatFieldsResolve.vadl
+++ b/vadl/test/resources/frontend-snapshots/nameresolution/nestedFormatFieldsResolve.vadl
@@ -23,7 +23,7 @@ instruction set architecture ISA = {
 //  Reported Diagnostics:
 //
 //  error: Missing Assembly
-//       ╭──[test/resources/frontend-snapshots/nameresolution/nestedFormatFieldsResolve.vadl:17:15]
+//       ╭── test/resources/frontend-snapshots/nameresolution/nestedFormatFieldsResolve.vadl:17:15
 //       │
 //    17 │   instruction BEQ : Btype = {
 //       │               ^^^

--- a/vadl/test/resources/frontend-snapshots/nameresolution/registersAvailableInInstruction.vadl
+++ b/vadl/test/resources/frontend-snapshots/nameresolution/registersAvailableInInstruction.vadl
@@ -12,7 +12,7 @@ instruction set architecture ISA = {
 //  Reported Diagnostics:
 //
 //  error: Missing Assembly
-//       ╭──[test/resources/frontend-snapshots/nameresolution/registersAvailableInInstruction.vadl:6:15]
+//       ╭── test/resources/frontend-snapshots/nameresolution/registersAvailableInInstruction.vadl:6:15
 //       │
 //     6 │   instruction BEQ : Btype = {
 //       │               ^^^

--- a/vadl/test/resources/frontend-snapshots/parser/invalidCastOfSizedType.vadl
+++ b/vadl/test/resources/frontend-snapshots/parser/invalidCastOfSizedType.vadl
@@ -7,7 +7,7 @@ constant apfelstrudel = 1 as String<99>
 //  Reported Diagnostics:
 //
 //  error: Invalid Type Notation
-//       ╭──[test/resources/frontend-snapshots/parser/invalidCastOfSizedType.vadl:4:30]
+//       ╭── test/resources/frontend-snapshots/parser/invalidCastOfSizedType.vadl:4:30
 //       │
 //     4 │ constant apfelstrudel = 1 as String<99>
 //       │                              ^^^^^^^^^^

--- a/vadl/test/resources/frontend-snapshots/parser/invalidForallFoldModelSyntaxTypeForOperator.vadl
+++ b/vadl/test/resources/frontend-snapshots/parser/invalidForallFoldModelSyntaxTypeForOperator.vadl
@@ -11,7 +11,7 @@ model FoldStat (): Stat = {
 //  Reported Diagnostics:
 //
 //  error: SyntaxType Mismatch
-//       ╭──[test/resources/frontend-snapshots/parser/invalidForallFoldModelSyntaxTypeForOperator.vadl:4:24]
+//       ╭── test/resources/frontend-snapshots/parser/invalidForallFoldModelSyntaxTypeForOperator.vadl:4:24
 //       │
 //     4 │ model TestOP (): Ex = {42}
 //       │                        ^^

--- a/vadl/test/resources/frontend-snapshots/parser/invalidHigherOrderMacroWithTooManyArguments.vadl
+++ b/vadl/test/resources/frontend-snapshots/parser/invalidHigherOrderMacroWithTooManyArguments.vadl
@@ -15,7 +15,7 @@ model InstrBHSD (modelid: InstrWithFunctElemSize, i: InstrWithFunct): IsaDefs = 
 //  Reported Diagnostics:
 //
 //  error: Invalid Model Invocation
-//       ╭──[test/resources/frontend-snapshots/parser/invalidHigherOrderMacroWithTooManyArguments.vadl:11:35]
+//       ╭── test/resources/frontend-snapshots/parser/invalidHigherOrderMacroWithTooManyArguments.vadl:11:35
 //       │
 //    11 │   $modelid ($i; ElementsB; SizeB; ".B")
 //       │                                   ^^^^ The model only expected 3 arguments but, you provided at least 4.

--- a/vadl/test/resources/frontend-snapshots/parser/invalidHigherOrderModelWrongArgumentCount.vadl
+++ b/vadl/test/resources/frontend-snapshots/parser/invalidHigherOrderModelWrongArgumentCount.vadl
@@ -161,28 +161,30 @@ model-type SVEWhileStatModel = (WhileRec, Id) -> Stat
 //  Reported Diagnostics:
 //
 //  error: The macro `SVEWhileCondInstr` expects 4 arguments but 1 were provided.
-//       ╭──[test/resources/frontend-snapshots/parser/invalidHigherOrderModelWrongArgumentCount.vadl:147:5]
+//       ╭── test/resources/frontend-snapshots/parser/invalidHigherOrderModelWrongArgumentCount.vadl:147:5
 //       │
 //   147 │     $SVEWhileCondInstr ($ExtInstrStr ($i;  "W"); WSize ; $elements ; $elSize ; $elStr)
 //       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //       │
 //
 //  error: SyntaxType Mismatch
-//       ╭──[test/resources/frontend-snapshots/parser/invalidHigherOrderModelWrongArgumentCount.vadl:142:148]
+//       ╭── test/resources/frontend-snapshots/parser/invalidHigherOrderModelWrongArgumentCount.vadl:142:148
 //       │
 //   142 │     $SVEWhileBaseInstr (WhileStatLSLE ; $ExtInstrIdStr($i ; LS ; "ls"); (LS ; $UMax($regSize) ; $PtrueBHSD($elSize) ; ugth ; $elements ; $elSize ; $elStr) ; $regSize)
 //       │                                                                                                                                                    ^^^^^^
 //       │
 //       Mismatched node type: Required `STR`, but got `INVALID`
+//
 //  error: SyntaxType Mismatch
-//       ╭──[test/resources/frontend-snapshots/parser/invalidHigherOrderModelWrongArgumentCount.vadl:147:25]
+//       ╭── test/resources/frontend-snapshots/parser/invalidHigherOrderModelWrongArgumentCount.vadl:147:25
 //       │
 //   147 │     $SVEWhileCondInstr ($ExtInstrStr ($i;  "W"); WSize ; $elements ; $elSize ; $elStr)
 //       │                         ^^^^^^^^^^^^
 //       │
 //       Mismatched node type: Required `InstrWithFunct (ID,STR,EX,ID)`, but got `INVALID`
+//
 //  error: Parsing Error
-//       ╭──[test/resources/frontend-snapshots/parser/invalidHigherOrderModelWrongArgumentCount.vadl:147:38]
+//       ╭── test/resources/frontend-snapshots/parser/invalidHigherOrderModelWrongArgumentCount.vadl:147:38
 //       │
 //   147 │     $SVEWhileCondInstr ($ExtInstrStr ($i;  "W"); WSize ; $elements ; $elSize ; $elStr)
 //       │                                      ^ The parser expected `)` here.

--- a/vadl/test/resources/frontend-snapshots/parser/invalidModelInvocationUsesRightLocation.vadl
+++ b/vadl/test/resources/frontend-snapshots/parser/invalidModelInvocationUsesRightLocation.vadl
@@ -16,7 +16,7 @@ constant second = false + $apfelstrudel()
 //  Reported Diagnostics:
 //
 //  error: Type Mismatch
-//       ╭──[test/resources/frontend-snapshots/parser/invalidModelInvocationUsesRightLocation.vadl:13:19]
+//       ╭── test/resources/frontend-snapshots/parser/invalidModelInvocationUsesRightLocation.vadl:13:19
 //       │
 //    13 │ constant second = false + $apfelstrudel()
 //       │                   ^^^^^^^^^^^^^^^^^^^^^^^ note: The left type is Bits<1> while right is Bits<6>

--- a/vadl/test/resources/frontend-snapshots/parser/invalidModelMissingReturnType.vadl
+++ b/vadl/test/resources/frontend-snapshots/parser/invalidModelMissingReturnType.vadl
@@ -8,7 +8,7 @@ model XYZ() = { }
 //  Reported Diagnostics:
 //
 //  error: Parsing Error
-//       ╭──[test/resources/frontend-snapshots/parser/invalidModelMissingReturnType.vadl:5:13]
+//       ╭── test/resources/frontend-snapshots/parser/invalidModelMissingReturnType.vadl:5:13
 //       │
 //     5 │ model XYZ() = { }
 //       │             ^ The parser expected `:` here.

--- a/vadl/test/resources/frontend-snapshots/parser/invalidModelWithErrorInModel.vadl
+++ b/vadl/test/resources/frontend-snapshots/parser/invalidModelWithErrorInModel.vadl
@@ -12,7 +12,7 @@ constant second = $apfelstrudel
 //  Reported Diagnostics:
 //
 //  error: Type Mismatch
-//       ╭──[test/resources/frontend-snapshots/parser/invalidModelWithErrorInModel.vadl:4:3]
+//       ╭── test/resources/frontend-snapshots/parser/invalidModelWithErrorInModel.vadl:4:3
 //       │
 //     4 │   false + 42
 //       │   ^^^^^^^^^^ note: The left type is Bits<1> while right is Bits<6>

--- a/vadl/test/resources/frontend-snapshots/parser/invalidModelWithTooManyArguments.vadl
+++ b/vadl/test/resources/frontend-snapshots/parser/invalidModelWithTooManyArguments.vadl
@@ -8,7 +8,7 @@ constant x = $flo(y; z)
 //  Reported Diagnostics:
 //
 //  error: Invalid Model Invocation
-//       ╭──[test/resources/frontend-snapshots/parser/invalidModelWithTooManyArguments.vadl:5:22]
+//       ╭── test/resources/frontend-snapshots/parser/invalidModelWithTooManyArguments.vadl:5:22
 //       │
 //     5 │ constant x = $flo(y; z)
 //       │                      ^ Model `flo` only expected 1 arguments but, you provided at least 2.

--- a/vadl/test/resources/frontend-snapshots/parser/invalidSymbolConflictIsaInheritance.vadl
+++ b/vadl/test/resources/frontend-snapshots/parser/invalidSymbolConflictIsaInheritance.vadl
@@ -10,7 +10,7 @@ instruction set architecture Sub extending Base1 = {
 //  Reported Diagnostics:
 //
 //  error: Symbol name already used: PC
-//       ╭──[test/resources/frontend-snapshots/parser/invalidSymbolConflictIsaInheritance.vadl:2:21]
+//       ╭── test/resources/frontend-snapshots/parser/invalidSymbolConflictIsaInheritance.vadl:2:21
 //       │
 //     2 │     program counter PC: Bits<32>
 //       │                     ^^ Second definition here.

--- a/vadl/test/resources/frontend-snapshots/parser/invalidSymbolConflictIsaMultiInheritance.vadl
+++ b/vadl/test/resources/frontend-snapshots/parser/invalidSymbolConflictIsaMultiInheritance.vadl
@@ -11,7 +11,7 @@ instruction set architecture Sub extending Base1, Base2 = { }
 //  Reported Diagnostics:
 //
 //  error: Symbol name already used: PC
-//       ╭──[test/resources/frontend-snapshots/parser/invalidSymbolConflictIsaMultiInheritance.vadl:6:14]
+//       ╭── test/resources/frontend-snapshots/parser/invalidSymbolConflictIsaMultiInheritance.vadl:6:14
 //       │
 //     2 │     program counter PC: Bits<32>
 //       │                     -- First defined here.

--- a/vadl/test/resources/frontend-snapshots/parser/invalidTypoInConstantKeyword.vadl
+++ b/vadl/test/resources/frontend-snapshots/parser/invalidTypoInConstantKeyword.vadl
@@ -7,7 +7,7 @@ const flo = 78
 //  Reported Diagnostics:
 //
 //  error: Parsing Error
-//       ╭──[test/resources/frontend-snapshots/parser/invalidTypoInConstantKeyword.vadl:4:1]
+//       ╭── test/resources/frontend-snapshots/parser/invalidTypoInConstantKeyword.vadl:4:1
 //       │
 //     4 │ const flo = 78
 //       │ ^^^^^ this symbol not expected in vadl

--- a/vadl/test/resources/frontend-snapshots/recursionchecker/invalidAliasRecursion.vadl
+++ b/vadl/test/resources/frontend-snapshots/recursionchecker/invalidAliasRecursion.vadl
@@ -7,7 +7,7 @@ instruction set architecture ISA = {
 //  Reported Diagnostics:
 //
 //  error: Infinite Recursion
-//       ╭──[test/resources/frontend-snapshots/recursionchecker/invalidAliasRecursion.vadl:2:3]
+//       ╭── test/resources/frontend-snapshots/recursionchecker/invalidAliasRecursion.vadl:2:3
 //       │
 //     2 │   alias register a = b
 //       │   ^^^^^^^^^^^^^^^^^^^^

--- a/vadl/test/resources/frontend-snapshots/recursionchecker/invalidConstantFunctionRecursion.vadl
+++ b/vadl/test/resources/frontend-snapshots/recursionchecker/invalidConstantFunctionRecursion.vadl
@@ -5,7 +5,7 @@ function b (x : SInt<32>) -> SInt<32> = a
 //  Reported Diagnostics:
 //
 //  error: Infinite Recursion
-//       ╭──[test/resources/frontend-snapshots/recursionchecker/invalidConstantFunctionRecursion.vadl:2:41]
+//       ╭── test/resources/frontend-snapshots/recursionchecker/invalidConstantFunctionRecursion.vadl:2:41
 //       │
 //     2 │ function b (x : SInt<32>) -> SInt<32> = a
 //       │                                         ^

--- a/vadl/test/resources/frontend-snapshots/recursionchecker/invalidConstantRecursion.vadl
+++ b/vadl/test/resources/frontend-snapshots/recursionchecker/invalidConstantRecursion.vadl
@@ -5,7 +5,7 @@ constant b = a
 //  Reported Diagnostics:
 //
 //  error: Infinite Recursion
-//       ╭──[test/resources/frontend-snapshots/recursionchecker/invalidConstantRecursion.vadl:1:1]
+//       ╭── test/resources/frontend-snapshots/recursionchecker/invalidConstantRecursion.vadl:1:1
 //       │
 //     1 │ constant a = b
 //       │ ^^^^^^^^^^^^^^

--- a/vadl/test/resources/frontend-snapshots/recursionchecker/invalidEnumerationFieldRecursion.vadl
+++ b/vadl/test/resources/frontend-snapshots/recursionchecker/invalidEnumerationFieldRecursion.vadl
@@ -7,7 +7,7 @@ enumeration rec : SInt<32> =
 //  Reported Diagnostics:
 //
 //  error: Infinite Recursion
-//       ╭──[test/resources/frontend-snapshots/recursionchecker/invalidEnumerationFieldRecursion.vadl:2:9]
+//       ╭── test/resources/frontend-snapshots/recursionchecker/invalidEnumerationFieldRecursion.vadl:2:9
 //       │
 //     2 │   { a = rec::b
 //       │         ^^^^^^

--- a/vadl/test/resources/frontend-snapshots/recursionchecker/invalidFormatRecursion.vadl
+++ b/vadl/test/resources/frontend-snapshots/recursionchecker/invalidFormatRecursion.vadl
@@ -4,7 +4,7 @@ format rec : Bits<16> = { a : rec }
 //  Reported Diagnostics:
 //
 //  error: Infinite Recursion
-//       ╭──[test/resources/frontend-snapshots/recursionchecker/invalidFormatRecursion.vadl:1:31]
+//       ╭── test/resources/frontend-snapshots/recursionchecker/invalidFormatRecursion.vadl:1:31
 //       │
 //     1 │ format rec : Bits<16> = { a : rec }
 //       │                               ^^^

--- a/vadl/test/resources/frontend-snapshots/recursionchecker/invalidTypeSystemConstantRecursion.vadl
+++ b/vadl/test/resources/frontend-snapshots/recursionchecker/invalidTypeSystemConstantRecursion.vadl
@@ -5,7 +5,7 @@ constant b: Bits<a> = 3
 //  Reported Diagnostics:
 //
 //  error: Infinite Recursion
-//       ╭──[test/resources/frontend-snapshots/recursionchecker/invalidTypeSystemConstantRecursion.vadl:1:1]
+//       ╭── test/resources/frontend-snapshots/recursionchecker/invalidTypeSystemConstantRecursion.vadl:1:1
 //       │
 //     1 │ constant a = b
 //       │ ^^^^^^^^^^^^^^

--- a/vadl/test/resources/frontend-snapshots/recursionchecker/invalidTypeSystemRecursion.vadl
+++ b/vadl/test/resources/frontend-snapshots/recursionchecker/invalidTypeSystemRecursion.vadl
@@ -5,7 +5,7 @@ constant y: Bits<x> = 1
 //  Reported Diagnostics:
 //
 //  error: Infinite Recursion
-//       ╭──[test/resources/frontend-snapshots/recursionchecker/invalidTypeSystemRecursion.vadl:1:1]
+//       ╭── test/resources/frontend-snapshots/recursionchecker/invalidTypeSystemRecursion.vadl:1:1
 //       │
 //     1 │ constant x: Bits<y> = 1
 //       │ ^^^^^^^^^^^^^^^^^^^^^^^

--- a/vadl/test/resources/frontend-snapshots/recursionchecker/invalidUsingRecursion.vadl
+++ b/vadl/test/resources/frontend-snapshots/recursionchecker/invalidUsingRecursion.vadl
@@ -5,7 +5,7 @@ using b = a
 //  Reported Diagnostics:
 //
 //  error: Infinite Recursion
-//       ╭──[test/resources/frontend-snapshots/recursionchecker/invalidUsingRecursion.vadl:1:11]
+//       ╭── test/resources/frontend-snapshots/recursionchecker/invalidUsingRecursion.vadl:1:11
 //       │
 //     1 │ using a = b
 //       │           ^

--- a/vadl/test/resources/frontend-snapshots/typechecker/assemblyBuiltinWithoutCast.vadl
+++ b/vadl/test/resources/frontend-snapshots/typechecker/assemblyBuiltinWithoutCast.vadl
@@ -17,7 +17,7 @@ assembly description AD for ABI = {
 //  Reported Diagnostics:
 //
 //  error: No RETURN_ADDRESS registers were declared but one was expected
-//       ╭──[test/resources/frontend-snapshots/typechecker/assemblyBuiltinWithoutCast.vadl:7:1]
+//       ╭── test/resources/frontend-snapshots/typechecker/assemblyBuiltinWithoutCast.vadl:7:1
 //       │
 //     7 │ application binary interface ABI for ISA = {}
 //       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/vadl/test/resources/frontend-snapshots/typechecker/assignToLetValue.vadl
+++ b/vadl/test/resources/frontend-snapshots/typechecker/assignToLetValue.vadl
@@ -27,7 +27,7 @@ instruction set architecture TEST = {
 //  Reported Diagnostics:
 //
 //  error: Cannot Write To Static Target
-//       ╭──[test/resources/frontend-snapshots/typechecker/assignToLetValue.vadl:19:7]
+//       ╭── test/resources/frontend-snapshots/typechecker/assignToLetValue.vadl:19:7
 //       │
 //    19 │       r(i) := 0
 //       │       ^^^^ This is not writable (originates from a LetStatement), but a static value.

--- a/vadl/test/resources/frontend-snapshots/typechecker/invalidBooleanType.vadl
+++ b/vadl/test/resources/frontend-snapshots/typechecker/invalidBooleanType.vadl
@@ -4,7 +4,7 @@ constant b: Bool<1> = true
 //  Reported Diagnostics:
 //
 //  error: Invalid Type Notation
-//       ╭──[test/resources/frontend-snapshots/typechecker/invalidBooleanType.vadl:1:13]
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidBooleanType.vadl:1:13
 //       │
 //     1 │ constant b: Bool<1> = true
 //       │             ^^^^^^^

--- a/vadl/test/resources/frontend-snapshots/typechecker/invalidBuiltitinCalls.vadl
+++ b/vadl/test/resources/frontend-snapshots/typechecker/invalidBuiltitinCalls.vadl
@@ -11,21 +11,21 @@ function abc(x: Bits<8>) -> Bits<8> = VADL::adds(1, x)
 //  Reported Diagnostics:
 //
 //  error: Type Mismatch
-//       ╭──[test/resources/frontend-snapshots/typechecker/invalidBuiltitinCalls.vadl:2:14]
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidBuiltitinCalls.vadl:2:14
 //       │
 //     2 │ constant a = VADL::add(1)
 //       │              ^^^^^^^^^^^^ Expected 2 arguments but got 1.
 //       │
 //
 //  error: Type Mismatch
-//       ╭──[test/resources/frontend-snapshots/typechecker/invalidBuiltitinCalls.vadl:3:14]
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidBuiltitinCalls.vadl:3:14
 //       │
 //     3 │ constant b = VADL::add(1, 2, 3)
 //       │              ^^^^^^^^^^^^^^^^^^ Expected 2 arguments but got 3.
 //       │
 //
 //  error: Type Mismatch
-//       ╭──[test/resources/frontend-snapshots/typechecker/invalidBuiltitinCalls.vadl:8:39]
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidBuiltitinCalls.vadl:8:39
 //       │
 //     8 │ function abc(x: Bits<8>) -> Bits<8> = VADL::adds(1, x)
 //       │                                       ^^^^^^^^^^^^^^^^ The builtin has the signature `(BitsType, BitsType) -> TupleType` but got `Bits<1>, Bits<8>`.

--- a/vadl/test/resources/frontend-snapshots/typechecker/invalidCastAfterEvalTruncates.vadl
+++ b/vadl/test/resources/frontend-snapshots/typechecker/invalidCastAfterEvalTruncates.vadl
@@ -5,7 +5,7 @@ constant b: UInt<a> = 3
 //  Reported Diagnostics:
 //
 //  error: Type Mismatch
-//       ╭──[test/resources/frontend-snapshots/typechecker/invalidCastAfterEvalTruncates.vadl:2:23]
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidCastAfterEvalTruncates.vadl:2:23
 //       │
 //     2 │ constant b: UInt<a> = 3
 //       │                       ^ Expected `UInt<1>` but got `Const<3>`.

--- a/vadl/test/resources/frontend-snapshots/typechecker/invalidConstNotEvaluatable.vadl
+++ b/vadl/test/resources/frontend-snapshots/typechecker/invalidConstNotEvaluatable.vadl
@@ -5,14 +5,15 @@ constant b = forall i: Bits<2> in 0..3 fold + with (4 as Bits<32>)
 //  Reported Diagnostics:
 //
 //  error: Invalid constant value
-//       ╭──[test/resources/frontend-snapshots/typechecker/invalidConstNotEvaluatable.vadl:1:14]
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidConstNotEvaluatable.vadl:1:14
 //       │
 //     1 │ constant a = "kuchen"
 //       │              ^^^^^^^^ Cannot evaluate strings (yet).
 //       │
 //       All constants must be able to be evaluated
+//
 //  error: Invalid constant value
-//       ╭──[test/resources/frontend-snapshots/typechecker/invalidConstNotEvaluatable.vadl:2:14]
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidConstNotEvaluatable.vadl:2:14
 //       │
 //     2 │ constant b = forall i: Bits<2> in 0..3 fold + with (4 as Bits<32>)
 //       │              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The constant evaluator cannot evaluate ForallExpr.

--- a/vadl/test/resources/frontend-snapshots/typechecker/invalidConstantAssignmentIntToBool.vadl
+++ b/vadl/test/resources/frontend-snapshots/typechecker/invalidConstantAssignmentIntToBool.vadl
@@ -4,7 +4,7 @@ constant b: Bool = 42
 //  Reported Diagnostics:
 //
 //  error: Type Mismatch
-//       ╭──[test/resources/frontend-snapshots/typechecker/invalidConstantAssignmentIntToBool.vadl:1:20]
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidConstantAssignmentIntToBool.vadl:1:20
 //       │
 //     1 │ constant b: Bool = 42
 //       │                    ^^ Expected `Bool` but got `Const<42>`.

--- a/vadl/test/resources/frontend-snapshots/typechecker/invalidDataTypeLimits.vadl
+++ b/vadl/test/resources/frontend-snapshots/typechecker/invalidDataTypeLimits.vadl
@@ -17,42 +17,42 @@ constant invalidMinBits8: Bits<8> = -1
 //  Reported Diagnostics:
 //
 //  error: Type Mismatch
-//       ╭──[test/resources/frontend-snapshots/typechecker/invalidDataTypeLimits.vadl:3:37]
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidDataTypeLimits.vadl:3:37
 //       │
 //     3 │ constant invalidMaxSInt8: SInt<8> = 128
 //       │                                     ^^^ Expected `SInt<8>` but got `Const<128>`.
 //       │
 //
 //  error: Type Mismatch
-//       ╭──[test/resources/frontend-snapshots/typechecker/invalidDataTypeLimits.vadl:4:37]
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidDataTypeLimits.vadl:4:37
 //       │
 //     4 │ constant invalidMinSInt8: SInt<8> = -129
 //       │                                     ^^^^ Expected `SInt<8>` but got `Const<-129>`.
 //       │
 //
 //  error: Type Mismatch
-//       ╭──[test/resources/frontend-snapshots/typechecker/invalidDataTypeLimits.vadl:8:37]
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidDataTypeLimits.vadl:8:37
 //       │
 //     8 │ constant invalidMaxUInt8: UInt<8> = 256
 //       │                                     ^^^ Expected `UInt<8>` but got `Const<256>`.
 //       │
 //
 //  error: Type Mismatch
-//       ╭──[test/resources/frontend-snapshots/typechecker/invalidDataTypeLimits.vadl:9:37]
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidDataTypeLimits.vadl:9:37
 //       │
 //     9 │ constant invalidMinUInt8: UInt<8> = -1
 //       │                                     ^^ Expected `UInt<8>` but got `Const<-1>`.
 //       │
 //
 //  error: Type Mismatch
-//       ╭──[test/resources/frontend-snapshots/typechecker/invalidDataTypeLimits.vadl:13:37]
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidDataTypeLimits.vadl:13:37
 //       │
 //    13 │ constant invalidMaxBits8: Bits<8> = 256
 //       │                                     ^^^ Expected `Bits<8>` but got `Const<256>`.
 //       │
 //
 //  error: Type Mismatch
-//       ╭──[test/resources/frontend-snapshots/typechecker/invalidDataTypeLimits.vadl:14:37]
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidDataTypeLimits.vadl:14:37
 //       │
 //    14 │ constant invalidMinBits8: Bits<8> = -1
 //       │                                     ^^ Expected `Bits<8>` but got `Const<-1>`.

--- a/vadl/test/resources/frontend-snapshots/typechecker/invalidDeclaredSIntTooNarrow.vadl
+++ b/vadl/test/resources/frontend-snapshots/typechecker/invalidDeclaredSIntTooNarrow.vadl
@@ -4,7 +4,7 @@ constant b: SInt<3> = 8
 //  Reported Diagnostics:
 //
 //  error: Type Mismatch
-//       ╭──[test/resources/frontend-snapshots/typechecker/invalidDeclaredSIntTooNarrow.vadl:1:23]
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidDeclaredSIntTooNarrow.vadl:1:23
 //       │
 //     1 │ constant b: SInt<3> = 8
 //       │                       ^ Expected `SInt<3>` but got `Const<8>`.

--- a/vadl/test/resources/frontend-snapshots/typechecker/invalidEnumWithTypes.vadl
+++ b/vadl/test/resources/frontend-snapshots/typechecker/invalidEnumWithTypes.vadl
@@ -8,7 +8,7 @@ enumeration ENUM: Bits<2> =
 //  Reported Diagnostics:
 //
 //  error: Type Mismatch
-//       ╭──[test/resources/frontend-snapshots/typechecker/invalidEnumWithTypes.vadl:3:7]
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidEnumWithTypes.vadl:3:7
 //       │
 //     3 │ , B = 0b0111111
 //       │       ^^^^^^^^^ Expected `Bits<2>` but got `Bits<6>`.

--- a/vadl/test/resources/frontend-snapshots/typechecker/invalidEvalDivisionByZero.vadl
+++ b/vadl/test/resources/frontend-snapshots/typechecker/invalidEvalDivisionByZero.vadl
@@ -13,70 +13,70 @@ constant j = VADL::umods(10, 0)
 //  Reported Diagnostics:
 //
 //  error: Constant value required
-//       ╭──[test/resources/frontend-snapshots/typechecker/invalidEvalDivisionByZero.vadl:1:14]
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidEvalDivisionByZero.vadl:1:14
 //       │
 //     1 │ constant a = 10 / 0
 //       │              ^^^^^^ Division by zero cannot be computed.
 //       │
 //
 //  error: Constant value required
-//       ╭──[test/resources/frontend-snapshots/typechecker/invalidEvalDivisionByZero.vadl:2:14]
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidEvalDivisionByZero.vadl:2:14
 //       │
 //     2 │ constant b = 10 % 0
 //       │              ^^^^^^ Division by zero cannot be computed.
 //       │
 //
 //  error: Constant value required
-//       ╭──[test/resources/frontend-snapshots/typechecker/invalidEvalDivisionByZero.vadl:3:14]
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidEvalDivisionByZero.vadl:3:14
 //       │
 //     3 │ constant c = VADL::sdiv(10, 0)
 //       │              ^^^^^^^^^^^^^^^^^ Division by zero cannot be computed.
 //       │
 //
 //  error: Constant value required
-//       ╭──[test/resources/frontend-snapshots/typechecker/invalidEvalDivisionByZero.vadl:4:14]
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidEvalDivisionByZero.vadl:4:14
 //       │
 //     4 │ constant d = VADL::udiv(10, 0)
 //       │              ^^^^^^^^^^^^^^^^^ Division by zero cannot be computed.
 //       │
 //
 //  error: Constant value required
-//       ╭──[test/resources/frontend-snapshots/typechecker/invalidEvalDivisionByZero.vadl:5:14]
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidEvalDivisionByZero.vadl:5:14
 //       │
 //     5 │ constant e = VADL::sdivs(10, 0)
 //       │              ^^^^^^^^^^^^^^^^^^ Division by zero cannot be computed.
 //       │
 //
 //  error: Constant value required
-//       ╭──[test/resources/frontend-snapshots/typechecker/invalidEvalDivisionByZero.vadl:6:14]
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidEvalDivisionByZero.vadl:6:14
 //       │
 //     6 │ constant f = VADL::udivs(10, 0)
 //       │              ^^^^^^^^^^^^^^^^^^ Division by zero cannot be computed.
 //       │
 //
 //  error: Constant value required
-//       ╭──[test/resources/frontend-snapshots/typechecker/invalidEvalDivisionByZero.vadl:7:14]
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidEvalDivisionByZero.vadl:7:14
 //       │
 //     7 │ constant g = VADL::smod(10, 0)
 //       │              ^^^^^^^^^^^^^^^^^ Division by zero cannot be computed.
 //       │
 //
 //  error: Constant value required
-//       ╭──[test/resources/frontend-snapshots/typechecker/invalidEvalDivisionByZero.vadl:8:14]
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidEvalDivisionByZero.vadl:8:14
 //       │
 //     8 │ constant h = VADL::umod(10, 0)
 //       │              ^^^^^^^^^^^^^^^^^ Division by zero cannot be computed.
 //       │
 //
 //  error: Constant value required
-//       ╭──[test/resources/frontend-snapshots/typechecker/invalidEvalDivisionByZero.vadl:9:14]
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidEvalDivisionByZero.vadl:9:14
 //       │
 //     9 │ constant i = VADL::smods(10, 0)
 //       │              ^^^^^^^^^^^^^^^^^^ Division by zero cannot be computed.
 //       │
 //
 //  error: Constant value required
-//       ╭──[test/resources/frontend-snapshots/typechecker/invalidEvalDivisionByZero.vadl:10:14]
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidEvalDivisionByZero.vadl:10:14
 //       │
 //    10 │ constant j = VADL::umods(10, 0)
 //       │              ^^^^^^^^^^^^^^^^^^ Division by zero cannot be computed.

--- a/vadl/test/resources/frontend-snapshots/typechecker/invalidFormatOutOfBoundsRange.vadl
+++ b/vadl/test/resources/frontend-snapshots/typechecker/invalidFormatOutOfBoundsRange.vadl
@@ -9,7 +9,7 @@ instruction set architecture TEST = {
 //  Reported Diagnostics:
 //
 //  error: Invalid Range
-//       ╭──[test/resources/frontend-snapshots/typechecker/invalidFormatOutOfBoundsRange.vadl:3:14]
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidFormatOutOfBoundsRange.vadl:3:14
 //       │
 //     3 │   { field   [32..0]             // wrong higher offset
 //       │              ^^^^^ Provided range `32..0` out of bounds for available range `31..0`

--- a/vadl/test/resources/frontend-snapshots/typechecker/invalidFormatOverusedBitsWithTypes.vadl
+++ b/vadl/test/resources/frontend-snapshots/typechecker/invalidFormatOverusedBitsWithTypes.vadl
@@ -7,7 +7,7 @@ format f : Bits<8> =
 //  Reported Diagnostics:
 //
 //  error: Invalid Format
-//       ╭──[test/resources/frontend-snapshots/typechecker/invalidFormatOverusedBitsWithTypes.vadl:1:1]
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidFormatOverusedBitsWithTypes.vadl:1:1
 //       │
 //     1 │> format f : Bits<8> =
 //     2 │>  { first: Bits<6>

--- a/vadl/test/resources/frontend-snapshots/typechecker/invalidFormatUnusedBitsWithTypes.vadl
+++ b/vadl/test/resources/frontend-snapshots/typechecker/invalidFormatUnusedBitsWithTypes.vadl
@@ -7,7 +7,7 @@ format f : Bits<8> =
 //  Reported Diagnostics:
 //
 //  error: Invalid Format
-//       ╭──[test/resources/frontend-snapshots/typechecker/invalidFormatUnusedBitsWithTypes.vadl:1:1]
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidFormatUnusedBitsWithTypes.vadl:1:1
 //       │
 //     1 │> format f : Bits<8> =
 //     2 │> { first: Bits<3>

--- a/vadl/test/resources/frontend-snapshots/typechecker/invalidFunctionCallTooFewArgsInTypeLiteral.vadl
+++ b/vadl/test/resources/frontend-snapshots/typechecker/invalidFunctionCallTooFewArgsInTypeLiteral.vadl
@@ -10,7 +10,7 @@ function flo(x: Bits<8>) -> Bits<8> = x + 1
 //  Reported Diagnostics:
 //
 //  error: Invalid Function Call
-//       ╭──[test/resources/frontend-snapshots/typechecker/invalidFunctionCallTooFewArgsInTypeLiteral.vadl:5:26]
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidFunctionCallTooFewArgsInTypeLiteral.vadl:5:26
 //       │
 //     5 │ constant abc = 7 as Bits<flo>
 //       │                          ^^^

--- a/vadl/test/resources/frontend-snapshots/typechecker/invalidFunctionDefinitionWrongReturnType.vadl
+++ b/vadl/test/resources/frontend-snapshots/typechecker/invalidFunctionDefinitionWrongReturnType.vadl
@@ -4,7 +4,7 @@ function addOne(n: SInt<8>) -> SInt<8> = false
 //  Reported Diagnostics:
 //
 //  error: Type Mismatch
-//       ╭──[test/resources/frontend-snapshots/typechecker/invalidFunctionDefinitionWrongReturnType.vadl:1:42]
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidFunctionDefinitionWrongReturnType.vadl:1:42
 //       │
 //     1 │ function addOne(n: SInt<8>) -> SInt<8> = false
 //       │                                ------- Return type defined here as `SInt<8>`

--- a/vadl/test/resources/frontend-snapshots/typechecker/invalidIfExprConditionNoBoolTest.vadl
+++ b/vadl/test/resources/frontend-snapshots/typechecker/invalidIfExprConditionNoBoolTest.vadl
@@ -4,7 +4,7 @@ constant x = if 4 then 3 as Bits<32> else 4 as Bits<32>
 //  Reported Diagnostics:
 //
 //  error: Type Mismatch
-//       ╭──[test/resources/frontend-snapshots/typechecker/invalidIfExprConditionNoBoolTest.vadl:1:14]
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidIfExprConditionNoBoolTest.vadl:1:14
 //       │
 //     1 │ constant x = if 4 then 3 as Bits<32> else 4 as Bits<32>
 //       │              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Expected `Bool` but got `Bits<3>`.

--- a/vadl/test/resources/frontend-snapshots/typechecker/invalidMatchExprBranchesDifferentTypeInFunction.vadl
+++ b/vadl/test/resources/frontend-snapshots/typechecker/invalidMatchExprBranchesDifferentTypeInFunction.vadl
@@ -9,7 +9,7 @@ function x(n: SInt<8>) -> Bits<64> = (match n with
 //  Reported Diagnostics:
 //
 //  error: Type Mismatch
-//       ╭──[test/resources/frontend-snapshots/typechecker/invalidMatchExprBranchesDifferentTypeInFunction.vadl:3:8]
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidMatchExprBranchesDifferentTypeInFunction.vadl:3:8
 //       │
 //     3 │ , 2 => 4 as Bits<32>
 //       │        ^^^^^^^^^ note: All previous branches were of type `Bits<16>`, but this is `Bits<32>`

--- a/vadl/test/resources/frontend-snapshots/typechecker/invalidMatchExprPatternDifferentType.vadl
+++ b/vadl/test/resources/frontend-snapshots/typechecker/invalidMatchExprPatternDifferentType.vadl
@@ -9,7 +9,7 @@ constant x = match 4 as Bits<32> with
 //  Reported Diagnostics:
 //
 //  error: Type Mismatch
-//       ╭──[test/resources/frontend-snapshots/typechecker/invalidMatchExprPatternDifferentType.vadl:3:3]
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidMatchExprPatternDifferentType.vadl:3:3
 //       │
 //     3 │ , 2 as Bits<8> => 4 as Bits<16>
 //       │   ^^^^^^^^^ Expected `Bits<32>`, but got `Bits<8>`

--- a/vadl/test/resources/frontend-snapshots/typechecker/invalidMinusOnBoolean.vadl
+++ b/vadl/test/resources/frontend-snapshots/typechecker/invalidMinusOnBoolean.vadl
@@ -4,7 +4,7 @@ constant i = -true
 //  Reported Diagnostics:
 //
 //  error: Type Mismatch
-//       ╭──[test/resources/frontend-snapshots/typechecker/invalidMinusOnBoolean.vadl:1:14]
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidMinusOnBoolean.vadl:1:14
 //       │
 //     1 │ constant i = -true
 //       │              ^^^^^

--- a/vadl/test/resources/frontend-snapshots/typechecker/invalidNegateInt.vadl
+++ b/vadl/test/resources/frontend-snapshots/typechecker/invalidNegateInt.vadl
@@ -4,7 +4,7 @@ constant b = !5
 //  Reported Diagnostics:
 //
 //  error: Type Mismatch: expected `Bool`, got `Const<5>`
-//       ╭──[test/resources/frontend-snapshots/typechecker/invalidNegateInt.vadl:1:14]
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidNegateInt.vadl:1:14
 //       │
 //     1 │ constant b = !5
 //       │              ^^

--- a/vadl/test/resources/frontend-snapshots/typechecker/invalidOperationTargetIsNoInstruction.vadl
+++ b/vadl/test/resources/frontend-snapshots/typechecker/invalidOperationTargetIsNoInstruction.vadl
@@ -7,7 +7,7 @@ instruction set architecture ISA = {
 //  Reported Diagnostics:
 //
 //  error: Invalid Operation Member
-//       ╭──[test/resources/frontend-snapshots/typechecker/invalidOperationTargetIsNoInstruction.vadl:3:27]
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidOperationTargetIsNoInstruction.vadl:3:27
 //       │
 //     3 │   operation BranchOp   = {PC}                   // empty branch set, elements added by annotation
 //       │                           ^^ note: Operation members must be instructions but this was 'CounterDefinition'

--- a/vadl/test/resources/frontend-snapshots/typechecker/invalidShiftLeftConstRightExplicit.vadl
+++ b/vadl/test/resources/frontend-snapshots/typechecker/invalidShiftLeftConstRightExplicit.vadl
@@ -14,7 +14,7 @@ instruction set architecture ISA = {
 //  Reported Diagnostics:
 //
 //  error: Type Mismatch
-//       ╭──[test/resources/frontend-snapshots/typechecker/invalidShiftLeftConstRightExplicit.vadl:8:28]
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidShiftLeftConstRightExplicit.vadl:8:28
 //       │
 //     8 │    instruction I: T = A := 6 >> a
 //       │                            ^^^^^^

--- a/vadl/test/resources/frontend-snapshots/typechecker/invalidSintType.vadl
+++ b/vadl/test/resources/frontend-snapshots/typechecker/invalidSintType.vadl
@@ -4,7 +4,7 @@ constant i: SInt = 42
 //  Reported Diagnostics:
 //
 //  error: Invalid Type Notation
-//       ╭──[test/resources/frontend-snapshots/typechecker/invalidSintType.vadl:1:13]
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidSintType.vadl:1:13
 //       │
 //     1 │ constant i: SInt = 42
 //       │             ^^^^

--- a/vadl/test/resources/frontend-snapshots/typechecker/invalidTypoInCustomType.vadl
+++ b/vadl/test/resources/frontend-snapshots/typechecker/invalidTypoInCustomType.vadl
@@ -6,7 +6,7 @@ constant a: Bits2 = 0b111
 //  Reported Diagnostics:
 //
 //  error: Unknown Type `Bits2`
-//       ╭──[test/resources/frontend-snapshots/typechecker/invalidTypoInCustomType.vadl:3:13]
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidTypoInCustomType.vadl:3:13
 //       │
 //     3 │ constant a: Bits2 = 0b111
 //       │             ^^^^^ No type with that name exists.

--- a/vadl/test/resources/frontend-snapshots/typechecker/invalidUsingRedeclaresBuiltinTypes.vadl
+++ b/vadl/test/resources/frontend-snapshots/typechecker/invalidUsingRedeclaresBuiltinTypes.vadl
@@ -13,28 +13,28 @@ instruction set architecture TEST = {
 //  Reported Diagnostics:
 //
 //  error: Symbol name already used: Instruction
-//       ╭──[test/resources/frontend-snapshots/typechecker/invalidUsingRedeclaresBuiltinTypes.vadl:2:7]
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidUsingRedeclaresBuiltinTypes.vadl:2:7
 //       │
 //     2 │ using Instruction = Bits<8>
 //       │       ^^^^^^^^^^^ This name is already claimed by a built-in type.
 //       │
 //
 //  error: Symbol name already used: SInt
-//       ╭──[test/resources/frontend-snapshots/typechecker/invalidUsingRedeclaresBuiltinTypes.vadl:3:7]
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidUsingRedeclaresBuiltinTypes.vadl:3:7
 //       │
 //     3 │ using SInt = Bits<8>
 //       │       ^^^^ This name is already claimed by a built-in type.
 //       │
 //
 //  error: Symbol name already used: Bool
-//       ╭──[test/resources/frontend-snapshots/typechecker/invalidUsingRedeclaresBuiltinTypes.vadl:4:7]
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidUsingRedeclaresBuiltinTypes.vadl:4:7
 //       │
 //     4 │ using Bool = Bits<1>
 //       │       ^^^^ This name is already claimed by a built-in type.
 //       │
 //
 //  error: Symbol name already used: FetchResult
-//       ╭──[test/resources/frontend-snapshots/typechecker/invalidUsingRedeclaresBuiltinTypes.vadl:7:10]
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidUsingRedeclaresBuiltinTypes.vadl:7:10
 //       │
 //     7 │   format FetchResult: Bits<32> =
 //       │          ^^^^^^^^^^^ This name is already claimed by a built-in type.


### PR DESCRIPTION
The file URI is no longer enclosed by brackets because recent IntelliJ versions could no longer open the link. (The last bracket was now parsed as part of the URI).

Previously in some cases there wasn't a newline between two errors, making them not that readable.

The "xy lines omitted" rendering for large error messages was wrongly indented.

Some coloring improvements, to better indicate which parts are important.
<img width="769" height="322" alt="Screenshot 2026-04-17 at 12 01 09" src="https://github.com/user-attachments/assets/dd3e22ce-31d5-4ea2-a82f-180c9948b727" />

Custom highlighting for text within backticks.
<img width="902" height="134" alt="Screenshot 2026-04-17 at 12 23 39" src="https://github.com/user-attachments/assets/80e110a6-dca4-49b7-9b2b-660a8bd2e561" />
