### PR TITLE
iss: Only unroll forall statements in helper instructions if necessary

### DIFF
--- a/vadl/main/vadl/iss/codegen/IssExceptionHandlingCodeGenerator.java
+++ b/vadl/main/vadl/iss/codegen/IssExceptionHandlingCodeGenerator.java
@@ -89,8 +89,7 @@ public class IssExceptionHandlingCodeGenerator extends IssProcGen
 
   @Override
   public void handle(CGenContext<Node> ctx, ReadRegTensorNode node) {
-    // use register variables defined at start
-    ctx().wr(readRegVariable(node));
+    emitReadReg(ctx, node);
   }
 
   /**

--- a/vadl/main/vadl/iss/codegen/IssInstrHelperGenerator.java
+++ b/vadl/main/vadl/iss/codegen/IssInstrHelperGenerator.java
@@ -170,8 +170,7 @@ public class IssInstrHelperGenerator extends IssProcGen
 
   @Override
   public void handle(CGenContext<Node> ctx, ReadRegTensorNode node) {
-    // use register variables defined at start
-    ctx().wr(readRegVariable(node));
+    emitReadReg(ctx, node);
   }
 
   @Handler

--- a/vadl/main/vadl/iss/codegen/IssProcGen.java
+++ b/vadl/main/vadl/iss/codegen/IssProcGen.java
@@ -18,22 +18,27 @@ package vadl.iss.codegen;
 
 import static vadl.error.DiagUtils.throwNotAllowed;
 
+import java.util.HashSet;
+import java.util.Set;
 import vadl.cppCodeGen.CppTypeMap;
 import vadl.cppCodeGen.context.CGenContext;
 import vadl.cppCodeGen.context.CNodeContext;
 import vadl.cppCodeGen.mixins.CDefaultMixins;
 import vadl.cppCodeGen.mixins.CInvalidMixins;
 import vadl.iss.passes.extensions.IssAccessorRegistry;
+import vadl.iss.passes.safeResourceRead.nodes.ExprSaveNode;
 import vadl.javaannotations.DispatchFor;
 import vadl.javaannotations.Handler;
 import vadl.utils.functionInterfaces.TriConsumer;
 import vadl.viam.graph.Graph;
 import vadl.viam.graph.Node;
 import vadl.viam.graph.control.InstrCallNode;
+import vadl.viam.graph.control.ScheduledNode;
 import vadl.viam.graph.dependency.AsmBuiltInCall;
 import vadl.viam.graph.dependency.FieldAccessRefNode;
 import vadl.viam.graph.dependency.FieldRefNode;
 import vadl.viam.graph.dependency.FoldNode;
+import vadl.viam.graph.dependency.ForIdxNode;
 import vadl.viam.graph.dependency.ReadRegTensorNode;
 import vadl.viam.passes.sideEffectScheduling.nodes.InstrExitNode;
 
@@ -57,6 +62,7 @@ abstract class IssProcGen implements CDefaultMixins.All,
   private final CNodeContext ctx;
   private final StringBuilder builder;
   private final IssAccessorRegistry accessorRegistry;
+  private final Set<ReadRegTensorNode> preloadedReadRegs = new HashSet<>();
 
   public IssProcGen(IssAccessorRegistry accessorRegistry) {
     this(accessorRegistry, IssProcGenDispatcher::dispatch);
@@ -93,11 +99,15 @@ abstract class IssProcGen implements CDefaultMixins.All,
    * @param graph that contains register reads
    */
   void initReadRegs(Graph graph) {
+    preloadedReadRegs.clear();
     graph.getNodes(ReadRegTensorNode.class)
         .forEach(this::initSingleReadReg);
   }
 
   void initSingleReadReg(ReadRegTensorNode read) {
+    if (dependsOnForallIndex(read)) {
+      return;
+    }
     var width = read.type().asDataType().bitWidth();
     read.ensure(width <= 64,
         "Helper read preload expects <=64-bit reads, got %d-bit on %s", width, read);
@@ -110,6 +120,7 @@ abstract class IssProcGen implements CDefaultMixins.All,
       ctx.wr(", ").gen(i);
     }
     ctx.ln(");");
