### PR TITLE
Refactor CLI decoder options

### DIFF
--- a/vadl-cli/main/vadl/cli/BaseCommand.java
+++ b/vadl-cli/main/vadl/cli/BaseCommand.java
@@ -17,7 +17,9 @@
 package vadl.cli;
 
 import static org.apache.commons.lang3.exception.ExceptionUtils.getStackTrace;
+import static picocli.CommandLine.MaxValuesExceededException;
 import static picocli.CommandLine.ScopeType.INHERIT;
+import static picocli.CommandLine.TypeConversionException;
 
 import com.google.errorprone.annotations.concurrent.LazyInit;
 import java.io.IOException;
@@ -29,11 +31,9 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.concurrent.Callable;
 import javax.annotation.Nullable;
 import picocli.CommandLine;
@@ -47,7 +47,6 @@ import vadl.ast.TypeChecker;
 import vadl.ast.Ungrouper;
 import vadl.ast.VadlParser;
 import vadl.ast.ViamLowering;
-import vadl.configuration.DecoderOptions;
 import vadl.configuration.DumpMode;
 import vadl.configuration.GeneralConfiguration;
 import vadl.dump.ArtifactTracker;
@@ -124,17 +123,6 @@ public abstract class BaseCommand implements Callable<Integer> {
       description = "Debug option to show the OpenVADL stacktrace of an emitted error."
   )
   boolean showStacktrace;
