### PR TITLE
CLI: Add spec stats

### DIFF
--- a/vadl-cli/main/vadl/cli/BaseCommand.java
+++ b/vadl-cli/main/vadl/cli/BaseCommand.java
@@ -42,6 +42,7 @@ import picocli.CommandLine.Parameters;
 import vadl.ast.Ast;
 import vadl.ast.AstDumper;
 import vadl.ast.ModelRemover;
+import vadl.ast.SpecStatAnalyser;
 import vadl.ast.TypeChecker;
 import vadl.ast.Ungrouper;
 import vadl.ast.VadlParser;
@@ -60,6 +61,7 @@ import vadl.pass.exception.DuplicatedPassKeyException;
 import vadl.utils.DiskVirtualFileSystem;
 import vadl.utils.EditorUtils;
 import vadl.utils.SourceLocation;
+import vadl.utils.VirtualFileSystem;
 import vadl.viam.Specification;
 
 /**
@@ -105,6 +107,12 @@ public abstract class BaseCommand implements Callable<Integer> {
       hidden = true,
       description = "Write pass timings to <output>/timings.csv")
   boolean writeTimingsCsv;
+
+  @Option(names = "--spec-stats",
+      scope = INHERIT,
+      hidden = true,
+      description = "Print the statistics of the specification")
+  boolean showSpecStats;
 
   @Option(names = "--expand-macros",
       scope = INHERIT,
@@ -262,6 +270,7 @@ public abstract class BaseCommand implements Callable<Integer> {
    */
   private Specification parseToVIAM() {
     var ast = parseToAst();
+    printSpecStats(ast, new DiskVirtualFileSystem());
     ast.timingRecorder.passTimings.forEach(
         t -> timings.add(new Timing(t.description(), t.durationNS() / 1000_000)));
     ast.timingRecorder.passTimings.clear();
@@ -295,6 +304,23 @@ public abstract class BaseCommand implements Callable<Integer> {
         System.out.printf("\t- %s\n", path);
       }
     }