+    preloadedReadRegs.add(read);
   }
 
   /**
@@ -124,6 +135,52 @@ abstract class IssProcGen implements CDefaultMixins.All,
       name += "_" + read.id;
     }
     return name;
+  }
+
+  void emitReadReg(CGenContext<Node> ctx, ReadRegTensorNode read) {
+    if (preloadedReadRegs.contains(read)) {
+      ctx.wr(readRegVariable(read));
+      return;
+    }
+    RegisterAccessEmitters.emitRead(ctx, read, accessorRegistry);
+  }
+
+  private String exprSaveVariable(ExprSaveNode save) {
+    return "expr_save_" + save.id().numericId();
+  }
+
+  private boolean dependsOnForallIndex(Node node) {
+    return dependsOnForallIndex(node, new HashSet<>());
+  }
+
+  private boolean dependsOnForallIndex(Node node, Set<Node> visited) {
+    if (!visited.add(node)) {
+      return false;
+    }
+    if (node instanceof ForIdxNode) {
+      return true;
+    }
+    return node.inputs().anyMatch(input -> dependsOnForallIndex(input, visited));
+  }
+
+  @Handler
+  @Override
+  public void handle(CGenContext<Node> ctx, ScheduledNode node) {
+    if (node.node() instanceof ExprSaveNode save) {
+      var type = CppTypeMap.nextFittingUInt(save.type().asDataType());
+      ctx.wr(type + " " + exprSaveVariable(save) + " = ")
+          .gen(save.value())
+          .ln(";");
+      ctx.gen(node.next());
+      return;
+    }
+    ctx.gen(node.node()).ln(";");
+    ctx.gen(node.next());
+  }
+
+  @Handler
+  public void handle(CGenContext<Node> ctx, ExprSaveNode toHandle) {
+    ctx.wr(exprSaveVariable(toHandle));
   }
 
   @Handler

--- a/vadl/main/vadl/iss/codegen/IssResetGen.java
+++ b/vadl/main/vadl/iss/codegen/IssResetGen.java
@@ -54,8 +54,7 @@ public class IssResetGen extends IssProcGen implements IssCMixins.CpuSourceWrite
 
   @Override
   public void handle(CGenContext<Node> ctx, ReadRegTensorNode node) {
-    // use register variables defined at start
-    ctx().wr(readRegVariable(node));
+    emitReadReg(ctx, node);
   }
 
   /**

--- a/vadl/main/vadl/iss/passes/IssLoopUnrollPass.java
+++ b/vadl/main/vadl/iss/passes/IssLoopUnrollPass.java
@@ -19,10 +19,15 @@ package vadl.iss.passes;
 import java.io.IOException;
 import javax.annotation.CheckForNull;
 import vadl.configuration.IssConfiguration;
+import vadl.iss.passes.safeResourceRead.IssSafeResourceReadAnalysis;
 import vadl.pass.PassName;
 import vadl.pass.PassResults;
+import vadl.viam.Counter;
+import vadl.viam.Instruction;
 import vadl.viam.Specification;
+import vadl.viam.graph.control.ForallNode;
 import vadl.viam.passes.loopUnrolling.LoopUnroller;
+import vadl.viam.passes.sideEffectScheduling.SideEffectSchedulingPass;
 
 /**
  * Pass to unroll forall statements in the ISS.
@@ -41,9 +46,23 @@ public class IssLoopUnrollPass extends AbstractIssPass {
   @CheckForNull
   @Override
   public Object execute(PassResults passResults, Specification viam) throws IOException {
-    // TODO: Run this only on instructions that can't be handled otherwise
-    allInstrs(viam).forEach(i -> new LoopUnroller(i.behavior()).run());
+    tcgInstrs(viam).forEach(i -> new LoopUnroller(i.behavior()).run());
+
+    var pc = viam.isa().get().pc();
+    helperInstrs(viam)
+        .filter(i -> i.behavior().getNodes(ForallNode.class).findAny().isPresent())
+        .filter(i -> helperLoopMustBeUnrolled(i, pc))
+        .forEach(i -> new LoopUnroller(i.behavior()).run());
 
     return null;
+  }
+
+  private boolean helperLoopMustBeUnrolled(Instruction instruction, @CheckForNull Counter pc) {
+    var unrolled = instruction.copy();
+    new LoopUnroller(unrolled.behavior()).run();
+
+    var scheduledProbe = unrolled.copy();
+    SideEffectSchedulingPass.schedule(scheduledProbe.behavior(), pc);
+    return IssSafeResourceReadAnalysis.requiresReadSave(scheduledProbe);
   }
 }

--- a/vadl/main/vadl/iss/passes/safeResourceRead/IssSafeResourceReadAnalysis.java
+++ b/vadl/main/vadl/iss/passes/safeResourceRead/IssSafeResourceReadAnalysis.java
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText : © 2026 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.iss.passes.safeResourceRead;
+
+import java.util.HashMap;
+import vadl.viam.Instruction;
+
+/**
+ * Small utility facade for reusing {@link IssResourceReadSecurer} outside the pass.
+ */
+public final class IssSafeResourceReadAnalysis {
+
+  private IssSafeResourceReadAnalysis() {
+  }
+
+  /**
+   * Returns whether the instruction would need at least one saved resource read.
+   */
+  public static boolean requiresReadSave(Instruction instruction) {
+    return new IssResourceReadSecurer(
+        instruction,
+        new IssSafeResourceReadPass.Result(new HashMap<>())
+    ).requiresReadSave();
+  }
+}