-
-  @Option(names = "--decoder",
-      split = ",",
-      scope = INHERIT,
-      description = "Options for the decoder generation. Valid options are: "
-          + "${COMPLETION-CANDIDATES}",
-      completionCandidates = DecoderOptsConverter.class,
-      converter = DecoderOptsConverter.class
-  )
-  @Nullable
-  Set<DecoderOpt> decoderOptions = new LinkedHashSet<>();
 
   /**
    * A list of timings. Will only be filled when the timings should be recorded.
@@ -365,7 +353,6 @@ public abstract class BaseCommand implements Callable<Integer> {
     }
 
     config = new GeneralConfiguration(input, output, dump);
-    config.setDecoderOptions(getDecoderOptions());
 
     return config;
   }
@@ -395,7 +382,7 @@ public abstract class BaseCommand implements Callable<Integer> {
       timings.add(new Timing("Total", (System.nanoTime() - totalStartTime) / 1_000_000));
 
 
-    } catch (CommandLine.TypeConversionException | CommandLine.MaxValuesExceededException e) {
+    } catch (TypeConversionException | MaxValuesExceededException e) {
       // Re-throw to let Picoli handle it
       throw e;
     } catch (Diagnostic d) {
@@ -464,44 +451,5 @@ public abstract class BaseCommand implements Callable<Integer> {
     writeTimingsCsv();
 
     return returnVal;
-  }
-
-  private DecoderOptions getDecoderOptions() {
-
-    if (decoderOptions == null) {
-      return new DecoderOptions();
-    }
-
-    final DecoderOptions result = new DecoderOptions();
-
-    var strategies = decoderOptions.stream()
-        .filter(DecoderStrategy.class::isInstance)
-        .map(DecoderStrategy.class::cast)
-        .toList();
-    if (strategies.size() > 1) {
-
-      if (spec == null) {
-        // Should not happen, but will satisfy Nullaway
-        throw new IllegalArgumentException("Multiple decoder strategies are not allowed.");
-      }
-
-      throw new CommandLine.MaxValuesExceededException(spec.commandLine(),
-          "Multiple decoder strategies are not allowed.");
-    }
-    if (strategies.size() == 1) {
-      result.setGenerator(strategies.getFirst().generator());
-    }
-
-    var skipOpts = decoderOptions.stream()
-        .filter(DecoderSkipOption.class::isInstance)
-        .map(DecoderSkipOption.class::cast)
-        .map(DecoderSkipOption::option)
-        .toList();
-
-    if (!skipOpts.isEmpty()) {
-      result.setOptsToSkip(skipOpts.toArray(new DecoderOptions.OptionToSkip[0]));
-    }
-
-    return result;
   }
 }

--- a/vadl-cli/main/vadl/cli/CheckCommand.java
+++ b/vadl-cli/main/vadl/cli/CheckCommand.java
@@ -16,8 +16,11 @@
 
 package vadl.cli;
 
+import java.util.Objects;
 import java.util.concurrent.Callable;
+import picocli.CommandLine;
 import picocli.CommandLine.Command;
+import vadl.cli.decoder.mixin.CheckDecoderOptions;
 import vadl.configuration.GeneralConfiguration;
 import vadl.pass.PassOrder;
 import vadl.pass.PassOrders;
@@ -32,8 +35,13 @@ import vadl.pass.PassOrders;
 )
 public class CheckCommand extends BaseCommand implements Callable<Integer> {
 
+  @CommandLine.Mixin
+  final CheckDecoderOptions decoderOptions = new CheckDecoderOptions();
+
   @Override
   PassOrder passOrder(GeneralConfiguration configuration) {
+    configuration.setDecoderOptions(
+        decoderOptions.getDecoderOptions(Objects.requireNonNull(spec).commandLine()));
     return PassOrders.check(configuration);
   }
 }

--- a/vadl-cli/main/vadl/cli/Helpers.java
+++ b/vadl-cli/main/vadl/cli/Helpers.java
@@ -16,18 +16,15 @@
 
 package vadl.cli;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Stack;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import org.apache.commons.lang3.stream.Streams;
 import picocli.CommandLine;
 import vadl.OpenVadlProperties;
-import vadl.configuration.DecoderOptions;
 import vadl.configuration.DumpMode;
 import vadl.configuration.IssConfiguration;
 
@@ -108,79 +105,6 @@ class IssOptsConverter implements CommandLine.ITypeConverter<IssConfiguration.Is
   }
 }
 
-interface DecoderOpt {
-}
-
-record DecoderStrategy(DecoderOptions.Generator generator) implements DecoderOpt {
-}
-
-record DecoderSkipOption(DecoderOptions.OptionToSkip option) implements DecoderOpt {
-}
-
-class DecoderOptsConverter implements Iterable<String>, CommandLine.ITypeConverter<DecoderOpt> {
-
-  static final String KEY_STRATEGY = "strategy";
-  static final String KEY_SKIP = "skip";
-
-  @Override
-  public DecoderOpt convert(String value) throws Exception {
-    final String[] fragments = value.split("=", -1);
-    if (fragments.length != 2) {
-      throw new CommandLine.TypeConversionException(
-          "Unable to parse decoder option '%s'".formatted(value));
-    }
-
-    if (KEY_STRATEGY.equals(fragments[0].trim())) {
-      var val = fragments[1].trim();
-      var strategy = DecoderOptions.Generator.fromSelector(val);
-      if (strategy != null) {
-        return new DecoderStrategy(strategy);
-      }
-
-      throw new CommandLine.TypeConversionException(
-          "Unable to parse decoder strategy '%s'. Available strategies are: %s".formatted(val,
-              Arrays.stream(DecoderOptions.Generator.values())
-                  .map(DecoderOptions.Generator::getSelector).toList()));
-    }
-
-    if (KEY_SKIP.equals(fragments[0].trim())) {
-      var val = fragments[1].trim();
-      var skipOpt = DecoderOptions.OptionToSkip.fromSelector(val);
-      if (skipOpt != null) {
-        return new DecoderSkipOption(skipOpt);
-      }
-
-      throw new CommandLine.TypeConversionException(
-          "Unable to parse decoder option to skip: '%s'. Available options are: %s".formatted(val,
-              Arrays.stream(DecoderOptions.OptionToSkip.values())
-                  .map(DecoderOptions.OptionToSkip::getSelector).toList()));
-    }
-
-    throw new CommandLine.TypeConversionException(
-        "Illegal decoder option '%s'. Available options are: %s".formatted(value,
-            List.of(KEY_SKIP, KEY_STRATEGY)));
-  }
-
-  public static List<String> getOptions() {
-
-    final List<String> options = new ArrayList<>();
-    for (DecoderOptions.Generator generator : DecoderOptions.Generator.values()) {
-      options.add(
-          "%n%s=%s (%s)".formatted(KEY_STRATEGY, generator.getSelector(), generator.getDesc()));
-    }
-    for (DecoderOptions.OptionToSkip skipOption : DecoderOptions.OptionToSkip.values()) {
-      options.add(
-          "%n%s=%s (%s)".formatted(KEY_SKIP, skipOption.getSelector(), skipOption.getDesc()));
-    }
-    return options;
-  }
-
-  @Nonnull
-  @Override
-  public Iterator<String> iterator() {
-    return getOptions().iterator();
-  }
-}
 
 class DumpModeConverter implements CommandLine.ITypeConverter<DumpMode>, Iterable<String>,
     CommandLine.IParameterConsumer {

--- a/vadl-cli/main/vadl/cli/IssCommand.java
+++ b/vadl-cli/main/vadl/cli/IssCommand.java
@@ -29,9 +29,11 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.NoSuchAlgorithmException;
 import java.util.EnumSet;
+import java.util.Objects;
 import org.apache.commons.io.file.PathUtils;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
+import vadl.cli.decoder.mixin.IssDecoderOptions;
 import vadl.configuration.GeneralConfiguration;
 import vadl.configuration.IssConfiguration;
 import vadl.pass.PassOrder;
@@ -65,6 +67,9 @@ public class IssCommand extends BaseCommand {
   private EnumSet<IssConfiguration.IssOptsToSkip> skipOpts = EnumSet.noneOf(
       IssConfiguration.IssOptsToSkip.class);
 
+  @CommandLine.Mixin
+  final IssDecoderOptions decoderOptions = new IssDecoderOptions();
+
   private static final String QEMU_VERSION = "9.2.2";
   private static final String QEMU_DOWNLOAD_URL =
       "https://github.com/qemu/qemu/archive/refs/tags/v" + QEMU_VERSION + ".tar.gz";
@@ -77,6 +82,8 @@ public class IssCommand extends BaseCommand {
     var issConfig = new IssConfiguration(configuration);
     issConfig.setDryRun(dryRun);
     issConfig.setOptsToSkip(skipOpts);
+    issConfig.setDecoderOptions(
+        decoderOptions.getDecoderOptions(Objects.requireNonNull(spec).commandLine()));
     return PassOrders.iss(issConfig);
   }
 

--- a/vadl-cli/main/vadl/cli/RtlCommand.java
+++ b/vadl-cli/main/vadl/cli/RtlCommand.java
@@ -19,9 +19,11 @@ package vadl.cli;
 import static picocli.CommandLine.ScopeType.INHERIT;
 
 import java.io.IOException;
+import java.util.Objects;
 import javax.annotation.Nullable;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
+import vadl.cli.decoder.mixin.RtlDecoderOptions;
 import vadl.configuration.GeneralConfiguration;
 import vadl.configuration.RtlConfiguration;
 import vadl.pass.PassOrder;
@@ -89,6 +91,9 @@ public class RtlCommand extends BaseCommand {
       description = "Don't emit generated files.")
   boolean dryRun;
 
+  @CommandLine.Mixin
+  final RtlDecoderOptions decoderOptions = new RtlDecoderOptions();
+
   @Override
   PassOrder passOrder(GeneralConfiguration configuration) throws IOException {
     var rtlConfig = new RtlConfiguration(configuration);
@@ -100,6 +105,8 @@ public class RtlCommand extends BaseCommand {
     rtlConfig.setProjectName(projectName);
     rtlConfig.setEmitRVFI(emitRVFI);
     rtlConfig.setDryRun(dryRun);
+    rtlConfig.setDecoderOptions(
+        decoderOptions.getDecoderOptions(Objects.requireNonNull(spec).commandLine()));
     return PassOrders.rtl(rtlConfig);
   }
 }

--- a/vadl-cli/main/vadl/cli/decoder/DecoderOptsConverter.java
+++ b/vadl-cli/main/vadl/cli/decoder/DecoderOptsConverter.java
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText : © 2026 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.cli.decoder;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import javax.annotation.Nonnull;
+import picocli.CommandLine;
+import vadl.cli.decoder.mixin.DecoderMixin.DecoderOpt;
+import vadl.cli.decoder.mixin.DecoderMixin.DecoderSkipOption;
+import vadl.cli.decoder.mixin.DecoderMixin.DecoderStrategy;
+import vadl.configuration.DecoderOptions;
+
+/**
+ * Base decoder options contributor and converter.
+ */
+public abstract class DecoderOptsConverter
+    implements Iterable<String>, CommandLine.ITypeConverter<DecoderOpt> {
+
+  private static final String KEY_STRATEGY = "strategy";
+  private static final String KEY_SKIP = "skip";
+
+  /**
+   * Allow subclasses to override the available options.
+   */
+  protected DecoderOptions.Generator[] strategies = DecoderOptions.Generator.values();
+  protected DecoderOptions.OptionToSkip[] skipOptions = DecoderOptions.OptionToSkip.values();
+
+  @Override
+  public DecoderOpt convert(String value) {
+    final String[] fragments = value.split("=", -1);
+    if (fragments.length != 2) {
+      throw new CommandLine.TypeConversionException(
+          "Unable to parse decoder option '%s'".formatted(value));
+    }
+
+    if (KEY_STRATEGY.equals(fragments[0].trim())) {
+      var val = fragments[1].trim();
+      var strategy = DecoderOptions.Generator.fromSelector(val, strategies);
+      if (strategy != null) {
+        return new DecoderStrategy(strategy);
+      }
+
+      throw new CommandLine.TypeConversionException(
+          "Unable to parse decoder strategy '%s'. Available strategies are: %s".formatted(val,
+              Arrays.stream(strategies)
+                  .map(DecoderOptions.Generator::getSelector).toList()));
+    }
+
+    if (KEY_SKIP.equals(fragments[0].trim())) {
+      var val = fragments[1].trim();
+      var skipOpt = DecoderOptions.OptionToSkip.fromSelector(val, skipOptions);
+      if (skipOpt != null) {
+        return new DecoderSkipOption(skipOpt);
+      }
+
+      throw new CommandLine.TypeConversionException(
+          "Unable to parse decoder option to skip: '%s'. Available options are: %s".formatted(val,
+              Arrays.stream(skipOptions)
+                  .map(DecoderOptions.OptionToSkip::getSelector).toList()));
+    }
+
+    throw new CommandLine.TypeConversionException(
+        "Illegal decoder option '%s'. Available options are: %s".formatted(value,
+            List.of(KEY_SKIP, KEY_STRATEGY)));
+  }
+
+  /**
+   * Get available options.
+   *
+   * @return The formatted options.
+   */
+  public List<String> getOptions() {
+
+    final List<String> options = new ArrayList<>();
+    for (DecoderOptions.Generator generator : strategies) {
+      options.add(
+          "%n%s=%s (%s)".formatted(KEY_STRATEGY, generator.getSelector(), generator.getDesc()));
+    }
+    for (DecoderOptions.OptionToSkip skipOption : skipOptions) {
+      options.add(
+          "%n%s=%s (%s)".formatted(KEY_SKIP, skipOption.getSelector(), skipOption.getDesc()));
+    }
+    return options;
+  }
+
+  @Nonnull
+  @Override
+  public Iterator<String> iterator() {
+    return getOptions().iterator();
+  }
+}

