### PR TITLE
frontend: Add current and nextnext program counter subcalls

### DIFF
--- a/vadl/main/vadl/ast/BehaviorLowering.java
+++ b/vadl/main/vadl/ast/BehaviorLowering.java
@@ -1327,8 +1327,12 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
           int offset = 0;
           for (var subcall : expr.subCalls) {
             var subcallName = subcall.identifier().name;
-            if (subcallName.equals("next")) {
+            if (subcallName.equals("current")) {
+              offset = 0;
+            } else if (subcallName.equals("next")) {
               offset += instrWidthInByte;
+            } else if (subcallName.equals("nextnext")) {
+              offset += instrWidthInByte * 2;
             } else {
               throw new IllegalStateException("unknown subcall: " + subcallName);
             }

--- a/vadl/main/vadl/ast/TypeChecker.java
+++ b/vadl/main/vadl/ast/TypeChecker.java
@@ -3511,7 +3511,7 @@ public class TypeChecker
           addErrorAndStopChecking(error("Invalid counter sub-call", expr)
               .locationDescription(expr, "Cannot do sub call and slice on counter.").build());
         }
-        var validSubCalls = List.of("next");
+        var validSubCalls = List.of("current", "next", "nextnext");
         if (expr.subCalls.size() != 1) {
           addErrorAndStopChecking(error("Invalid counter sub-call", expr)
               .locationDescription(expr, "Only a single sub-call expected.").build());

--- a/vadl/test/resources/frontend-snapshots/lowering/readProgramCounterStates.vadl
+++ b/vadl/test/resources/frontend-snapshots/lowering/readProgramCounterStates.vadl
@@ -1,0 +1,170 @@
+// INCLUDE-VIAM-DUMP
+
+// This test verifies that the subcalls of a program counter can be read
+
+instruction set architecture TEST = {
+
+  register X: Bits<5><8>
+  program counter PC: Bits<8>
+
+  format Frmt : Bits<8> = { a: Bits<8> }
+
+  model ReadPC(name: Id, readExpr: Ex): IsaDefs = {
+    instruction $name : Frmt = { X(0) := $readExpr}
+    assembly $name = AsStr($name)
+    encoding $name = { a = 1 }
+  }
+
+  $ReadPC(CurrentInstr; PC.current)
+  $ReadPC(Nextnstr; PC.next)
+  $ReadPC(NextNextInstr; PC.nextnext)
+}
+
+
+//  Reported Diagnostics:
+//
+//  No diagnostics were reported, the input was correctly parsed, typechecked and lowered.
+//
+//
+//  VIAM Dump:
+//
+//    Specification name: "readProgramCounterStates"
+//    . Definitions: 1
+//    . InstructionSetArchitecture name: "TEST"
+//    . : PC: PC
+//    . : InstructionCount: 3
+//    . : PseudoInstructionCount: 0
+//    . : FormatCount: 1
+//    . : FunctionCount: 0
+//    . : OperationCount: 0
+//    . : ExceptionCount: 0
+//    . : RelocationCount: 0
+//    . : RegisterCount: 2
+//    . : MemoryCount: 0
+//    . : ArtificialResourceCount: 0
+//    . : Format name: "Frmt"
+//    . : ' Type: b8
+//    . : ' FieldCount: 1
+//    . : ' FieldAccessCount: 0
+//    . : ' FieldEncodingCount: 0
+//    . : ' Field name: "a"
+//    . : ' | Type: b8
+//    . : ' | BitSlice: [7..0]
+//    . : ' | RefFormat: -
+//    . : RegisterTensor name: "X"
+//    . : ' Type: b8
+//    . : ' Dimensions: [0:b3x5, 1:b3x8]
+//    . : ' ConstraintCount: 0
+//    . : RegisterTensor name: "PC"
+//    . : ' Type: b8
+//    . : ' Dimensions: [0:b3x8]
+//    . : ' ConstraintCount: 0
+//    . : Instruction name: "CurrentInstr" format: "Frmt"
+//    . : ' Inputs: PC
+//    . : ' Outputs: X
+//    . : ' Encoding: encoding
+//    . : ' Assembly: TEST::CurrentInstr::assembly
+//    . : ' Behavior Graph:
+//    . : ' | n0 Constant             in: ()      succ: ()     type: b3   const: 0x0: Bits<3>
+//    . : ' | n1 ReadsRegisterTensor  in: ()      succ: ()     type: b8   reg: PC
+//    . : ' | n2 Constant             in: ()      succ: ()     type: u8   const: 0x0: UInt<8>
+//    . : ' | n3 BuiltInCall          in: (n1 n2) succ: ()     type: b8   builtin: VADL::add   operator: +
+//    . : ' | n4 WritesRegisterTensor in: (n0 n3) succ: ()     reg: X
+//    . : ' | n5 InstrEnd             in: (n4)    succ: ()     effects: 1
+//    . : ' | n6 Start                in: ()      succ: (n5)   next: set
+//    . : ' Assembly name: "TEST::CurrentInstr::assembly"
+//    . : ' | Function: TEST::CurrentInstr::assembly::func
+//    . : ' | FieldAccesses: []
+//    . : ' | Function name: "TEST::CurrentInstr::assembly::func"
+//    . : ' | . Type: ()->String
+//    . : ' | . Signature: () -> String
+//    . : ' | . Parameters: []
+//    . : ' | . Behavior Graph:
+//    . : ' | . : n0 Constant in: ()   succ: ()     type: String   const: "CurrentInstr"
+//    . : ' | . : n1 Return   in: (n0) succ: ()     retType: String
+//    . : ' | . : n2 Start    in: ()   succ: (n1)   next: set
+//    . : ' Encoding name: "encoding"
+//    . : ' | Type: b8
+//    . : ' | Format: Frmt
+//    . : ' | FieldEncodings: 1
+//    . : ' | NonEncodedFields: []
+//    . : ' | HasConstraint: false
+//    . : ' | Field name: "a"
+//    . : ' | . Field: a
+//    . : ' | . Type: b8
+//    . : ' | . Constant: 0x1: Bits<8>
+//    . : Instruction name: "Nextnstr" format: "Frmt"
+//    . : ' Inputs: PC
+//    . : ' Outputs: X
+//    . : ' Encoding: encoding
+//    . : ' Assembly: TEST::Nextnstr::assembly
+//    . : ' Behavior Graph:
+//    . : ' | n0 Constant             in: ()      succ: ()     type: b3   const: 0x0: Bits<3>
+//    . : ' | n1 ReadsRegisterTensor  in: ()      succ: ()     type: b8   reg: PC
+//    . : ' | n2 Constant             in: ()      succ: ()     type: u8   const: 0x4: UInt<8>
+//    . : ' | n3 BuiltInCall          in: (n1 n2) succ: ()     type: b8   builtin: VADL::add   operator: +
+//    . : ' | n4 WritesRegisterTensor in: (n0 n3) succ: ()     reg: X
+//    . : ' | n5 InstrEnd             in: (n4)    succ: ()     effects: 1
+//    . : ' | n6 Start                in: ()      succ: (n5)   next: set
+//    . : ' Assembly name: "TEST::Nextnstr::assembly"
+//    . : ' | Function: TEST::Nextnstr::assembly::func
+//    . : ' | FieldAccesses: []
+//    . : ' | Function name: "TEST::Nextnstr::assembly::func"
+//    . : ' | . Type: ()->String
+//    . : ' | . Signature: () -> String
+//    . : ' | . Parameters: []
+//    . : ' | . Behavior Graph:
+//    . : ' | . : n0 Constant in: ()   succ: ()     type: String   const: "Nextnstr"
+//    . : ' | . : n1 Return   in: (n0) succ: ()     retType: String
+//    . : ' | . : n2 Start    in: ()   succ: (n1)   next: set
+//    . : ' Encoding name: "encoding"
+//    . : ' | Type: b8
+//    . : ' | Format: Frmt
+//    . : ' | FieldEncodings: 1
+//    . : ' | NonEncodedFields: []
+//    . : ' | HasConstraint: false
+//    . : ' | Field name: "a"
+//    . : ' | . Field: a
+//    . : ' | . Type: b8
+//    . : ' | . Constant: 0x1: Bits<8>
+//    . : Instruction name: "NextNextInstr" format: "Frmt"
+//    . : ' Inputs: PC
+//    . : ' Outputs: X
+//    . : ' Encoding: encoding
+//    . : ' Assembly: TEST::NextNextInstr::assembly
+//    . : ' Behavior Graph:
+//    . : ' | n0 Constant             in: ()      succ: ()     type: b3   const: 0x0: Bits<3>
+//    . : ' | n1 ReadsRegisterTensor  in: ()      succ: ()     type: b8   reg: PC
+//    . : ' | n2 Constant             in: ()      succ: ()     type: u8   const: 0x8: UInt<8>
+//    . : ' | n3 BuiltInCall          in: (n1 n2) succ: ()     type: b8   builtin: VADL::add   operator: +
+//    . : ' | n4 WritesRegisterTensor in: (n0 n3) succ: ()     reg: X
+//    . : ' | n5 InstrEnd             in: (n4)    succ: ()     effects: 1
+//    . : ' | n6 Start                in: ()      succ: (n5)   next: set
+//    . : ' Assembly name: "TEST::NextNextInstr::assembly"
+//    . : ' | Function: TEST::NextNextInstr::assembly::func
+//    . : ' | FieldAccesses: []
+//    . : ' | Function name: "TEST::NextNextInstr::assembly::func"
+//    . : ' | . Type: ()->String
+//    . : ' | . Signature: () -> String
+//    . : ' | . Parameters: []
+//    . : ' | . Behavior Graph:
+//    . : ' | . : n0 Constant in: ()   succ: ()     type: String   const: "NextNextInstr"
+//    . : ' | . : n1 Return   in: (n0) succ: ()     retType: String
+//    . : ' | . : n2 Start    in: ()   succ: (n1)   next: set
+//    . : ' Encoding name: "encoding"
+//    . : ' | Type: b8
+//    . : ' | Format: Frmt
+//    . : ' | FieldEncodings: 1
+//    . : ' | NonEncodedFields: []
+//    . : ' | HasConstraint: false
+//    . : ' | Field name: "a"
+//    . : ' | . Field: a
+//    . : ' | . Type: b8
+//    . : ' | . Constant: 0x1: Bits<8>
+//    . : Counter name: "PC"
+//    . : ' RegisterTensor: PC
+//    . : ' Indices: []
+//    . : ' ResultType: b8
+//
+//
+// Part of the class vadl.ast.FrontendSnapshotTests


### PR DESCRIPTION
These subcalls were long overdue and are now really needed to get hexagon running.