### PR TITLE
spec: Add hexagon spec

### DIFF
--- a/sys/hexagon/hexagon.vadl
+++ b/sys/hexagon/hexagon.vadl
@@ -81,7 +81,9 @@ instruction set architecture QDSP6 =
   alias register UTIMERHI        = C(31)   // Qtimer register (high)
 
   [next]
-  group counter PC : Address
+  // TODO: Reenable group counter
+  // group counter PC : Address
+  program counter PC : Address
 
   // Valid 64-byte pairs:
   // R1:0, R3:2, ... R29:28, R31:30
@@ -126,14 +128,17 @@ instruction set architecture QDSP6 =
       , 2 => P.P2(0) = 1
       , _ => P.P3(0) = 1
       }
-  process Pset ( reg: PredicateIndex, val: Byte ) = {
-    match (reg) with
-      { 0 => P.P0 := val
-      , 1 => P.P1 := val
-      , 2 => P.P2 := val
-      , 3 => P.P3 := val
-      }
-  }
+
+  // TODO: Reenable proces
+  // process Pset ( reg: PredicateIndex, val: Byte ) = {
+  // match (reg) with
+  //     { 0 => P.P0 := val
+  //     , 1 => P.P1 := val
+  //     , 2 => P.P2 := val
+  //     , 3 => P.P3 := val
+  //     }
+  // }
+  function Pset(reg: PredicateIndex, val: Byte) -> Word = 0
   function Pget ( reg: PredicateIndex ) -> Byte =
     match (reg) with
       { 0 => P.P0
@@ -146,12 +151,12 @@ instruction set architecture QDSP6 =
   // The encoded `imm` is actually smaller than Word, usually between 6 and 16 bits
   function extendU(imm: UWord) -> UWord = imm
   function extendS(imm: SWord) -> SWord = imm
-  function extendUExtender(imm: UWord, extender: Bits<26>) -> UWord = (extender, imm as Bits<6>)
-  function extendSExtender(imm: SWord, extender: Bits<26>) -> SWord = (extender, imm as Bits<6>)
+  function extendUExtender(imm: UWord, extender: Bits<26>) -> UWord = (extender, imm as Bits<6>) as UWord
+  function extendSExtender(imm: SWord, extender: Bits<26>) -> SWord = (extender, imm as Bits<6>) as SWord
   // e.g. for `call #r22:2`
   function extendR2(imm: SWord) -> SWord = scaledImmR2(imm)
   // "When constant extenders are used, scaled immediates are not scaled by the processor"
-  function extendR2Extender(imm: SWord, extender: Bits<26>) -> SWord = align32((extender, imm as Bits<6>))
+  function extendR2Extender(imm: SWord, extender: Bits<26>) -> SWord = align32((extender, imm as Bits<6>) as SWord)
 
   function toPValue(v: Bool) -> Byte = if v then 0xff else 0x00
 
@@ -179,6 +184,7 @@ instruction set architecture QDSP6 =
     , c      [13]
     , t5     [12..8]
     , d5     [4..0]
+    , unused [7..5]
     }
 
   // ----------------------------------  operation ALU32/ALU ---------------------------------
@@ -203,6 +209,7 @@ instruction set architecture QDSP6 =
     , parse  [15..14]
     , imm    [23..22, 20..16, 13..5]
     , d5     [4..0]
+    , unused [21]
     , immS   = imm as UInt<16>
     }
 
@@ -217,7 +224,10 @@ instruction set architecture QDSP6 =
     , parse   [47..46]
     , imm     [55..54, 52..48, 45..37]
     , d5      [36..32]
-    , immS    = extendSExtender(imm, immX)
+    // TODO: Reenable and delete the second line
+    // , immS    = extendSExtender(imm as SWord, immX)
+    , immS    = imm as SWord
+    , unused  [53]
     }
 
   model TransferBase ( name: Id, iformat: Id, encs: Encs, asmprefix: Ex, asmpostfix: Ex, dst: Ex, val: Ex, asm: Ex ) : IsaDefs = {
@@ -233,7 +243,7 @@ instruction set architecture QDSP6 =
   $TransferBase( TransferImmLow ; TransferImmHalfFormat; rs=0b0, majop=0b001, minop=0b1  ; ""              ; ".L"; x5; (R(x5) & 0xFFFF0000) | (immU as UInt<32>);            ("#", decimal(immU)))
   $TransferBase( TransferImmHigh; TransferImmHalfFormat; rs=0b0, majop=0b010, minop=0b1  ; ""              ; ".H"; x5; (R(x5) & 0x0000FFFF) | ((immU as UInt<32>) << 16);    ("#", decimal(immU)))
   $TransferBase( TransferImm    ; TransferImmFormat    ; rs=0b1, majop=0b000             ; ""              ; ""  ; d5; immS;                                                 ("#", decimal(immS)))
-  $TransferBase( TransferImmX   ; TransferImmXFormat   ; rs=0b1, majop=0b000, iclassX=0  ; AsmImmextU(immX); ""  ; d5; immS;                                                 ("#", decimal(immS)))
+  $TransferBase( TransferImmX   ; TransferImmXFormat   ; rs=0b1, majop=0b000, iclassX=0  ; AsmImmextU(immX as Word); ""  ; d5; immS;                                                 ("#", decimal(immS)))
   $TransferBase( TransferReg    ; StandardFormat       ; c=0b0, majop=0b0000, minop=0b011; ""              ; ""  ; d5; R(s5);                                                AsmR(s5))
 
   format AddImmFormat : Word =
@@ -261,6 +271,7 @@ instruction set architecture QDSP6 =
     , s5     [20..16]
     , t5     [12..8]
     , d5     [4..0]
+    , unused [13, 7..5]
     }
 
   model ALUBase ( name: Id, iformat: Id, encs: Encs, op: Id, lhs: Ex, rhs: Ex, asm: Ex ) : IsaDefs = {
@@ -273,11 +284,11 @@ instruction set architecture QDSP6 =
     assembly $name = (AsmR(d5), " = ", AsStr(op), "(", $asm, ")")
   }
 
-  $ALUBase ( AddImm    ; AddImmFormat ; iclass=0b1011                               ; add   ; R(s5); extendS(imm) ; (AsmR(s5),",#",decimal(imm)) )
+  $ALUBase ( AddImm    ; AddImmFormat ; iclass=0b1011                               ; add   ; R(s5); extendS(imm as SWord) ; (AsmR(s5),",#",decimal(imm)) )
   $ALUBase ( AddReg    ; ALURegFormat ; iclass=0b1111, p=0, majop=0b011, minop=0b000; add   ; R(s5); R(t5)        ; (AsmR(s5),"," ,AsmR(t5))     )
   // TODO @nmischkulnig missing builtin VADL::satadd
   // $AddBase ( AddRegSat ; ALURegFormat ; iclass=0b1111, p=0, majop=0b110, minop=0b010; satadd; R(s5)         ; R(t5); (AsmR(s5),",#",AsmR(t5))     )
-  $ALUBase ( SubImm    ; ALUImmFormat ; iclass=0b0111,      majop=0b0110, minop=0b01; sub   ; extendS(imm)  ; R(s5); (decimal(imm),",#",AsmR(s5)))
+  $ALUBase ( SubImm    ; ALUImmFormat ; iclass=0b0111,      majop=0b0110, minop=0b01; sub   ; extendS(imm as SWord)  ; R(s5); (decimal(imm),",#",AsmR(s5)))
   $ALUBase ( SubReg    ; ALURegFormat ; iclass=0b1111, p=0, majop=0b011, minop=0b001; sub   ; R(t5)         ; R(s5); (AsmR(t5),"," ,AsmR(s5))    )
   // TODO @nmischkulnig missing builtin VADL::satsub
   // $ALUBase ( SubRegSat ; ALURegFormat ; iclass=0b1111, p=0, majop=0b110, minop=0b110; satsub; R(t5)         ; R(s5); (AsmR(t5),"#", AsmR(s5))    )
@@ -287,8 +298,8 @@ instruction set architecture QDSP6 =
   $ALUBase( XorReg ; StandardFormat; iclass = 0b1111, majop = 0b0001, minop = 0b011 ; xor ;           R(s5)  ; R(t5)       ; (AsmR(s5),"," ,AsmR(t5)) )
   $ALUBase( AndNReg; StandardFormat; iclass = 0b1111, majop = 0b0001, minop = 0b100 ; and ; VADL::not(R(s5)) ; R(t5)       ; (AsmR(t5),",~",AsmR(s5)) )
   $ALUBase( OrNReg ; StandardFormat; iclass = 0b1111, majop = 0b0001, minop = 0b101 ; or  ; VADL::not(R(s5)) ; R(t5)       ; (AsmR(t5),",~",AsmR(s5)) )
-  $ALUBase( AndImm ; ALUImmFormat  ; iclass = 0b0111, majop = 0b0110, minop = 0b00  ; and ;           R(s5)  ; extendS(imm); (AsmR(s5),",#",decimal(imm)) )
-  $ALUBase( OrImm  ; ALUImmFormat  ; iclass = 0b0111, majop = 0b0110, minop = 0b10  ; or  ;           R(s5)  ; extendS(imm); (AsmR(s5),",#",decimal(imm)) )
+  $ALUBase( AndImm ; ALUImmFormat  ; iclass = 0b0111, majop = 0b0110, minop = 0b00  ; and ;           R(s5)  ; extendS(imm as SWord); (AsmR(s5),",#",decimal(imm)) )
+  $ALUBase( OrImm  ; ALUImmFormat  ; iclass = 0b0111, majop = 0b0110, minop = 0b10  ; or  ;           R(s5)  ; extendS(imm as SWord); (AsmR(s5),",#",decimal(imm)) )
 
   // TODO: Reenable this annotation
 
@@ -336,6 +347,7 @@ instruction set architecture QDSP6 =
     , s5     [20..16]
     , t5     [12..8]
     , d2     [1..0]
+    , unused [23, 13, 7..5]
     }
 
   model CmpBase ( name: Id, iformat: Id, encs: Encs, cond: Ex, asm: Ex ) : IsaDefs = {
@@ -343,7 +355,8 @@ instruction set architecture QDSP6 =
     // [ operation ALU32_PRED_WRITING ]
     instruction $name : $iformat = {
       let val = toPValue($cond) in {
-        Pset(d2, val)
+        // TODO: Renable this call
+        // Pset(d2, val)
       }
     }
     encoding $name = { op=0b00, $encs }
@@ -353,7 +366,8 @@ instruction set architecture QDSP6 =
   $CmpBase( CmpImmEq  ; CmpImmFormat ; iclass = 0b0111, rs=0, majop = 0b101, minop = 0b00, neg = 0b0;  (R(s5) = extendS(immS)); ( "cmp.eq(" ,AsmR(s5),",#",decimal(immS),")") )
   $CmpBase( CmpImmNeq ; CmpImmFormat ; iclass = 0b0111, rs=0, majop = 0b101, minop = 0b00, neg = 0b1; !(R(s5) = extendS(immS)); ("!cmp.eq(" ,AsmR(s5),",#",decimal(immS),")") )
   $CmpBase( CmpImmGt  ; CmpImmFormat ; iclass = 0b0111, rs=0, majop = 0b101, minop = 0b01, neg = 0b0;  (R(s5) as SInt) > extendS(immS); ( "cmp.gt(" ,AsmR(s5),",#",decimal(immS),")") )
-  $CmpBase( CmpImmLte ; CmpImmFormat ; iclass = 0b0111, rs=0, majop = 0b101, minop = 0b01, neg = 0b1; !(R(s5) as SInt) > extendS(immS); ("!cmp.gt(" ,AsmR(s5),",#",decimal(immS),")") )
+  // TODO: Reenable this macro call
+  //$CmpBase( CmpImmLte ; CmpImmFormat ; iclass = 0b0111, rs=0, majop = 0b101, minop = 0b01, neg = 0b1; !(R(s5) as SInt) > extendS(immS); ("!cmp.gt(" ,AsmR(s5),",#",decimal(immS),")") )
   $CmpBase( CmpImmGtu ; CmpImmUFormat; iclass = 0b0111, rs=0, majop = 0b101, minop = 0b100, neg = 0b0; (R(s5) as UInt) > extendU(immU); ( "cmp.gtu(",AsmR(s5),",#",decimal(immU),")") )
   $CmpBase( CmpImmLteu; CmpImmUFormat; iclass = 0b0111, rs=0, majop = 0b101, minop = 0b100, neg = 0b1; (R(s5) as UInt) > extendU(immU); ("!cmp.gtu(",AsmR(s5),",#",decimal(immU),")") )
 
@@ -375,6 +389,7 @@ instruction set architecture QDSP6 =
     , op     [13]
     , imm    [12..5]
     , d5     [4..0]
+    , unused [23]
     , immS   = imm as SWord
     }
   format CombineImmFormat : Word =
@@ -399,6 +414,7 @@ instruction set architecture QDSP6 =
     , s5     [20..16]
     , t5     [12..8]
     , d5     [4..0]
+    , unused [13, 7..5]
     }
 
   model CombineWordBase ( name: Id, iformat: Id, encs: Encs, vhigh: Ex, vlow: Ex, asm: Ex ) : IsaDefs = {
@@ -421,8 +437,8 @@ instruction set architecture QDSP6 =
     assembly $name = (AsmRR(d5), "=combine(", $asm, ")")
   }
 
-  $CombineDoubleBase( CombineDoubleRegImm; CombineRegImmFormat; iclass=0b0111, rs=0, majop=0b011, minop=0b00, op=1; R(rs); extendS(immS); (AsmR(rs),",#",decimal(immS)))
-  $CombineDoubleBase( CombineDoubleImmReg; CombineRegImmFormat; iclass=0b0111, rs=0, majop=0b011, minop=0b01, op=1; extendS(immS); R(rs); ("#",decimal(immS),",",AsmR(rs)))
+  $CombineDoubleBase( CombineDoubleRegImm; CombineRegImmFormat; iclass=0b0111, rs=0, majop=0b011, minop=0b00, op=1; R(rs); extendS(immS); (AsmR(rs as Index),",#",decimal(immS)))
+  $CombineDoubleBase( CombineDoubleImmReg; CombineRegImmFormat; iclass=0b0111, rs=0, majop=0b011, minop=0b01, op=1; extendS(immS); R(rs); ("#",decimal(immS),",",AsmR(rs as Index)))
   $CombineDoubleBase( CombineDoubleImmSS ; CombineImmFormat   ; iclass=0b0111, rs=1, majop=0b100, minop=0b0 ; extendS(immhighS); immlowS; ("#",decimal(immhighS),",#",decimal(immlowS)))
   $CombineDoubleBase( CombineDoubleImmSU ; CombineImmFormat   ; iclass=0b0111, rs=1, majop=0b100, minop=0b1 ; extendS(immhighS); immlowU; ("#",decimal(immhighS),",#",decimal(immlowU)))
 
@@ -459,6 +475,7 @@ instruction set architecture QDSP6 =
     , ps     [7]
     , u2     [6..5]
     , d5     [4..0]
+    , unused [22]
     }
 
   model ALUPredBase ( name: Id, iformat: Id, encs: Encs, op: Id, lhs: Ex, rhs: Ex, asmprefix: Ex, asm: Ex, pred: Ex ) : IsaDefs = {
@@ -471,10 +488,10 @@ instruction set architecture QDSP6 =
     assembly $name = ($asmprefix, AsmR(d5), " = ", AsStr($op), "(", $asm, ")")
   }
 
-  $ALUPredBase( AddImmPredPos; AddPredImmFormat; iclass=0b0111, rs=0, majop=0b100, ps=0, dn=0; add; R(s5); extendS(immS); AsmPred(u2, false, false); (AsmR(s5),",#",decimal(immS));  testpred(u2))
-  // $ALUPredBase( AddImmPred; AddPredImmFormat; iclass=0b0111, rs=0, majop=0b100, ps=0, dn=1; add; R(s5); extendS(immS); AsmPred(u2, false, true ); (AsmR(s5),",#",decimal(immS));  testpred(u2))
-  $ALUPredBase( AddImmPredNeg; AddPredImmFormat; iclass=0b0111, rs=0, majop=0b100, ps=1, dn=0; add; R(s5); extendS(immS); AsmPred(u2, true , false); (AsmR(s5),",#",decimal(immS)); !testpred(u2))
-  // $ALUPredBase( AddImmPred; AddPredImmFormat; iclass=0b0111, rs=0, majop=0b100, ps=1, dn=1; add; R(s5); extendS(immS); AsmPred(u2, true , true ); (AsmR(s5),",#",decimal(immS)); !testpred(u2))
+  $ALUPredBase( AddImmPredPos; AddPredImmFormat; iclass=0b0111, rs=0, majop=0b100, ps=0, dn=0; add; R(s5); extendS(immS as SWord); AsmPred(u2, false, false); (AsmR(s5),",#",decimal(immS));  testpred(u2))
+  // $ALUPredBase( AddImmPred; AddPredImmFormat; iclass=0b0111, rs=0, majop=0b100, ps=0, dn=1; add; R(s5); extendS(immS as SWord); AsmPred(u2, false, true ); (AsmR(s5),",#",decimal(immS));  testpred(u2))
+  $ALUPredBase( AddImmPredNeg; AddPredImmFormat; iclass=0b0111, rs=0, majop=0b100, ps=1, dn=0; add; R(s5); extendS(immS as SWord); AsmPred(u2, true , false); (AsmR(s5),",#",decimal(immS)); !testpred(u2))
+  // $ALUPredBase( AddImmPred; AddPredImmFormat; iclass=0b0111, rs=0, majop=0b100, ps=1, dn=1; add; R(s5); extendS(immS as SWord); AsmPred(u2, true , true ); (AsmR(s5),",#",decimal(immS)); !testpred(u2))
 
   $ALUPredBase( AddRegPredPos; ALUPredRegFormat; iclass=0b1111, p=1, majop=0b011, minop=0b00, dn=0, ps=0; add; R(s5); R(t5); AsmPred(u2, false, false); (AsmR(s5),",",AsmR(t5));  testpred(u2))
   $ALUPredBase( AddRegPredNeg; ALUPredRegFormat; iclass=0b1111, p=1, majop=0b011, minop=0b00, dn=0, ps=1; add; R(s5); R(t5); AsmPred(u2, true , false); (AsmR(s5),",",AsmR(t5)); !testpred(u2))
@@ -532,7 +549,8 @@ instruction set architecture QDSP6 =
     , op     [27..16]
     , imm    [12..7]
     , d5     [4..0]
-    , immU   = extendU(imm)
+    , unused [13, 6..5]
+    , immU   = extendU(imm as UWord)
     }
   format AddRegPCXFormat : Double =
     { iclassX [31..28]
@@ -544,19 +562,23 @@ instruction set architecture QDSP6 =
     , op     [59..48]
     , imm    [44..39]
     , d5     [36..32]
-    , immU   = extendUExtender(imm, immX)
+    , unused [45, 38..37]
+    // TODO: Renable this statement and delete the bottom line
+    // , immU   = extendUExtender(imm as UWord, immX)
+    , immU   = imm as UWord
     }
   model AddRegPCBase ( name: Id, iformat: Id, encs: Encs, asmPrefix: Ex, asmimm: Id ) : IsaDefs = {
     // TODO: Reenable this annotation
     // [ operation CR ]
     instruction $name : $iformat = {
-      R(d5) := PC.current + immU
+      // TODO: Reenable this subcall
+      //R(d5) := PC.current + immU
     }
     encoding $name = { iclass = 0b0110, op = 0b101001001001, $encs }
     assembly $name = ($asmPrefix, AsmR(d5), "=add(pc,", $asmimm(immU),")")
   }
   $AddRegPCBase( AddRegPC ; AddRegPCFormat ; /* unneeded */ iclass=0b0110; ""              ; AsmImmU )