--- a/vadl-cli/main/vadl/cli/decoder/mixin/CheckDecoderOptions.java
+++ b/vadl-cli/main/vadl/cli/decoder/mixin/CheckDecoderOptions.java
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText : © 2026 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.cli.decoder.mixin;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+import picocli.CommandLine;
+import vadl.cli.decoder.DecoderOptsConverter;
+import vadl.configuration.DecoderOptions;
+
+/**
+ * Decoder options available to the {@link vadl.cli.CheckCommand}.
+ */
+public class CheckDecoderOptions extends DecoderMixin {
+
+  @CommandLine.Option(names = "--decoder",
+      split = ",",
+      description = "Options for the decoder generation. Valid options are: "
+          + "${COMPLETION-CANDIDATES}",
+      completionCandidates = CheckDecoderOptsContributor.class,
+      converter = CheckDecoderOptsContributor.class
+  )
+  private final Set<DecoderOpt> decoderOptions = new LinkedHashSet<>();
+
+  @Override
+  protected Set<DecoderOpt> getOptions() {
+    return decoderOptions;
+  }
+
+  private static class CheckDecoderOptsContributor extends DecoderOptsConverter {
+
+    public CheckDecoderOptsContributor() {
+      strategies = DecoderOptions.Generator.values();
+      skipOptions = DecoderOptions.OptionToSkip.values();
+    }
+  }
+
+}

