### PR TITLE
iss: Optimize assignments of forall tensor expressions 

### DIFF
--- a/vadl/main/vadl/iss/codegen/IssProcGen.java
+++ b/vadl/main/vadl/iss/codegen/IssProcGen.java
@@ -113,13 +113,9 @@ abstract class IssProcGen implements CDefaultMixins.All,
         "Helper read preload expects <=64-bit reads, got %d-bit on %s", width, read);
     var valueType = CppTypeMap.nextFittingUInt(read.type().asDataType());
     var name = readRegVariable(read);
-    var accessName = RegisterAccessEmitters.readAccessorName(read, accessorRegistry);
-    ctx.wr(valueType + " " + name + " = ")
-        .wr(accessName + "(env");
-    for (var i : RegisterAccessEmitters.readAccessorArgs(read)) {
-      ctx.wr(", ").gen(i);
-    }
-    ctx.ln(");");
+    ctx.wr(valueType + " " + name + " = ");
+    RegisterAccessEmitters.emitRead(ctx, read, accessorRegistry);
+    ctx.ln(";");
     preloadedReadRegs.add(read);
   }
 

--- a/vadl/main/vadl/iss/passes/IssLoopUnrollPass.java
+++ b/vadl/main/vadl/iss/passes/IssLoopUnrollPass.java
@@ -26,6 +26,7 @@ import vadl.viam.Counter;
 import vadl.viam.Instruction;
 import vadl.viam.Specification;
 import vadl.viam.graph.control.ForallNode;
+import vadl.viam.passes.canonicalization.Canonicalizer;
 import vadl.viam.passes.loopUnrolling.LoopUnroller;
 import vadl.viam.passes.sideEffectScheduling.SideEffectSchedulingPass;
 