-  $AddRegPCBase( AddRegPCX; AddRegPCXFormat; iclassX=0    ; AsmImmextU(immX); AsmImmUX )
+  $AddRegPCBase( AddRegPCX; AddRegPCXFormat; iclassX=0    ; AsmImmextU(immX as Word); AsmImmUX )
 
   format LogicalPredFormat : Word =
     { iclass [31..28]
@@ -567,13 +589,15 @@ instruction set architecture QDSP6 =
     , t2     [9..8]
     , u2     [7..6]
     , d2     [1..0]
+    , unused [19..18, 12..10, 5..2]
     }
   // This instruction may execute on either slot2 or slot3, even though it is a CR-type
   model LogicalPredBase ( name: Id, encs: Encs, val: Ex, asm: Ex ) : IsaDefs = {
     // TODO: Reenable this annotation
     // [ operation CR23 ]
     instruction $name : LogicalPredFormat = {
-      Pset(d2, $val)
+      // TODO: Reeable this call
+      //Pset(d2, $val)
     }
     encoding $name = { iclass = 0b0110, opc = 0b10110, $encs }
     assembly $name = (AsmP(d2), "=", $asm)
@@ -605,6 +629,7 @@ instruction set architecture QDSP6 =
     , u2     [9,8]
     , s5     [20..16]
     , hintnew[12..11]
+    , unused [13, 10, 7..0]
     }
 
   model CallRegBase ( name: Id, encs: Encs, asm: Ex, pred: Ex ) : IsaDefs = {
@@ -650,7 +675,8 @@ instruction set architecture QDSP6 =
     , parse  [15..14]
     , op     [27..25]
     , imm    [24..16,13..1]
-    , immS = scaledImmR2(imm)
+    , unused [0]
+    , immS = scaledImmR2(imm as SWord)
     }
   format JumpImmPredFormat : Word =
     { iclass [31..28]
@@ -659,7 +685,8 @@ instruction set architecture QDSP6 =
     , hintnew[12..11]
     , imm    [23..22,20..16,13,7..1]
     , u2     [9..8]
-    , immS = scaledImmR2(imm)
+    , unused [10, 0]
+    , immS = scaledImmR2(imm as SWord)
     }
 
   model JumpImmBase ( name: Id, iformat: Id, encs: Encs, asmprefix: Ex, asmpostfix: Ex, pred: Ex ) : IsaDefs = {
@@ -667,7 +694,8 @@ instruction set architecture QDSP6 =
     // [ operation J ]
     instruction $name : $iformat = {
       if $pred then {
-        PC := PC.current + extendR2(imm)
+        // TODO: Reebable once this subcall is implemented
+        // PC := PC.current + extendR2(imm)
       }
     }
     encoding $name = { $encs }
@@ -693,6 +721,7 @@ instruction set architecture QDSP6 =
     , pred   [9,8]
     , neg    [21]
     , imm    [23,22,20..16,13,7..1]
+    , unused [12, 10, 0]
     }
 
   model CallImmBase ( name: Id, iformat: Id, encs: Encs, asm: Ex, pred: Ex ) : IsaDefs = {
@@ -701,7 +730,8 @@ instruction set architecture QDSP6 =
     instruction $name : $iformat = {
       if $pred then {
         LR := PC.next
-        PC := PC.current + extendR2(imm)
+        // TODO: Reenable once this subcall is implemented
+        //PC := PC.current + extendR2(imm)
       }
     }
     encoding $name = { iclass = 0b0101, $encs }
@@ -721,7 +751,8 @@ instruction set architecture QDSP6 =
     , hint   [13]
     , s4     [19..16]
     , disp   [21..20,7..1]
-    , dispS  = scaledImmR2(disp)
+    , unused [12..10, 0]
+    , dispS  = scaledImmR2(disp as SWord)
     // Available registers are R0-R7 and R16-R23
     , s5     = if s4 <= 7 then (s4 as Index) else ((s4 as Index) + 8)
     , d2     = d1 as PredicateIndex // for the constraints
@@ -736,8 +767,9 @@ instruction set architecture QDSP6 =
     , s4     [19..16]
     , imm    [12..8]
     , disp   [21..20,7..1]
+    , unused [0]
     , immU   = imm as UWord
-    , dispS  = scaledImmR2(disp)
+    , dispS  = scaledImmR2(disp as SWord)
     // Available registers are R0-R7 and R16-R23
     , s5     = if s4 <= 7 then (s4 as Index) else ((s4 as Index) + 8)
     , d2     = d1 as PredicateIndex // for the constraints
@@ -752,7 +784,8 @@ instruction set architecture QDSP6 =
     , s4     [19..16]
     , t4     [11..8]
     , disp   [21..20,7..1]
-    , dispS  = scaledImmR2(disp)
+    , unused [0]
+    , dispS  = scaledImmR2(disp as SWord)
     // Available registers are R0-R7 and R16-R23
     , s5     = if s4 <= 7 then (s4 as Index) else ((s4 as Index) + 8)
     , t5     = if t4 <= 7 then (t4 as Index) else ((t4 as Index) + 8)
@@ -765,9 +798,11 @@ instruction set architecture QDSP6 =
     instruction $name : $iformat = {
       let pred   = $predEx in
       let pvalue = toPValue($predEx) in {
-        Pset($p, pvalue)
+        // TODO: Reenable this call
+        // Pset($p, pvalue)
         if pred then {
-          PC := PC.current + extendR2(disp)
+          // TODO: Reenable subcall
+          // PC := PC.current + extendR2(disp)
         }
       }
     }
@@ -786,7 +821,7 @@ instruction set architecture QDSP6 =
   }
 
   $CmpJump( CmpJumpEqMinus1; CmpJumpFormat   ; op=0b001100;  R(s5)          =  -1            ; ("cmp.eq(",AsmR(s5),"#-1)") )
-  $CmpJump( CmpJumpGtMinus1; CmpJumpFormat   ; op=0b001101; (R(s5) as SInt) > (-1 as SInt)   ; ("cmp.gt(",AsmR(s5),"#-1)") )
+  $CmpJump( CmpJumpGtMinus1; CmpJumpFormat   ; op=0b001101; (R(s5) as SInt) > (-1 as SWord)  ; ("cmp.gt(",AsmR(s5),"#-1)") )
   $CmpJump( CmpJumpTstBit0 ; CmpJumpFormat   ; op=0b001111; (R(s5) & 0b1)   = 1              ; ("tstbit(",AsmR(s5),"#0)") )
   $CmpJump( CmpJumpEqImm   ; CmpJumpImmFormat; op=0b0000  ;  R(s5)          = immU           ; ("cmp.eq(",AsmR(s5),"#",decimal(immU),")") )
   $CmpJump( CmpJumpGtImm   ; CmpJumpImmFormat; op=0b0001  ; (R(s5)(15..0) as UWord) > immU   ; ("cmp.gt(",AsmR(s5),"#",decimal(immU),")") )
@@ -832,7 +867,7 @@ instruction set architecture QDSP6 =
     // [ operation LD ]
     instruction $name : $iformat = {
       if $pred then {
-        R(d5) := MEM<$size>($addr) as $type
+        R(d5) := MEM<$size>($addr) as $type as Word
       }
     }
     encoding $name = { $encs }
@@ -854,14 +889,14 @@ instruction set architecture QDSP6 =
   }
 
   model LoadBase ( base: LoadBaseT, name: Id, type: Id, size: Lit, scale: Lit, asmfunc: Ex) : IsaDefs = {
-    $base( AsId( $name, AsStr($type), "GPRel" )        ; LoadFormat          ; iclass=0b0100, gp=1, type1=0b1,      type=MemoryAccessType::$type, unsigned=0; $size; GP + scaledImmU(immGPRel, $scale)    ; AsId(S, AsStr($type)); ""; ($asmfunc, AsmAddrGPRel(immGPRel))       ; true )
-    $base( AsId( $name, AsStr($type), "RegRel" )       ; LoadFormat          ; iclass=0b1001, gp=0, type1=0b1,      type=MemoryAccessType::$type, unsigned=0; $size; R(s5) + scaledImmS(immRegRel, $scale); AsId(S, AsStr($type)); ""; ($asmfunc, AsmAddrRegRel(s5, immRegRel)) ; true )
-    $base( AsId( $name, AsStr($type), "PredPosRegRel" ); LoadRegRelPredFormat; iclass=0b0100, op=0b010, dn=0, ps=0, type=MemoryAccessType::$type, unsigned=0; $size; R(s5) + scaledImmS(immRegRel, $scale); AsId(S, AsStr($type)); AsmPred(t2, false, false); ($asmfunc, AsmAddrRegRel(s5, immRegRel)) ;  testpred(t2) )
-    $base( AsId( $name, AsStr($type), "PredNegRegRel" ); LoadRegRelPredFormat; iclass=0b0100, op=0b010, dn=0, ps=1, type=MemoryAccessType::$type, unsigned=0; $size; R(s5) + scaledImmS(immRegRel, $scale); AsId(S, AsStr($type)); AsmPred(t2, true , false); ($asmfunc, AsmAddrRegRel(s5, immRegRel)) ; !testpred(t2) )
+    $base( AsId( $name, AsStr($type), "GPRel" )        ; LoadFormat          ; iclass=0b0100, gp=1, type1=0b1,      type=MemoryAccessType::$type, unsigned=0; $size; GP + scaledImmU(immGPRel as SWord, $scale)    ; AsId(S, AsStr($type)); ""; ($asmfunc, AsmAddrGPRel(immGPRel))       ; true )
+    $base( AsId( $name, AsStr($type), "RegRel" )       ; LoadFormat          ; iclass=0b1001, gp=0, type1=0b1,      type=MemoryAccessType::$type, unsigned=0; $size; R(s5) + scaledImmS(immRegRel as SWord, $scale); AsId(S, AsStr($type)); ""; ($asmfunc, AsmAddrRegRel(s5, immRegRel as SInt<11>)) ; true )
+    $base( AsId( $name, AsStr($type), "PredPosRegRel" ); LoadRegRelPredFormat; iclass=0b0100, op=0b010, dn=0, ps=0, type=MemoryAccessType::$type, unsigned=0; $size; R(s5) + scaledImmS(immRegRel as SWord, $scale); AsId(S, AsStr($type)); AsmPred(t2, false, false); ($asmfunc, AsmAddrRegRel(s5, immRegRel as SInt<11>)) ;  testpred(t2) )
+    $base( AsId( $name, AsStr($type), "PredNegRegRel" ); LoadRegRelPredFormat; iclass=0b0100, op=0b010, dn=0, ps=1, type=MemoryAccessType::$type, unsigned=0; $size; R(s5) + scaledImmS(immRegRel as SWord, $scale); AsId(S, AsStr($type)); AsmPred(t2, true , false); ($asmfunc, AsmAddrRegRel(s5, immRegRel as SInt<11>)) ; !testpred(t2) )
   }
   model LoadBaseU (base: LoadBaseT, name: Id, type: Id, size: Lit, scale: Lit, asmfunc: Ex) : IsaDefs = {
-    $base( AsId( $name, "U", AsStr($type), "GPRel" ) ; LoadFormat; iclass=0b0100, gp=1, type1=0b1, type=MemoryAccessType::$type, unsigned=1; $size; GP + scaledImmU(immGPRel, $scale)    ; AsId(U, AsStr($type)); ""; ($asmfunc, AsmAddrGPRel(immGPRel))       ; true )
-    $base( AsId( $name, "U", AsStr($type), "RegRel" ); LoadFormat; iclass=0b1001, gp=0, type1=0b1, type=MemoryAccessType::$type, unsigned=1; $size; R(s5) + scaledImmS(immRegRel, $scale); AsId(U, AsStr($type)); ""; ($asmfunc, AsmAddrRegRel(s5, immRegRel)) ; true )
+    $base( AsId( $name, "U", AsStr($type), "GPRel" ) ; LoadFormat; iclass=0b0100, gp=1, type1=0b1, type=MemoryAccessType::$type, unsigned=1; $size; GP + scaledImmU(immGPRel as SWord, $scale)    ; AsId(U, AsStr($type)); ""; ($asmfunc, AsmAddrGPRel(immGPRel))       ; true )
+    $base( AsId( $name, "U", AsStr($type), "RegRel" ); LoadFormat; iclass=0b1001, gp=0, type1=0b1, type=MemoryAccessType::$type, unsigned=1; $size; R(s5) + scaledImmS(immRegRel as SWord, $scale); AsId(U, AsStr($type)); ""; ($asmfunc, AsmAddrRegRel(s5, immRegRel)) ; true )
   }
 
   $LoadBase ( LoadSizeBase;   Load ; Byte   ; 1 ; 0; "memb"  )
@@ -883,6 +918,7 @@ instruction set architecture QDSP6 =
     , hintnew  [12..11]
     , op1      [10]
     , pred     [9..8]
+    , unused   [7..5]
     }
 
   // TODO: Reenable this annotation
@@ -964,12 +1000,12 @@ instruction set architecture QDSP6 =
   }
 
   model StoreBase   ( base: StoreBaseT, name: Id, type: Id, size: Lit, scale: Lit, asmfunc: Ex) : IsaDefs = {
-    $base( AsId( $name, AsStr($type), "GPRel" )      ; iclass=0b0100, gp=1, type1=0, type=MemoryAccessType::$type, unsigned = 0; $size; GP + scaledImmU(immGPRel, $scale)    ; $type; 0        ; ($asmfunc, AsmAddrGPRel(immGPRel))       ; "")
-    $base( AsId( $name, AsStr($type), "RegRel" )     ; iclass=0b1010, gp=0, type1=1, type=MemoryAccessType::$type, unsigned = 0; $size; R(s5) + scaledImmS(immRegRel, $scale); $type; 0        ; ($asmfunc, AsmAddrRegRel(s5, immRegRel)) ; "")
+    $base( AsId( $name, AsStr($type), "GPRel" )      ; iclass=0b0100, gp=1, type1=0, type=MemoryAccessType::$type, unsigned = 0; $size; GP + scaledImmU(immGPRel as SWord, $scale)    ; $type; 0        ; ($asmfunc, AsmAddrGPRel(immGPRel))       ; "")
+    $base( AsId( $name, AsStr($type), "RegRel" )     ; iclass=0b1010, gp=0, type1=1, type=MemoryAccessType::$type, unsigned = 0; $size; R(s5) + scaledImmS(immRegRel as SWord, $scale); $type; 0        ; ($asmfunc, AsmAddrRegRel(s5, immRegRel)) ; "")
   }
   model StoreBaseHigh( base: StoreBaseT, name: Id, type: Id, size: Lit, scale: Lit, asmfunc: Ex) : IsaDefs = {
-    $base( AsId( $name, "H", AsStr($type), "GPRel" ) ; iclass=0b0100, gp=1, type1=0, type=MemoryAccessType::$type, unsigned = 1; $size; GP + scaledImmU(immGPRel, $scale)    ; $type; $size * 8; ($asmfunc, AsmAddrGPRel(immGPRel))       ; ".H")
-    $base( AsId( $name, "H", AsStr($type), "RegRel" ); iclass=0b1010, gp=0, type1=1, type=MemoryAccessType::$type, unsigned = 1; $size; R(s5) + scaledImmS(immRegRel, $scale); $type; $size * 8; ($asmfunc, AsmAddrRegRel(s5, immRegRel)) ; ".H")
+    $base( AsId( $name, "H", AsStr($type), "GPRel" ) ; iclass=0b0100, gp=1, type1=0, type=MemoryAccessType::$type, unsigned = 1; $size; GP + scaledImmU(immGPRel as SWord, $scale)    ; $type; $size * 8; ($asmfunc, AsmAddrGPRel(immGPRel))       ; ".H")
+    $base( AsId( $name, "H", AsStr($type), "RegRel" ); iclass=0b1010, gp=0, type1=1, type=MemoryAccessType::$type, unsigned = 1; $size; R(s5) + scaledImmS(immRegRel as SWord, $scale); $type; $size * 8; ($asmfunc, AsmAddrRegRel(s5, immRegRel)) ; ".H")
   }
 
   $StoreBase    ( StoreSizeBase ;  Store ; Byte ;   1 ; 0; "memb"  )
@@ -986,8 +1022,9 @@ instruction set architecture QDSP6 =
     , s5        [20..16]
     , immOffset [12..7]
     , imm       [13,6..0]
+    , unused    [24..23]
     , immOffsetU= immOffset as UInt
-    , immS      = extendS(imm)
+    , immS      = extendS(imm as SWord)
     // , d2       = imm(6..5) as PredicateIndex
     // , immSPred = (imm(6),imm(4..0)) as PredicateIndex
     }
@@ -1003,8 +1040,12 @@ instruction set architecture QDSP6 =
     , s5        [52..48]
     , immOffset [44..39]
     , imm       [45,38..32]
+    , unused    [56..55]
     , immOffsetU= immOffset as UInt
-    , immS      = extendSExtender(imm, immX)
+    // TODO: Reenable this line and delete the bottom one
+    //, immS      = extendSExtender(imm as SWord, immX)
+    , immS      = imm as SWord
+
     // , d2       = imm(6..5) as PredicateIndex
     // , immSPred = (imm(6),imm(4..0)) as PredicateIndex
     }
@@ -1013,18 +1054,18 @@ instruction set architecture QDSP6 =
     // TODO: Reenable this annotation
     // [ operation ST ]
     instruction $name : $iformat = {
-      if $pred then MEM<$size>( R(s5) + scaledImmU(immOffsetU, $scale) ) := $imm
+      if $pred then MEM<$size>( R(s5) + scaledImmU(immOffsetU as SWord, $scale) ) := $imm
     }
     encoding $name = { iclass = 0b0011, type=MemoryAccessType::$type, $encs }
-    assembly $name = ($asmprefix,"(",AsmR(s5),"+#",decimal(scaledImmU(immOffsetU, $scale)),")", "=#", decimal($imm))
+    assembly $name = ($asmprefix,"(",AsmR(s5),"+#",decimal(scaledImmU(immOffsetU as SWord, $scale)),")", "=#", decimal($imm))
   }
 
   $StoreImmSizeBase( StoreImmByte ; StoreImmFormat ; Byte;            amode = 0b110 ; 1 ; 0; immS as SByte; "memb" ; true )
   $StoreImmSizeBase( StoreImmHalf ; StoreImmFormat ; Half;            amode = 0b110 ; 2 ; 1; immS as SHalf; "memh" ; true )
   $StoreImmSizeBase( StoreImmWord ; StoreImmFormat ; Word;            amode = 0b110 ; 4 ; 2; immS as SWord; "memw" ; true )
-  $StoreImmSizeBase( StoreImmByteX; StoreImmXFormat; Byte; iclassX=0, amode = 0b110 ; 1 ; 0; immS as SByte; (AsmImmextU(immX), "memb") ; true )
-  $StoreImmSizeBase( StoreImmHalfX; StoreImmXFormat; Half; iclassX=0, amode = 0b110 ; 2 ; 1; immS as SHalf; (AsmImmextU(immX), "memh") ; true )
-  $StoreImmSizeBase( StoreImmWordX; StoreImmXFormat; Word; iclassX=0, amode = 0b110 ; 4 ; 2; immS as SWord; (AsmImmextU(immX), "memw") ; true )
+  $StoreImmSizeBase( StoreImmByteX; StoreImmXFormat; Byte; iclassX=0, amode = 0b110 ; 1 ; 0; immS as SByte; (AsmImmextU(immX as Word), "memb") ; true )
+  $StoreImmSizeBase( StoreImmHalfX; StoreImmXFormat; Half; iclassX=0, amode = 0b110 ; 2 ; 1; immS as SHalf; (AsmImmextU(immX as Word), "memh") ; true )
+  $StoreImmSizeBase( StoreImmWordX; StoreImmXFormat; Word; iclassX=0, amode = 0b110 ; 4 ; 2; immS as SWord; (AsmImmextU(immX as Word), "memw") ; true )
 
 
   format AllocFrameFormat : Word =
@@ -1035,7 +1076,7 @@ instruction set architecture QDSP6 =
     , unsigned [21]
     , opc      [20..16,13..11]
     , imm      [10..0]
-    , immU = (imm as UInt<11>) * (8 as UInt<4>)
+    , immU = (imm as UInt<11>) * (8 as UInt<11>)
     }
 
   // TODO: Reenable this annotation