--- a/vadl-cli/main/vadl/cli/decoder/mixin/DecoderMixin.java
+++ b/vadl-cli/main/vadl/cli/decoder/mixin/DecoderMixin.java
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText : © 2026 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.cli.decoder.mixin;
+
+import java.util.Set;
+import picocli.CommandLine;
+import picocli.CommandLine.MaxValuesExceededException;
+import vadl.configuration.DecoderOptions;
+import vadl.configuration.DecoderOptions.Generator;
+import vadl.configuration.DecoderOptions.OptionToSkip;
+
+/**
+ * Base functionality for the decoder option mixins.
+ */
+public abstract class DecoderMixin {
+
+  protected abstract Set<DecoderOpt> getOptions();
+
+  /**
+   * Get the decoder options passed by the user.
+   *
+   * @param cmd The command line.
+   * @return The options.
+   */
+  public DecoderOptions getDecoderOptions(CommandLine cmd) {
+
+    final var decoderOptions = getOptions();
+
+    if (decoderOptions == null) {
+      return new DecoderOptions();
+    }
+
+    final DecoderOptions result = new DecoderOptions();
+
+    var strategies = decoderOptions.stream()
+        .filter(DecoderStrategy.class::isInstance)
+        .map(DecoderStrategy.class::cast)
+        .toList();
+
+    if (strategies.size() > 1) {
+
+      throw new MaxValuesExceededException(cmd, "Multiple decoder strategies are not allowed.");
+    }
+
+    if (strategies.size() == 1) {
+      result.setGenerator(strategies.getFirst().generator());
+    }
+
+    var skipOpts = decoderOptions.stream()
+        .filter(DecoderSkipOption.class::isInstance)
+        .map(DecoderSkipOption.class::cast)
+        .map(DecoderSkipOption::option)
+        .toList();
+
+    if (!skipOpts.isEmpty()) {
+      result.setOptsToSkip(skipOpts.toArray(new OptionToSkip[0]));
+    }
+
+    return result;
+  }
+
+  /**
+   * Common base interface for a decoder option.
+   */
+  public sealed interface DecoderOpt {
+  }
+
+  /**
+   * Strategy option.
+   *
+   * @param generator The generator strategy.
+   */
+  public record DecoderStrategy(Generator generator) implements DecoderOpt {
+  }
+
+  /**
+   * Skip options.
+   *
+   * @param option The option to skip.
+   */
+  public record DecoderSkipOption(OptionToSkip option) implements DecoderOpt {
+  }
+
+}