--- a/vadl/main/vadl/iss/passes/safeResourceRead/IssSafeResourceReadPass.java
+++ b/vadl/main/vadl/iss/passes/safeResourceRead/IssSafeResourceReadPass.java
@@ -147,23 +147,39 @@ class IssResourceReadSecurer {
    * Runs the resource read securer on the instruction.
    */
   void run() {
-    // Use post-lowering graph resources instead of Instruction.readResources() cache,
-    // because alias lowering rewrites accesses to their effective base resources.
-    var readResources = instruction.behavior().getNodes(ReadResourceNode.class)
-        .map(ReadResourceNode::resourceDefinition)
-        .collect(Collectors.toSet());
-
-    for (var resource : readResources) {
-      handleReadResource(resource);
-    }
+    readResources().forEach(resource -> {
+      var saveLocation = saveLocation(resource);
+      if (saveLocation != null) {
+        applySave(resource, saveLocation);
+      }
+    });
   }
 
   /**
-   * Handles securing reads for a specific resource.
+   * Determines whether securing this instruction would require at least one saved resource read.
+   *
+   * <p>This is intentionally a dry-run variant of {@link #run()} so analyses can ask the same
+   * question without mutating the graph.</p>
+   */
+  boolean requiresReadSave() {
+    return readResources().anyMatch(resource -> saveLocation(resource) != null);
+  }
+
+  private Stream<Resource> readResources() {
+    // Use post-lowering graph resources instead of Instruction.readResources() cache,
+    // because alias lowering rewrites accesses to their effective base resources.
+    return instruction.behavior().getNodes(ReadResourceNode.class)
+        .map(ReadResourceNode::resourceDefinition)
+        .collect(Collectors.toSet())
+        .stream();
+  }
+
+  /**
+   * Determines the save location for a specific resource, if a save is needed.
    *
    * @param resource The resource to secure reads for.
    */
-  private void handleReadResource(Resource resource) {
+  private @Nullable ControlNode saveLocation(Resource resource) {
     var writeSchedules = instruction.behavior().getNodes(WriteResourceNode.class)
         .filter(wn -> wn.resourceDefinition() == resource)
         .map(wn -> wn.usages()
@@ -177,12 +193,16 @@ class IssResourceReadSecurer {
         .filter(wn -> wn.resourceDefinition() == resource)
         .toList();
 
-    var saveLocation = determineIfReadSaveIsRequired(reads, writeSchedules);
-    if (saveLocation == null) {
-      // No read save required
-      return;
-    }
+    return determineIfReadSaveIsRequired(reads, writeSchedules);
+  }
 
+  /**
+   * Applies saved reads for a resource at the provided control location.
+   */
+  private void applySave(Resource resource, ControlNode saveLocation) {
+    var reads = instruction.behavior().getNodes(ReadResourceNode.class)
+        .filter(wn -> wn.resourceDefinition() == resource)
+        .toList();
     for (var read : reads) {
       // Set spill location for conflicting read resources
       result.readTempSpillLocations().put(read, saveLocation);

--- a/vadl/main/vadl/viam/passes/sideEffectScheduling/SideEffectSchedulingPass.java
+++ b/vadl/main/vadl/viam/passes/sideEffectScheduling/SideEffectSchedulingPass.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -113,6 +113,13 @@ public class SideEffectSchedulingPass extends Pass {
       });
     }
     return null;
+  }
+
+  /**
+   * Schedules side effects in one behavior graph.
+   */
+  public static void schedule(Graph behavior, @Nullable Counter pc) {
+    SideEffectScheduler.run(behavior, pc);
   }
 }
 


### PR DESCRIPTION
Currently, all forall statement loops are unrolled, as we couldn't guarantee read-write independence between loop iterations.

This PR adds a check for this property, by running a dummy unroll+scheduling+safeRead pass combination on a cloned instruction graph. If this shows that a save expression would be created, we must unroll the loop. Otherwise, we can emit the `forall` statement as C `for` loop.