### PR TITLE
diagnostic: Deflate similar diagnostics into one

### DIFF
--- a/vadl-cli/main/vadl/cli/BaseCommand.java
+++ b/vadl-cli/main/vadl/cli/BaseCommand.java
@@ -392,7 +392,8 @@ public abstract class BaseCommand implements Callable<Integer> {
       }
       returnVal = 1;
     } catch (DiagnosticList d) {
-      System.out.println(new DiagnosticPrinter(new DiskVirtualFileSystem()).toString(d));
+      System.out.println(
+          new DiagnosticPrinter(new DiskVirtualFileSystem()).toString(d.deflateSimilar()));
       if (showStacktrace) {
         System.out.println(getStackTrace(d));
       }
@@ -427,7 +428,8 @@ public abstract class BaseCommand implements Callable<Integer> {
 
     if (!DeferredDiagnosticStore.isEmpty()) {
       System.out.println(new DiagnosticPrinter(new DiskVirtualFileSystem()).toString(
-          DeferredDiagnosticStore.getAll()));
+          Diagnostic.collapseSimilar(DeferredDiagnosticStore.getAll())
+      ));
 
       // Only exit abnormally if any diagnostic message is an error.
       if (DeferredDiagnosticStore.getAll().stream()

--- a/vadl-lsp/main/vadl/lsp/VadlTextDocumentService.java
+++ b/vadl-lsp/main/vadl/lsp/VadlTextDocumentService.java
@@ -273,7 +273,7 @@ public class VadlTextDocumentService implements TextDocumentService {
       } catch (DiagnosticList dl) {
         log.debug("Raw diagnostics ({}): {}", document.uri, dl.getMessage());
         List<String> importedFileErrors = new ArrayList<>();
-        for (vadl.error.Diagnostic item : dl.items) {
+        for (vadl.error.Diagnostic item : dl.deflateSimilar().items) {
           Path itemPath = item.multiLocation.primaryLocation().location().path();
           if (!Objects.equals(itemPath, path)) {
             if (itemPath == null) {

--- a/vadl/main/vadl/error/Diagnostic.java
+++ b/vadl/main/vadl/error/Diagnostic.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -16,10 +16,12 @@
 
 package vadl.error;
 
+import com.google.common.collect.Streams;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
 import org.jetbrains.annotations.Contract;
+import vadl.utils.Pair;
 import vadl.utils.SourceLocation;
 import vadl.utils.WithLocation;
 
@@ -45,6 +47,12 @@ import vadl.utils.WithLocation;
  *   3 │ constant flo = 18                      // A secondary location of the multilocation
  *     │          --- First definition          // Which also has a message
  *     │
+ *     ├─ From these 2 model invocation (outermost call first): // This code was generated from a
+ *     │    1) file.vadl:11:2                   // The first incocation started here
+ *     │       file.vadl:9:4                    // Then called the actual model here
+ *     │    2) file.vadl:14:2                   // A second invocation started here
+ *     │
+ *     │
  *     Each variable can only be declared once. // Messages can also belong to the whole diagnostic
  *     help: Find another awesome name.
  * </pre>
@@ -60,6 +68,61 @@ public class Diagnostic extends RuntimeException {
   public final List<Message> messages;
 
   /**
+   * The same diagnostic can be created from multiple macro invocations. They might get collapsed
+   * into one diagnostic, in which case this field is used to store them all.
+   *
+   * <p>Let's start first with the inner List which is a backtrace like you get in Java for
+   * stacktraces, except this tracs macro invocation chains and not funciton calls. Also, unlike
+   * Java, the innermost call is last.
+   *
+   * <p>The outer list is now of such backtraces. In VADL it is quite common that macro's get
+   * invoked multiple times, somtimes even hundrets of times. Since the parser already expands the
+   * calls the rest of the compiler pipeline will emit virtually the same diagnostic for each
+   * invocation, with only the {@code expandedFrom} of the source location being different.
+   * The method {@link #collapseSimilar(List)} then can be used to collapse all similar diagnostics,
+   * that only differ in the macro trace. This way we can only emit a sinlge diagnostic for our
+   * users even and print all the traces where it got invoked from at once.
+   *
+   * <b>Example</b>
+   * <pre>
+   * model badboi(name: Id): Defs = {
+   *   constant $name: Bits<32> = "Not a bits"
+   * }
+   *
+   * model middle(name: Id): Defs = {
+   *   $badboi($name)
+   * }
+   *
+   * model outer(name: Id): Defs = {
+   *   $middle($name)
+   * }
+   *
+   * $outer(apfel)
+   * $middle(strudel)
+   * $badboi(minister)
+   * </pre>
+   *
+   * <p>Which after collapsing the diagnostics will show as:
+   * <pre>
+   * error: Type Mismatch
+   *   ╭── example.vadl:2:30
+   *   │
+   * 2 │   constant $name: Bits<32> = "Not a bits"
+   *   │                              ^^^^^^^^^^^^ Expected Bits<32> but got String.
+   *   │
+   *   ├─ From these 3 model invocations (outermost call first):
+   *   │    1) example.vadl:13:1
+   *   │       example.vadl:10:3
+   *   │       example.vadl:6:3
+   *   │    2) example.vadl:14:1
+   *   │       example.vadl:6:3
+   *   │    3) example.vadl:15:1
+   *   │
+   * </pre>
+   */
+  public final List<List<SourceLocation>> macroTraces;
+
+  /**
    * It's generally recommended to not instantiate Diagnostics on their own but to make use of the
    * {@link Diagnostic#error(String, WithLocation)} and
    * {@link Diagnostic#warning(String, WithLocation)}
@@ -71,6 +134,13 @@ public class Diagnostic extends RuntimeException {
     this.reason = reason;
     this.multiLocation = multiLocation;
     this.messages = messages;
+    this.macroTraces = new ArrayList<>();
+
+    var initialTrace = multiLocation.primaryLocation.location.expandedFromStack().reversed();
+    initialTrace.removeLast();
+    if (!initialTrace.isEmpty()) {
+      this.macroTraces.add(initialTrace);
+    }
   }
 
   /**
@@ -122,6 +192,30 @@ public class Diagnostic extends RuntimeException {
     }
   }
 
+  /**
+   * Diagnostics that only differ in the macro trace will get collapsed into one.
+   *
+   * <p>A detailed explaination of how and why can be found in the documentation of
+   * {@link #macroTraces}.
+   *
+   * @param diagnostics to collapse.
+   * @return the deflated diagnostics.
+   */
+  public static List<Diagnostic> collapseSimilar(List<Diagnostic> diagnostics) {
+    var deflated = new ArrayList<Diagnostic>();
+    for (var diagnostic : diagnostics) {
+      var similar = deflated.stream()
+          .filter(d -> d.equalsIgnoringMacroTraces(diagnostic))
+          .findFirst();
+
+      similar.ifPresentOrElse(
+          d -> d.macroTraces.addAll(diagnostic.macroTraces),
+          () -> deflated.add(diagnostic)
+      );
+    }
+    return deflated;
+  }
+
   @Override
   public String getMessage() {
     var sb = new StringBuilder();
@@ -154,6 +248,19 @@ public class Diagnostic extends RuntimeException {
       });
     });
     return sb.toString();
+  }
+
+  /**
+   * Checks if two diagnostics are equal ignoring the macro traces.
+   *
+   * @param other diagnostic to compare to.
+   * @return true if the diagnostics are equal, false otherwise.
+   */
+  public boolean equalsIgnoringMacroTraces(Diagnostic other) {
+    return this.level == other.level
+        && this.reason.equals(other.reason)
+        && this.multiLocation.equalsIgnoringExpandedFrom(other.multiLocation)
+        && this.messages.equals(other.messages);
   }
 
   @Override
@@ -216,6 +323,23 @@ public class Diagnostic extends RuntimeException {
       secondaryLocations.add(labeledLocation);
       return labeledLocation;
     }
+
+    /**
+     * Checks if two multilocations are equal ignoring the expandedFrom stack.
+     *
+     * @param other to compare to.
+     * @return true if the multilocations are equal, false otherwise.
+     */
+    public boolean equalsIgnoringExpandedFrom(MultiLocation other) {
+      if (this.secondaryLocations.size() != other.secondaryLocations.size()) {
+        return false;
+      }
+
+      return this.primaryLocation.equalsIgnoringExpandedFrom(other.primaryLocation)
+          && Streams.zip(this.secondaryLocations.stream(), other.secondaryLocations.stream(),
+              (a, b) -> Pair.of(a, b))
+          .allMatch(pair -> pair.left().equalsIgnoringExpandedFrom(pair.right()));
+    }
   }
 
   /**
@@ -225,6 +349,17 @@ public class Diagnostic extends RuntimeException {
    * @param labels   to annotate
    */
   public record LabeledLocation(SourceLocation location, List<Message> labels) {
+
+    /**
+     * Checks if two locations are equal ignoring the expandedFrom stack.
+     *
+     * @param other to compare to.
+     * @return true if the locations are equal, false otherwise.
+     */
+    public boolean equalsIgnoringExpandedFrom(LabeledLocation other) {
+      return this.location.equalsIgnoringExpandedFrom(other.location)
+          && this.labels.equals(other.labels);
+    }
   }
 
   /**

--- a/vadl/main/vadl/error/DiagnosticList.java
+++ b/vadl/main/vadl/error/DiagnosticList.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -32,5 +32,14 @@ public class DiagnosticList extends RuntimeException {
 
   private static String buildErrorMessage(List<Diagnostic> errors) {
     return errors.stream().map(Diagnostic::getMessage).collect(Collectors.joining("\n"));
+  }
+
+  /**
+   * Deflates similar diagnostics into one.
+   *
+   * @return the deflated diagnostic list.
+   */
+  public DiagnosticList deflateSimilar() {
+    return new DiagnosticList(Diagnostic.collapseSimilar(items));
   }
 }

--- a/vadl/main/vadl/error/DiagnosticPrinter.java
+++ b/vadl/main/vadl/error/DiagnosticPrinter.java
@@ -146,9 +146,11 @@ public class DiagnosticPrinter {
         builder.append(sourceDelimiter(previous.location(), snippet.location()));
       }
 
-      printExpandedSourcePreview(snippet,
+      printSourcePreview(snippet,
           snippet.equals(diagnostic.multiLocation.primaryLocation()), diagnostic.level, builder);
     }
+
+    printMacroBackTrace(diagnostic, builder);
     builder.append("\n     %s│%s\n".formatted(colors.cyan(), colors.reset()));
   }
 