--- a/vadl-cli/main/vadl/cli/decoder/mixin/IssDecoderOptions.java
+++ b/vadl-cli/main/vadl/cli/decoder/mixin/IssDecoderOptions.java
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText : © 2026 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.cli.decoder.mixin;
+
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import picocli.CommandLine;
+import vadl.cli.decoder.DecoderOptsConverter;
+import vadl.configuration.DecoderOptions.Generator;
+import vadl.configuration.DecoderOptions.OptionToSkip;
+
+/**
+ * Decoder options available to the {@link vadl.cli.IssCommand}.
+ */
+public class IssDecoderOptions extends DecoderMixin {
+
+  @CommandLine.Option(names = "--decoder",
+      split = ",",
+      description = "Options for the decoder generation. Valid options are: "
+          + "${COMPLETION-CANDIDATES}",
+      completionCandidates = IssDecoderOptsContributor.class,
+      converter = IssDecoderOptsContributor.class
+  )
+  private final Set<DecoderOpt> decoderOptions = new LinkedHashSet<>();
+
+  @Override
+  protected Set<DecoderOpt> getOptions() {
+    return decoderOptions;
+  }
+
+  private static class IssDecoderOptsContributor extends DecoderOptsConverter {
+
+    public IssDecoderOptsContributor() {
+      strategies = Arrays.stream(Generator.values())
+          .filter(g -> g != Generator.RTL_TABLE)
+          .toArray(Generator[]::new);
+      skipOptions = Arrays.stream(OptionToSkip.values())
+          .filter(s -> s != OptionToSkip.OPT_ALL)
+          .toArray(OptionToSkip[]::new);
+    }
+
+  }
+
+}

--- a/vadl-cli/main/vadl/cli/decoder/mixin/RtlDecoderOptions.java
+++ b/vadl-cli/main/vadl/cli/decoder/mixin/RtlDecoderOptions.java
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText : © 2026 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.cli.decoder.mixin;
+
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import picocli.CommandLine;
+import vadl.cli.decoder.DecoderOptsConverter;
+import vadl.configuration.DecoderOptions.Generator;
+import vadl.configuration.DecoderOptions.OptionToSkip;
+
+/**
+ * Decoder options available to the {@link vadl.cli.RtlCommand}.
+ */
+public class RtlDecoderOptions extends DecoderMixin {
+
+  @CommandLine.Option(names = "--decoder",
+      split = ",",
+      description = "Options for the decoder generation. Valid options are: "
+          + "${COMPLETION-CANDIDATES}",
+      completionCandidates = RtlDecoderOptsContributor.class,
+      converter = RtlDecoderOptsContributor.class
+  )
+  private final Set<DecoderOpt> decoderOptions = new LinkedHashSet<>();
+
+  @Override
+  protected Set<DecoderOpt> getOptions() {
+    return decoderOptions;
+  }
+
+  private static class RtlDecoderOptsContributor extends DecoderOptsConverter {
+
+    public RtlDecoderOptsContributor() {
+      strategies = Generator.values();
+      skipOptions = Arrays.stream(OptionToSkip.values())
+          .filter(s -> s != OptionToSkip.OPT_ALL)
+          .toArray(OptionToSkip[]::new);
+    }
+  }
+
+}