@@ -1060,6 +1101,7 @@ instruction set architecture QDSP6 =
     { iclass [31..28]
     , opc    [27..21,7..5]
     , parse  [15..14]
+    , unused [20..16, 13..8, 4..0]
     }
   // TODO: Reenable this annotation
   // [ operation SYSTEMSolo ]
@@ -1079,6 +1121,7 @@ instruction set architecture QDSP6 =
     , x5     [20..16]
     , shift  [12..8]
     , majop  [4,2..1]
+    , unused [0]
     , immU   = imm as UWord
     , shiftU = shift as UInt
     }
@@ -1119,6 +1162,7 @@ instruction set architecture QDSP6 =
     , s5     [20..16]
     , t5     [12..8]
     , d5     [4..0]
+    , unused [5, 13, 21]
     }
 
   model BitOp( name: Id, iformat: Id, encs: Encs, val: Ex, asmfunc: Ex, asmRhs: Ex ) : IsaDefs = {
@@ -1149,6 +1193,7 @@ instruction set architecture QDSP6 =
     , majop  [23..21]
     , s5     [20..16]
     , d2     [1..0]
+    , unused [13..2]
     }
   format TransferRPFormat : Word =
     { iclass [31..28]
@@ -1157,13 +1202,15 @@ instruction set architecture QDSP6 =
     , majop  [22]
     , s2     [17..16]
     , d5     [4..0]
+    , unused [23, 21..18, 13..5]
     }
 
   // TODO: Reenable this annotation
 
   // [ operation XTYPE ]
   instruction TransferPR : TransferPRFormat = {
-    Pset(d2, R(s5) as Byte)
+    // TODO: Reenable
+    // Pset(d2, R(s5) as Byte)
   }
   encoding TransferPR = { iclass=0b1000, regtype=0b0101, majop=0b010 }
   assembly TransferPR = (AsmP(d2), " = ", AsmR(s5))
@@ -1172,7 +1219,7 @@ instruction set architecture QDSP6 =
 
   // [ operation XTYPE ]
   instruction TransferRP : TransferRPFormat = {
-    R(d5) := Pget(s2)
+    R(d5) := Pget(s2) as Word
   }
   encoding TransferRP = { iclass=0b1000, regtype=0b1001, majop=0b1 }
   assembly TransferRP = (AsmR(d5), " = ", AsmP(s2))
@@ -1186,6 +1233,7 @@ instruction set architecture QDSP6 =
     , op     [21]
     , s5     [20..16]
     , t5     [12..8]
+    , unused [7, 13]
     , x2     [6..5]
     , d5     [4..0]
     , d2     = x2  // for the constraints
@@ -1201,10 +1249,11 @@ instruction set architecture QDSP6 =
       let c = (P(x2) as Bits<1>) as Word in
       // This just really just VADL::adds(a, b, c)
       let temp, tempstatus = VADL::adds(a, if $sub then VADL::not(b) else b) in
-      let result, status = VADL::adds(temp, c) in {
+      let result, status = VADL::adds(temp, c as Double) in {
         R(d5  ) := result(31..0)
         R(d5+1) := result(63..32)
-        Pset(x2, tempstatus.carry | status.carry)
+        // TODO: Reenable this statement
+        //Pset(x2, (tempstatus.carry | status.carry) as Byte)
       }
     }
     encoding $name = { iclass=0b1100, regtype=0b0010, majop=0b11, op = match : Lit ($sub = true => 1; _ => 0 ) }
@@ -1407,24 +1456,27 @@ instruction set architecture QDSP6 =
   //   0. In memory, instructions in a packet must appear in strictly decreasing slot order.
   //   Additionally, if an instruction can go in a higher-numbered slot, and that slot is empty,
   //   then it must be moved into the higher-numbered slot.
-  // TODO: Reenable this annotation
+  // TODO: Reenable this annotation and group definition
   // [ assert :  VLIW.length <= 4 ]
-  group VLIW = (
-    (
-      ( XTYPE<0..1> | ALU32<0..1> | J<0..1> | CR<0..1> ).
-      ( XTYPE<0..1> | ALU32<0..1> | J<0..1> | JR<0..1> | CR23<0..1> ).
-      ( LD<0..1> | ST<0..1> | ALU32<0..1> ).
-      ( LD<0..1> | ST<0..1> | ALU32<0..1> /* | MEMOP<0..1> | NV<0..1> | SYSTEM<0..1> */)
-    )
-    | SYSTEMSolo
-  )
+  // group VLIW = (
+  //   (
+  //     ( XTYPE<0..1> | ALU32<0..1> | J<0..1> | CR<0..1> ).
+  //     ( XTYPE<0..1> | ALU32<0..1> | J<0..1> | JR<0..1> | CR23<0..1> ).
+  //     ( LD<0..1> | ST<0..1> | ALU32<0..1> ).
+  //     ( LD<0..1> | ST<0..1> | ALU32<0..1> /* | MEMOP<0..1> | NV<0..1> | SYSTEM<0..1> */)
+  //   )
+  //   | SYSTEMSolo
+  // )
 }
 
 
-application binary interface ABI for QDSP6 =
-{
-}
+// TODO: Reenable this definition
+// application binary interface ABI for QDSP6 =
+// {
+// }
 
+// TODO: Reenable this definition
+/*
 processor CPU implements QDSP6 with ABI =
 {
 
@@ -1508,3 +1560,4 @@ processor CPU implements QDSP6 with ABI =
 
   }
 }
+*/

