### PR TITLE
Add logback config to native image

### DIFF
--- a/vadl-cli/build.gradle.kts
+++ b/vadl-cli/build.gradle.kts
@@ -26,7 +26,12 @@ application {
 graalvmNative {
     binaries {
         named("main") {
-            resources.autodetect()
+            resources {
+                autodetection {
+                    enabled = true
+                    ignoreExistingResourcesConfigFile = true
+                }
+            }
             imageName.set("openvadl")
             mainClass.set(application.mainClass)
             buildArgs.addAll("-O2", "--gc=epsilon")

--- a/vadl-cli/main/resources/META-INF/native-image/vadl/reflect-config.json
+++ b/vadl-cli/main/resources/META-INF/native-image/vadl/reflect-config.json
@@ -14,5 +14,9 @@
   {
     "name": "java.lang.String",
     "allPublicMethods": true
+  },
+  {
+    "name": "ch.qos.logback.core.ConsoleAppender",
+    "allPublicMethods": true
   }
 ]


### PR DESCRIPTION
The logback configuration was not included in the native build, thus logback fell back to `DEBUG` level. This change will fix the issue of noisy logs when using the native image build.

Fyi, the log level can still be manually changed, by passing the `vadl.log.level` option. E.g.:

```
openvadl check sys/hexagon/hexagon.vadl -Dvadl.log.level=DEBUG
```