### PR TITLE
iss: Fix >64 bit CPU reset and register dump

### DIFF
--- a/vadl/main/resources/templates/iss/target/gen-arch/cpu.c
+++ b/vadl/main/resources/templates/iss/target/gen-arch/cpu.c
@@ -24,6 +24,11 @@ const char * const [(${gen_arch_lower})]_cpu_[(${reg.name_lower})]_names[(${reg.
 {
     [(${access.body})] }
 [/]
+[# th:each="access : ${base_clear_cpu_accessors}"]
+[(${access.signature})]
+{
+    [(${access.body})] }
+[/]
 
 /* Alias accessors map unified ISS alias metadata to CPU-side helper access. */
 [# th:each="access : ${alias_cpu_read_accessors}"]
@@ -89,16 +94,13 @@ static void [(${gen_arch_lower})]_cpu_reset_hold(Object *obj, ResetType type)
     [(${gen_arch_upper})]CPU *cpu = [(${gen_arch_upper})]_CPU(cs);
     [(${gen_arch_upper})]CPUClass *vcc = [(${gen_arch_upper})]_CPU_GET_CLASS(obj);
     CPU[(${gen_arch_upper})]State *env = &cpu->env;
-    int i;
 
     if (vcc->parent_phases.hold) {
         vcc->parent_phases.hold(obj, type);
     }
 
-    [# th:each="reg, iterState : ${register_tensors}"][# th:if="${reg.index_dims.size} == 0"]
-    env->[(${reg.name_lower})] = 0; [/][/]
-    [# th:each="reg, iterState : ${register_tensors}"][# th:if="${reg.index_dims.size} > 0"]
-    memset(env->[(${reg.name_lower})], 0, sizeof(env->[(${reg.name_lower})])); [/][/]
+    [# th:each="access : ${base_clear_cpu_accessors}"]
+    [(${access.name})](env); [/]
 
 [(${reset})]
 }
@@ -300,8 +302,6 @@ static const TypeInfo [(${gen_arch_lower})]_cpu_arch_types[] = {
 
 static void [(${gen_arch_lower})]_cpu_register_types(void)
 {
-    int i;
-
     type_register_static_array([(${gen_arch_lower})]_cpu_arch_types, 1);
 }
 

--- a/vadl/main/resources/templates/iss/target/gen-arch/cpu.h
+++ b/vadl/main/resources/templates/iss/target/gen-arch/cpu.h
@@ -90,6 +90,9 @@ int [(${gen_arch_lower})]_cpu_gdb_write_register(CPUState *cpu, uint8_t *buf, in
 [# th:each="access : ${base_accessors}"]
 [(${access.signature})];
 [/]
+[# th:each="access : ${base_clear_cpu_accessors}"]
+[(${access.signature})];
+[/]
 
 // Alias register accessors consumed by unified ISS helper/procedure/exception paths.
 [# th:each="access : ${alias_cpu_read_accessors}"]

--- a/vadl/main/vadl/iss/passes/extensions/RegInfo.java
+++ b/vadl/main/vadl/iss/passes/extensions/RegInfo.java
@@ -188,6 +188,13 @@ public class RegInfo extends DefinitionExtension<RegisterTensor> implements Rend
   }
 
   /**
+   * Returns whether this register is stored as an array in the CPU state.
+   */
+  public boolean hasCpuStateArrayStorage() {
+    return isGVec() || reg().maxNumberOfAccessIndices() > 0;
+  }
+
+  /**
    * Returns the C type width for register values.
    *
    * @return the bit width of the C type

--- a/vadl/main/vadl/iss/template/target/BaseClearCpuAccessors.java
+++ b/vadl/main/vadl/iss/template/target/BaseClearCpuAccessors.java
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText : © 2026 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.iss.template.target;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import vadl.configuration.IssConfiguration;
+import vadl.iss.passes.extensions.RegInfo;
+import vadl.viam.RegisterTensor;
+import vadl.viam.Specification;
+
+/**
+ * Renders CPU-side helpers that clear base register storage.
+ */
+final class BaseClearCpuAccessors {
+
+  private BaseClearCpuAccessors() {
+  }
+
+  static List<Map<String, Object>> renderClearAccessors(Specification specification,
+                                                        IssConfiguration config) {
+    var out = new ArrayList<Map<String, Object>>();
+    specification.isa().get().registerTensors()
+        .forEach(reg -> out.add(renderClearAccessor(reg, config)));
+    return out;
+  }
+
+  private static Map<String, Object> renderClearAccessor(RegisterTensor reg,
+                                                         IssConfiguration config) {
+    var info = reg.expectExtension(RegInfo.class);
+    var regLower = reg.simpleName().toLowerCase();
+    var signature = "void cpu_clear_" + regLower + "("
+        + "CPU" + config.targetName().toUpperCase() + "State *env)";
+
+    var body = info.hasCpuStateArrayStorage()
+        ? "memset(env->" + regLower + ", 0, sizeof(env->" + regLower + "));"
+        : "env->" + regLower + " = 0;";
+
+    return Map.of(
+        "name", "cpu_clear_" + regLower,
+        "signature", signature,
+        "body", body
+    );
+  }
+}

--- a/vadl/main/vadl/iss/template/target/EmitIssCpuHeaderPass.java
+++ b/vadl/main/vadl/iss/template/target/EmitIssCpuHeaderPass.java
@@ -45,6 +45,8 @@ public class EmitIssCpuHeaderPass extends IssTemplateRenderingPass {
     var accessorRegistry = passResults.lastResultOf(IssRegisterAccessInfoRetrievalPass.class,
         IssAccessorRegistry.class);
     vars.put("base_accessors", accessorRegistry.baseAccessors());
+    vars.put("base_clear_cpu_accessors",
+        BaseClearCpuAccessors.renderClearAccessors(specification, configuration()));
     vars.put("alias_cpu_read_accessors",
         AliasCpuAccessors.renderReadAccessors(accessorRegistry, configuration()));
     vars.put("alias_cpu_write_accessors",

--- a/vadl/main/vadl/iss/template/target/EmitIssCpuSourcePass.java
+++ b/vadl/main/vadl/iss/template/target/EmitIssCpuSourcePass.java
@@ -21,6 +21,7 @@ import vadl.configuration.IssConfiguration;
 import vadl.iss.codegen.IssResetGen;
 import vadl.iss.passes.IssRegisterAccessInfoRetrievalPass;
 import vadl.iss.passes.extensions.IssAccessorRegistry;
+import vadl.iss.passes.extensions.RegInfo;
 import vadl.iss.template.IssTemplateRenderingPass;
 import vadl.pass.PassResults;
 import vadl.utils.codegen.CCodeBuilder;
@@ -51,6 +52,8 @@ public class EmitIssCpuSourcePass extends IssTemplateRenderingPass {
     vars.put("reg_dump_code", dumpRegsCode(specification));
     vars.put("reset", getResetCode(specification, accessorRegistry));
     vars.put("base_accessors", accessorRegistry.baseAccessors());
+    vars.put("base_clear_cpu_accessors",
+        BaseClearCpuAccessors.renderClearAccessors(specification, configuration()));
     vars.put("alias_cpu_read_accessors",
         AliasCpuAccessors.renderReadAccessors(accessorRegistry, configuration()));
     vars.put("alias_cpu_write_accessors",
@@ -85,8 +88,11 @@ public class EmitIssCpuSourcePass extends IssTemplateRenderingPass {
     var names = target + "_cpu_" + regLower + "_names";
 
     var dims = reg.indexDimensions();
+    var regInfo = reg.expectExtension(RegInfo.class);
 
-    if (dims.isEmpty()) {
+    if (regInfo.execClass() == RegInfo.ExecClass.HELPER_ONLY) {
+      dumpHelperOnlyRegCode(sb, reg, regLower, names, dims.size());
+    } else if (dims.isEmpty()) {
       sb.callStmt("qemu_fprintf", "f",
           "\" " + reg.simpleName() + ":    \" TARGET_FMT_lx \"\\n\"",
           "env->" + regLower);
@@ -97,33 +103,72 @@ public class EmitIssCpuSourcePass extends IssTemplateRenderingPass {
       if (isWideElement) {
         var bytesPerReg = reg.resultType().bitWidth() / 8;
         sb.varDecl("uint8_t *", "p", "(uint8_t *) env->" + regLower);
-        sb.forLoop("i", flatSize, (_) -> {
+        sb.forLoop("i", flatSize, (indexLoop) -> {
           sb.callStmt("qemu_fprintf", "f", "\" %-8s \"", names + "[i]");
-          sb.forLoop("int j = " + (bytesPerReg - 1), "j >= 0", "j--", (_) -> {
+          sb.forLoop("int j = " + (bytesPerReg - 1), "j >= 0", "j--", (byteLoop) -> {
             sb.callStmt("qemu_fprintf", "f", "\"%02x\"",
                 "*(p + i * " + bytesPerReg + " + j)");
           });
           sb.callStmt("qemu_fprintf", "f", "\"\\n\"");
         });
       } else {
-        sb.forLoop("i", flatSize, (_) -> {
+        sb.forLoop("i", flatSize, (indexLoop) -> {
           sb.callStmt("qemu_fprintf", "f", "\" %-8s \" TARGET_FMT_lx", names + "[i]",
               "env->" + regLower + "[i]");
-          sb.ifStmt("(i & 3) == 3", (_) ->
+          sb.ifStmt("(i & 3) == 3", (thenBranch) ->
               sb.callStmt("qemu_fprintf", "f", "\"\\n\"")
           );
         });
       }
     } else {
-      sb.forLoop("i", dims.getFirst().size(), (_) -> {
+      sb.forLoop("i", dims.getFirst().size(), (indexLoop) -> {
         sb.callStmt("qemu_fprintf", "f", "\" %-8s \"", names + "[i]");
         sb.varDecl("uint8_t *", "p", "(uint8_t *) env->" + regLower);
         var innerSizeBytes = reg.resultType(1).bitWidth() / 8;
-        sb.forLoop("int j = " + (innerSizeBytes - 1), "j >= 0", "j--", (_) -> {
+        sb.forLoop("int j = " + (innerSizeBytes - 1), "j >= 0", "j--", (byteLoop) -> {
           sb.callStmt("qemu_fprintf", "f", "\"%02x\"", "*(p + i * " + innerSizeBytes + " + j)");
         });
         sb.callStmt("qemu_fprintf", "f", "\"\\n\"");
       });
     }
+  }
+
+  private void dumpHelperOnlyRegCode(CCodeBuilder sb, RegisterTensor reg, String regLower,
+                                     String names, int indexDimCount) {
+    var bytesPerReg = reg.resultType(indexDimCount).bitWidth() / 8;
+    if (indexDimCount == 0) {
+      sb.callStmt("qemu_fprintf", "f", "\" " + reg.simpleName() + ":    \"");
+      sb.forLoop("int j = " + (bytesPerReg - 1), "j >= 0", "j--", (byteLoop) -> {
+        sb.callStmt("qemu_fprintf", "f", "\"%02x\"",
+            "(uint8_t) cpu_get_" + regLower + "_chunk(env, ((uint64_t) j) * 8, 8)");
+      });
+      sb.callStmt("qemu_fprintf", "f", "\"\\n\"");
+      return;
+    }
+
+    if (indexDimCount == 1) {
+      sb.forLoop("i", reg.indexDimensions().getFirst().size(), (indexLoop) -> {
+        sb.callStmt("qemu_fprintf", "f", "\" %-8s \"", names + "[i]");
+        sb.forLoop("int j = " + (bytesPerReg - 1), "j >= 0", "j--", (byteLoop) -> {
+          sb.callStmt("qemu_fprintf", "f", "\"%02x\"",
+              "(uint8_t) cpu_get_" + regLower + "_chunk(env, i, ((uint64_t) j) * 8, 8)");
+        });
+        sb.callStmt("qemu_fprintf", "f", "\"\\n\"");
+      });
+      return;
+    }
+
+    sb.appendLn("{").indent();
+    sb.varDecl("uint8_t *", "p", "(uint8_t *) env->" + regLower);
+    var bytesPerFirstIndex = reg.resultType(1).bitWidth() / 8;
+    sb.forLoop("i", reg.indexDimensions().getFirst().size(), (indexLoop) -> {
+      sb.callStmt("qemu_fprintf", "f", "\" %-8s \"", names + "[i]");
+      sb.forLoop("int j = " + (bytesPerFirstIndex - 1), "j >= 0", "j--", (byteLoop) -> {
+        sb.callStmt("qemu_fprintf", "f", "\"%02x\"",
+            "*(p + i * " + bytesPerFirstIndex + " + j)");
+      });
+      sb.callStmt("qemu_fprintf", "f", "\"\\n\"");
+    });
+    sb.unindent().appendLn("}");
   }
 }


### PR DESCRIPTION
This PR fixes a bug where the generated `reset` and register content dumping code was broken for registers >64 bit. 

This fixes compilation of the `aarch64/vprocessor.vadl` with `VL > 512`.
However, without any optimizations in place, the generation (i.e. the generated helpers) explode, which causes unusable linking times.