--- a/sys/hexagon/hexagon.vadl
+++ b/sys/hexagon/hexagon.vadl
@@ -231,8 +231,7 @@ instruction set architecture QDSP6 =
     }
 
   model TransferBase ( name: Id, iformat: Id, encs: Encs, asmprefix: Ex, asmpostfix: Ex, dst: Ex, val: Ex, asm: Ex ) : IsaDefs = {
-    // TODO: Reenable this annotation
-    // [ operation ALU32 ]
+    [ operation: ALU32 ]
     instruction $name : $iformat = {
       R($dst) := $val
     }
@@ -275,8 +274,7 @@ instruction set architecture QDSP6 =
     }
 
   model ALUBase ( name: Id, iformat: Id, encs: Encs, op: Id, lhs: Ex, rhs: Ex, asm: Ex ) : IsaDefs = {
-    // TODO: Reenable this annotation
-    // [ operation ALU32 ]
+    [ operation: ALU32 ]
     instruction $name : $iformat = {
       R(d5) := VADL::$op($lhs, $rhs)
     }
@@ -301,9 +299,7 @@ instruction set architecture QDSP6 =
   $ALUBase( AndImm ; ALUImmFormat  ; iclass = 0b0111, majop = 0b0110, minop = 0b00  ; and ;           R(s5)  ; extendS(imm as SWord); (AsmR(s5),",#",decimal(imm)) )
   $ALUBase( OrImm  ; ALUImmFormat  ; iclass = 0b0111, majop = 0b0110, minop = 0b10  ; or  ;           R(s5)  ; extendS(imm as SWord); (AsmR(s5),",#",decimal(imm)) )
 
-  // TODO: Reenable this annotation
-
-  // [ operation ALU32 ]
+  [ operation: ALU32 ]
   instruction Nop : StandardFormat = {}
   encoding Nop = { iclass = 0b0111, majop = 0b1111 }
   assembly Nop = ("nop")
@@ -351,8 +347,7 @@ instruction set architecture QDSP6 =
     }
 
   model CmpBase ( name: Id, iformat: Id, encs: Encs, cond: Ex, asm: Ex ) : IsaDefs = {
-    // TODO: Reenable this annotation
-    // [ operation ALU32_PRED_WRITING ]
+    [ operation: ALU32_PRED_WRITING ]
     instruction $name : $iformat = {
       let val = toPValue($cond) in {
         // TODO: Renable this call
@@ -418,8 +413,7 @@ instruction set architecture QDSP6 =
     }
 
   model CombineWordBase ( name: Id, iformat: Id, encs: Encs, vhigh: Ex, vlow: Ex, asm: Ex ) : IsaDefs = {
-    // TODO: Reenable this annotation
-    // [ operation ALU32 ]
+    [ operation: ALU32 ]
     instruction $name : $iformat = {
       R( d5 ) := ($vhigh as Half, $vlow as Half)
     }
@@ -427,8 +421,7 @@ instruction set architecture QDSP6 =
     assembly $name = (AsmR(d5), "=", $asm)
   }
   model CombineDoubleBase ( name: Id, iformat: Id, encs: Encs, vhigh: Ex, vlow: Ex, asm: Ex ) : IsaDefs = {
-    // TODO: Reenable this annotation
-    // [ operation ALU32 ]
+    [ operation: ALU32 ]
     instruction $name : $iformat = {
       R( d5   ) := $vlow
       R( d5+1 ) := $vhigh
@@ -479,8 +472,7 @@ instruction set architecture QDSP6 =
     }
 
   model ALUPredBase ( name: Id, iformat: Id, encs: Encs, op: Id, lhs: Ex, rhs: Ex, asmprefix: Ex, asm: Ex, pred: Ex ) : IsaDefs = {
-    // TODO: Reenable this annotation
-    // [ operation ALU32 ]
+    [ operation: ALU32 ]
     instruction $name : $iformat = {
       R(d5) := VADL::$op($lhs, $rhs)
     }
@@ -510,8 +502,7 @@ instruction set architecture QDSP6 =
     }
 
   model TransferControlBase ( name: Id, encs: Encs, asmDst: Id, asmSrc: Id, stats: Stats ) : IsaDefs = {
-    // TODO: Reenable this annotation
-    // [ operation CR ]
+    [ operation: CR ]
     instruction $name : StandardFormat = {
       $stats
     }
@@ -568,8 +559,7 @@ instruction set architecture QDSP6 =
     , immU   = imm as UWord
     }
   model AddRegPCBase ( name: Id, iformat: Id, encs: Encs, asmPrefix: Ex, asmimm: Id ) : IsaDefs = {
-    // TODO: Reenable this annotation
-    // [ operation CR ]
+    [ operation: CR ]
     instruction $name : $iformat = {
       // TODO: Reenable this subcall
       //R(d5) := PC.current + immU
@@ -593,8 +583,7 @@ instruction set architecture QDSP6 =
     }
   // This instruction may execute on either slot2 or slot3, even though it is a CR-type
   model LogicalPredBase ( name: Id, encs: Encs, val: Ex, asm: Ex ) : IsaDefs = {
-    // TODO: Reenable this annotation
-    // [ operation CR23 ]
+    [ operation: CR23 ]
     instruction $name : LogicalPredFormat = {
       // TODO: Reeable this call
       //Pset(d2, $val)
@@ -633,8 +622,7 @@ instruction set architecture QDSP6 =
     }
 
   model CallRegBase ( name: Id, encs: Encs, asm: Ex, pred: Ex ) : IsaDefs = {
-    // TODO: Reenable this annotation
-    // [ operation JR ]
+    [ operation: JR ]
     instruction $name : BranchRegFormat = {
       if $pred then {
         LR := PC.next
@@ -651,8 +639,7 @@ instruction set architecture QDSP6 =
 
 
   model JumpRegBase ( name: Id, encs: Encs, asmprefix: Ex, asmpostfix: Ex, pred: Ex ) : IsaDefs = {
-    // TODO: Reenable this annotation
-    // [ operation JR ]
+    [ operation: JR ]
     instruction $name : BranchRegFormat = {
       if $pred then {
         PC := R(s5)
@@ -690,8 +677,7 @@ instruction set architecture QDSP6 =
     }
 
   model JumpImmBase ( name: Id, iformat: Id, encs: Encs, asmprefix: Ex, asmpostfix: Ex, pred: Ex ) : IsaDefs = {
-    // TODO: Reenable this annotation
-    // [ operation J ]
+    [ operation: J ]
     instruction $name : $iformat = {
       if $pred then {
         // TODO: Reebable once this subcall is implemented
@@ -725,8 +711,7 @@ instruction set architecture QDSP6 =
     }
 
   model CallImmBase ( name: Id, iformat: Id, encs: Encs, asm: Ex, pred: Ex ) : IsaDefs = {
-    // TODO: Reenable this annotation
-    // [ operation J ]
+    [ operation: J ]
     instruction $name : $iformat = {
       if $pred then {
         LR := PC.next
@@ -793,8 +778,7 @@ instruction set architecture QDSP6 =
     }
 
   model CmpJumpBase ( name: Id, iformat: Id, encs: Encs, neg: Val, p: Val, predEx: Ex, asmPred: Ex, asmHint: Ex ) : IsaDefs = {
-    // TODO: Reenable this annotation
-    // [ operation J_PRED_WRITING ]
+    [ operation: J_PRED_WRITING ]
     instruction $name : $iformat = {
       let pred   = $predEx in
       let pvalue = toPValue($predEx) in {
@@ -863,8 +847,7 @@ instruction set architecture QDSP6 =
 
   model-type LoadBaseT = ( Id, Id, Encs, Lit, Ex, Id, Ex, Ex, Ex ) -> IsaDefs
   model LoadSizeBase ( name: Id, iformat: Id, encs: Encs, size: Lit, addr: Ex, type: Id, asmprefix: Ex, asm: Ex, pred: Ex ) : IsaDefs = {
-    // TODO: Reenable this annotation
-    // [ operation LD ]
+    [ operation: LD ]
     instruction $name : $iformat = {
       if $pred then {
         R(d5) := MEM<$size>($addr) as $type as Word
@@ -874,8 +857,7 @@ instruction set architecture QDSP6 =
     assembly $name = ($asmprefix, AsmR(d5), "=", $asm)
   }
   model LoadDoubleBase ( name: Id, iformat: Id, encs: Encs, size: Lit, addr: Ex, type: Id, asmprefix: Ex, asm: Ex, pred: Ex ): IsaDefs = {
-    // TODO: Reenable this annotation
-    // [ operation LD ]
+    [ operation: LD ]
     instruction $name : $iformat = {
       if $pred then {
         let result = MEM<8>($addr) as $type in {
@@ -921,9 +903,7 @@ instruction set architecture QDSP6 =
     , unused   [7..5]
     }
 
-  // TODO: Reenable this annotation
-
-  // [ operation LD ]
+  [ operation: LD ]
   instruction DeallocFrame : DeallocFrameFormat = {
     let restored = MEM<8>(FP) as Double in
     let LRnew = frameUnscramble(restored(63..32)) in {
@@ -937,8 +917,7 @@ instruction set architecture QDSP6 =
 
 
   model DecallocReturnBase ( name: Id, encs: Encs, asmprefix: Ex, asmpostfix: Ex, pred: Ex ) : IsaDefs = {
-    // TODO: Reenable this annotation
-    // [ operation LD ]
+  [ operation: LD ]
     instruction $name : DeallocFrameFormat = {
       if $pred then {
         let restored = MEM<8>(FP) as Double in
@@ -981,8 +960,7 @@ instruction set architecture QDSP6 =
 
   model-type StoreBaseT = ( Id, Encs, Lit, Ex, Id, Ex, Ex, Ex ) -> IsaDefs
   model StoreSizeBase ( name: Id, encs: Encs, size: Lit, addr: Ex, type: Id, shift: Ex, asmprefix: Ex, asmpostfix: Ex ) : IsaDefs = {
-    // TODO: Reenable this annotation
-    // [ operation ST ]
+[ operation: ST ]
     instruction $name : StoreFormat = {
       MEM<$size>($addr) := (R(t5) >> ($shift as UInt<6>)) as $type
     }
@@ -990,8 +968,7 @@ instruction set architecture QDSP6 =
     assembly $name = ($asmprefix, "=", AsmR(t5), $asmpostfix)
   }
   model StoreDoubleBase ( name: Id, encs: Encs, size: Lit, addr: Ex, type: Id, shift: Ex, asmprefix: Ex, asmpostfix: Ex ) : IsaDefs = {
-    // TODO: Reenable this annotation
-    // [ operation ST ]
+[ operation: ST ]
     instruction $name : StoreFormat = {
       MEM<$size>($addr) := ((R(t5+1), R(t5))) as $type
     }
@@ -1051,8 +1028,7 @@ instruction set architecture QDSP6 =
     }
 
   model StoreImmSizeBase ( name: Id, iformat: Id, type: Id, encs: Encs, size: Val, scale: Val, imm: Ex, asmprefix: Ex, pred: Ex ) : IsaDefs = {
-    // TODO: Reenable this annotation
-    // [ operation ST ]
+    [ operation: ST ]
     instruction $name : $iformat = {
       if $pred then MEM<$size>( R(s5) + scaledImmU(immOffsetU as SWord, $scale) ) := $imm
     }
@@ -1079,9 +1055,7 @@ instruction set architecture QDSP6 =
     , immU = (imm as UInt<11>) * (8 as UInt<11>)
     }
 
-  // TODO: Reenable this annotation
-
-  // [ operation ST ]
+  [ operation: ST ]
   instruction AllocFrame : AllocFrameFormat = {
     let SPnew = SP - 8 in {
       MEM<8>(SPnew) := (frameScramble( LR ), FP)
@@ -1103,8 +1077,7 @@ instruction set architecture QDSP6 =
     , parse  [15..14]
     , unused [20..16, 13..8, 4..0]
     }
-  // TODO: Reenable this annotation
-  // [ operation SYSTEMSolo ]
+  [ operation: SYSTEMSolo ]
   instruction Brkpt : BrkptFormat = {
     PC := 0xeeeeeeee
   }
@@ -1127,8 +1100,7 @@ instruction set architecture QDSP6 =
     }
 
   model ALUImmShifted ( name: Id, encs: Encs, op: Id, shiftop: Id ) : IsaDefs = {
-    // TODO: Reenable this annotation
-    // [ operation XTYPE ]
+[ operation: XTYPE ]
     instruction $name : AddImmShiftedFormat = {
       R(x5) := VADL::$op(immU, VADL::$shiftop(R(x5), shiftU) as UInt)
     }
@@ -1166,8 +1138,7 @@ instruction set architecture QDSP6 =
     }
 
   model BitOp( name: Id, iformat: Id, encs: Encs, val: Ex, asmfunc: Ex, asmRhs: Ex ) : IsaDefs = {
-    // TODO: Reenable this annotation
-    // [ operation XTYPE ]
+[ operation: XTYPE ]
     instruction $name : $iformat = {
       R(d5) := $val
     }
@@ -1205,9 +1176,7 @@ instruction set architecture QDSP6 =
     , unused [23, 21..18, 13..5]
     }
 
-  // TODO: Reenable this annotation
-
-  // [ operation XTYPE ]
+  [ operation: XTYPE ]
   instruction TransferPR : TransferPRFormat = {
     // TODO: Reenable
     // Pset(d2, R(s5) as Byte)
@@ -1215,9 +1184,7 @@ instruction set architecture QDSP6 =
   encoding TransferPR = { iclass=0b1000, regtype=0b0101, majop=0b010 }
   assembly TransferPR = (AsmP(d2), " = ", AsmR(s5))
 
-  // TODO: Reenable this annotation
-
-  // [ operation XTYPE ]
+  [ operation: XTYPE ]
   instruction TransferRP : TransferRPFormat = {
     R(d5) := Pget(s2) as Word
   }
@@ -1241,8 +1208,7 @@ instruction set architecture QDSP6 =
     }
 
   model ALUDoubleCarryBase( name: Id, sub: Bool ) : IsaDefs = {
-    // TODO: Reenable this annotation
-    // [ operation XTYPE_PRED_WRITING ]
+[ operation: XTYPE_PRED_WRITING ]
     instruction $name : ALUDoubleCarryFormat = {
       let a = (R(s5+1),R(s5)) in
       let b = (R(t5+1),R(t5)) in

--- a/sys/hexagon/hexagon.vadl
+++ b/sys/hexagon/hexagon.vadl
@@ -649,7 +649,8 @@ instruction set architecture QDSP6 =
     assembly $name = ($asmprefix, "jumpr", $asmpostfix, " ", AsmR(s5))
   }
 
-  $JumpRegBase( JumpReg         ; op = 0b0010100; ""; ""; true )
+  // Hexagon V60/V61 Programmer's Reference Manual p. 236
+  $JumpRegBase( JumpReg         ; op = 0b0010100; ""; ""; true ) // jumpr Rs
   $JumpRegBase( JumpRegPredPosNT; op = 0b0011010, hintnew = 0b00; AsmPred(u2, false, false); ":nt ";  testpred(u2) )
   $JumpRegBase( JumpRegPredPosT ; op = 0b0011010, hintnew = 0b10; AsmPred(u2, false, false); ":t " ;  testpred(u2) )
   $JumpRegBase( JumpRegPredNegNT; op = 0b0011011, hintnew = 0b00; AsmPred(u2, true , false); ":nt "; !testpred(u2) )
@@ -723,9 +724,10 @@ instruction set architecture QDSP6 =
     assembly $name = ($asm, "call #", decimal(imm))
   }
 
-  $CallImmBase( CallImm       ; CallImmFormat    ; op = 0b1010; ""; true )
-  $CallImmBase( CallImmPredPos; CallImmPredFormat; op = 0b101, neg = 0b0; AsmPred(pred, false, false) ; testpred(pred) )
-  $CallImmBase( CallImmPredNeg; CallImmPredFormat; op = 0b101, neg = 0b1; AsmPred(pred, true , false); !testpred(pred) )
+  // Hexagon V60/V61 Programmer's Reference Manual p. 238
+  $CallImmBase( CallImm       ; CallImmFormat    ; op = 0b1010; ""; true ) // call #r22:2
+  $CallImmBase( CallImmPredPos; CallImmPredFormat; op = 0b11010, neg = 0b0; AsmPred(pred, false, false) ; testpred(pred) ) // if (Pu) call #r15:2
+  $CallImmBase( CallImmPredNeg; CallImmPredFormat; op = 0b11010, neg = 0b1; AsmPred(pred, true , false); !testpred(pred) ) // if (!Pu) call #r15:2
 
   format CmpJumpFormat : Word =
     { iclass [31..28]

--- a/sys/hexagon/hexagon.vadl
+++ b/sys/hexagon/hexagon.vadl
@@ -1,0 +1,1510 @@
+// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Qualcomm Hexagon (QDSP6) V60
+
+instruction set architecture QDSP6 =
+{
+  using Byte    = Bits<8>           // byte, memory size
+  using Half    = Bits<16>          // half word size
+  using Word    = Bits<32>          // word size
+  using Double  = Bits<64>          // double word size
+  using Address = Word              // address has word size
+
+  using UByte = UInt<8>
+  using UHalf = UInt<16>
+  using UWord = UInt<32>
+  using UDouble = UInt<64>
+  using SByte = SInt<8>
+  using SHalf = SInt<16>
+  using SWord = SInt<32>
+  using SDouble = SInt<64>
+
+  using Index          = Bits<5>           // register index for 32 registers
+  using PredicateIndex = Bits<2>           // predicate index for 4 predicates
+
+  // TODO: Reenable this annotation
+  // [littleEndian]
+  memory MEM : Address -> Byte      // 32-bit, byte-addressable address space
+  // Instructions and instruction packets must be 32-bit aligned
+  // Data must be aligned to its native access size.
+  // Any unaligned memory access will cause a memory-alignment exception.
+
+  register R   : Index -> Word   // general purpose register
+  alias register SP : Word = R(29)    // stack pointer
+  alias register FP : Word = R(30)    // frame pointer
+  alias register LR : Word = R(31)    // link register
+
+  format USRFormat : Word =
+    { unimplemented [31..1]
+    , OVF    [0]                      // Sticky Saturation Overflow
+    }
+
+  constant C_INDEX_P  : Index = 4
+  constant C_INDEX_PC : Index = 9
+  register C   : Index -> Word        // control register
+  alias register SA0             = C(0)    // Loop start address register 0
+  alias register LC0             = C(1)    // Loop count register 0
+  alias register SA1             = C(2)    // Loop start address register 1
+  alias register LC1             = C(3)    // Loop count register 1
+  // TODO [read/write partial] is incompatible with alias registers
+  //             P               = C(4)    // Predicate registers 3:0
+  alias register M0              = C(6)    // Modifier register 0
+  alias register M1              = C(7)    // Modifier register 1
+  alias register USR : USRFormat = C(8)    // User status register
+  // TODO @nmischkulnig: `alias group/program register` isn't completely implemented
+  // [next]
+  // alias program counter PC : Address = C(9)    // Program counter
+  alias register UGP             = C(10)   // User general pointer
+  alias register GP              = C(11)   // Global pointer. 6..0 should always be 0 (read only)
+  alias register CS0             = C(12)   // Circular start register 0
+  alias register CS1             = C(13)   // Circular start register 1
+  alias register UPCYCLELO       = C(14)   // Cycle count register (low)
+  alias register UPCYCLEHI       = C(15)   // Cycle count register (high)
+  alias register FRAMELIMIT      = C(16)   // Frame limit register
+  alias register FRAMEKEY        = C(17)   // Frame key register
+  alias register PKTCOUNTLO      = C(18)   // Packet count register (low)
+  alias register PKTCOUNTHI      = C(19)   // Packet count register (high)
+  alias register UTIMERLO        = C(30)   // Qtimer register (low)
+  alias register UTIMERHI        = C(31)   // Qtimer register (high)
+
+  [next]
+  group counter PC : Address
+
+  // Valid 64-byte pairs:
+  // R1:0, R3:2, ... R29:28, R31:30
+  // C1:0, C3:2, ... C29:28, C31:30
+
+  function AsmR (reg: Index) -> String = ("R", decimal(reg))
+  function AsmRR(reg: Index) -> String = ("R", decimal(reg+1), ":", decimal(reg))
+  function AsmC (reg: Index) -> String = ("C", decimal(reg))
+  function AsmCC(reg: Index) -> String = ("C", decimal(reg+1), ":", decimal(reg))
+  function AsmP (reg: PredicateIndex) -> String = ("P", decimal(reg))
+  function AsmImmU(v: UWord) -> String = ("#", decimal(v), ")")
+  function AsmImmUX(v: UWord) -> String = ("##", decimal(v), ")")
+  function AsmImmS(v: SWord) -> String = ("#", decimal(v), ")")
+  function AsmImmSX(v: SWord) -> String = ("##", decimal(v), ")")
+  function AsmImmextS(v: Word) -> String = ("immext(#", decimal(v), ")")
+  function AsmImmextU(v: Word) -> String = ("immext(#", decimal(v), ")")
+  function AsmAddrAbsSet (reg: Index, imm6: UInt<6>) -> String = ("(",AsmR(reg),"=#",decimal(imm6),")")
+  function AsmAddrGPRel  (imm16: UInt<16>) -> String = ("(gp+#",decimal(imm16),")")
+  function AsmAddrRegRel (reg: Index, imm11: SInt<11>) -> String = ("(",AsmR(reg),"+#",decimal(imm11),")")
+  function AsmPred (reg: PredicateIndex, neg: Bool, dotnew: Bool) -> String =
+    ("if(",
+      (if neg then "!" as String else "" as String),
+      AsmP(reg),
+      (if dotnew then ".new" as String else "" as String),
+    ")")
+
+  format PFormat : Word =
+    { P3   : Byte
+    , P2   : Byte
+    , P1   : Byte
+    , P0   : Byte
+    }
+  // TODO: Reenable this annotation
+  // [ read partial ]  // This is the default but it's essential that multiple instruction in a bundle
+  // [ write partial ] // can write to (different) predicate subregisters
+  register P : PFormat
+
+  function testpred (reg: PredicateIndex) -> Bool =
+    match (reg) with
+      { 0 => P.P0(0) = 1
+      , 1 => P.P1(0) = 1
+      , 2 => P.P2(0) = 1
+      , _ => P.P3(0) = 1
+      }
+  process Pset ( reg: PredicateIndex, val: Byte ) = {
+    match (reg) with
+      { 0 => P.P0 := val
+      , 1 => P.P1 := val
+      , 2 => P.P2 := val
+      , 3 => P.P3 := val
+      }
+  }
+  function Pget ( reg: PredicateIndex ) -> Byte =
+    match (reg) with
+      { 0 => P.P0
+      , 1 => P.P1
+      , 2 => P.P2
+      , _ => P.P3
+      }
+
+  // "apply_extension" from the spec
+  // The encoded `imm` is actually smaller than Word, usually between 6 and 16 bits
+  function extendU(imm: UWord) -> UWord = imm
+  function extendS(imm: SWord) -> SWord = imm
+  function extendUExtender(imm: UWord, extender: Bits<26>) -> UWord = (extender, imm as Bits<6>)
+  function extendSExtender(imm: SWord, extender: Bits<26>) -> SWord = (extender, imm as Bits<6>)
+  // e.g. for `call #r22:2`
+  function extendR2(imm: SWord) -> SWord = scaledImmR2(imm)
+  // "When constant extenders are used, scaled immediates are not scaled by the processor"
+  function extendR2Extender(imm: SWord, extender: Bits<26>) -> SWord = align32((extender, imm as Bits<6>))
+
+  function toPValue(v: Bool) -> Byte = if v then 0xff else 0x00
+
+  function align32 (v: SWord) -> SWord = (v >> 2) << 2
+  function scaledImmR2(imm: SWord) -> SWord = imm << 2
+  function scaledImmU (imm: SWord, scale: UInt<2>) -> SWord = imm << scale
+  function scaledImmS (imm: SWord, scale: UInt<2>) -> SWord = imm << scale
+
+  function frameScramble  (addr: Address) -> Address = VADL::xor(addr, FRAMEKEY)
+  function frameUnscramble(addr: Address) -> Address = VADL::xor(addr, FRAMEKEY)
+
+  enumeration MemoryAccessType : Bits<2> =
+    { Byte   = 0b00
+    , Half   = 0b01
+    , Word   = 0b10
+    , Double = 0b11
+    }
+
+  format StandardFormat : Word =
+    { iclass [31..28]
+    , parse  [15..14]
+    , majop  [27..24]
+    , minop  [23..21]
+    , s5     [20..16]
+    , c      [13]
+    , t5     [12..8]
+    , d5     [4..0]
+    }
+
+  // ----------------------------------  operation ALU32/ALU ---------------------------------
+
+  format TransferImmHalfFormat : Word =
+    { iclass [31..28]
+    , rs     [27]
+    , majop  [26..24]
+    , minop  [21]
+    , parse  [15..14]
+    , imm    [23..22, 13..0]
+    , x5     [20..16]
+    , s5     = x5
+    , d5     = x5
+    , immU   = imm as UInt<16>
+    }
+
+  format TransferImmFormat : Word =
+    { iclass [31..28]
+    , rs     [27]
+    , majop  [26..24]
+    , parse  [15..14]
+    , imm    [23..22, 20..16, 13..5]
+    , d5     [4..0]
+    , immS   = imm as UInt<16>
+    }
+
+  format TransferImmXFormat : Double =
+    { iclassX [31..28]
+    , parseX  [15..14]
+    , immX    [27..16,13..0]
+    // ---
+    , iclass  [63..60]
+    , rs      [59]
+    , majop   [58..56]
+    , parse   [47..46]
+    , imm     [55..54, 52..48, 45..37]
+    , d5      [36..32]
+    , immS    = extendSExtender(imm, immX)
+    }
+
+  model TransferBase ( name: Id, iformat: Id, encs: Encs, asmprefix: Ex, asmpostfix: Ex, dst: Ex, val: Ex, asm: Ex ) : IsaDefs = {
+    // TODO: Reenable this annotation
+    // [ operation ALU32 ]
+    instruction $name : $iformat = {
+      R($dst) := $val
+    }
+    encoding $name = { iclass = 0b0111, $encs }
+    assembly $name = ($asmprefix, AsmR($dst), $asmpostfix, " = ", $asm)
+  }
+
+  $TransferBase( TransferImmLow ; TransferImmHalfFormat; rs=0b0, majop=0b001, minop=0b1  ; ""              ; ".L"; x5; (R(x5) & 0xFFFF0000) | (immU as UInt<32>);            ("#", decimal(immU)))
+  $TransferBase( TransferImmHigh; TransferImmHalfFormat; rs=0b0, majop=0b010, minop=0b1  ; ""              ; ".H"; x5; (R(x5) & 0x0000FFFF) | ((immU as UInt<32>) << 16);    ("#", decimal(immU)))
+  $TransferBase( TransferImm    ; TransferImmFormat    ; rs=0b1, majop=0b000             ; ""              ; ""  ; d5; immS;                                                 ("#", decimal(immS)))
+  $TransferBase( TransferImmX   ; TransferImmXFormat   ; rs=0b1, majop=0b000, iclassX=0  ; AsmImmextU(immX); ""  ; d5; immS;                                                 ("#", decimal(immS)))
+  $TransferBase( TransferReg    ; StandardFormat       ; c=0b0, majop=0b0000, minop=0b011; ""              ; ""  ; d5; R(s5);                                                AsmR(s5))
+
+  format AddImmFormat : Word =
+    { iclass [31..28]
+    , parse  [15..14]
+    , imm    [27..21,13..5]
+    , s5     [20..16]
+    , d5     [4..0]
+    }
+  format ALUImmFormat : Word =
+    { iclass [31..28]
+    , parse  [15..14]
+    , majop  [27..24]
+    , minop  [23..22]
+    , imm    [21,13..5]
+    , s5     [20..16]
+    , d5     [4..0]
+    }
+  format ALURegFormat : Word =
+    { iclass [31..28]
+    , parse  [15..14]
+    , p      [27]
+    , majop  [26..24]
+    , minop  [23..21]
+    , s5     [20..16]
+    , t5     [12..8]
+    , d5     [4..0]
+    }
+
+  model ALUBase ( name: Id, iformat: Id, encs: Encs, op: Id, lhs: Ex, rhs: Ex, asm: Ex ) : IsaDefs = {
+    // TODO: Reenable this annotation
+    // [ operation ALU32 ]
+    instruction $name : $iformat = {
+      R(d5) := VADL::$op($lhs, $rhs)
+    }
+    encoding $name = { $encs }
+    assembly $name = (AsmR(d5), " = ", AsStr(op), "(", $asm, ")")
+  }
+
+  $ALUBase ( AddImm    ; AddImmFormat ; iclass=0b1011                               ; add   ; R(s5); extendS(imm) ; (AsmR(s5),",#",decimal(imm)) )
+  $ALUBase ( AddReg    ; ALURegFormat ; iclass=0b1111, p=0, majop=0b011, minop=0b000; add   ; R(s5); R(t5)        ; (AsmR(s5),"," ,AsmR(t5))     )
+  // TODO @nmischkulnig missing builtin VADL::satadd
+  // $AddBase ( AddRegSat ; ALURegFormat ; iclass=0b1111, p=0, majop=0b110, minop=0b010; satadd; R(s5)         ; R(t5); (AsmR(s5),",#",AsmR(t5))     )
+  $ALUBase ( SubImm    ; ALUImmFormat ; iclass=0b0111,      majop=0b0110, minop=0b01; sub   ; extendS(imm)  ; R(s5); (decimal(imm),",#",AsmR(s5)))
+  $ALUBase ( SubReg    ; ALURegFormat ; iclass=0b1111, p=0, majop=0b011, minop=0b001; sub   ; R(t5)         ; R(s5); (AsmR(t5),"," ,AsmR(s5))    )
+  // TODO @nmischkulnig missing builtin VADL::satsub
+  // $ALUBase ( SubRegSat ; ALURegFormat ; iclass=0b1111, p=0, majop=0b110, minop=0b110; satsub; R(t5)         ; R(s5); (AsmR(t5),"#", AsmR(s5))    )
+
+  $ALUBase( AndReg ; StandardFormat; iclass = 0b1111, majop = 0b0001, minop = 0b000 ; and ;           R(s5)  ; R(t5)       ; (AsmR(s5),"," ,AsmR(t5)) )
+  $ALUBase( OrReg  ; StandardFormat; iclass = 0b1111, majop = 0b0001, minop = 0b001 ; or  ;           R(s5)  ; R(t5)       ; (AsmR(s5),"," ,AsmR(t5)) )
+  $ALUBase( XorReg ; StandardFormat; iclass = 0b1111, majop = 0b0001, minop = 0b011 ; xor ;           R(s5)  ; R(t5)       ; (AsmR(s5),"," ,AsmR(t5)) )
+  $ALUBase( AndNReg; StandardFormat; iclass = 0b1111, majop = 0b0001, minop = 0b100 ; and ; VADL::not(R(s5)) ; R(t5)       ; (AsmR(t5),",~",AsmR(s5)) )
+  $ALUBase( OrNReg ; StandardFormat; iclass = 0b1111, majop = 0b0001, minop = 0b101 ; or  ; VADL::not(R(s5)) ; R(t5)       ; (AsmR(t5),",~",AsmR(s5)) )
+  $ALUBase( AndImm ; ALUImmFormat  ; iclass = 0b0111, majop = 0b0110, minop = 0b00  ; and ;           R(s5)  ; extendS(imm); (AsmR(s5),",#",decimal(imm)) )
+  $ALUBase( OrImm  ; ALUImmFormat  ; iclass = 0b0111, majop = 0b0110, minop = 0b10  ; or  ;           R(s5)  ; extendS(imm); (AsmR(s5),",#",decimal(imm)) )
+
+  // TODO: Reenable this annotation
+
+  // [ operation ALU32 ]
+  instruction Nop : StandardFormat = {}
+  encoding Nop = { iclass = 0b0111, majop = 0b1111 }
+  assembly Nop = ("nop")
+
+  format CmpImmFormat : Word =
+    { iclass [31..28]
+    , parse  [15..14]
+    , rs     [27]
+    , majop  [26..24]
+    , minop  [23..22]
+    , neg    [4]
+    , op     [3..2]
+    , s5     [20..16]
+    , d2     [1..0]
+    , imm    [21,13..5]
+    , immS   = imm as SWord
+    }
+
+  format CmpImmUFormat : Word =
+    { iclass [31..28]
+    , parse  [15..14]
+    , rs     [27]
+    , majop  [26..24]
+    , minop  [23..21]
+    , neg    [4]
+    , op     [3..2]
+    , s5     [20..16]
+    , d2     [1..0]
+    , imm    [13..5]
+    , immU   = imm as UWord
+    }
+
+  format CmpRegFormat : Word =
+    { iclass [31..28]
+    , parse  [15..14]
+    , p      [27]
+    , majop  [26..24]
+    , minop  [22..21]
+    , neg    [4]
+    , op     [3..2]
+    , s5     [20..16]
+    , t5     [12..8]
+    , d2     [1..0]
+    }
+
+  model CmpBase ( name: Id, iformat: Id, encs: Encs, cond: Ex, asm: Ex ) : IsaDefs = {
+    // TODO: Reenable this annotation
+    // [ operation ALU32_PRED_WRITING ]
+    instruction $name : $iformat = {
+      let val = toPValue($cond) in {
+        Pset(d2, val)
+      }
+    }
+    encoding $name = { op=0b00, $encs }
+    assembly $name = (AsmP(d2), "=", $asm)
+  }
+
+  $CmpBase( CmpImmEq  ; CmpImmFormat ; iclass = 0b0111, rs=0, majop = 0b101, minop = 0b00, neg = 0b0;  (R(s5) = extendS(immS)); ( "cmp.eq(" ,AsmR(s5),",#",decimal(immS),")") )
+  $CmpBase( CmpImmNeq ; CmpImmFormat ; iclass = 0b0111, rs=0, majop = 0b101, minop = 0b00, neg = 0b1; !(R(s5) = extendS(immS)); ("!cmp.eq(" ,AsmR(s5),",#",decimal(immS),")") )
+  $CmpBase( CmpImmGt  ; CmpImmFormat ; iclass = 0b0111, rs=0, majop = 0b101, minop = 0b01, neg = 0b0;  (R(s5) as SInt) > extendS(immS); ( "cmp.gt(" ,AsmR(s5),",#",decimal(immS),")") )
+  $CmpBase( CmpImmLte ; CmpImmFormat ; iclass = 0b0111, rs=0, majop = 0b101, minop = 0b01, neg = 0b1; !(R(s5) as SInt) > extendS(immS); ("!cmp.gt(" ,AsmR(s5),",#",decimal(immS),")") )
+  $CmpBase( CmpImmGtu ; CmpImmUFormat; iclass = 0b0111, rs=0, majop = 0b101, minop = 0b100, neg = 0b0; (R(s5) as UInt) > extendU(immU); ( "cmp.gtu(",AsmR(s5),",#",decimal(immU),")") )
+  $CmpBase( CmpImmLteu; CmpImmUFormat; iclass = 0b0111, rs=0, majop = 0b101, minop = 0b100, neg = 0b1; (R(s5) as UInt) > extendU(immU); ("!cmp.gtu(",AsmR(s5),",#",decimal(immU),")") )
+
+  $CmpBase( CmpRegEq  ; CmpRegFormat; iclass = 0b1111, p=0, majop = 0b010, minop = 0b00, neg = 0b0;  (R(s5) = R(t5)); ( "cmp.eq(" ,AsmR(s5),",",AsmR(t5),")") )
+  $CmpBase( CmpRegNeq ; CmpRegFormat; iclass = 0b1111, p=0, majop = 0b010, minop = 0b00, neg = 0b1; !(R(s5) = R(t5)); ("!cmp.eq(" ,AsmR(s5),",",AsmR(t5),")") )
+  $CmpBase( CmpRegGt  ; CmpRegFormat; iclass = 0b1111, p=0, majop = 0b010, minop = 0b10, neg = 0b0;  ((R(s5) as SInt) > (R(t5) as SInt)); ( "cmp.gt(" ,AsmR(s5),",",AsmR(t5),")") )
+  $CmpBase( CmpRegLte ; CmpRegFormat; iclass = 0b1111, p=0, majop = 0b010, minop = 0b10, neg = 0b1; !((R(s5) as SInt) > (R(t5) as SInt)); ("!cmp.gt(" ,AsmR(s5),",",AsmR(t5),")") )
+  $CmpBase( CmpRegGtu ; CmpRegFormat; iclass = 0b1111, p=0, majop = 0b010, minop = 0b11, neg = 0b0;  ((R(s5) as UInt) > (R(t5) as UInt)); ( "cmp.gtu(",AsmR(s5),",",AsmR(t5),")") )
+  $CmpBase( CmpRegLteu; CmpRegFormat; iclass = 0b1111, p=0, majop = 0b010, minop = 0b11, neg = 0b1; !((R(s5) as UInt) > (R(t5) as UInt)); ("!cmp.gtu(",AsmR(s5),",",AsmR(t5),")") )
+
+
+  format CombineRegImmFormat : Word =
+    { iclass [31..28]
+    , parse  [15..14]
+    , rs     [27]
+    , majop  [26..24]
+    , minop  [22..21]
+    , s5     [20..16]
+    , op     [13]
+    , imm    [12..5]
+    , d5     [4..0]
+    , immS   = imm as SWord
+    }
+  format CombineImmFormat : Word =
+    { iclass [31..28]
+    , parse  [15..14]
+    , rs     [27]
+    , majop  [26..24]
+    , minop  [23]
+    , immlow [22..16,13]
+    , immhigh[12..5]
+    , d5     [4..0]
+    , immhighS = immhigh as SWord
+    , immlowS  = immlow as SWord
+    , immlowU  = immlow(5..0) as UWord
+    }
+  format CombineRegWordFormat : Word =
+    { iclass [31..28]
+    , parse  [15..14]
+    , p      [27]
+    , majop  [26..24]
+    , minop  [23..21]
+    , s5     [20..16]
+    , t5     [12..8]
+    , d5     [4..0]
+    }
+
+  model CombineWordBase ( name: Id, iformat: Id, encs: Encs, vhigh: Ex, vlow: Ex, asm: Ex ) : IsaDefs = {
+    // TODO: Reenable this annotation
+    // [ operation ALU32 ]
+    instruction $name : $iformat = {
+      R( d5 ) := ($vhigh as Half, $vlow as Half)
+    }
+    encoding $name = { $encs }
+    assembly $name = (AsmR(d5), "=", $asm)
+  }
+  model CombineDoubleBase ( name: Id, iformat: Id, encs: Encs, vhigh: Ex, vlow: Ex, asm: Ex ) : IsaDefs = {
+    // TODO: Reenable this annotation
+    // [ operation ALU32 ]
+    instruction $name : $iformat = {
+      R( d5   ) := $vlow
+      R( d5+1 ) := $vhigh
+    }
+    encoding $name = { $encs }
+    assembly $name = (AsmRR(d5), "=combine(", $asm, ")")
+  }
+
+  $CombineDoubleBase( CombineDoubleRegImm; CombineRegImmFormat; iclass=0b0111, rs=0, majop=0b011, minop=0b00, op=1; R(rs); extendS(immS); (AsmR(rs),",#",decimal(immS)))
+  $CombineDoubleBase( CombineDoubleImmReg; CombineRegImmFormat; iclass=0b0111, rs=0, majop=0b011, minop=0b01, op=1; extendS(immS); R(rs); ("#",decimal(immS),",",AsmR(rs)))
+  $CombineDoubleBase( CombineDoubleImmSS ; CombineImmFormat   ; iclass=0b0111, rs=1, majop=0b100, minop=0b0 ; extendS(immhighS); immlowS; ("#",decimal(immhighS),",#",decimal(immlowS)))
+  $CombineDoubleBase( CombineDoubleImmSU ; CombineImmFormat   ; iclass=0b0111, rs=1, majop=0b100, minop=0b1 ; extendS(immhighS); immlowU; ("#",decimal(immhighS),",#",decimal(immlowU)))
+
+  $CombineWordBase  ( CombineWordRegHH   ; CombineRegWordFormat; iclass=0b1111, p=0, majop=0b011, minop=0b100 ; R(t5) >> 16; R(s5) >> 16; (AsmR(t5),".H,",AsmR(s5),".H"))
+  $CombineWordBase  ( CombineWordRegHL   ; CombineRegWordFormat; iclass=0b1111, p=0, majop=0b011, minop=0b101 ; R(t5) >> 16; R(s5)      ; (AsmR(t5),".H,",AsmR(s5),".L"))
+  $CombineWordBase  ( CombineWordRegLH   ; CombineRegWordFormat; iclass=0b1111, p=0, majop=0b011, minop=0b110 ; R(t5)      ; R(s5) >> 16; (AsmR(t5),".L,",AsmR(s5),".H"))
+  $CombineWordBase  ( CombineWordRegLL   ; CombineRegWordFormat; iclass=0b1111, p=0, majop=0b011, minop=0b111 ; R(t5)      ; R(s5)      ; (AsmR(t5),".L,",AsmR(s5),".L"))
+  // not implemented: Rdd=combine(Rs,Rt)
+
+  // ----------------------------------  operation ALU32/PRED ---------------------------------
+
+  format AddPredImmFormat : Word =
+    { iclass [31..28]
+    , parse  [15..14]
+    , rs     [27]
+    , majop  [26..24]
+    , ps     [23]
+    , u2     [22..21]
+    , s5     [20..16]
+    , dn     [13]
+    , imm    [12..5]
+    , d5     [4..0]
+    , immS   = imm as SInt
+    }
+  format ALUPredRegFormat : Word =
+    { iclass [31..28]
+    , parse  [15..14]
+    , p      [27]
+    , majop  [26..24]
+    , minop  [23,21]
+    , s5     [20..16]
+    , dn     [13]
+    , t5     [12..8]
+    , ps     [7]
+    , u2     [6..5]
+    , d5     [4..0]
+    }
+
+  model ALUPredBase ( name: Id, iformat: Id, encs: Encs, op: Id, lhs: Ex, rhs: Ex, asmprefix: Ex, asm: Ex, pred: Ex ) : IsaDefs = {
+    // TODO: Reenable this annotation
+    // [ operation ALU32 ]
+    instruction $name : $iformat = {
+      R(d5) := VADL::$op($lhs, $rhs)
+    }
+    encoding $name = { $encs }
+    assembly $name = ($asmprefix, AsmR(d5), " = ", AsStr($op), "(", $asm, ")")
+  }
+
+  $ALUPredBase( AddImmPredPos; AddPredImmFormat; iclass=0b0111, rs=0, majop=0b100, ps=0, dn=0; add; R(s5); extendS(immS); AsmPred(u2, false, false); (AsmR(s5),",#",decimal(immS));  testpred(u2))
+  // $ALUPredBase( AddImmPred; AddPredImmFormat; iclass=0b0111, rs=0, majop=0b100, ps=0, dn=1; add; R(s5); extendS(immS); AsmPred(u2, false, true ); (AsmR(s5),",#",decimal(immS));  testpred(u2))
+  $ALUPredBase( AddImmPredNeg; AddPredImmFormat; iclass=0b0111, rs=0, majop=0b100, ps=1, dn=0; add; R(s5); extendS(immS); AsmPred(u2, true , false); (AsmR(s5),",#",decimal(immS)); !testpred(u2))
+  // $ALUPredBase( AddImmPred; AddPredImmFormat; iclass=0b0111, rs=0, majop=0b100, ps=1, dn=1; add; R(s5); extendS(immS); AsmPred(u2, true , true ); (AsmR(s5),",#",decimal(immS)); !testpred(u2))
+
+  $ALUPredBase( AddRegPredPos; ALUPredRegFormat; iclass=0b1111, p=1, majop=0b011, minop=0b00, dn=0, ps=0; add; R(s5); R(t5); AsmPred(u2, false, false); (AsmR(s5),",",AsmR(t5));  testpred(u2))
+  $ALUPredBase( AddRegPredNeg; ALUPredRegFormat; iclass=0b1111, p=1, majop=0b011, minop=0b00, dn=0, ps=1; add; R(s5); R(t5); AsmPred(u2, true , false); (AsmR(s5),",",AsmR(t5)); !testpred(u2))
+  $ALUPredBase( SubRegPredPos; ALUPredRegFormat; iclass=0b1111, p=1, majop=0b011, minop=0b01, dn=0, ps=0; sub; R(t5); R(s5); AsmPred(u2, false, false); (AsmR(t5),",",AsmR(s5));  testpred(u2))
+  $ALUPredBase( SubRegPredNeg; ALUPredRegFormat; iclass=0b1111, p=1, majop=0b011, minop=0b01, dn=0, ps=1; sub; R(t5); R(s5); AsmPred(u2, true , false); (AsmR(t5),",",AsmR(s5)); !testpred(u2))
+
+
+  // ----------------------------------  operation CR ---------------------------------
+
+  // The value of C(idx) as prescribed by the ISA
+  function getCIsa(idx: Index) -> Word =
+    match idx with
+    { C_INDEX_P  => P
+    , C_INDEX_PC => PC
+    , _          => C(idx)
+    }
+
+  model TransferControlBase ( name: Id, encs: Encs, asmDst: Id, asmSrc: Id, stats: Stats ) : IsaDefs = {
+    // TODO: Reenable this annotation
+    // [ operation CR ]
+    instruction $name : StandardFormat = {
+      $stats
+    }
+    encoding $name = { iclass = 0b0110, $encs }
+    assembly $name = ($asmDst(d5), "=", $asmSrc(s5))
+  }
+
+  // TODO @nmischkulnig PC is "not writable" in this instruction. The assembler rejects this as well.
+  // It's unclear if this should trigger an exception or simply ignore the attempted write.
+  $TransferControlBase( TransferCR  ; majop = 0b0010, minop = 0b001; AsmC ; AsmR; {
+    let val = R(s5) in
+    if d5 = C_INDEX_P then {
+      P := val
+    }
+    else if d5 != C_INDEX_PC then C(d5) := val
+  })
+  $TransferControlBase( TransferCCRR; majop = 0b0011, minop = 0b001; AsmCC; AsmRR; {
+    let valLo = R(s5) in
+    let valHi = R(s5+1) in
+    if d5 = C_INDEX_P then { // C5:4 = Rx:y
+      P := valLo
+      C(d5+1) := valHi
+    }
+    else if (d5+1) != C_INDEX_PC then { // C9:8 = Rx:y
+      C(d5  ) := valLo
+      C(d5+1) := valHi
+    }
+  })
+  $TransferControlBase( TransferRRCC; majop = 0b1000, minop = 0b000; AsmRR; AsmCC; R(d5) := getCIsa(s5) R(d5+1) := getCIsa(s5+1) )
+  $TransferControlBase( TransferRC  ; majop = 0b1010, minop = 0b000; AsmR ; AsmC ; R(d5) := getCIsa(s5)                          )
+
+  format AddRegPCFormat : Word =
+    { iclass [31..28]
+    , parse  [15..14]
+    , op     [27..16]
+    , imm    [12..7]
+    , d5     [4..0]
+    , immU   = extendU(imm)
+    }
+  format AddRegPCXFormat : Double =
+    { iclassX [31..28]
+    , parseX  [15..14]
+    , immX    [27..16,13..0]
+    // ---
+    , iclass [63..60]
+    , parse  [47..46]
+    , op     [59..48]
+    , imm    [44..39]
+    , d5     [36..32]
+    , immU   = extendUExtender(imm, immX)
+    }
+  model AddRegPCBase ( name: Id, iformat: Id, encs: Encs, asmPrefix: Ex, asmimm: Id ) : IsaDefs = {
+    // TODO: Reenable this annotation
+    // [ operation CR ]
+    instruction $name : $iformat = {
+      R(d5) := PC.current + immU
+    }
+    encoding $name = { iclass = 0b0110, op = 0b101001001001, $encs }
+    assembly $name = ($asmPrefix, AsmR(d5), "=add(pc,", $asmimm(immU),")")
+  }
+  $AddRegPCBase( AddRegPC ; AddRegPCFormat ; /* unneeded */ iclass=0b0110; ""              ; AsmImmU )
+  $AddRegPCBase( AddRegPCX; AddRegPCXFormat; iclassX=0    ; AsmImmextU(immX); AsmImmUX )
+
+  format LogicalPredFormat : Word =
+    { iclass [31..28]
+    , parse  [15..14]
+    , opc    [27..24,13]
+    , op     [23..20]
+    , s2     [17..16]
+    , t2     [9..8]
+    , u2     [7..6]
+    , d2     [1..0]
+    }
+  // This instruction may execute on either slot2 or slot3, even though it is a CR-type
+  model LogicalPredBase ( name: Id, encs: Encs, val: Ex, asm: Ex ) : IsaDefs = {
+    // TODO: Reenable this annotation
+    // [ operation CR23 ]
+    instruction $name : LogicalPredFormat = {
+      Pset(d2, $val)
+    }
+    encoding $name = { iclass = 0b0110, opc = 0b10110, $encs }
+    assembly $name = (AsmP(d2), "=", $asm)
+  }
+  $LogicalPredBase(LogicalPredAnd       ; op=0b0000; VADL::and(Pget(t2),Pget(s2))                                ; ("and(", AsmP(t2), ",", AsmP(s2), ")") )
+  $LogicalPredBase(LogicalPredAndAnd    ; op=0b0001; VADL::and(Pget(s2),VADL::and(Pget(t2),Pget(u2)))            ; ("and(", AsmP(s2), ",and(", AsmP(t2), ",", AsmP(u2), "))") )
+  $LogicalPredBase(LogicalPredOr        ; op=0b0010; VADL::or(Pget(t2),Pget(s2))                                 ; ( "or(", AsmP(t2), ",", AsmP(s2), ")") )
+  $LogicalPredBase(LogicalPredAndOr     ; op=0b0011; VADL::and(Pget(s2),VADL::or(Pget(t2),Pget(u2)))             ; ("and(", AsmP(s2), ",or(", AsmP(t2), ",", AsmP(u2), "))") )
+  $LogicalPredBase(LogicalPredXor       ; op=0b0100; VADL::xor(Pget(s2),Pget(t2))                                ; ("xor(", AsmP(s2), ",", AsmP(t2), ")") )
+  $LogicalPredBase(LogicalPredOrAnd     ; op=0b0101; VADL::or(Pget(s2),VADL::and(Pget(t2),Pget(u2)))             ; ( "or(", AsmP(s2), ",and(", AsmP(t2), ",", AsmP(u2), "))") )
+  $LogicalPredBase(LogicalPredAndNot    ; op=0b0110; VADL::and(Pget(t2),!Pget(s2))                               ; ("and(", AsmP(t2), ",!", AsmP(s2), ")") )
+  $LogicalPredBase(LogicalPredOrOr      ; op=0b0111; VADL::or(Pget(s2),VADL::or(Pget(t2),Pget(u2)))              ; ( "or(", AsmP(s2), ",or(", AsmP(t2), ",", AsmP(u2), "))") )
+  $LogicalPredBase(LogicalPredAndAndNot ; op=0b1001; VADL::and(Pget(s2),VADL::and(Pget(t2),VADL::not(Pget(u2)))) ; ("and(", AsmP(s2), ",and(", AsmP(t2), ",!", AsmP(u2), "))") )
+  $LogicalPredBase(LogicalPredAndOrNot  ; op=0b1011; VADL::and(Pget(s2),VADL::or(Pget(t2),VADL::not(Pget(u2))))  ; ("and(", AsmP(s2), ",or(", AsmP(t2), ",!", AsmP(u2), "))") )
+  $LogicalPredBase(LogicalPredNot       ; op=0b1100; VADL::not(Pget(s2))                                         ; ("not(", AsmP(s2), ")") )
+  $LogicalPredBase(LogicalPredOrAndNot  ; op=0b1101; VADL::or(Pget(s2),VADL::and(Pget(t2),VADL::not(Pget(u2))))  ; ( "or(", AsmP(s2), ",and(", AsmP(t2), ",!", AsmP(u2), "))") )
+  $LogicalPredBase(LogicalPredOrNot     ; op=0b1110; VADL::or(Pget(t2),!Pget(s2))                                ; ( "or(", AsmP(t2), ",!", AsmP(s2), ")") )
+  $LogicalPredBase(LogicalPredOrOrNot   ; op=0b1111; VADL::or(Pget(s2),VADL::or(Pget(t2),VADL::not(Pget(u2))))   ; ( "or(", AsmP(s2), ",or(", AsmP(t2), ",!", AsmP(u2), "))") )
+
+  // ----------------------------------  operation JR ---------------------------------
+  // Missing instructions:
+  //  - new value predicates: `if ([!]Pu.new) jumpr:{t,nt} Rs`
+  //  - hintjr
+
+  format BranchRegFormat : Word =
+    { iclass [31..28]
+    , parse  [15..14]
+    , op     [27..21]
+    , u2     [9,8]
+    , s5     [20..16]
+    , hintnew[12..11]
+    }
+
+  model CallRegBase ( name: Id, encs: Encs, asm: Ex, pred: Ex ) : IsaDefs = {
+    // TODO: Reenable this annotation
+    // [ operation JR ]
+    instruction $name : BranchRegFormat = {
+      if $pred then {
+        LR := PC.next
+        PC := R(s5)
+      }
+    }
+    encoding $name = { iclass = 0b0101, $encs }
+    assembly $name = ($asm, "callr ", AsmR(s5))
+  }
+
+  $CallRegBase( CallReg       ; op = 0b0000101; ""; true )
+  $CallRegBase( CallRegPredPos; op = 0b0001000; AsmPred(u2, false, false);  testpred(u2) )
+  $CallRegBase( CallRegPredNeg; op = 0b0001001; AsmPred(u2, true , false); !testpred(u2) )
+
+
+  model JumpRegBase ( name: Id, encs: Encs, asmprefix: Ex, asmpostfix: Ex, pred: Ex ) : IsaDefs = {
+    // TODO: Reenable this annotation
+    // [ operation JR ]
+    instruction $name : BranchRegFormat = {
+      if $pred then {
+        PC := R(s5)
+      }
+    }
+    encoding $name = { iclass = 0b0101, $encs }
+    assembly $name = ($asmprefix, "jumpr", $asmpostfix, " ", AsmR(s5))
+  }
+
+  $JumpRegBase( JumpReg         ; op = 0b0010100; ""; ""; true )
+  $JumpRegBase( JumpRegPredPosNT; op = 0b0011010, hintnew = 0b00; AsmPred(u2, false, false); ":nt ";  testpred(u2) )
+  $JumpRegBase( JumpRegPredPosT ; op = 0b0011010, hintnew = 0b10; AsmPred(u2, false, false); ":t " ;  testpred(u2) )
+  $JumpRegBase( JumpRegPredNegNT; op = 0b0011011, hintnew = 0b00; AsmPred(u2, true , false); ":nt "; !testpred(u2) )
+  $JumpRegBase( JumpRegPredNegT ; op = 0b0011011, hintnew = 0b10; AsmPred(u2, true , false); ":t " ; !testpred(u2) )
+
+  // ----------------------------------  operation J ---------------------------------
+
+  format JumpImmFormat : Word =
+    { iclass [31..28]
+    , parse  [15..14]
+    , op     [27..25]
+    , imm    [24..16,13..1]
+    , immS = scaledImmR2(imm)
+    }
+  format JumpImmPredFormat : Word =
+    { iclass [31..28]
+    , parse  [15..14]
+    , op     [27..24,21]
+    , hintnew[12..11]
+    , imm    [23..22,20..16,13,7..1]
+    , u2     [9..8]
+    , immS = scaledImmR2(imm)
+    }
+
+  model JumpImmBase ( name: Id, iformat: Id, encs: Encs, asmprefix: Ex, asmpostfix: Ex, pred: Ex ) : IsaDefs = {
+    // TODO: Reenable this annotation
+    // [ operation J ]
+    instruction $name : $iformat = {
+      if $pred then {
+        PC := PC.current + extendR2(imm)
+      }
+    }
+    encoding $name = { $encs }
+    assembly $name = ($asmprefix, "jump", $asmpostfix, " ", decimal(immS))
+  }
+
+  $JumpImmBase( JumpImm         ; JumpImmFormat    ; iclass = 0b0101, op = 0b100; ""; ""; true )
+  $JumpImmBase( JumpImmPredPosNT; JumpImmPredFormat; iclass = 0b0101, op = 0b11000, hintnew = 0b00; AsmPred(u2, false, false); ":nt ";  testpred(u2) )
+  $JumpImmBase( JumpImmPredPosT ; JumpImmPredFormat; iclass = 0b0101, op = 0b11000, hintnew = 0b10; AsmPred(u2, false, false); ":t " ;  testpred(u2) )
+  $JumpImmBase( JumpImmPredNegNT; JumpImmPredFormat; iclass = 0b0101, op = 0b11001, hintnew = 0b00; AsmPred(u2, true , false); ":nt "; !testpred(u2) )
+  $JumpImmBase( JumpImmPredNegT ; JumpImmPredFormat; iclass = 0b0101, op = 0b11001, hintnew = 0b10; AsmPred(u2, true , false); ":t " ; !testpred(u2) )
+
+  format CallImmFormat : Word =
+    { iclass [31..28]
+    , parse  [15..14]
+    , op     [27..25,0]
+    , imm [24..16,13..1]
+    }
+  format CallImmPredFormat : Word =
+    { iclass [31..28]
+    , parse  [15..14]
+    , op     [27..24,11]
+    , pred   [9,8]
+    , neg    [21]
+    , imm    [23,22,20..16,13,7..1]
+    }
+
+  model CallImmBase ( name: Id, iformat: Id, encs: Encs, asm: Ex, pred: Ex ) : IsaDefs = {
+    // TODO: Reenable this annotation
+    // [ operation J ]
+    instruction $name : $iformat = {
+      if $pred then {
+        LR := PC.next
+        PC := PC.current + extendR2(imm)
+      }
+    }
+    encoding $name = { iclass = 0b0101, $encs }
+    assembly $name = ($asm, "call #", decimal(imm))
+  }
+
+  $CallImmBase( CallImm       ; CallImmFormat    ; op = 0b1010; ""; true )
+  $CallImmBase( CallImmPredPos; CallImmPredFormat; op = 0b101, neg = 0b0; AsmPred(pred, false, false) ; testpred(pred) )
+  $CallImmBase( CallImmPredNeg; CallImmPredFormat; op = 0b101, neg = 0b1; AsmPred(pred, true , false); !testpred(pred) )
+
+  format CmpJumpFormat : Word =
+    { iclass [31..28]
+    , parse  [15..14]
+    , op     [27..26,24..23,9..8]
+    , d1     [25]
+    , neg    [22]
+    , hint   [13]
+    , s4     [19..16]
+    , disp   [21..20,7..1]
+    , dispS  = scaledImmR2(disp)
+    // Available registers are R0-R7 and R16-R23
+    , s5     = if s4 <= 7 then (s4 as Index) else ((s4 as Index) + 8)
+    , d2     = d1 as PredicateIndex // for the constraints
+    }
+  format CmpJumpImmFormat : Word =
+    { iclass [31..28]
+    , parse  [15..14]
+    , op     [27..26,24..23]
+    , d1     [25]
+    , neg    [22]
+    , hint   [13]
+    , s4     [19..16]
+    , imm    [12..8]
+    , disp   [21..20,7..1]
+    , immU   = imm as UWord
+    , dispS  = scaledImmR2(disp)
+    // Available registers are R0-R7 and R16-R23
+    , s5     = if s4 <= 7 then (s4 as Index) else ((s4 as Index) + 8)
+    , d2     = d1 as PredicateIndex // for the constraints
+    }
+  format CmpJumpRegFormat : Word =
+    { iclass [31..28]
+    , parse  [15..14]
+    , op     [27..23]
+    , d1     [12]
+    , neg    [22]
+    , hint   [13]
+    , s4     [19..16]
+    , t4     [11..8]
+    , disp   [21..20,7..1]
+    , dispS  = scaledImmR2(disp)
+    // Available registers are R0-R7 and R16-R23
+    , s5     = if s4 <= 7 then (s4 as Index) else ((s4 as Index) + 8)
+    , t5     = if t4 <= 7 then (t4 as Index) else ((t4 as Index) + 8)
+    , d2     = d1 as PredicateIndex // for the constraints
+    }
+
+  model CmpJumpBase ( name: Id, iformat: Id, encs: Encs, neg: Val, p: Val, predEx: Ex, asmPred: Ex, asmHint: Ex ) : IsaDefs = {
+    // TODO: Reenable this annotation
+    // [ operation J_PRED_WRITING ]
+    instruction $name : $iformat = {
+      let pred   = $predEx in
+      let pvalue = toPValue($predEx) in {
+        Pset($p, pvalue)
+        if pred then {
+          PC := PC.current + extendR2(disp)
+        }
+      }
+    }
+    encoding $name = { iclass=0b0001, neg=$neg, d1=$p, $encs }
+    assembly $name = (AsmP($p), "=", $asmPred, "; ", AsmPred($p, $neg, true), " jump:", $asmHint, " #", decimal(dispS))
+  }
+  model CmpJump ( name: Id, iformat: Id, encs: Encs, predEx: Ex, asmPred: Ex ) : IsaDefs = {
+    $CmpJumpBase( AsId($name, "P0", "Pos", "NT"); $iformat; hint=0, $encs; 0; 0;  ($predEx); $asmPred; "nt" )
+    $CmpJumpBase( AsId($name, "P1", "Pos", "NT"); $iformat; hint=0, $encs; 0; 1;  ($predEx); $asmPred; "nt" )
+    $CmpJumpBase( AsId($name, "P0", "Neg", "NT"); $iformat; hint=0, $encs; 1; 0; !($predEx); $asmPred; "nt" )
+    $CmpJumpBase( AsId($name, "P1", "Neg", "NT"); $iformat; hint=0, $encs; 1; 1; !($predEx); $asmPred; "nt" )
+    $CmpJumpBase( AsId($name, "P0", "Pos", "T" ); $iformat; hint=1, $encs; 0; 0;  ($predEx); $asmPred; "t" )
+    $CmpJumpBase( AsId($name, "P1", "Pos", "T" ); $iformat; hint=1, $encs; 0; 1;  ($predEx); $asmPred; "t" )
+    $CmpJumpBase( AsId($name, "P0", "Neg", "T" ); $iformat; hint=1, $encs; 1; 0; !($predEx); $asmPred; "t" )
+    $CmpJumpBase( AsId($name, "P1", "Neg", "T" ); $iformat; hint=1, $encs; 1; 1; !($predEx); $asmPred; "t" )
+  }
+
+  $CmpJump( CmpJumpEqMinus1; CmpJumpFormat   ; op=0b001100;  R(s5)          =  -1            ; ("cmp.eq(",AsmR(s5),"#-1)") )
+  $CmpJump( CmpJumpGtMinus1; CmpJumpFormat   ; op=0b001101; (R(s5) as SInt) > (-1 as SInt)   ; ("cmp.gt(",AsmR(s5),"#-1)") )
+  $CmpJump( CmpJumpTstBit0 ; CmpJumpFormat   ; op=0b001111; (R(s5) & 0b1)   = 1              ; ("tstbit(",AsmR(s5),"#0)") )
+  $CmpJump( CmpJumpEqImm   ; CmpJumpImmFormat; op=0b0000  ;  R(s5)          = immU           ; ("cmp.eq(",AsmR(s5),"#",decimal(immU),")") )
+  $CmpJump( CmpJumpGtImm   ; CmpJumpImmFormat; op=0b0001  ; (R(s5)(15..0) as UWord) > immU   ; ("cmp.gt(",AsmR(s5),"#",decimal(immU),")") )
+  $CmpJump( CmpJumpGtuImm  ; CmpJumpImmFormat; op=0b0010  ; (R(s5) as UInt) > immU           ; ("cmp.gtu(",AsmR(s5),"#",decimal(immU),")") )
+  $CmpJump( CmpJumpEqReg   ; CmpJumpRegFormat; op=0b01000 ;  R(s5)          = R(t5)          ; ("cmp.eq(",AsmR(s5),"",AsmR(t5),")") )
+  $CmpJump( CmpJumpGtReg   ; CmpJumpRegFormat; op=0b01001 ; (R(s5) as SInt) > (R(t5) as SInt); ("cmp.gt(",AsmR(s5),"",AsmR(t5),")") )
+  $CmpJump( CmpJumpGtuReg  ; CmpJumpRegFormat; op=0b01010 ; (R(s5)(15..0) as UWord) > R(t5)  ; ("cmp.gtu(",AsmR(s5),"",AsmR(t5),")") )
+
+  // ----------------------------------  operation LD ---------------------------------
+
+  format LoadFormat : Word =
+    { iclass   [31..28]
+    , parse    [15..14]
+    , d5       [4..0]
+    , data     [26..25,20..16,13..5]
+    , gp       [27]
+    , type1    [24]
+    , type     [23..22]
+    , unsigned [21]
+    , immGPRel = data as UInt
+    , immRegRel= (data(15..14),data(8..0)) as SInt
+    , s5       = data(13..9)
+    }
+
+  format LoadRegRelPredFormat : Word =
+    { iclass   [31..28]
+    , parse    [15..14]
+    , op       [27,24,13]
+    , ps       [26]
+    , dn       [25]
+    , type     [23..22]
+    , unsigned [21]
+    , s5       [20..16]
+    , t2       [12..11]
+    , imm      [10..5]
+    , d5       [4..0]
+    , immRegRel= imm as UInt
+    }
+
+  model-type LoadBaseT = ( Id, Id, Encs, Lit, Ex, Id, Ex, Ex, Ex ) -> IsaDefs
+  model LoadSizeBase ( name: Id, iformat: Id, encs: Encs, size: Lit, addr: Ex, type: Id, asmprefix: Ex, asm: Ex, pred: Ex ) : IsaDefs = {
+    // TODO: Reenable this annotation
+    // [ operation LD ]
+    instruction $name : $iformat = {
+      if $pred then {
+        R(d5) := MEM<$size>($addr) as $type
+      }
+    }
+    encoding $name = { $encs }
+    assembly $name = ($asmprefix, AsmR(d5), "=", $asm)
+  }
+  model LoadDoubleBase ( name: Id, iformat: Id, encs: Encs, size: Lit, addr: Ex, type: Id, asmprefix: Ex, asm: Ex, pred: Ex ): IsaDefs = {
+    // TODO: Reenable this annotation
+    // [ operation LD ]
+    instruction $name : $iformat = {
+      if $pred then {
+        let result = MEM<8>($addr) as $type in {
+          R(d5)   := result(31..0)
+          R(d5+1) := result(63..32)
+        }
+      }
+    }
+    encoding $name = { $encs }
+    assembly $name = ($asmprefix, AsmRR(d5), "=", $asm)
+  }
+
+  model LoadBase ( base: LoadBaseT, name: Id, type: Id, size: Lit, scale: Lit, asmfunc: Ex) : IsaDefs = {
+    $base( AsId( $name, AsStr($type), "GPRel" )        ; LoadFormat          ; iclass=0b0100, gp=1, type1=0b1,      type=MemoryAccessType::$type, unsigned=0; $size; GP + scaledImmU(immGPRel, $scale)    ; AsId(S, AsStr($type)); ""; ($asmfunc, AsmAddrGPRel(immGPRel))       ; true )
+    $base( AsId( $name, AsStr($type), "RegRel" )       ; LoadFormat          ; iclass=0b1001, gp=0, type1=0b1,      type=MemoryAccessType::$type, unsigned=0; $size; R(s5) + scaledImmS(immRegRel, $scale); AsId(S, AsStr($type)); ""; ($asmfunc, AsmAddrRegRel(s5, immRegRel)) ; true )
+    $base( AsId( $name, AsStr($type), "PredPosRegRel" ); LoadRegRelPredFormat; iclass=0b0100, op=0b010, dn=0, ps=0, type=MemoryAccessType::$type, unsigned=0; $size; R(s5) + scaledImmS(immRegRel, $scale); AsId(S, AsStr($type)); AsmPred(t2, false, false); ($asmfunc, AsmAddrRegRel(s5, immRegRel)) ;  testpred(t2) )
+    $base( AsId( $name, AsStr($type), "PredNegRegRel" ); LoadRegRelPredFormat; iclass=0b0100, op=0b010, dn=0, ps=1, type=MemoryAccessType::$type, unsigned=0; $size; R(s5) + scaledImmS(immRegRel, $scale); AsId(S, AsStr($type)); AsmPred(t2, true , false); ($asmfunc, AsmAddrRegRel(s5, immRegRel)) ; !testpred(t2) )
+  }
+  model LoadBaseU (base: LoadBaseT, name: Id, type: Id, size: Lit, scale: Lit, asmfunc: Ex) : IsaDefs = {
+    $base( AsId( $name, "U", AsStr($type), "GPRel" ) ; LoadFormat; iclass=0b0100, gp=1, type1=0b1, type=MemoryAccessType::$type, unsigned=1; $size; GP + scaledImmU(immGPRel, $scale)    ; AsId(U, AsStr($type)); ""; ($asmfunc, AsmAddrGPRel(immGPRel))       ; true )
+    $base( AsId( $name, "U", AsStr($type), "RegRel" ); LoadFormat; iclass=0b1001, gp=0, type1=0b1, type=MemoryAccessType::$type, unsigned=1; $size; R(s5) + scaledImmS(immRegRel, $scale); AsId(U, AsStr($type)); ""; ($asmfunc, AsmAddrRegRel(s5, immRegRel)) ; true )
+  }
+
+  $LoadBase ( LoadSizeBase;   Load ; Byte   ; 1 ; 0; "memb"  )
+  $LoadBaseU( LoadSizeBase;   Load ; Byte   ; 1 ; 0; "memub" )
+  $LoadBase ( LoadSizeBase;   Load ; Half   ; 2 ; 1; "memh"  )
+  $LoadBaseU( LoadSizeBase;   Load ; Half   ; 2 ; 1; "memuh" )
+  $LoadBase ( LoadSizeBase;   Load ; Word   ; 4 ; 2; "memw"  )
+  $LoadBase ( LoadDoubleBase; Load ; Double ; 8 ; 3; "memd"  )
+
+  format DeallocFrameFormat : Word =
+    { iclass   [31..28]
+    , parse    [15..14]
+    , d5       [4..0]
+    , amode    [27..25]
+    , type     [24..22]
+    , unsigned [21]
+    , opc      [20..16]
+    , neg      [13]
+    , hintnew  [12..11]
+    , op1      [10]
+    , pred     [9..8]
+    }
+
+  // TODO: Reenable this annotation
+
+  // [ operation LD ]
+  instruction DeallocFrame : DeallocFrameFormat = {
+    let restored = MEM<8>(FP) as Double in
+    let LRnew = frameUnscramble(restored(63..32)) in {
+      SP := FP + 8
+      LR := LRnew
+      FP := restored(31..0)
+    }
+  }
+  encoding DeallocFrame = { iclass = 0b1001, amode=0b000, type=0b000, unsigned=0b0, opc=0b11110, neg = 0, d5 = 0b11110 }
+  assembly DeallocFrame = ("deallocframe")
+
+
+  model DecallocReturnBase ( name: Id, encs: Encs, asmprefix: Ex, asmpostfix: Ex, pred: Ex ) : IsaDefs = {
+    // TODO: Reenable this annotation
+    // [ operation LD ]
+    instruction $name : DeallocFrameFormat = {
+      if $pred then {
+        let restored = MEM<8>(FP) as Double in
+        let LRnew = frameUnscramble(restored(63..32)) in {
+          SP := FP + 8
+          LR := LRnew
+          FP := restored(31..0)
+          PC := LRnew
+        }
+      }
+    }
+    encoding $name = { iclass = 0b1001, amode = 0b011, type = 0b000, unsigned = 0b0, opc = 0b11110, op1 = 0b0, d5 = 0b11110, $encs }
+    assembly $name = ($asmprefix, "dealloc_return", $asmpostfix)
+  }
+
+  $DecallocReturnBase( DecallocReturn        ; hintnew = 0b00, neg = 0b0; ""; ""; true )
+  $DecallocReturnBase( DecallocReturnPredPos ; hintnew = 0b10, neg = 0b0; AsmPred(pred, false, false); "" ;  testpred(pred) )
+  $DecallocReturnBase( DecallocReturnPredNeg ; hintnew = 0b10, neg = 0b1; AsmPred(pred, true , false); " "; !testpred(pred) )
+
+
+  // ----------------------------------  operation MEMOP ---------------------------------
+
+
+
+  // ----------------------------------  operation ST ---------------------------------
+
+  format StoreFormat : Word =
+    { iclass   [31..28]
+    , parse    [15..14]
+    , t5       [12..8]
+    , data     [26..25,20..16,13,7..0]
+    , gp       [27]
+    , type1    [24]
+    , type     [23..22]
+    , unsigned [21]
+    , immGPRel = data as UInt
+    , immRegRel= (data(15..14),data(8..0)) as SInt
+    , s5       = data(13..9)
+    }
+
+  model-type StoreBaseT = ( Id, Encs, Lit, Ex, Id, Ex, Ex, Ex ) -> IsaDefs
+  model StoreSizeBase ( name: Id, encs: Encs, size: Lit, addr: Ex, type: Id, shift: Ex, asmprefix: Ex, asmpostfix: Ex ) : IsaDefs = {
+    // TODO: Reenable this annotation
+    // [ operation ST ]
+    instruction $name : StoreFormat = {
+      MEM<$size>($addr) := (R(t5) >> ($shift as UInt<6>)) as $type
+    }
+    encoding $name = { $encs }
+    assembly $name = ($asmprefix, "=", AsmR(t5), $asmpostfix)
+  }
+  model StoreDoubleBase ( name: Id, encs: Encs, size: Lit, addr: Ex, type: Id, shift: Ex, asmprefix: Ex, asmpostfix: Ex ) : IsaDefs = {
+    // TODO: Reenable this annotation
+    // [ operation ST ]
+    instruction $name : StoreFormat = {
+      MEM<$size>($addr) := ((R(t5+1), R(t5))) as $type
+    }
+    encoding $name = { $encs }
+    assembly $name = ($asmprefix, "=", AsmR(t5), $asmpostfix)
+  }
+
+  model StoreBase   ( base: StoreBaseT, name: Id, type: Id, size: Lit, scale: Lit, asmfunc: Ex) : IsaDefs = {
+    $base( AsId( $name, AsStr($type), "GPRel" )      ; iclass=0b0100, gp=1, type1=0, type=MemoryAccessType::$type, unsigned = 0; $size; GP + scaledImmU(immGPRel, $scale)    ; $type; 0        ; ($asmfunc, AsmAddrGPRel(immGPRel))       ; "")
+    $base( AsId( $name, AsStr($type), "RegRel" )     ; iclass=0b1010, gp=0, type1=1, type=MemoryAccessType::$type, unsigned = 0; $size; R(s5) + scaledImmS(immRegRel, $scale); $type; 0        ; ($asmfunc, AsmAddrRegRel(s5, immRegRel)) ; "")
+  }
+  model StoreBaseHigh( base: StoreBaseT, name: Id, type: Id, size: Lit, scale: Lit, asmfunc: Ex) : IsaDefs = {
+    $base( AsId( $name, "H", AsStr($type), "GPRel" ) ; iclass=0b0100, gp=1, type1=0, type=MemoryAccessType::$type, unsigned = 1; $size; GP + scaledImmU(immGPRel, $scale)    ; $type; $size * 8; ($asmfunc, AsmAddrGPRel(immGPRel))       ; ".H")
+    $base( AsId( $name, "H", AsStr($type), "RegRel" ); iclass=0b1010, gp=0, type1=1, type=MemoryAccessType::$type, unsigned = 1; $size; R(s5) + scaledImmS(immRegRel, $scale); $type; $size * 8; ($asmfunc, AsmAddrRegRel(s5, immRegRel)) ; ".H")
+  }
+
+  $StoreBase    ( StoreSizeBase ;  Store ; Byte ;   1 ; 0; "memb"  )
+  $StoreBase    ( StoreSizeBase ;  Store ; Half ;   2 ; 1; "memh"  )
+  $StoreBaseHigh( StoreSizeBase ;  Store ; Half ;   2 ; 1; "memh"  )
+  $StoreBase    ( StoreSizeBase ;  Store ; Word ;   4 ; 2; "memw"  )
+  $StoreBase    ( StoreDoubleBase; Store ; Double ; 8 ; 3; "memd"  )
+
+  format StoreImmFormat : Word =
+    { iclass    [31..28]
+    , parse     [15..14]
+    , amode     [27..25]
+    , type      [22..21]
+    , s5        [20..16]
+    , immOffset [12..7]
+    , imm       [13,6..0]
+    , immOffsetU= immOffset as UInt
+    , immS      = extendS(imm)
+    // , d2       = imm(6..5) as PredicateIndex
+    // , immSPred = (imm(6),imm(4..0)) as PredicateIndex
+    }
+  format StoreImmXFormat : Double =
+    { iclassX [31..28]
+    , parseX  [15..14]
+    , immX    [27..16,13..0]
+    // ---
+    , iclass    [63..60]
+    , parse     [47..46]
+    , amode     [59..57]
+    , type      [54..53]
+    , s5        [52..48]
+    , immOffset [44..39]
+    , imm       [45,38..32]
+    , immOffsetU= immOffset as UInt
+    , immS      = extendSExtender(imm, immX)
+    // , d2       = imm(6..5) as PredicateIndex
+    // , immSPred = (imm(6),imm(4..0)) as PredicateIndex
+    }
+
+  model StoreImmSizeBase ( name: Id, iformat: Id, type: Id, encs: Encs, size: Val, scale: Val, imm: Ex, asmprefix: Ex, pred: Ex ) : IsaDefs = {
+    // TODO: Reenable this annotation
+    // [ operation ST ]
+    instruction $name : $iformat = {
+      if $pred then MEM<$size>( R(s5) + scaledImmU(immOffsetU, $scale) ) := $imm
+    }
+    encoding $name = { iclass = 0b0011, type=MemoryAccessType::$type, $encs }
+    assembly $name = ($asmprefix,"(",AsmR(s5),"+#",decimal(scaledImmU(immOffsetU, $scale)),")", "=#", decimal($imm))
+  }
+
+  $StoreImmSizeBase( StoreImmByte ; StoreImmFormat ; Byte;            amode = 0b110 ; 1 ; 0; immS as SByte; "memb" ; true )
+  $StoreImmSizeBase( StoreImmHalf ; StoreImmFormat ; Half;            amode = 0b110 ; 2 ; 1; immS as SHalf; "memh" ; true )
+  $StoreImmSizeBase( StoreImmWord ; StoreImmFormat ; Word;            amode = 0b110 ; 4 ; 2; immS as SWord; "memw" ; true )
+  $StoreImmSizeBase( StoreImmByteX; StoreImmXFormat; Byte; iclassX=0, amode = 0b110 ; 1 ; 0; immS as SByte; (AsmImmextU(immX), "memb") ; true )
+  $StoreImmSizeBase( StoreImmHalfX; StoreImmXFormat; Half; iclassX=0, amode = 0b110 ; 2 ; 1; immS as SHalf; (AsmImmextU(immX), "memh") ; true )
+  $StoreImmSizeBase( StoreImmWordX; StoreImmXFormat; Word; iclassX=0, amode = 0b110 ; 4 ; 2; immS as SWord; (AsmImmextU(immX), "memw") ; true )
+
+
+  format AllocFrameFormat : Word =
+    { iclass   [31..28]
+    , parse    [15..14]
+    , amode    [27..25]
+    , type     [24..22]
+    , unsigned [21]
+    , opc      [20..16,13..11]
+    , imm      [10..0]
+    , immU = (imm as UInt<11>) * (8 as UInt<4>)
+    }
+
+  // TODO: Reenable this annotation
+
+  // [ operation ST ]
+  instruction AllocFrame : AllocFrameFormat = {
+    let SPnew = SP - 8 in {
+      MEM<8>(SPnew) := (frameScramble( LR ), FP)
+      FP := SPnew
+      // frame_check_limit(SPnew - immU);
+      SP := SPnew - immU
+    }
+  }
+
+  encoding AllocFrame = { iclass = 0b1010, amode = 0b000, type=0b010, unsigned=0, opc=0b11101000 }
+  assembly AllocFrame = ("allocframe(", ")")
+
+
+  // ----------------------------------  operation SYSTEM ---------------------------------
+
+  format BrkptFormat : Word =
+    { iclass [31..28]
+    , opc    [27..21,7..5]
+    , parse  [15..14]
+    }
+  // TODO: Reenable this annotation
+  // [ operation SYSTEMSolo ]
+  instruction Brkpt : BrkptFormat = {
+    PC := 0xeeeeeeee
+  }
+  encoding Brkpt = { iclass = 0b0110, opc = 0b1100001000 }
+  assembly Brkpt = ( "brkpt" )
+
+  // ----------------------------------  operation XTYPE ---------------------------------
+
+  format AddImmShiftedFormat : Word =
+    { iclass [31..28]
+    , parse  [15..14]
+    , regtype[27..24]
+    , imm    [23..21,13,7..5,3]
+    , x5     [20..16]
+    , shift  [12..8]
+    , majop  [4,2..1]
+    , immU   = imm as UWord
+    , shiftU = shift as UInt
+    }
+
+  model ALUImmShifted ( name: Id, encs: Encs, op: Id, shiftop: Id ) : IsaDefs = {
+    // TODO: Reenable this annotation
+    // [ operation XTYPE ]
+    instruction $name : AddImmShiftedFormat = {
+      R(x5) := VADL::$op(immU, VADL::$shiftop(R(x5), shiftU) as UInt)
+    }
+    encoding $name = { iclass=0b1101, regtype=0b1110, $encs }
+    assembly $name = (AsmR(x5), " = ", AsStr($op), "(#", decimal(immU), AsStr($shiftop), "(", AsmR(x5), "#", decimal(shiftU), "))")
+  }
+
+  $ALUImmShifted ( AddImmAsl ; majop=0b010 ; add ; lsl )
+  $ALUImmShifted ( SubImmAsl ; majop=0b011 ; sub ; lsl )
+  $ALUImmShifted ( AddImmLsr ; majop=0b110 ; add ; lsr )
+  $ALUImmShifted ( SubImmLsr ; majop=0b111 ; sub ; lsr )
+
+  format BitOpImmFormat : Word =
+    { iclass [31..28]
+    , parse  [15..14]
+    , regtype[27..24]
+    , majop  [23..22]
+    , op     [21,13]
+    , minop  [7..5]
+    , s5     [20..16]
+    , imm    [12..8]
+    , d5     [4..0]
+    , immU   = imm as UInt // no constant extender!
+    }
+  format BitOpRegFormat : Word =
+    { iclass [31..28]
+    , parse  [15..14]
+    , regtype[27..24]
+    , majop  [23..22]
+    , minop  [7..6]
+    , s5     [20..16]
+    , t5     [12..8]
+    , d5     [4..0]
+    }
+
+  model BitOp( name: Id, iformat: Id, encs: Encs, val: Ex, asmfunc: Ex, asmRhs: Ex ) : IsaDefs = {
+    // TODO: Reenable this annotation
+    // [ operation XTYPE ]
+    instruction $name : $iformat = {
+      R(d5) := $val
+    }
+    encoding $name = { $encs }
+    assembly $name = (AsmR(d5), " = ", $asmfunc, "(", AsmR(s5), ",", $asmRhs, ")")
+  }
+  $BitOp( BitSetImm   ;BitOpImmFormat; iclass=0b1000, regtype=0b1100, majop=0b11, op=0b00, minop=0b000 ; R(s5) |          ((1 as Word) << imm) ; "setbit"    ; ("#",decimal(imm)) )
+  $BitOp( BitClrImm   ;BitOpImmFormat; iclass=0b1000, regtype=0b1100, majop=0b11, op=0b00, minop=0b001 ; R(s5) & VADL::not((1 as Word) << imm) ; "clrbit"    ; ("#",decimal(imm)) )
+  $BitOp( BitToggleImm;BitOpImmFormat; iclass=0b1000, regtype=0b1100, majop=0b11, op=0b00, minop=0b010 ; R(s5) ^          ((1 as Word) << imm) ; "togglebit" ; ("#",decimal(imm)) )
+
+  // TODO @nmischkulnig: not entirely sure what they mean:
+  // "If a register is used to indicate the bit position, and the value of the least-significant 7
+  // bits of Rt is out of range, then the destination register will be unchanged."
+  // $BitOp( BitSetReg   ;BitOpRegFormat; iclass=0b1100, regtype=0b0110, majop=0b10, minop=0b00 ; R(s5) | TODO ; "setbit"    ; (AsmR(t5)) )
+  // $BitOp( BitClrReg   ;BitOpRegFormat; iclass=0b1100, regtype=0b0110, majop=0b10, minop=0b01 ; R(s5) & TODO ; "clrbit"    ; (AsmR(t5)) )
+  // $BitOp( BitToggleReg;BitOpRegFormat; iclass=0b1100, regtype=0b0110, majop=0b10, minop=0b10 ; R(s5) ^ TODO ; "togglebit" ; (AsmR(t5)) )
+
+
+  format TransferPRFormat : Word =
+    { iclass [31..28]
+    , parse  [15..14]
+    , regtype[27..24]
+    , majop  [23..21]
+    , s5     [20..16]
+    , d2     [1..0]
+    }
+  format TransferRPFormat : Word =
+    { iclass [31..28]
+    , parse  [15..14]
+    , regtype[27..24]
+    , majop  [22]
+    , s2     [17..16]
+    , d5     [4..0]
+    }
+
+  // TODO: Reenable this annotation
+
+  // [ operation XTYPE ]
+  instruction TransferPR : TransferPRFormat = {
+    Pset(d2, R(s5) as Byte)
+  }
+  encoding TransferPR = { iclass=0b1000, regtype=0b0101, majop=0b010 }
+  assembly TransferPR = (AsmP(d2), " = ", AsmR(s5))
+
+  // TODO: Reenable this annotation
+
+  // [ operation XTYPE ]
+  instruction TransferRP : TransferRPFormat = {
+    R(d5) := Pget(s2)
+  }
+  encoding TransferRP = { iclass=0b1000, regtype=0b1001, majop=0b1 }
+  assembly TransferRP = (AsmR(d5), " = ", AsmP(s2))
+
+
+  format ALUDoubleCarryFormat : Word =
+    { iclass [31..28]
+    , parse  [15..14]
+    , regtype[27..24]
+    , majop  [23..22]
+    , op     [21]
+    , s5     [20..16]
+    , t5     [12..8]
+    , x2     [6..5]
+    , d5     [4..0]
+    , d2     = x2  // for the constraints
+    , u2     = x2  // for the constraints
+    }
+
+  model ALUDoubleCarryBase( name: Id, sub: Bool ) : IsaDefs = {
+    // TODO: Reenable this annotation
+    // [ operation XTYPE_PRED_WRITING ]
+    instruction $name : ALUDoubleCarryFormat = {
+      let a = (R(s5+1),R(s5)) in
+      let b = (R(t5+1),R(t5)) in
+      let c = (P(x2) as Bits<1>) as Word in
+      // This just really just VADL::adds(a, b, c)
+      let temp, tempstatus = VADL::adds(a, if $sub then VADL::not(b) else b) in
+      let result, status = VADL::adds(temp, c) in {
+        R(d5  ) := result(31..0)
+        R(d5+1) := result(63..32)
+        Pset(x2, tempstatus.carry | status.carry)
+      }
+    }
+    encoding $name = { iclass=0b1100, regtype=0b0010, majop=0b11, op = match : Lit ($sub = true => 1; _ => 0 ) }
+    assembly $name = (AsmRR(d5), " = ", if $sub then "sub" else "add", "(", AsmRR(s5), ",", AsmRR(t5), ",", AsmP(x2), "):carry")
+  }
+  $ALUDoubleCarryBase( AddDoubleCarry; false)
+  $ALUDoubleCarryBase( SubDoubleCarry; true )
+
+  // -------------------------------------------------------------------------------------
+
+
+//   format ConstantExtenderFormat : Word =
+//     { iclass [31..28]
+//     , parse  [15..14]
+//     , imm    [27..16,13..0]
+//     }
+
+//   pseudo instruction Neg( d5: Index, s5: Index ) = {
+//     SubImm{ d5 = d5, imm = 0, s5 = rs }
+//   }
+//   assembly Neg = (AsmR(rd),'=neg(',AsmR(rs),')')
+
+
+  // These operations correspond to the classes and therefore form a partition over all instructions
+  operation XTYPE = { XTYPE_PRED_WRITING }
+  operation ALU32 = { ALU32_PRED_WRITING }
+  operation CR = { CR23 }
+  operation JR = {}
+  operation J = { J_PRED_WRITING }
+  operation LD = {}
+  operation MEMOP = {}
+  operation NV = {}
+  operation ST = {}
+  operation SYSTEM = {}
+  operation SYSTEMSolo = {}
+
+  operation ALL = { XTYPE, ALU32, CR, JR, J, LD, MEMOP, NV, ST, SYSTEM, SYSTEMSolo }
+
+  operation CR23 = {} // This instruction may execute on either slot2 or slot3, even though it is a CR-type
+
+  // TODO ideally these would also be annotations?
+  operation TRANSFER_C_R = { TransferCR }
+  operation TRANSFER_CC_RR = { TransferCCRR }
+  operation TRANSFER_P_R = { TransferPR }
+  operation ARITH_CARRY = { AddDoubleCarry, SubDoubleCarry }    // these carry instructions have special restrictions
+  operation MEMLOCKED_L2FETCH_TRACE = { /* memw_locked, memd_locked, l2fetch, trace */ }
+  operation CACHE_MAINTENANCE_SPECIAL = { /* dccleana, dcinva, dccleaninva, dczeroa */ }
+  operation JUMP_IMM = { JumpImm }
+  operation JUMP_CMP_NEW = { } // `if ([!]cmp.xx(Rs.new, Rt)) jump`
+
+  operation ALU32_XTYPE_NON_FP = { ALU32 /*, TODO NONFP */} // ALU32 or (non-FP) XTYPE instructions
+  operation CONDITIONAL_NEW = {} // conditional instruction that have a dot-.new predicate TODO currently empty
+  operation FLOATING_POINT = {} // all FP instructions TODO currently empty
+  operation SATURATING = { /* AddRegSat, SubRegSat */ } // saturating arithmetic instructions
+  operation DEALLOC_RETURN = { DecallocReturn, DecallocReturnPredPos, DecallocReturnPredNeg } // all dealloc_return variants
+  operation LD_ST = { LD, ST }
+
+  operation ALU32_PRED_WRITING = {  } // helper operation
+  operation J_PRED_WRITING = {  }     // helper operation
+  operation XTYPE_PRED_WRITING = {  } // helper operation
+  // These are all predicate writing instructions except for transfers
+  operation PRED_WRITING = { ALU32_PRED_WRITING, J_PRED_WRITING, XTYPE_PRED_WRITING }
+
+  // TODO Not very efficient because `b` is always evaluated
+  function implies(a: Bool, b: Bool) -> Bool = (!a) | b
+
+  // `parse` field:
+  //    11 = last instruction in packet
+  //    01/10 = not last
+  //    00 = duplex instruction
+  // An instruction packet can contain one duplex and up to two other (non-duplex) instructions.
+  // The duplex must always appear as the last word in a packet.
+  // TODO: Reenable this annotation
+  // [ stop :  let parse = VLIW(VLIW.length - 1).parse in ( ( parse = 0b00 ) | (parse = 0b11 ) ) ]
+
+  // The constant extender effectively serves as a prefix for an instruction: it is not executed in
+  // a slot, nor does it consume any slot resources. Within a packet, a constant extender must be
+  // positioned immediately before the instruction that it extends. If a constant extender is
+  // encoded in a packet for an instruction that does not accept a constant extender, the execution
+  // result is undefined.
+  // - -> Handled via variable length instructions (a version with and without extender prefix)
+
+  // "Grouping constraints"
+  // - Dot-new conditional instructions (Section 6.2.4) must be grouped in a packet with an
+  //   instruction that generates dot-new predicates.
+    //    TODO disabled because CONDITIONAL_NEW is empty
+    //    [ assert :  forall i in {CONDITIONAL_NEW} then ((i.dn = 0) | (exists j in {PRED_WRITING} then j.d2 = i.u2)) ]
+  // - ST-class instructions can be placed in Slot 1. However, in this case Slot 0 must contain a
+  //   second ST-class instruction (Section 5.5). = "dual store"
+  //   - Unlike most packetized operations, dual stores are not executed in parallel (Section
+  //      3.4.1). Instead, the store instruction in Slot 1 effectively executes first, followed by
+  //      the store instruction in Slot 0.
+  //   - -> this should be the case already with the regex
+  // - J-class instructions can be placed in Slots 2 or 3. However, only certain combinations of
+  //   program flow instructions (J or JR) can be grouped together in a packet (Section 7.8).
+  //   Otherwise, at most one program flow instruction is allowed in a packet. = "dual jump"
+  //    - May not be first in dual jump: unconditional `jump`
+          // TODO: Reenable this annotation
+          // [ assert :  !( (VLIW.length >= 2) & ((VLIW(0) ∈ JUMP_IMM) & (VLIW(1) ∈ J)) ) ]
+  //    - May not be in dual jump: `if ([!]cmp.xx(Rs.new, Rt)) jump`
+          // TODO: Reenable this annotation
+          // [ assert :  !( (VLIW.length >= 2) & (((VLIW(0) ∈ JUMP_CMP_NEW) & (VLIW(1) ∈ J)) | ((VLIW(0) ∈ J) & (VLIW(1) ∈ JUMP_CMP_NEW))) ) ]
+  //    - May not be in dual jump: all `jumpr` (JR is only allowed in slot 1)
+          // TODO: Reenable this annotation
+          // [ assert :  !( (VLIW.length >= 2) & ((VLIW(0) ∈ J) & (VLIW(1) ∈ JR))) ]
+  //    - May not be in dual jump: all `dealloc_return`
+          // TODO: Reenable this annotation
+          // [ assert :  !( (VLIW.length >= 2) & (((VLIW(0) ∈ J) & (VLIW(1) ∈ J)) & exists in {DEALLOC_RETURN}) ) ]
+  //    - May not be in dual jump: `endloopN`
+  //      - -> See loop section below
+  // - JR-class instructions can be placed in Slot 2. However, when encoded in a duplex jumpr R31
+  //   can be placed in Slot 0 (Section 10.4).
+  //   - TODO (no duplexes yet)
+  // - Restrictions exist which limit the instructions that can appear in a packet at the setup or
+  //   end of a hardware loop (Section 7.3.4).
+  //   - The loop setup packet in loopN or spNloop0 (Section 7.3.4) cannot contain a speculative
+  //     indirect jump, new-value compare jump, or dealloc_return.
+  //   - endloopN instructions (Section 7.3.2) do not use any slots.
+  //     - The endloopN instruction is actually a pseudo-instruction encoded in bits 15:14 of each
+  //       instruction. Therefore, no distinct 32-bit encoding exists for this instruction.
+  //     - This instruction cannot be grouped in a packet with any program flow instructions
+  //       (including jumps or calls).
+  //     - The loop end packet in loop0 cannot contain any instruction that changes SA0o r LC0.
+  //       Similarly, the loop end packet in loop1 cannot contain any instruction that changes SA1
+  //       or LC1.
+  //     - The loop end packet in spNloop0 cannot contain any instruction that changes P3.
+  //   - TODO (no hardware loops yet)
+  // - A user control register transfer to the control register USR cannot be grouped with a
+  //   floating point instruction (Section 2.3.3).
+  //   - USR contains rounding modes, floating trap enable flags
+  //   - -> see below in dependency constraints
+  // - The SYSTEM-class instructions include prefetch, cache operations, bus operations, load
+  //   locked, and store conditional instructions (Section 5.10). These instructions have the
+  //   following grouping rules:
+  //    - brkpt,trap,pause,icinva,isync,and syncht are solo instructions.They must not be grouped
+  //      with other instructions in a packet.
+  //      - -> handled via regex
+  //    - memw_locked,memd_locked,l2fetch,and trace must execute on Slot 0. They must be grouped
+  //      only with ALU32 or (non-FP) XTYPE instructions.
+          // TODO: Reenable this annotation
+          // [ assert :  implies(VLIW(VLIW.length-1) ∈ MEMLOCKED_L2FETCH_TRACE, forall j in {ALL} then ((j = VLIW(VLIW.length-1)) | (j ∈ ALU32_XTYPE_NON_FP)) ) ]
+  //    - dccleana,dcinva,dccleaninva,and dczeroa must execute on Slot 0. Slot 1 must be empty or an
+  //      ALU32 instruction. Note that Slot 1 being empty means that Slot 2 or 3 follow immediately.
+          // TODO: Reenable this annotation
+          // [ assert :  implies(VLIW(VLIW.length-1) ∈ CACHE_MAINTENANCE_SPECIAL, (VLIW.length = 1) | !(VLIW(VLIW.length-2) ∈ LD_ST)) ]
+
+  // "Dependency constraints"
+  // - Instructions in a packet cannot write to the same destination register. The assembler
+  //   automatically flags such packets as invalid. If the processor executes a packet with two
+  //   writes to the same general register, an error exception is raised.
+  //   - TODO
+  // - If the processor executes a packet which performs multiple writes to the same predicate or
+  //   control register, the behavior is undefined. Three special cases exist for this rule:
+  //    - Conditional writes are allowed to target the same destination register only if at most one
+  //      of the writes is actually performed (Section 6.2.5).
+  //      -  multiple writes with different predicates are allowed. If multiple predicates are true
+  //         at runtime:
+  //         -  When writing to general registers, an error exception is raised.
+  //         -  When writing to predicate or control registers, the result is undefined.
+  //    - The overflow flag in the status register has defined behavior when multiple instructions
+  //      write to it (Section 2.3.3). Note that instructions that write to the entire user status
+  //      register (for example, USR=R2) are not allowed to be grouped in a packet with any
+  //      instruction that writes to a bit in the user status register.
+  //      - (floating point because it reads trap/rounding flags from USR)
+  //      - l2fetch sets "L2 prefetch active". But it can only be together with ALU and non-FP XTYPE anyway
+  //      - all instructions that set the OVF Sticky Saturation Overflow
+       // TODO: Reenable this annotation
+       // [ assert :  !( (exists i in {TRANSFER_C_R,TRANSFER_CC_RR} then i.d5 = 8) & exists in {FLOATING_POINT, SATURATING} ) ]
+  //    - Multiple compare instructions are allowed to target the same predicate register in order
+  //      to perform a logical AND of the results (Section 6.2.3).
+  //      - If a packet contains endloopN, it cannot perform an auto-AND with predicate register P3.
+  //        - TODO
+  //      - If a packet contains a register transfer from a general register to a predicate
+  //        register, then no other instruction in the packet can write to the same predicate
+  //        register. (As a result, a register transfer to P3:0 or C5:4 cannot be grouped with any
+  //        other predicate-writing instruction.)
+            // TODO: Reenable this annotation
+            // [ assert :  !( ((exists i in {TRANSFER_C_R,TRANSFER_CC_RR} then i.d5 = 4) | (exists in {TRANSFER_P_R})) &
+            //     exists in {PRED_WRITING} ) ]
+  //      - The instructions spNloop0, decbin, tlbmatch, memw_locked, memd_locked, add:carry,
+  //        sub:carry, sfcmp, and dfcmp cannot be grouped with another instruction that sets the
+  //        same predicate register.
+            // TODO: Reenable this annotation
+            // [ assert : forall i in {ARITH_CARRY /*, CMP_FP, TODO */} then !(
+            //     ((exists j in {PRED_WRITING} then (i != j) & (j.d2 = i.u2)) |
+            //      (exists j in {TRANSFER_C_R,TRANSFER_CC_RR} then j.d5 = 4)) |
+            //      (exists j in {TRANSFER_P_R} then j.d2 = i.u2 )
+            //   ) ]
+
+
+	// Hexagon V60/V61 Programmer's Reference Manual p. 26
+  // - S0: Load/Store Unit 1. Instructions: LD, ST, ALU32, MEMOP, NV, SYSTEM
+  // - S1: Load/Store Unit 2. Instructions: LD, ST, ALU32
+  // - S2: Execute Unit 2. Instructions: XTYPE, ALU32, J, JR
+  // - S3: Execute Unit 3. Instructions: XTYPE, ALU32, J, CR
+  //
+  // "Ordering constraints"
+  // - The assembler automatically encodes instructions in the packet in the proper order.
+  // - In the binary encoding of a packet the instructions must be ordered from Slot 3 down to Slot
+  //   0. In memory, instructions in a packet must appear in strictly decreasing slot order.
+  //   Additionally, if an instruction can go in a higher-numbered slot, and that slot is empty,
+  //   then it must be moved into the higher-numbered slot.
+  // TODO: Reenable this annotation
+  // [ assert :  VLIW.length <= 4 ]
+  group VLIW = (
+    (
+      ( XTYPE<0..1> | ALU32<0..1> | J<0..1> | CR<0..1> ).
+      ( XTYPE<0..1> | ALU32<0..1> | J<0..1> | JR<0..1> | CR23<0..1> ).
+      ( LD<0..1> | ST<0..1> | ALU32<0..1> ).
+      ( LD<0..1> | ST<0..1> | ALU32<0..1> /* | MEMOP<0..1> | NV<0..1> | SYSTEM<0..1> */)
+    )
+    | SYSTEMSolo
+  )
+}
+
+
+application binary interface ABI for QDSP6 =
+{
+}
+
+processor CPU implements QDSP6 with ABI =
+{
+
+  stop with @Brkpt = PC = 0xeeee'eeee
+
+  reset =
+  {
+    FRAMEKEY := 0
+    SP       := 0x40000000
+
+    PC := start
+    if executable then halt
+  }
+  memory region [RAM] DRAM in MEM =
+  {
+    // SP   := 0x40000000
+
+    // //                                        PP
+    // MEM<4>( 0x80000000 ) := 0b01101100001000001100000000000000 // 0x6c20c000  { 	brkpt }
+
+    // Performs *(4) = fib(10) = 55 = 0x37
+    //                                        PP
+    // _start:
+    MEM<4>( 0x80000000 ) := 0b10100000100111011100000000000001 // 0xa09dc001  { 	allocframe(#0x8) }
+    MEM<4>( 0x80000004 ) := 0b01111000000000001100000101000000 // 0x7800c140  { 	r0 = #0xa }
+    MEM<4>( 0x80000008 ) := 0b01011010000000001100000000010100 // 0x5a00c014  { 	call 0x80000030 }
+    MEM<4>( 0x8000000c ) := 0b10100111100111101110000011111111 // 0xa79ee0ff  { 	memw(r30+#-0x4) = r0 }
+    MEM<4>( 0x80000010 ) := 0b10010111100111101111111111100000 // 0x979effe0  { 	r0 = memw(r30+#-0x4) }
+    MEM<4>( 0x80000014 ) := 0b01111000000000001100000010001010 // 0x7800c08a  { 	r10 = #0x4 }
+    MEM<4>( 0x80000018 ) := 0b10100001100010101100000000000000 // 0xa18ac000  { 	memw(r10+#0x0) = r0 }
+    MEM<4>( 0x8000001c ) := 0b01101100001000001100000000000000 // 0x6c20c000  { 	brkpt }
+    MEM<4>( 0x80000020 ) := 0b01111111000000000100000000000000 // 0x7f004000  { 	nop
+    MEM<4>( 0x80000024 ) := 0b01111111000000000100000000000000 // 0x7f004000    	nop
+    MEM<4>( 0x80000028 ) := 0b01111111000000000100000000000000 // 0x7f004000    	nop
+    MEM<4>( 0x8000002c ) := 0b10010110000111101100000000011110 // 0x961ec01e    	dealloc_return }
+    // fibonacci:
+    MEM<4>( 0x80000030 ) := 0b10100000100111011100000000000010 // 0xa09dc002  { 	allocframe(#0x10) }
+    MEM<4>( 0x80000034 ) := 0b10100111100111101110000011111110 // 0xa79ee0fe  { 	memw(r30+#-0x8) = r0 }
+    MEM<4>( 0x80000038 ) := 0b10010111100111101111111111000000 // 0x979effc0  { 	r0 = memw(r30+#-0x8) }
+    MEM<4>( 0x8000003c ) := 0b01110101100000001100000000100000 // 0x7580c020  { 	p0 = cmp.gtu(r0,#0x1) }
+    MEM<4>( 0x80000040 ) := 0b01011100000000001100000000001010 // 0x5c00c00a  { 	if (p0) jump:nt 0x80000054 }
+    MEM<4>( 0x80000044 ) := 0b01011000000000001100000000000010 // 0x5800c002  { 	jump 0x80000048 }
+    MEM<4>( 0x80000048 ) := 0b10010111100111101111111111000000 // 0x979effc0  { 	r0 = memw(r30+#-0x8) }
+    MEM<4>( 0x8000004c ) := 0b10100111100111101110000011111111 // 0xa79ee0ff  { 	memw(r30+#-0x4) = r0 }
+    MEM<4>( 0x80000050 ) := 0b01011000000000001100000000011010 // 0x5800c01a  { 	jump 0x80000084 }
+    MEM<4>( 0x80000054 ) := 0b10010111100111101111111111000000 // 0x979effc0  { 	r0 = memw(r30+#-0x8) }
+    MEM<4>( 0x80000058 ) := 0b10111111111000001111111111100000 // 0xbfe0ffe0  { 	r0 = add(r0,#-0x1) }
+    MEM<4>( 0x8000005c ) := 0b01011011111111111111111111101010 // 0x5bffffea  { 	call 0x80000030 }
+    MEM<4>( 0x80000060 ) := 0b10100111100111101110000011111101 // 0xa79ee0fd  { 	memw(r30+#-0xc) = r0 }
+    MEM<4>( 0x80000064 ) := 0b10010111100111101111111111000000 // 0x979effc0  { 	r0 = memw(r30+#-0x8) }
+    MEM<4>( 0x80000068 ) := 0b10111111111000001111111111000000 // 0xbfe0ffc0  { 	r0 = add(r0,#-0x2) }
+    MEM<4>( 0x8000006c ) := 0b01011011111111111111111111100010 // 0x5bffffe2  { 	call 0x80000030 }
+    MEM<4>( 0x80000070 ) := 0b01110000011000001100000000000001 // 0x7060c001  { 	r1 = r0 }
+    MEM<4>( 0x80000074 ) := 0b10010111100111101111111110100000 // 0x979effa0  { 	r0 = memw(r30+#-0xc) }
+    MEM<4>( 0x80000078 ) := 0b11110011000000001100000100000000 // 0xf300c100  { 	r0 = add(r0,r1) }
+    MEM<4>( 0x8000007c ) := 0b10100111100111101110000011111111 // 0xa79ee0ff  { 	memw(r30+#-0x4) = r0 }
+    MEM<4>( 0x80000080 ) := 0b01011000000000001100000000000010 // 0x5800c002  { 	jump 0x80000084 }
+    MEM<4>( 0x80000084 ) := 0b10010111100111101111111111100000 // 0x979effe0  { 	r0 = memw(r30+#-0x4) }
+    MEM<4>( 0x80000088 ) := 0b10010110000111101100000000011110 // 0x961ec01e  { 	dealloc_return }
+
+
+    // // Constraint violation because of add-carry with concurrent predicate write
+    // //                                        PP
+    // // _start:
+    // MEM<4>( 0x80000000 ) := 0b11000010110000000100001000001010 // 0xc2c0c20a  { 	r11:10 = add(r1:0,r3:2,p0):carry
+    // MEM<4>( 0x80000004 ) := 0b10000101010101001100000000000000 // 0x8554c000    	p0 = r20 } // invalid
+    // // MEM<4>( 0x80000004 ) := 0b10000101010101001100000000000001 // 0x8554c001    	p1 = r20 } // valid
+
+    // // Constraint violation because of double jump with unconditional as first
+    // //                                        PP
+    // // _start:
+    // MEM<4>( 0x80000000 ) := 0b01011000000000000100000000010010 // 0x5800c012  { 	jump 0x80000024 }
+    // MEM<4>( 0x80000004 ) := 0b01011100000000001100000000010000 // 0x5c00c010    	if (p0) jump:nt 0x80000024 }
+
+    // // Constraint violation by writing to a P3:0 and P0 simultaneously
+    // //                                        PP
+    // // _start:
+    // MEM<4>( 0x80000000 ) := 0b01111000000000001100000000001010 // 0x7800c00a  { 	r10 = #0x0 }
+    // MEM<4>( 0x80000004 ) := 0b01100010001010100100000000000100 // 0x622ac004  {  	p3:0 = r10
+    // MEM<4>( 0x80000008 ) := 0b01110101000010101100000000000000 // 0x750ac000    	p0 = cmp.eq(r10,#0x0) }
+
+  }
+}

--- a/vadl/main/vadl/vdt/utils/BitPattern.java
+++ b/vadl/main/vadl/vdt/utils/BitPattern.java
@@ -165,6 +165,40 @@ public class BitPattern implements Vector<PBit>, Predicate<BitVector> {
   }
 
   /**
+   * Truncates the pattern by removing higher order bits.
+   *
+   * @param width the width to truncate to
+   * @return A bit pattern of the specified width
+   */
+  public BitPattern leftTrunc(int width) {
+    return BitPattern.fromBitVector(
+        BitVector.fromValue(toMaskVector().toValue(), width),
+        BitVector.fromValue(toBitVector().toValue(), width)
+    );
+  }
+
+  /**
+   * Truncates the pattern by removing lower order bits.
+   *
+   * @param width the width to truncate to
+   * @return A bit pattern of the specified width
+   */
+  public BitPattern rightTrunc(int width) {
+    if (width() < width) {
+      throw new IllegalArgumentException("Target width must be leq than the actual width");
+    }
+
+    final var mask = toMaskVector();
+    final var value = toBitVector();
+
+    final var truncateWidth = width() - width;
+    return BitPattern.fromBitVector(
+        BitVector.fromValue(mask.toValue().shiftRight(truncateWidth), width),
+        BitVector.fromValue(value.toValue().shiftRight(truncateWidth), width)
+    );
+  }
+
+  /**
    * Convert a bit pattern to a bit vector. This is a helper method to convert the bit pattern with
    * potentially ignored (don't care) bits to a bit vector. The ignored bits in the pattern are
    * set to 0 in the resulting bit vector.

--- a/vadl/main/vadl/vdt/utils/SequentialInstructionDecoder.java
+++ b/vadl/main/vadl/vdt/utils/SequentialInstructionDecoder.java
@@ -50,7 +50,17 @@ public class SequentialInstructionDecoder {
 
     for (DecodeEntry entry : insns) {
 
-      if (!entry.pattern().test(insn)) {
+      BitPattern p = entry.pattern();
+
+      if (p.width() < insn.width()) {
+        p = p.rightPad(insn.width() - p.width());
+      } else if (p.width() > insn.width()) {
+        p = p.rightTrunc(insn.width());
+      }
+
+      assert p.width() == insn.width();
+
+      if (!p.test(insn)) {
         continue;
       }
 

--- a/vadl/test/vadl/ast/FrontendIntegrationTest.java
+++ b/vadl/test/vadl/ast/FrontendIntegrationTest.java
@@ -31,6 +31,7 @@ public class FrontendIntegrationTest {
       "../sys/aarch64/sve.vadl",
       "../sys/aarch64/virt.vadl",
       "../sys/aarch64/vprocessor.vadl",
+      "../sys/hexagon/hexagon.vadl",
       "../sys/ppc64/ppc64.vadl",
       "../sys/risc-v/rv32i.vadl",
       "../sys/risc-v/rv32im.vadl",

--- a/vadl/test/vadl/vdt/utils/SequentialInstructionDecoderTest.java
+++ b/vadl/test/vadl/vdt/utils/SequentialInstructionDecoderTest.java
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText : © 2026 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.vdt.utils;
+
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import vadl.vdt.impl.irregular.model.DecodeEntry;
+import vadl.viam.Identifier;
+import vadl.viam.Instruction;
+import vadl.viam.graph.Graph;
+
+public class SequentialInstructionDecoderTest {
+
+  @ParameterizedTest
+  @MethodSource("testSource")
+  void testMatchInsn(BitPattern pattern, BitVector encoding) {
+
+    /* GIVEN */
+    var decoder = new SequentialInstructionDecoder(List.of(
+        toInsn("i", pattern)
+    ));
+
+    /* WHEN */
+    List<DecodeEntry> result = decoder.decode(encoding);
+
+    /* THEN */
+    Assertions.assertEquals(1, result.size());
+    Assertions.assertEquals("i", result.getFirst().source().simpleName());
+  }
+
+  static Stream<Arguments> testSource() {
+    return Stream.of(
+        // Pattern should be extended to match the prefix of the encoding
+        Arguments.of(
+            BitPattern.fromBitVector(
+                BitVector.fromValue(new BigInteger("00000e0f", 16), 32),
+                BitVector.fromValue(new BigInteger("00008052", 16), 32)
+            ),
+            BitVector.fromValue(new BigInteger("882a805200006000", 16), 64)
+        ),
+        // Pattern should be truncated so only its prefix is matched against a shorter insn
+        Arguments.of(
+            BitPattern.fromBitVector(
+                BitVector.fromValue(new BigInteger("00000e0f", 16), 32),
+                BitVector.fromValue(new BigInteger("00008052", 16), 32)
+            ),
+            BitVector.fromValue(new BigInteger("000080", 16), 24)
+        )
+    );
+  }
+
+  private DecodeEntry toInsn(String name, BitPattern pattern) {
+    var i = new Instruction(Identifier.noLocation(name), new Graph("behavior"), null, null);
+    return new DecodeEntry(i, pattern.width(), pattern, Set.of());
+  }
+}


### PR DESCRIPTION
This adds a minimal version of the hexagon spec.
Many annotations, and definitions aren't implemented because they don't work.

**For the reviewer:** The original commit of this PR contains the hexagon spec with minimal changes from the original VADL implementation and the second then adapts it to compile with the new frontend. It might make sense to review only look over the second commit.