--- a/vadl/main/vadl/configuration/DecoderOptions.java
+++ b/vadl/main/vadl/configuration/DecoderOptions.java
@@ -53,14 +53,16 @@ public class DecoderOptions {
      * Resolve the generator strategy from its selector.
      *
      * @param selector The selector to match.
+     * @param options  The restriction on the available options, if any.
      * @return The generator, or null if no match was found.
      */
     @Nullable
-    public static Generator fromSelector(String selector) {
+    public static Generator fromSelector(String selector, Generator... options) {
       if (selector == null || selector.isBlank()) {
         return null;
       }
-      for (Generator gen : values()) {
+      final var opts = options.length == 0 ? Generator.values() : options;
+      for (Generator gen : opts) {
         if (gen.getSelector().equals(selector)) {
           return gen;
         }
@@ -74,6 +76,9 @@ public class DecoderOptions {
    */
   public enum OptionToSkip {
 
+    OPT_ALL("Skip all decoder related verification and generation passes, default: enabled",
+        "all"),
+
     OPT_CONSTRAINT_SYNTHESIS("Skip constraint synthesis for decoder generation, default: enabled",
         "constraint-synthesis"),
 
@@ -81,7 +86,7 @@ public class DecoderOptions {
         "encoding-verification"),
 
     OPT_DECODER_VERIFICATION("Skip the correctness verification of the decode tree, default: "
-                                 + "enabled", "decoder-verification");
+        + "enabled", "decoder-verification");
 
     private final String selector;
     private final String desc;
@@ -103,14 +108,16 @@ public class DecoderOptions {
      * Resolve the skipped option from its selector.
      *
      * @param selector The selector to match.
+     * @param options  The restriction on the available options, if any.
      * @return The skipped option, or null if no match was found.
      */
     @Nullable
-    public static OptionToSkip fromSelector(String selector) {
+    public static OptionToSkip fromSelector(String selector, OptionToSkip... options) {
       if (selector == null || selector.isBlank()) {
         return null;
       }
-      for (OptionToSkip opt : values()) {
+      final var opts = options.length == 0 ? OptionToSkip.values() : options;
+      for (OptionToSkip opt : opts) {
         if (opt.getSelector().equals(selector)) {
           return opt;
         }

--- a/vadl/main/vadl/pass/PassOrders.java
+++ b/vadl/main/vadl/pass/PassOrders.java
@@ -17,6 +17,7 @@
 package vadl.pass;
 
 import static vadl.configuration.DecoderOptions.Generator.RTL_TABLE;
+import static vadl.configuration.DecoderOptions.OptionToSkip.OPT_ALL;
 import static vadl.configuration.DecoderOptions.OptionToSkip.OPT_CONSTRAINT_SYNTHESIS;
 import static vadl.configuration.DecoderOptions.OptionToSkip.OPT_DECODER_VERIFICATION;
 import static vadl.configuration.DecoderOptions.OptionToSkip.OPT_ENCODING_VERIFICATION;
@@ -667,6 +668,13 @@ public class PassOrders {
    * @param config from which to decide if a dump is wanted.
    */
   private static void addDecodePasses(PassOrder order, GeneralConfiguration config) {
+
+    var skipAll = Stream.of(config.getDecoderOptions().getOptsToSkip())
+        .anyMatch(o -> o == OPT_ALL);
+
+    if (skipAll) {
+      return;
+    }
 
     // VDT Decode Passes
     order


### PR DESCRIPTION
Refactored the decoder options a bit in general, since not all options make sense for all backends/commands.

- Introduce `skip=all` option to disable all decoder passes for the `check` command.
- restrict the scope of some options to the relevant commands (e.g. `rtl-table` to the `rtl` command)

Example of a `check` command which skips all decoder passes (also including timings, so you can verify that the passes are actually ignored):
```
openvadl check --decoder skip=all --timings sys/risc-v/rv64im.vadl
```
or with gradle run, if you prefer:
```
run --args="check --decoder skip=all --timings sys/risc-v/rv64im.vadl"
```