@@ -181,31 +183,47 @@ public class DiagnosticPrinter {
   /**
    * Print a location and the chain of expansions from which it originated.
    *
-   * @param location  to print.
-   * @param isPrimary whether it's the main reason of the diagnostic.
-   * @param builder   into which the preview will be printed.
+   * @param diagnostic for which the macro backtrace will be printed.
+   * @param builder    into which the preview will be printed.
    */
-  private void printExpandedSourcePreview(Diagnostic.LabeledLocation location, boolean isPrimary,
-                                          Diagnostic.Level level,
-                                          StringBuilder builder) {
-    // Print the original preview
-    printSourcePreview(location, isPrimary, level, builder);
-
-    // Print also the chain/stack of the location from which this error was expanded form
-    var last = location.location();
-    var next = location.location().expandedFrom();
-    while (next != null) {
-      builder.append("\n");
-      builder.append(sourceDelimiter(last, next));
-      printSourcePreview(
-          new Diagnostic.LabeledLocation(
-              next,
-              List.of(
-                  new Diagnostic.Message(Diagnostic.MsgType.PLAIN, "from this model invocation"))),
-          false, level, builder);
-      last = next;
-      next = next.expandedFrom();
+  private void printMacroBackTrace(Diagnostic diagnostic, StringBuilder builder) {
+    if (diagnostic.macroTraces.isEmpty()) {
+      return;
     }
+
+    var tracesCount = diagnostic.macroTraces.size();
+    var title = switch (tracesCount) {
+      case 1 -> "From this model invocation (outermost call first):";
+      default -> "From these %d model invocations (outermost call first):".formatted(
+          diagnostic.macroTraces.size());
+    };
+    builder.append("\n     %s│\n     ├─%s %s\n".formatted(colors.cyan(), colors.reset(), title));
+
+    var blockBuilder = new StringJoiner("\n");
+    for (int i = 0; i < diagnostic.macroTraces.size(); i++) {
+      var trace = diagnostic.macroTraces.get(i);
+      var firstLocation = trace.getFirst();
+      var firstIDEString = firstLocation.toIDEString(fileSystem,
+          forceRelativePaths ? SourceLocation.IDEDetectionMode.RELATIVE :
+              SourceLocation.IDEDetectionMode.AUTO, forceUnixPaths);
+
+      if (tracesCount == 1) {
+        blockBuilder.add("   %s".formatted(firstIDEString));
+      } else {
+        blockBuilder.add("%d) %s".formatted(i + 1, firstIDEString));
+      }
+
+      for (int j = 1; j < trace.size(); j++) {
+        var location = trace.get(j);
+        blockBuilder.add("   %s".formatted(location.toIDEString(fileSystem,
+            forceRelativePaths ? SourceLocation.IDEDetectionMode.RELATIVE :
+                SourceLocation.IDEDetectionMode.AUTO, forceUnixPaths)));
+      }
+    }
+
+    builder.append(
+        indentBy(blockBuilder.toString(),
+            "     %s│%s    ".formatted(colors.cyan(), colors.reset())));
   }
 
   /**

--- a/vadl/main/vadl/utils/SourceLocation.java
+++ b/vadl/main/vadl/utils/SourceLocation.java
@@ -331,6 +331,22 @@ public record SourceLocation(
     return printPath;
   }
 
+  /**
+   * Same as the default equals, but ignores the expandedFrom field.
+   *
+   * @param other source location to compare to.
+   * @return true if the source locations are equal, ignoring the expandedFrom field
+   */
+  @SuppressWarnings("ReferenceEquality") // I know what I'm doing.
+  public boolean equalsIgnoringExpandedFrom(SourceLocation other) {
+    if (this == other) {
+      return true;
+    }
+    return Objects.equals(path, other.path)
+        && Objects.equals(begin, other.begin)
+        && Objects.equals(end, other.end);
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/vadl/test/resources/frontend-snapshots/imports/invalidImportWhereWithIsMacroOfWrongType.vadl
+++ b/vadl/test/resources/frontend-snapshots/imports/invalidImportWhereWithIsMacroOfWrongType.vadl
@@ -25,9 +25,9 @@ constant flo = $numPlusOne()
 //       │
 //     4 │   42
 //       │   ^^
-//       ⋮
-//     8 │ import base::numPlusOne with ($WithTarget())
-//       │                               ------------- from this model invocation
+//       │
+//       ├─ From this model invocation (outermost call first):
+//       │       test/resources/frontend-snapshots/imports/invalidImportWhereWithIsMacroOfWrongType.vadl:8:31
 //       │
 //       Expected node of type Str, received Ex - GroupedExpr
 //

--- a/vadl/test/resources/frontend-snapshots/macro/invalidSameErrorFromMultipleInvocations.vadl
+++ b/vadl/test/resources/frontend-snapshots/macro/invalidSameErrorFromMultipleInvocations.vadl
@@ -1,0 +1,42 @@
+// Previously, this would print an error for each invocation.
+// https://github.com/OpenVADL/openvadl/issues/890
+
+model badboi(name: Id): Defs = {
+  constant $name: Bits<32> = "Not a bits"
+}
+
+model middle(name: Id): Defs = {
+  $badboi($name)
+}
+
+model outer(name: Id): Defs = {
+  $middle($name)
+}
+
+$outer(apfel)
+$outer(flo)
+$outer(freitag)
+
+
+//  Reported Diagnostics:
+//
+//  error: Type Mismatch
+//       ╭── test/resources/frontend-snapshots/macro/invalidSameErrorFromMultipleInvocations.vadl:5:30
+//       │
+//     5 │   constant $name: Bits<32> = "Not a bits"
+//       │                              ^^^^^^^^^^^^ Expected `Bits<32>` but got `String`.
+//       │
+//       ├─ From these 3 model invocations (outermost call first):
+//       │    1) test/resources/frontend-snapshots/macro/invalidSameErrorFromMultipleInvocations.vadl:16:1
+//       │       test/resources/frontend-snapshots/macro/invalidSameErrorFromMultipleInvocations.vadl:13:3
+//       │       test/resources/frontend-snapshots/macro/invalidSameErrorFromMultipleInvocations.vadl:9:3
+//       │    2) test/resources/frontend-snapshots/macro/invalidSameErrorFromMultipleInvocations.vadl:17:1
+//       │       test/resources/frontend-snapshots/macro/invalidSameErrorFromMultipleInvocations.vadl:13:3
+//       │       test/resources/frontend-snapshots/macro/invalidSameErrorFromMultipleInvocations.vadl:9:3
+//       │    3) test/resources/frontend-snapshots/macro/invalidSameErrorFromMultipleInvocations.vadl:18:1
+//       │       test/resources/frontend-snapshots/macro/invalidSameErrorFromMultipleInvocations.vadl:13:3
+//       │       test/resources/frontend-snapshots/macro/invalidSameErrorFromMultipleInvocations.vadl:9:3
+//       │
+//
+//
+// Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl/test/resources/frontend-snapshots/macro/invalidTopLevelMacroProducesIsaDef.vadl
+++ b/vadl/test/resources/frontend-snapshots/macro/invalidTopLevelMacroProducesIsaDef.vadl
@@ -14,9 +14,9 @@ $instr()
 //       │
 //     4 │   instruction ABC: X = { }
 //       │   ^^^^^^^^^^^^^^^^^^^^^^^^
-//       ⋮
-//     7 │ $instr()
-//       │ -------- from this model invocation
+//       │
+//       ├─ From this model invocation (outermost call first):
+//       │       test/resources/frontend-snapshots/macro/invalidTopLevelMacroProducesIsaDef.vadl:7:1
 //       │
 //       Expected node of type Defs, received IsaDefs
 //

--- a/vadl/test/resources/frontend-snapshots/parser/invalidForallFoldModelSyntaxTypeForOperator.vadl
+++ b/vadl/test/resources/frontend-snapshots/parser/invalidForallFoldModelSyntaxTypeForOperator.vadl
@@ -15,9 +15,9 @@ model FoldStat (): Stat = {
 //       │
 //     4 │ model TestOP (): Ex = {42}
 //       │                        ^^
-//       ⋮
-//     7 │   Reg := forall i: Bits<4> in 0 .. 3 fold $TestOP() with Reg(i)
-//       │                                           --------- from this model invocation
+//       │
+//       ├─ From this model invocation (outermost call first):
+//       │       test/resources/frontend-snapshots/parser/invalidForallFoldModelSyntaxTypeForOperator.vadl:7:43
 //       │
 //       Expected node of type BinOp, received Ex - GroupedExpr
 //

--- a/vadl/test/resources/frontend-snapshots/parser/invalidModelWithErrorInModel.vadl
+++ b/vadl/test/resources/frontend-snapshots/parser/invalidModelWithErrorInModel.vadl
@@ -16,9 +16,9 @@ constant second = $apfelstrudel
 //       │
 //     4 │   false + 42
 //       │   ^^^^^^^^^^ note: The left type is `Bits<1>` while right is `Bits<6>`
-//       ⋮
-//     9 │ constant second = $apfelstrudel
-//       │                   ------------- from this model invocation
+//       │
+//       ├─ From this model invocation (outermost call first):
+//       │       test/resources/frontend-snapshots/parser/invalidModelWithErrorInModel.vadl:9:19
 //       │
 //       Both types on the left and right side of an binary operation should be equal.
 //

--- a/vadl/test/vadl/ast/FrontendSnapshotTests.java
+++ b/vadl/test/vadl/ast/FrontendSnapshotTests.java
@@ -96,7 +96,7 @@ public class FrontendSnapshotTests {
       ViamLocationExistenceChecker.verify(spec);
 
     } catch (DiagnosticList d) {
-      diagnostics = d.items;
+      diagnostics = d.deflateSimilar().items;
     } catch (Diagnostic d) {
       diagnostics = List.of(d);
     } finally {


### PR DESCRIPTION
If two diagnostics only differ in the location they got expanded from, then they will now be collapsed into a single diagnostic with two macro backtraces attached to it.

The backtraces are now also more compact.

Closes: #894 
Closes: #890 