+  }
+
+  protected void printSpecStats(Ast ast, VirtualFileSystem fileSystem) {
+    if (!showSpecStats) {
+      return;
+    }
+
+    System.out.println("\nSpecification Statistics:");
+    var stats = SpecStatAnalyser.run(ast, fileSystem);
+    System.out.printf("\t- %-30s %6d\n", "Files:", stats.files);
+    System.out.printf("\t- %-30s %6d\n", "Lines of Code:", stats.linesOfCode);
+    System.out.printf("\t- %-30s %6d\n", "Function Definitions:", stats.functionDefinitions);
+    System.out.printf("\t- %-30s %6d\n", "Format Definitions:", stats.formatDefinitions);
+    System.out.printf("\t- %-30s %6d\n", "Instruction Definitions:", stats.instructionDefinition);
+    System.out.printf("\t- %-30s %6d\n", "Total Definitions:", stats.totalDefinitions);
+    System.out.printf("\t- %-30s %6d\n", "Total Statements:", stats.totalStatements);
+    System.out.printf("\t- %-30s %6d\n", "Total Expressions:", stats.totalExpressions);
   }
 
   protected void printTimings() {

--- a/vadl-lsp/main/vadl/lsp/LspSnapshotFileSystem.java
+++ b/vadl-lsp/main/vadl/lsp/LspSnapshotFileSystem.java
@@ -20,7 +20,6 @@ import static vadl.lsp.LspUtils.toPath;
 import static vadl.lsp.LspUtils.toUri;
 
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
@@ -90,7 +89,7 @@ class LspSnapshotFileSystem implements VirtualFileSystem {
   }
 
   @Override
-  public Stream<String> readLines(Path path) throws IOException {
+  public Stream<String> readLines(Path path) {
     String uri = toUri(path);
     readFiles.add(uri);
 
@@ -126,11 +125,7 @@ class LspSnapshotFileSystem implements VirtualFileSystem {
     }
 
     List<String> textLines;
-    try {
-      textLines = underlyingFileSystem.readLines(toPath(uri)).toList();
-    } catch (IOException e) {
-      return null;
-    }
+    textLines = underlyingFileSystem.readLines(toPath(uri)).toList();
     return new Document(uri, -1, textLines);
   }
 

--- a/vadl/main/vadl/ast/Ast.java
+++ b/vadl/main/vadl/ast/Ast.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import vadl.types.Type;
 import vadl.utils.SourceLocation;
@@ -56,6 +57,38 @@ public class Ast {
   public void withPassTiming(String name, Runnable pass) {
     timingRecorder.withPassTiming(name, pass);
   }
+
+  /**
+   * Returns the list of all files that are included from this AST.
+   *
+   * @param recursive if true, recursively include files from imported modules.
+   * @return the list of paths.
+   */
+  public List<Path> includedFiles(boolean recursive) {
+    return definitions.stream()
+        .filter(def -> def instanceof ImportDefinition)
+        .flatMap(def -> {
+          var ast = ((ImportDefinition) def).moduleAst;
+          var stream = Stream.of(ast.filePath);
+          if (recursive) {
+            stream = Stream.concat(stream, ast.includedFiles(true).stream());
+          }
+          return stream;
+        })
+        .toList();
+  }
+
+  /**
+   * Returns the list of all files that were read to generate this AST.
+   *
+   * @return the list of paths.
+   */
+  public List<Path> allReadFiles() {
+    var paths = new ArrayList<>(includedFiles(true));
+    paths.addFirst(filePath);
+    return paths;
+  }
+
 
   /**
    * Convert the tree back into sourcecode.

--- a/vadl/main/vadl/ast/SpecStatAnalyser.java
+++ b/vadl/main/vadl/ast/SpecStatAnalyser.java
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText : © 2026 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.ast;
+
+import java.nio.file.Path;
+import vadl.utils.VirtualFileSystem;
+
+/**
+ * An AST analyzer that collects statistics about the content of the specification.
+ */
+public class SpecStatAnalyser extends RecursiveAstVisitor {
+
+  private static final SpecStats stats = new SpecStats();
+  private final VirtualFileSystem fileSystem;
+
+  private SpecStatAnalyser(VirtualFileSystem fileSystem) {
+    this.fileSystem = fileSystem;
+  }
+
+  /**
+   * Runs the analyser on the given AST and returns the collected statistics.
+   *
+   * @param ast to analyze.
+   * @param fileSystem from which the files can be read again to calcuulate the lines of code.
+   * @return the collected statistics.
+   */
+  public static SpecStats run(Ast ast, VirtualFileSystem fileSystem) {
+    var analyser = new SpecStatAnalyser(fileSystem);
+    ast.definitions.forEach(definition -> definition.accept(analyser));
+
+    ast.allReadFiles().forEach(analyser::handlePath);
+
+    return analyser.stats;
+  }
+
+  private void handlePath(Path path) {
+    stats.files++;
+    fileSystem.readLines(path).forEach(line -> stats.linesOfCode++);
+  }
+
+  @Override
+  public void beforeTravel(Definition definition) {
+    stats.totalDefinitions++;
+    if (definition instanceof FunctionDefinition) {
+      stats.functionDefinitions++;
+    }
+    if (definition instanceof FormatDefinition) {
+      stats.formatDefinitions++;
+    }
+    if (definition instanceof InstructionDefinition) {
+      stats.instructionDefinition++;
+    }
+  }
+
+  @Override
+  public void beforeTravel(Statement statement) {
+    stats.totalStatements++;
+  }
+
+  @Override
+  public void beforeTravel(Expr expr) {
+    stats.totalExpressions++;
+  }
+
+  @Override
+  public Void visit(ImportDefinition definition) {
+    beforeTravel(definition);
+    definition.moduleAst.definitions.forEach(def -> def.accept(this));
+    afterTravel(definition);
+    return null;
+  }
+
+  /**
+   * Statistics container to hold the collected data.
+   */
+  public static class SpecStats {
+    public int files = 0;
+    public int linesOfCode = 0;
+    public int functionDefinitions = 0;
+    public int formatDefinitions = 0;
+    public int instructionDefinition = 0;
+    public int totalDefinitions = 0;
+    public int totalStatements = 0;
+    public int totalExpressions = 0;
+  }
+
+}

--- a/vadl/main/vadl/utils/SourceLocation.java
+++ b/vadl/main/vadl/utils/SourceLocation.java
@@ -19,7 +19,6 @@ package vadl.utils;
 import static java.util.Objects.requireNonNull;
 import static vadl.utils.EditorUtils.isIntelliJIDE;
 
-import java.io.IOException;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -30,8 +29,6 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * References a location span in source.
@@ -49,8 +46,6 @@ public record SourceLocation(
     Position end,
     @Nullable SourceLocation expandedFrom
 ) implements WithLocation, Comparable<SourceLocation> {
-
-  private static final Logger logger = LoggerFactory.getLogger(SourceLocation.class);
 
 
   public static final SourceLocation INVALID_SOURCE_LOCATION =
@@ -313,9 +308,6 @@ public record SourceLocation(
           })
           .collect(Collectors.joining("\n"));
 
-    } catch (IOException e) {
-      logger.error(e.getMessage(), e);
-      return "Failed to load source location " + this.toConciseString() + ": " + e.getMessage();
     }
   }
 

--- a/vadl/main/vadl/utils/VirtualFileSystem.java
+++ b/vadl/main/vadl/utils/VirtualFileSystem.java
@@ -18,7 +18,6 @@ package vadl.utils;
 
 
 import java.io.BufferedReader;
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
@@ -72,9 +71,8 @@ public interface VirtualFileSystem {
    *
    * @param path          to read from.
    * @return              a stream of the lines from the file.
-   * @throws IOException  if the file cannot be read.
    */
-  default Stream<String> readLines(Path path) throws IOException {
+  default Stream<String> readLines(Path path) {
     return new BufferedReader(new InputStreamReader(getInputStream(path), StandardCharsets.UTF_8))
         .lines();
   }


### PR DESCRIPTION
We mostly only need this for publications where we _approximate_ the size of specs based on the instruction count, lines of code etc.

**Note for the reviewer:** This PR also includes a commit that removes the unused `IOException` from the VFS. We must have missed that previously, but I wanted to do that now because otherwise the new code would have also had to include that exception.