@@ -58,8 +59,19 @@ public class IssLoopUnrollPass extends AbstractIssPass {
   }
 
   private boolean helperLoopMustBeUnrolled(Instruction instruction, @CheckForNull Counter pc) {
+    // Probe the unrolled form: unrolling removes iteration boundaries, so the scheduled graph
+    // exposes cross-iteration read/write conflicts that the loop form hides (the loop form
+    // has only a single scheduled write per body, which always passes the conflict check).
+    // IssSafeResourceReadAnalysis knows how to treat CHUNK accesses with disjoint constant
+    // (bitOffset, bitWidth) windows as independent, so same-chunk reuse patterns (e.g. a
+    // per-element tensor write where iteration i reads and writes the same chunk) do not
+    // trigger a false-positive unroll decision.
     var unrolled = instruction.copy();
     new LoopUnroller(unrolled.behavior()).run();
+    // Fold the constants that unrolling produced (e.g. `VADL::mul(const(i), const(w))` → const)
+    // so that IssSafeResourceReadAnalysis can see literal CHUNK (bitOffset, bitWidth) windows
+    // and partition accesses by disjoint constant windows.
+    Canonicalizer.canonicalize(unrolled.behavior());
 
     var scheduledProbe = unrolled.copy();
     SideEffectSchedulingPass.schedule(scheduledProbe.behavior(), pc);

--- a/vadl/main/vadl/iss/passes/IssTensorAssignmentToForallPass.java
+++ b/vadl/main/vadl/iss/passes/IssTensorAssignmentToForallPass.java
@@ -1,0 +1,159 @@
+// SPDX-FileCopyrightText : © 2026 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.iss.passes;
+
+import static java.util.Objects.requireNonNull;
+import static vadl.iss.passes.opDecomposition.decomposer.ForallSubstitution.copyWithIndexSubstitution;
+import static vadl.utils.StreamUtils.only;
+
+import java.io.IOException;
+import javax.annotation.CheckForNull;
+import vadl.configuration.IssConfiguration;
+import vadl.iss.passes.nodes.IssWriteRegNode;
+import vadl.pass.PassName;
+import vadl.pass.PassResults;
+import vadl.types.BuiltInTable;
+import vadl.types.Type;
+import vadl.viam.Constant;
+import vadl.viam.Specification;
+import vadl.viam.graph.NodeList;
+import vadl.viam.graph.control.AbstractEndNode;
+import vadl.viam.graph.control.BranchBeginNode;
+import vadl.viam.graph.control.BranchEndNode;
+import vadl.viam.graph.control.ForallEndNode;
+import vadl.viam.graph.control.ForallNode;
+import vadl.viam.graph.dependency.ExpressionNode;
+import vadl.viam.graph.dependency.TensorNode;
+
+/**
+ * Lowers full tensor assignments to element-wise forall statements.
+ *
+ * <p>Tensor expressions describe a value construction. For target-sized tensors, keeping that
+ * expression intact is already efficient: helper generation can emit the tensor construction as a
+ * local helper loop, and operation decomposition can still process oversized inputs below it when
+ * needed.</p>
+ *
+ * <p>Wide tensor assignments are different. Materializing the whole tensor value would force later
+ * passes to split the aggregate write into target-sized chunks. Rewriting</p>
+ *
+ * <pre>{@code
+ * Reg := tensor_body
+ * }</pre>
+ *
+ * <p>to</p>
+ *
+ * <pre>{@code
+ * forall i do
+ *   Reg(i) := tensor_body(i)
+ * }</pre>
+ *
+ * <p>keeps the element computation local to the write chunk and lets the normal forall statement
+ * handling decide whether helper code can keep a loop or must fall back to unrolling. End-node side
+ * effects do not define a relative order, so the pass may extract one tensor write from an end node
+ * that also contains other side effects.</p>
+ */
+public class IssTensorAssignmentToForallPass extends AbstractIssPass {
+
+  public IssTensorAssignmentToForallPass(IssConfiguration configuration) {
+    super(configuration);
+  }
+
+  @Override
+  public PassName getName() {
+    return PassName.of("ISS Tensor Assignment To Forall Pass");
+  }
+
+  @CheckForNull
+  @Override
+  public Object execute(PassResults passResults, Specification viam) throws IOException {
+    allInstrs(viam).forEach(instruction ->
+        instruction.behavior().getNodes(IssWriteRegNode.class)
+            .filter(this::canLower)
+            .toList()
+            .forEach(this::lower));
+    return null;
+  }
+
+  private boolean canLower(IssWriteRegNode write) {
+    if (write.windowKind() != IssWriteRegNode.WindowKind.FULL
+        || write.accessKind() != IssWriteRegNode.AccessKind.BASE
+        || !(write.value() instanceof TensorNode tensor)) {
+      return false;
+    }
+
+    var ends = write.usages().gather(only(AbstractEndNode.class)).toList();
+    if (ends.size() != 1) {
+      return false;
+    }
+
+    var end = ends.getFirst();
+    var targetWidth = configuration().targetSize().width;
+    return end.predecessor() != null
+        && end.sideEffects().contains(write)
+        && write.writeBitWidth() > targetWidth
+        && tensor.body().type().asDataType().bitWidth() <= targetWidth;
+  }
+
+  private void lower(IssWriteRegNode write) {
+    var tensor = (TensorNode) write.value();
+    var graph = write.ensureGraph();
+    var end = write.usages().gather(only(AbstractEndNode.class)).findFirst().orElseThrow();
+    var predecessor = requireNonNull(end.predecessor());
+
+    var loopIdx = tensor.idx().copy();
+    var elementValue = copyWithIndexSubstitution(tensor.body(), tensor.idx(), loopIdx);
+    var elementWidth = tensor.body().type().asDataType().bitWidth();
+    var bitOffset = BuiltInTable.MUL.call(
+        loopIdx,
+        Constant.Value.of(elementWidth, loopIdx.type()).toNode()
+    );
+    var bitWidth = Constant.Value.of(elementWidth, Type.bits(32)).toNode();
+
+    var elementWrite = new IssWriteRegNode(
+        write.regTensor(),
+        write.indices().copy(),
+        elementValue,
+        write.staticCounterAccess(),
+        write.nullableCondition() == null ? null
+            : copyWithIndexSubstitution(write.nullableCondition(), tensor.idx(), loopIdx),
+        write.accessKind(),
+        write.writeGuardKind(),
+        write.accessorName(),
+        write.aliasResource(),
+        new NodeList<>(write.accessorIndices().stream().map(ExpressionNode::copy).toList()),
+        IssWriteRegNode.WindowKind.CHUNK,
+        bitOffset,
+        bitWidth
+    );
+    elementWrite.setSourceLocationIfNotSet(write.location());
+
+    var branchEnd = graph.addWithInputs(new BranchEndNode(new NodeList<>(elementWrite)));
+    var branchBegin = graph.add(new BranchBeginNode(branchEnd));
+    var forall = graph.addWithInputs(new ForallNode(loopIdx, branchBegin));
+    var forallEnd = graph.addWithInputs(new ForallEndNode(branchEnd, end));
+    forallEnd.setSourceLocationIfNotSet(write.location());
+
+    predecessor.unlinkNext();
+    predecessor.setNext(forall);
+
+    end.removeSideEffect(write);
+    if (write.usageCount() == 0) {
+      write.safeDelete();
+    }
+    forall.setSourceLocationIfNotSet(write.location());
+  }
+}

--- a/vadl/main/vadl/iss/passes/opDecomposition/decomposer/FoldDecomposer.java
+++ b/vadl/main/vadl/iss/passes/opDecomposition/decomposer/FoldDecomposer.java
@@ -27,7 +27,6 @@ import vadl.viam.graph.control.ReturnNode;
 import vadl.viam.graph.dependency.BuiltInCall;
 import vadl.viam.graph.dependency.ExpressionNode;
 import vadl.viam.graph.dependency.FoldNode;
-import vadl.viam.graph.dependency.ForIdxNode;
 
 /**
  * Decomposes {@link FoldNode} expressions by materializing only the requested result slice.

--- a/vadl/main/vadl/iss/passes/opDecomposition/decomposer/ForallSubstitution.java
+++ b/vadl/main/vadl/iss/passes/opDecomposition/decomposer/ForallSubstitution.java
@@ -16,14 +16,13 @@
 
 package vadl.iss.passes.opDecomposition.decomposer;
 
-import java.util.IdentityHashMap;
+import vadl.utils.GraphUtils;
 import vadl.viam.Constant;
-import vadl.viam.graph.Canonicalizable;
 import vadl.viam.graph.dependency.ExpressionNode;
 import vadl.viam.graph.dependency.ForIdxNode;
 
 /**
- * Utility for instantiating forall bodies by replacing the forall-index node with a constant.
+ * Utility for instantiating forall bodies by replacing the forall-index node.
  */
 public final class ForallSubstitution {
 
@@ -34,40 +33,14 @@ public final class ForallSubstitution {
                                                          ForIdxNode idx,
                                                          int idxValue) {
     var idxConst = Constant.Value.of(idxValue, idx.type()).toNode();
-    return copyWithNodeSubstitution(root, idx, idxConst, new IdentityHashMap<>());
+    return copyWithIndexSubstitution(root, idx, idxConst);
   }
 
-  private static ExpressionNode copyWithNodeSubstitution(ExpressionNode node,
-                                                         ForIdxNode toReplace,
-                                                         ExpressionNode replacement,
-                                                         IdentityHashMap<ExpressionNode,
-                                                             ExpressionNode> cache) {
-    if (matchesForallIdx(node, toReplace)) {
-      return replacement;
-    }
-
-    var cached = cache.get(node);
-    if (cached != null) {
-      return cached;
-    }
-
-    var copy = (ExpressionNode) node.shallowCopy();
-    cache.put(node, copy);
-    copy.applyOnInputs((self, input) -> {
-      if (input instanceof ExpressionNode inputExpr) {
-        return copyWithNodeSubstitution(inputExpr, toReplace, replacement, cache);
-      }
-      return input;
-    });
-
-    if (copy instanceof Canonicalizable canonicalizable) {
-      var canonical = canonicalizable.canonical();
-      if (canonical instanceof ExpressionNode exprCanonical) {
-        copy = exprCanonical;
-      }
-    }
-    cache.put(node, copy);
-    return copy;
+  public static ExpressionNode copyWithIndexSubstitution(ExpressionNode root,
+                                                         ForIdxNode idx,
+                                                         ExpressionNode replacement) {
+    return GraphUtils.copyWithNodeSubstitution(root,
+        node -> matchesForallIdx(node, idx) ? replacement : null);
   }
 
   private static boolean matchesForallIdx(ExpressionNode node, ForIdxNode idx) {

--- a/vadl/main/vadl/iss/passes/safeResourceRead/IssSafeResourceReadPass.java
+++ b/vadl/main/vadl/iss/passes/safeResourceRead/IssSafeResourceReadPass.java
@@ -32,6 +32,8 @@ import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import vadl.configuration.IssConfiguration;
 import vadl.iss.passes.AbstractIssPass;
+import vadl.iss.passes.nodes.IssReadRegNode;
+import vadl.iss.passes.nodes.IssWriteRegNode;
 import vadl.iss.passes.safeResourceRead.nodes.ExprSaveNode;
 import vadl.pass.PassName;
 import vadl.pass.PassResults;
@@ -39,6 +41,7 @@ import vadl.viam.Instruction;
 import vadl.viam.Resource;
 import vadl.viam.Specification;
 import vadl.viam.graph.Graph;
+import vadl.viam.graph.Node;
 import vadl.viam.graph.control.AbstractBeginNode;
 import vadl.viam.graph.control.AbstractEndNode;
 import vadl.viam.graph.control.BranchEndNode;
@@ -48,6 +51,7 @@ import vadl.viam.graph.control.DirectionalNode;
 import vadl.viam.graph.control.MergeNode;
 import vadl.viam.graph.control.ScheduledNode;
 import vadl.viam.graph.control.StartNode;
+import vadl.viam.graph.dependency.ConstantNode;
 import vadl.viam.graph.dependency.DependencyNode;
 import vadl.viam.graph.dependency.ExpressionNode;
 import vadl.viam.graph.dependency.ReadResourceNode;
@@ -148,9 +152,11 @@ class IssResourceReadSecurer {
    */
   void run() {
     readResources().forEach(resource -> {
-      var saveLocation = saveLocation(resource);
-      if (saveLocation != null) {
-        applySave(resource, saveLocation);
+      for (var group : saveGroupsFor(resource)) {
+        for (var read : group.reads()) {
+          result.readTempSpillLocations().put(read, group.location());
+          saveResourceRead(read, group.location());
+        }
       }
     });
   }
@@ -162,7 +168,7 @@ class IssResourceReadSecurer {
    * question without mutating the graph.</p>
    */
   boolean requiresReadSave() {
-    return readResources().anyMatch(resource -> saveLocation(resource) != null);
+    return readResources().anyMatch(resource -> !saveGroupsFor(resource).isEmpty());
   }
 
   private Stream<Resource> readResources() {
@@ -175,39 +181,127 @@ class IssResourceReadSecurer {
   }
 
   /**
-   * Determines the save location for a specific resource, if a save is needed.
+   * Returns the save groups needed to secure reads of {@code resource}. Each group binds a
+   * set of reads to a single control node at which they must be spilled. An empty list means
+   * no save is needed for this resource.
    *
-   * @param resource The resource to secure reads for.
+   * <p>When every access on {@code resource} is an {@link IssReadRegNode} /
+   * {@link IssWriteRegNode} with a constant CHUNK window and all windows are pairwise
+   * non-overlapping, accesses are partitioned per window and the conflict analysis is run
+   * independently per partition. This is precise enough to recognize unrolled per-element
+   * tensor writes where iteration {@code i} only reads and writes its own chunk offset —
+   * a pattern the conservative whole-resource analysis would falsely flag as requiring saves.
    */
-  private @Nullable ControlNode saveLocation(Resource resource) {
-    var writeSchedules = instruction.behavior().getNodes(WriteResourceNode.class)
+  private List<SaveGroup> saveGroupsFor(Resource resource) {
+    var allReads = instruction.behavior().getNodes(ReadResourceNode.class)
         .filter(wn -> wn.resourceDefinition() == resource)
+        .toList();
+    var allWrites = instruction.behavior().getNodes(WriteResourceNode.class)
+        .filter(wn -> wn.resourceDefinition() == resource)
+        .toList();
+
+    var partition = tryPartitionByChunkWindow(allReads, allWrites);
+    if (partition != null) {
+      var groups = new ArrayList<SaveGroup>();
+      for (var bucket : partition.values()) {
+        var loc = determineIfReadSaveIsRequired(bucket.reads, writeSchedulesOf(bucket.writes));
+        if (loc != null) {
+          groups.add(new SaveGroup(bucket.reads, loc));
+        }
+      }
+      return groups;
+    }
+
+    var loc = determineIfReadSaveIsRequired(allReads, writeSchedulesOf(allWrites));
+    if (loc == null) {
+      return List.of();
+    }
+    return List.of(new SaveGroup(allReads, loc));
+  }
+
+  private static List<ControlNode> writeSchedulesOf(List<? extends WriteResourceNode> writes) {
+    return writes.stream()
         .map(wn -> wn.usages()
             // if the write is scheduled or used by an instr exit
             .filter(u -> u instanceof ScheduledNode || u instanceof InstrExitNode)
             .map(ControlNode.class::cast)
             .findAny().get())
         .toList();
-
-    var reads = instruction.behavior().getNodes(ReadResourceNode.class)
-        .filter(wn -> wn.resourceDefinition() == resource)
-        .toList();
-
-    return determineIfReadSaveIsRequired(reads, writeSchedules);
   }
 
   /**
-   * Applies saved reads for a resource at the provided control location.
+   * Partitions reads and writes by their constant CHUNK window. Returns {@code null} if any
+   * access is not a constant CHUNK, or if any two distinct windows overlap partially. When
+   * non-null, every returned bucket describes a bit range that is disjoint from every other
+   * bucket's range, so the conflict analysis can treat them as independent sub-resources.
    */
-  private void applySave(Resource resource, ControlNode saveLocation) {
-    var reads = instruction.behavior().getNodes(ReadResourceNode.class)
-        .filter(wn -> wn.resourceDefinition() == resource)
-        .toList();
-    for (var read : reads) {
-      // Set spill location for conflicting read resources
-      result.readTempSpillLocations().put(read, saveLocation);
-      saveResourceRead(read, saveLocation);
+  private static @Nullable Map<ChunkWindow, ChunkBucket> tryPartitionByChunkWindow(
+      List<ReadResourceNode> reads, List<WriteResourceNode> writes) {
+    var buckets = new HashMap<ChunkWindow, ChunkBucket>();
+    for (var r : reads) {
+      var w = chunkWindowOf(r);
+      if (w == null) {
+        return null;
+      }
+      buckets.computeIfAbsent(w, k -> new ChunkBucket()).reads.add(r);
     }
+    for (var wr : writes) {
+      var w = chunkWindowOf(wr);
+      if (w == null) {
+        return null;
+      }
+      buckets.computeIfAbsent(w, k -> new ChunkBucket()).writes.add(wr);
+    }
+    // Require pairwise non-overlap (equal windows share a bucket and are fine).
+    var keys = new ArrayList<>(buckets.keySet());
+    for (int i = 0; i < keys.size(); i++) {
+      for (int j = i + 1; j < keys.size(); j++) {
+        if (partiallyOverlaps(keys.get(i), keys.get(j))) {
+          return null;
+        }
+      }
+    }
+    return buckets;
+  }
+
+  @SuppressWarnings("LocalVariableName")
+  private static boolean partiallyOverlaps(ChunkWindow a, ChunkWindow b) {
+    long aLo = a.offset();
+    long aHi = aLo + a.width();
+    long bLo = b.offset();
+    long bHi = bLo + b.width();
+    return aHi > bLo && bHi > aLo;
+  }
+
+  private static @Nullable ChunkWindow chunkWindowOf(Node n) {
+    if (n instanceof IssReadRegNode r && r.windowKind() == IssReadRegNode.WindowKind.CHUNK) {
+      return windowFromNodes(r.bitOffset(), r.bitWidth());
+    }
+    if (n instanceof IssWriteRegNode w && w.windowKind() == IssWriteRegNode.WindowKind.CHUNK) {
+      return windowFromNodes(w.bitOffset(), w.bitWidth());
+    }
+    return null;
+  }
+
+  private static @Nullable ChunkWindow windowFromNodes(ExpressionNode offset,
+                                                       ExpressionNode width) {
+    if (offset instanceof ConstantNode co && width instanceof ConstantNode cw) {
+      return new ChunkWindow(
+          co.constant().asVal().intValue(),
+          cw.constant().asVal().intValue());
+    }
+    return null;
+  }
+
+  private record ChunkWindow(int offset, int width) {
+  }
+
+  private static final class ChunkBucket {
+    final List<ReadResourceNode> reads = new ArrayList<>();
+    final List<WriteResourceNode> writes = new ArrayList<>();
+  }
+
+  private record SaveGroup(List<ReadResourceNode> reads, ControlNode location) {
   }
 
   /**

--- a/vadl/main/vadl/pass/PassOrders.java
+++ b/vadl/main/vadl/pass/PassOrders.java
@@ -69,6 +69,7 @@ import vadl.iss.passes.IssRegisterAccessLoweringPass;
 import vadl.iss.passes.IssSelectLoweringPass;
 import vadl.iss.passes.IssTcgSchedulingPass;
 import vadl.iss.passes.IssTcgVAllocationPass;
+import vadl.iss.passes.IssTensorAssignmentToForallPass;
 import vadl.iss.passes.opDecomposition.IssOpDecompositionPass;
 import vadl.iss.passes.safeResourceRead.IssSafeResourceReadPass;
 import vadl.iss.passes.tcgLowering.IssTcgContextPass;
@@ -522,6 +523,7 @@ public class PassOrders {
         .add(new IssRegisterAccessLoweringPass(config))
         .add(new IssExecStrategyPass(config))
         .add(new IssBitfieldWriteLoweringPass(config))
+        .add(new IssTensorAssignmentToForallPass(config))
         // run canonicalization, as register access lowering may create constant nodes
         .add(new CanonicalizationPass(config))
         .add(new IssOpDecompositionPass(config))

--- a/vadl/main/vadl/utils/GraphUtils.java
+++ b/vadl/main/vadl/utils/GraphUtils.java
@@ -19,6 +19,7 @@ package vadl.utils;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
@@ -32,6 +33,7 @@ import vadl.types.DataType;
 import vadl.types.Type;
 import vadl.types.UIntType;
 import vadl.viam.Constant;
+import vadl.viam.graph.Canonicalizable;
 import vadl.viam.graph.Graph;
 import vadl.viam.graph.GraphVisitor;
 import vadl.viam.graph.Node;
@@ -134,6 +136,63 @@ public class GraphUtils {
         .filter(n -> n.usages()
             .noneMatch(u -> u instanceof DependencyNode)
         );
+  }
+
+  /**
+   * Copies an expression tree while substituting selected expression nodes.
+   *
+   * <p>The {@code substitution} function is called before a node is copied. Returning a non-null
+   * expression replaces the current node and stops traversal for that branch. Returning
+   * {@code null} keeps the node and recursively copies its expression inputs. Shared input nodes
+   * stay shared in the copied result through identity-based memoization.</p>
+   *
+   * <p>Copied nodes are canonicalized when they implement {@link Canonicalizable}. The substituted
+   * replacement itself is returned as provided and is not copied.</p>
+   *
+   * @param root the expression root to copy
+   * @param substitution function returning a replacement expression, or {@code null} to keep
+   *                     copying
+   * @return the copied expression root with substitutions applied
+   */
+  public static ExpressionNode copyWithNodeSubstitution(
+      ExpressionNode root,
+      Function<ExpressionNode, ExpressionNode> substitution
+  ) {
+    return copyWithNodeSubstitution(root, substitution, new IdentityHashMap<>());
+  }
+
+  private static ExpressionNode copyWithNodeSubstitution(
+      ExpressionNode node,
+      Function<ExpressionNode, ExpressionNode> substitution,
+      IdentityHashMap<ExpressionNode, ExpressionNode> cache
+  ) {
+    var replacement = substitution.apply(node);
+    if (replacement != null) {
+      return replacement;
+    }
+
+    var cached = cache.get(node);
+    if (cached != null) {
+      return cached;
+    }
+
+    var copy = (ExpressionNode) node.shallowCopy();
+    cache.put(node, copy);
+    copy.applyOnInputs((self, input) -> {
+      if (input instanceof ExpressionNode inputExpr) {
+        return copyWithNodeSubstitution(inputExpr, substitution, cache);
+      }
+      return input;
+    });
+
+    if (copy instanceof Canonicalizable canonicalizable) {
+      var canonical = canonicalizable.canonical();
+      if (canonical instanceof ExpressionNode exprCanonical) {
+        copy = exprCanonical;
+      }
+    }
+    cache.put(node, copy);
+    return copy;
   }
 
   /**

--- a/vadl/test/vadl/iss/passes/IssTensorAssignmentToForallPassTest.java
+++ b/vadl/test/vadl/iss/passes/IssTensorAssignmentToForallPassTest.java
@@ -1,0 +1,147 @@
+// SPDX-FileCopyrightText : © 2026 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.iss.passes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import vadl.AbstractTest;
+import vadl.TestUtils;
+import vadl.configuration.IssConfiguration;
+import vadl.iss.passes.nodes.IssWriteRegNode;
+import vadl.pass.PassResults;
+import vadl.types.BitsType;
+import vadl.types.BuiltInTable;
+import vadl.types.Type;
+import vadl.viam.Constant;
+import vadl.viam.InstructionSetArchitecture;
+import vadl.viam.RegisterTensor;
+import vadl.viam.Specification;
+import vadl.viam.graph.NodeList;
+import vadl.viam.graph.control.ForallEndNode;
+import vadl.viam.graph.control.ForallNode;
+import vadl.viam.graph.control.InstrEndNode;
+import vadl.viam.graph.control.StartNode;
+import vadl.viam.graph.dependency.BuiltInCall;
+import vadl.viam.graph.dependency.ForIdxNode;
+import vadl.viam.graph.dependency.SideEffectNode;
+import vadl.viam.graph.dependency.TensorNode;
+
+public class IssTensorAssignmentToForallPassTest extends AbstractTest {
+
+  @Test
+  public void lowersWideTensorAssignmentToChunkedForallWrite() throws IOException {
+    var fixture = createTensorWriteFixture("wide", 128, 16);
+
+    runPass(fixture.specification());
+
+    var graph = fixture.instruction().behavior();
+    assertEquals(1, graph.getNodes(ForallNode.class).count());
+    assertEquals(1, graph.getNodes(ForallEndNode.class).count());
+    assertEquals(1, graph.getNodes(IssWriteRegNode.class)
+        .filter(write -> write.windowKind() == IssWriteRegNode.WindowKind.CHUNK)
+        .count());
+    assertEquals(0, graph.getNodes(IssWriteRegNode.class)
+        .filter(write -> write.value() instanceof TensorNode)
+        .count());
+
+    var end = graph.getNodes(InstrEndNode.class).findFirst().orElseThrow();
+    assertSame(fixture.otherWrite(), end.sideEffects().getFirst());
+    assertFalse(end.sideEffects().contains(fixture.tensorWrite()));
+    assertTrue(fixture.tensorWrite().isDeleted());
+
+    var chunkWrite = graph.getNodes(IssWriteRegNode.class)
+        .filter(write -> write.windowKind() == IssWriteRegNode.WindowKind.CHUNK)
+        .findFirst()
+        .orElseThrow();
+    assertEquals(8, chunkWrite.writeBitWidth());
+    var value = assertInstanceOf(BuiltInCall.class, chunkWrite.value());
+    var bitOffset = assertInstanceOf(BuiltInCall.class, chunkWrite.bitOffset());
+    assertInstanceOf(ForIdxNode.class, value.arg(0));
+    assertSame(value.arg(0), bitOffset.arg(0));
+  }
+
+  @Test
+  public void keepsTargetSizedTensorAssignmentIntact() throws IOException {
+    var fixture = createTensorWriteFixture("target_sized", 64, 8);
+
+    runPass(fixture.specification());
+
+    var graph = fixture.instruction().behavior();
+    assertEquals(0, graph.getNodes(ForallNode.class).count());
+    assertEquals(1, graph.getNodes(IssWriteRegNode.class)
+        .filter(write -> write.value() instanceof TensorNode)
+        .count());
+    assertFalse(fixture.tensorWrite().isDeleted());
+  }
+
+  private void runPass(Specification specification) throws IOException {
+    var configuration = IssConfiguration.from(getConfiguration(false));
+    new IssTensorAssignmentToForallPass(configuration).execute(new PassResults(), specification);
+  }
+
+  private static Fixture createTensorWriteFixture(String name, int regBitWidth, int lanes) {
+    var spec = TestUtils.createSpecification(name + ".specification");
+    var format = TestUtils.createFormat(name + ".format", BitsType.bits(32));
+    var instruction = TestUtils.createInstruction(name + ".instruction", format);
+    var reg = RegisterTensor.of(TestUtils.createIdentifier(name + ".reg"), regBitWidth);
+    var otherReg = RegisterTensor.of(TestUtils.createIdentifier(name + ".other_reg"), 64);
+
+    var idx = new ForIdxNode(Type.bits(8), 0, lanes - 1);
+    var tensor = new TensorNode(Type.bits(regBitWidth), idx,
+        BuiltInTable.ADD.call(idx, Constant.Value.of(1, Type.bits(8)).toNode()));
+    var tensorWrite = new IssWriteRegNode(reg, new NodeList<>(), tensor, null);
+    var otherWrite = new IssWriteRegNode(otherReg, new NodeList<>(),
+        Constant.Value.zero(Type.bits(64).asDataType()).toNode(), null);
+
+    var graph = instruction.behavior();
+    var end = graph.addWithInputs(new InstrEndNode(
+        new NodeList<SideEffectNode>(List.of(tensorWrite, otherWrite))));
+    graph.add(new StartNode(end));
+
+    spec.add(new InstructionSetArchitecture(
+        TestUtils.createIdentifier(name + ".isa"),
+        spec,
+        List.of(format),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        List.of(instruction),
+        Collections.emptyList(),
+        List.of(reg, otherReg),
+        null,
+        Collections.emptyList(),
+        Collections.emptyList()
+    ));
+
+    return new Fixture(spec, instruction, tensorWrite, otherWrite);
+  }
+
+  private record Fixture(Specification specification,
+                         vadl.viam.Instruction instruction,
+                         IssWriteRegNode tensorWrite,
+                         IssWriteRegNode otherWrite) {
+  }
+}

--- a/vadl/test/vadl/utils/GraphUtilsTest.java
+++ b/vadl/test/vadl/utils/GraphUtilsTest.java
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText : © 2026 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.utils;
+
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.junit.jupiter.api.Test;
+import vadl.types.BuiltInTable;
+import vadl.types.Type;
+import vadl.viam.Constant;
+import vadl.viam.graph.dependency.BuiltInCall;
+import vadl.viam.graph.dependency.ConstantNode;
+import vadl.viam.graph.dependency.ForIdxNode;
+
+public class GraphUtilsTest {
+
+  @Test
+  public void copyWithNodeSubstitutionUsesReplacementForMatchingNodes() {
+    var idx = new ForIdxNode(Type.bits(8), 0, 7);
+    var shared = BuiltInTable.ADD.call(idx, bits(1));
+    var root = BuiltInTable.XOR.call(shared, shared);
+    var replacement = new ForIdxNode(Type.bits(8), 0, 7);
+
+    var copy = (BuiltInCall) GraphUtils.copyWithNodeSubstitution(root,
+        node -> node == shared ? replacement : null);
+
+    assertNotSame(root, copy);
+    assertSame(replacement, copy.arguments().get(0));
+    assertSame(replacement, copy.arguments().get(1));
+  }
+
+  @Test
+  public void copyWithNodeSubstitutionPreservesSharedCopiedSubgraphs() {
+    var idx = new ForIdxNode(Type.bits(8), 0, 7);
+    var shared = BuiltInTable.ADD.call(idx, bits(1));
+    var root = BuiltInTable.XOR.call(shared, shared);
+
+    var copy = (BuiltInCall) GraphUtils.copyWithNodeSubstitution(root, node -> null);
+
+    assertNotSame(root, copy);
+    assertNotSame(shared, copy.arguments().get(0));
+    assertSame(copy.arguments().get(0), copy.arguments().get(1));
+  }
+
+  private static ConstantNode bits(long value) {
+    return Constant.Value.of(value, Type.bits(8)).toNode();
+  }
+}


### PR DESCRIPTION
For instructions that compute a vector result as tensor expression and assign the expression cross-lane to the vector register like in AArch64 SVE:
```
Z(zdn) := forall i : IndexE in 0..NElems-1
                  tensor if pred(i)
                    then VADL::add(left(i), right(i))
                    else left(i)
```
we can transform it into an equivalent `forall do` statement:
```
forall i : IndexE in 0..NElems-1 do
   Z(zdn)(i) := if pred(i)
       then VADL::add(left(i), right(i))
       else left(i)
```

This allows the application of optimization as for normal `forall do` statements. Specifically, the forall unroll prevention that was merged in #896, combined with this transformation, allows the rendering of tensor expressions as `for` loops in C.

To achieve this, this PR also enhances the analysis performed by the `SafeResourceReadPass`. It now considers constant read/write chunk windows and recognizes whether two distinct register regions are accessed independently during different iterations.