### PR TITLE
lcb: Generate predicate functions per format / field-access

### DIFF
--- a/vadl/main/vadl/lcb/passes/llvmLowering/CreateFunctionsFromImmediatesPass.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/CreateFunctionsFromImmediatesPass.java
@@ -18,10 +18,12 @@ package vadl.lcb.passes.llvmLowering;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
@@ -139,6 +141,7 @@ public class CreateFunctionsFromImmediatesPass extends Pass {
     var encodings = new IdentityHashMap<Instruction, List<GcbCppEncodeFunction>>();
     var encodingWrappers = new IdentityHashMap<Instruction, GcbCppEncodingWrapperFunction>();
 
+    var predicateMethods = new HashMap<Identifier, GcbCppFunctionWithBody>();
     var predicates = new IdentityHashMap<TableGenImmediateRecord, GcbCppFunctionWithBody>();
     var immediates = (List<TableGenImmediateRecord>) passResults.lastResultOf(
         GenerateTableGenImmediateRecordPass.class);
@@ -155,7 +158,13 @@ public class CreateFunctionsFromImmediatesPass extends Pass {
 
       decodingWrappers.put(immediate, decodingWrapper(immediate));
       decodings.put(immediate, decoding(immediate));
-      predicates.put(immediate, predicate(stackPointerType, immediate));
+
+      var predicateMethodId = immediate.predicateMethod();
+      var predicateMethod = Optional.ofNullable(predicateMethods.get(predicateMethodId))
+          .orElseGet(() -> predicate(stackPointerType, immediate));
+      predicateMethods.putIfAbsent(predicateMethodId, predicateMethod);
+
+      predicates.put(immediate, predicateMethod);
     }
 
     for (var pair : tableGenMachineInstructions.entrySet()) {

--- a/vadl/main/vadl/lcb/passes/llvmLowering/tablegen/model/TableGenImmediateRecord.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/tablegen/model/TableGenImmediateRecord.java
@@ -72,7 +72,7 @@ public class TableGenImmediateRecord {
 
   public static Identifier createPredicateMethod(PrintableInstruction instruction,
                                                  Format.FieldAccess fieldAccess) {
-    return fieldAccess.identifier.last().prepend(instruction.identifier())
+    return fieldAccess.identifier.last().prepend(fieldAccess.format().identifier)
         .append("predicate");
   }
 

--- a/vadl/main/vadl/lcb/template/superClass/AbstractEmitImmediateFilePass.java
+++ b/vadl/main/vadl/lcb/template/superClass/AbstractEmitImmediateFilePass.java
@@ -23,6 +23,7 @@ import static vadl.lcb.template.utils.ImmediatePredicateFunctionProvider.generat
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Set;
 import vadl.configuration.LcbConfiguration;
 import vadl.cppCodeGen.model.CppFunctionName;
 import vadl.cppCodeGen.model.GcbCppFunctionWithBody;
@@ -70,7 +71,7 @@ public abstract class AbstractEmitImmediateFilePass extends LcbTemplateRendering
             .map(GcbCppFunctionWithBody::code)
             .sorted()
             .toList(),
-        "predicateFunctions", predicateFunctions.values().stream()
+        "predicateFunctions", Set.copyOf(predicateFunctions.values()).stream()
             .map(GcbCppFunctionWithBody::code)
             .sorted()
             .toList());

--- a/vadl/test/resources/snapshots/aarch64/InstrInfoTableGen.td
+++ b/vadl/test/resources/snapshots/aarch64/InstrInfoTableGen.td
@@ -259,7 +259,7 @@ class AArch64Base_ADDWASR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_ADDWASR_imm6AsInt32
     : AArch64Base_ADDWASR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ADDWASR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubSftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_ADDWASR_imm6AsLabel : AArch64Base_ADDWASR_imm6<OtherVT>;
 
@@ -271,7 +271,7 @@ class AArch64Base_ADDWI_imm12X<ValueType ty> : Operand<ty>
 
 def AArch64Base_ADDWI_imm12XAsInt64
     : AArch64Base_ADDWI_imm12X<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_ADDWI_imm12X_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_AddSubImmFormat_imm12X_predicate(Imm); }]>;
 
 def AArch64Base_ADDWI_imm12XAsLabel : AArch64Base_ADDWI_imm12X<OtherVT>;
 
@@ -283,7 +283,7 @@ class AArch64Base_ADDWI12_imm12S<ValueType ty> : Operand<ty>
 
 def AArch64Base_ADDWI12_imm12SAsInt64
     : AArch64Base_ADDWI12_imm12S<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_ADDWI12_imm12S_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_AddSubImmFormat_imm12S_predicate(Imm); }]>;
 
 def AArch64Base_ADDWI12_imm12SAsLabel : AArch64Base_ADDWI12_imm12S<OtherVT>;
 
@@ -295,7 +295,7 @@ class AArch64Base_ADDWLSL_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_ADDWLSL_imm6AsInt32
     : AArch64Base_ADDWLSL_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ADDWLSL_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubSftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_ADDWLSL_imm6AsLabel : AArch64Base_ADDWLSL_imm6<OtherVT>;
 
@@ -307,7 +307,7 @@ class AArch64Base_ADDWLSR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_ADDWLSR_imm6AsInt32
     : AArch64Base_ADDWLSR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ADDWLSR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubSftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_ADDWLSR_imm6AsLabel : AArch64Base_ADDWLSR_imm6<OtherVT>;
 
@@ -319,7 +319,7 @@ class AArch64Base_ADDWSASR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_ADDWSASR_imm6AsInt32
     : AArch64Base_ADDWSASR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ADDWSASR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubSftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_ADDWSASR_imm6AsLabel : AArch64Base_ADDWSASR_imm6<OtherVT>;
 
@@ -331,7 +331,7 @@ class AArch64Base_ADDWSI_imm12X<ValueType ty> : Operand<ty>
 
 def AArch64Base_ADDWSI_imm12XAsInt64
     : AArch64Base_ADDWSI_imm12X<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_ADDWSI_imm12X_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_AddSubImmFormat_imm12X_predicate(Imm); }]>;
 
 def AArch64Base_ADDWSI_imm12XAsLabel : AArch64Base_ADDWSI_imm12X<OtherVT>;
 
@@ -343,7 +343,7 @@ class AArch64Base_ADDWSI12_imm12S<ValueType ty> : Operand<ty>
 
 def AArch64Base_ADDWSI12_imm12SAsInt64
     : AArch64Base_ADDWSI12_imm12S<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_ADDWSI12_imm12S_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_AddSubImmFormat_imm12S_predicate(Imm); }]>;
 
 def AArch64Base_ADDWSI12_imm12SAsLabel : AArch64Base_ADDWSI12_imm12S<OtherVT>;
 
@@ -355,7 +355,7 @@ class AArch64Base_ADDWSLSL_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_ADDWSLSL_imm6AsInt32
     : AArch64Base_ADDWSLSL_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ADDWSLSL_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubSftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_ADDWSLSL_imm6AsLabel : AArch64Base_ADDWSLSL_imm6<OtherVT>;
 
@@ -367,7 +367,7 @@ class AArch64Base_ADDWSLSR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_ADDWSLSR_imm6AsInt32
     : AArch64Base_ADDWSLSR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ADDWSLSR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubSftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_ADDWSLSR_imm6AsLabel : AArch64Base_ADDWSLSR_imm6<OtherVT>;
 
@@ -379,7 +379,7 @@ class AArch64Base_ADDWSSXSB_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_ADDWSSXSB_imm3AsInt32
     : AArch64Base_ADDWSSXSB_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ADDWSSXSB_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_ADDWSSXSB_imm3AsLabel : AArch64Base_ADDWSSXSB_imm3<OtherVT>;
 
@@ -391,7 +391,7 @@ class AArch64Base_ADDWSSXSH_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_ADDWSSXSH_imm3AsInt32
     : AArch64Base_ADDWSSXSH_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ADDWSSXSH_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_ADDWSSXSH_imm3AsLabel : AArch64Base_ADDWSSXSH_imm3<OtherVT>;
 
@@ -403,7 +403,7 @@ class AArch64Base_ADDWSSXSW_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_ADDWSSXSW_imm3AsInt32
     : AArch64Base_ADDWSSXSW_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ADDWSSXSW_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_ADDWSSXSW_imm3AsLabel : AArch64Base_ADDWSSXSW_imm3<OtherVT>;
 
@@ -415,7 +415,7 @@ class AArch64Base_ADDWSSXSX_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_ADDWSSXSX_imm3AsInt32
     : AArch64Base_ADDWSSXSX_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ADDWSSXSX_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_ADDWSSXSX_imm3AsLabel : AArch64Base_ADDWSSXSX_imm3<OtherVT>;
 
@@ -427,7 +427,7 @@ class AArch64Base_ADDWSUXSB_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_ADDWSUXSB_imm3AsInt32
     : AArch64Base_ADDWSUXSB_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ADDWSUXSB_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_ADDWSUXSB_imm3AsLabel : AArch64Base_ADDWSUXSB_imm3<OtherVT>;
 
@@ -439,7 +439,7 @@ class AArch64Base_ADDWSUXSH_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_ADDWSUXSH_imm3AsInt32
     : AArch64Base_ADDWSUXSH_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ADDWSUXSH_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_ADDWSUXSH_imm3AsLabel : AArch64Base_ADDWSUXSH_imm3<OtherVT>;
 
@@ -451,7 +451,7 @@ class AArch64Base_ADDWSUXSW_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_ADDWSUXSW_imm3AsInt32
     : AArch64Base_ADDWSUXSW_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ADDWSUXSW_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_ADDWSUXSW_imm3AsLabel : AArch64Base_ADDWSUXSW_imm3<OtherVT>;
 
@@ -463,7 +463,7 @@ class AArch64Base_ADDWSUXSX_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_ADDWSUXSX_imm3AsInt32
     : AArch64Base_ADDWSUXSX_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ADDWSUXSX_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_ADDWSUXSX_imm3AsLabel : AArch64Base_ADDWSUXSX_imm3<OtherVT>;
 
@@ -475,7 +475,7 @@ class AArch64Base_ADDWSXSB_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_ADDWSXSB_imm3AsInt32
     : AArch64Base_ADDWSXSB_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ADDWSXSB_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_ADDWSXSB_imm3AsLabel : AArch64Base_ADDWSXSB_imm3<OtherVT>;
 
@@ -487,7 +487,7 @@ class AArch64Base_ADDWSXSH_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_ADDWSXSH_imm3AsInt32
     : AArch64Base_ADDWSXSH_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ADDWSXSH_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_ADDWSXSH_imm3AsLabel : AArch64Base_ADDWSXSH_imm3<OtherVT>;
 
@@ -499,7 +499,7 @@ class AArch64Base_ADDWSXSW_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_ADDWSXSW_imm3AsInt32
     : AArch64Base_ADDWSXSW_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ADDWSXSW_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_ADDWSXSW_imm3AsLabel : AArch64Base_ADDWSXSW_imm3<OtherVT>;
 
@@ -511,7 +511,7 @@ class AArch64Base_ADDWSXSX_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_ADDWSXSX_imm3AsInt32
     : AArch64Base_ADDWSXSX_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ADDWSXSX_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_ADDWSXSX_imm3AsLabel : AArch64Base_ADDWSXSX_imm3<OtherVT>;
 
@@ -523,7 +523,7 @@ class AArch64Base_ADDWUXSB_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_ADDWUXSB_imm3AsInt32
     : AArch64Base_ADDWUXSB_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ADDWUXSB_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_ADDWUXSB_imm3AsLabel : AArch64Base_ADDWUXSB_imm3<OtherVT>;
 
@@ -535,7 +535,7 @@ class AArch64Base_ADDWUXSH_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_ADDWUXSH_imm3AsInt32
     : AArch64Base_ADDWUXSH_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ADDWUXSH_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_ADDWUXSH_imm3AsLabel : AArch64Base_ADDWUXSH_imm3<OtherVT>;
 
@@ -547,7 +547,7 @@ class AArch64Base_ADDWUXSW_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_ADDWUXSW_imm3AsInt32
     : AArch64Base_ADDWUXSW_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ADDWUXSW_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_ADDWUXSW_imm3AsLabel : AArch64Base_ADDWUXSW_imm3<OtherVT>;
 
@@ -559,7 +559,7 @@ class AArch64Base_ADDWUXSX_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_ADDWUXSX_imm3AsInt32
     : AArch64Base_ADDWUXSX_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ADDWUXSX_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_ADDWUXSX_imm3AsLabel : AArch64Base_ADDWUXSX_imm3<OtherVT>;
 
@@ -571,7 +571,7 @@ class AArch64Base_ADDXASR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_ADDXASR_imm6AsInt32
     : AArch64Base_ADDXASR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ADDXASR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubSftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_ADDXASR_imm6AsLabel : AArch64Base_ADDXASR_imm6<OtherVT>;
 
@@ -583,7 +583,7 @@ class AArch64Base_ADDXI_imm12X<ValueType ty> : Operand<ty>
 
 def AArch64Base_ADDXI_imm12XAsInt64
     : AArch64Base_ADDXI_imm12X<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_ADDXI_imm12X_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_AddSubImmFormat_imm12X_predicate(Imm); }]>;
 
 def AArch64Base_ADDXI_imm12XAsLabel : AArch64Base_ADDXI_imm12X<OtherVT>;
 
@@ -595,7 +595,7 @@ class AArch64Base_ADDXI12_imm12S<ValueType ty> : Operand<ty>
 
 def AArch64Base_ADDXI12_imm12SAsInt64
     : AArch64Base_ADDXI12_imm12S<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_ADDXI12_imm12S_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_AddSubImmFormat_imm12S_predicate(Imm); }]>;
 
 def AArch64Base_ADDXI12_imm12SAsLabel : AArch64Base_ADDXI12_imm12S<OtherVT>;
 
@@ -607,7 +607,7 @@ class AArch64Base_ADDXLSL_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_ADDXLSL_imm6AsInt32
     : AArch64Base_ADDXLSL_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ADDXLSL_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubSftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_ADDXLSL_imm6AsLabel : AArch64Base_ADDXLSL_imm6<OtherVT>;
 
@@ -619,7 +619,7 @@ class AArch64Base_ADDXLSR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_ADDXLSR_imm6AsInt32
     : AArch64Base_ADDXLSR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ADDXLSR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubSftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_ADDXLSR_imm6AsLabel : AArch64Base_ADDXLSR_imm6<OtherVT>;
 
@@ -631,7 +631,7 @@ class AArch64Base_ADDXSASR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_ADDXSASR_imm6AsInt32
     : AArch64Base_ADDXSASR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ADDXSASR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubSftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_ADDXSASR_imm6AsLabel : AArch64Base_ADDXSASR_imm6<OtherVT>;
 
@@ -643,7 +643,7 @@ class AArch64Base_ADDXSI_imm12X<ValueType ty> : Operand<ty>
 
 def AArch64Base_ADDXSI_imm12XAsInt64
     : AArch64Base_ADDXSI_imm12X<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_ADDXSI_imm12X_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_AddSubImmFormat_imm12X_predicate(Imm); }]>;
 
 def AArch64Base_ADDXSI_imm12XAsLabel : AArch64Base_ADDXSI_imm12X<OtherVT>;
 
@@ -655,7 +655,7 @@ class AArch64Base_ADDXSI12_imm12S<ValueType ty> : Operand<ty>
 
 def AArch64Base_ADDXSI12_imm12SAsInt64
     : AArch64Base_ADDXSI12_imm12S<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_ADDXSI12_imm12S_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_AddSubImmFormat_imm12S_predicate(Imm); }]>;
 
 def AArch64Base_ADDXSI12_imm12SAsLabel : AArch64Base_ADDXSI12_imm12S<OtherVT>;
 
@@ -667,7 +667,7 @@ class AArch64Base_ADDXSLSL_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_ADDXSLSL_imm6AsInt32
     : AArch64Base_ADDXSLSL_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ADDXSLSL_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubSftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_ADDXSLSL_imm6AsLabel : AArch64Base_ADDXSLSL_imm6<OtherVT>;
 
@@ -679,7 +679,7 @@ class AArch64Base_ADDXSLSR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_ADDXSLSR_imm6AsInt32
     : AArch64Base_ADDXSLSR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ADDXSLSR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubSftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_ADDXSLSR_imm6AsLabel : AArch64Base_ADDXSLSR_imm6<OtherVT>;
 
@@ -691,7 +691,7 @@ class AArch64Base_ADDXSSXSB_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_ADDXSSXSB_imm3AsInt32
     : AArch64Base_ADDXSSXSB_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ADDXSSXSB_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_ADDXSSXSB_imm3AsLabel : AArch64Base_ADDXSSXSB_imm3<OtherVT>;
 
@@ -703,7 +703,7 @@ class AArch64Base_ADDXSSXSH_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_ADDXSSXSH_imm3AsInt32
     : AArch64Base_ADDXSSXSH_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ADDXSSXSH_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_ADDXSSXSH_imm3AsLabel : AArch64Base_ADDXSSXSH_imm3<OtherVT>;
 
@@ -715,7 +715,7 @@ class AArch64Base_ADDXSSXSW_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_ADDXSSXSW_imm3AsInt32
     : AArch64Base_ADDXSSXSW_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ADDXSSXSW_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_ADDXSSXSW_imm3AsLabel : AArch64Base_ADDXSSXSW_imm3<OtherVT>;
 
@@ -727,7 +727,7 @@ class AArch64Base_ADDXSSXSX_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_ADDXSSXSX_imm3AsInt32
     : AArch64Base_ADDXSSXSX_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ADDXSSXSX_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_ADDXSSXSX_imm3AsLabel : AArch64Base_ADDXSSXSX_imm3<OtherVT>;
 
@@ -739,7 +739,7 @@ class AArch64Base_ADDXSUXSB_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_ADDXSUXSB_imm3AsInt32
     : AArch64Base_ADDXSUXSB_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ADDXSUXSB_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_ADDXSUXSB_imm3AsLabel : AArch64Base_ADDXSUXSB_imm3<OtherVT>;
 
@@ -751,7 +751,7 @@ class AArch64Base_ADDXSUXSH_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_ADDXSUXSH_imm3AsInt32
     : AArch64Base_ADDXSUXSH_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ADDXSUXSH_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_ADDXSUXSH_imm3AsLabel : AArch64Base_ADDXSUXSH_imm3<OtherVT>;
 
@@ -763,7 +763,7 @@ class AArch64Base_ADDXSUXSW_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_ADDXSUXSW_imm3AsInt32
     : AArch64Base_ADDXSUXSW_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ADDXSUXSW_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_ADDXSUXSW_imm3AsLabel : AArch64Base_ADDXSUXSW_imm3<OtherVT>;
 
@@ -775,7 +775,7 @@ class AArch64Base_ADDXSUXSX_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_ADDXSUXSX_imm3AsInt32
     : AArch64Base_ADDXSUXSX_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ADDXSUXSX_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_ADDXSUXSX_imm3AsLabel : AArch64Base_ADDXSUXSX_imm3<OtherVT>;
 
@@ -787,7 +787,7 @@ class AArch64Base_ADDXSXSB_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_ADDXSXSB_imm3AsInt32
     : AArch64Base_ADDXSXSB_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ADDXSXSB_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_ADDXSXSB_imm3AsLabel : AArch64Base_ADDXSXSB_imm3<OtherVT>;
 
@@ -799,7 +799,7 @@ class AArch64Base_ADDXSXSH_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_ADDXSXSH_imm3AsInt32
     : AArch64Base_ADDXSXSH_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ADDXSXSH_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_ADDXSXSH_imm3AsLabel : AArch64Base_ADDXSXSH_imm3<OtherVT>;
 
@@ -811,7 +811,7 @@ class AArch64Base_ADDXSXSW_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_ADDXSXSW_imm3AsInt32
     : AArch64Base_ADDXSXSW_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ADDXSXSW_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_ADDXSXSW_imm3AsLabel : AArch64Base_ADDXSXSW_imm3<OtherVT>;
 
@@ -823,7 +823,7 @@ class AArch64Base_ADDXSXSX_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_ADDXSXSX_imm3AsInt32
     : AArch64Base_ADDXSXSX_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ADDXSXSX_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_ADDXSXSX_imm3AsLabel : AArch64Base_ADDXSXSX_imm3<OtherVT>;
 
@@ -835,7 +835,7 @@ class AArch64Base_ADDXUXSB_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_ADDXUXSB_imm3AsInt32
     : AArch64Base_ADDXUXSB_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ADDXUXSB_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_ADDXUXSB_imm3AsLabel : AArch64Base_ADDXUXSB_imm3<OtherVT>;
 
@@ -847,7 +847,7 @@ class AArch64Base_ADDXUXSH_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_ADDXUXSH_imm3AsInt32
     : AArch64Base_ADDXUXSH_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ADDXUXSH_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_ADDXUXSH_imm3AsLabel : AArch64Base_ADDXUXSH_imm3<OtherVT>;
 
@@ -859,7 +859,7 @@ class AArch64Base_ADDXUXSW_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_ADDXUXSW_imm3AsInt32
     : AArch64Base_ADDXUXSW_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ADDXUXSW_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_ADDXUXSW_imm3AsLabel : AArch64Base_ADDXUXSW_imm3<OtherVT>;
 
@@ -871,7 +871,7 @@ class AArch64Base_ADDXUXSX_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_ADDXUXSX_imm3AsInt32
     : AArch64Base_ADDXUXSX_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ADDXUXSX_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_ADDXUXSX_imm3AsLabel : AArch64Base_ADDXUXSX_imm3<OtherVT>;
 
@@ -883,7 +883,7 @@ class AArch64Base_ADR_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_ADR_offsetAsInt64
     : AArch64Base_ADR_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_ADR_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_RelAddressFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_ADR_offsetAsLabel : AArch64Base_ADR_offset<OtherVT>;
 
@@ -895,7 +895,7 @@ class AArch64Base_ADRP_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_ADRP_offsetAsInt64
     : AArch64Base_ADRP_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_ADRP_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_RelAddressFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_ADRP_offsetAsLabel : AArch64Base_ADRP_offset<OtherVT>;
 
@@ -907,7 +907,7 @@ class AArch64Base_ANDIW_immWSize<ValueType ty> : Operand<ty>
 
 def AArch64Base_ANDIW_immWSizeAsInt32
     : AArch64Base_ANDIW_immWSize<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ANDIW_immWSize_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicImmFormat_immWSize_predicate(Imm); }]>;
 
 def AArch64Base_ANDIW_immWSizeAsLabel : AArch64Base_ANDIW_immWSize<OtherVT>;
 
@@ -919,7 +919,7 @@ class AArch64Base_ANDIX_immXSize<ValueType ty> : Operand<ty>
 
 def AArch64Base_ANDIX_immXSizeAsInt64
     : AArch64Base_ANDIX_immXSize<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_ANDIX_immXSize_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_LogicImmFormat_immXSize_predicate(Imm); }]>;
 
 def AArch64Base_ANDIX_immXSizeAsLabel : AArch64Base_ANDIX_immXSize<OtherVT>;
 
@@ -931,7 +931,7 @@ class AArch64Base_ANDSIW_immWSize<ValueType ty> : Operand<ty>
 
 def AArch64Base_ANDSIW_immWSizeAsInt32
     : AArch64Base_ANDSIW_immWSize<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ANDSIW_immWSize_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicImmFormat_immWSize_predicate(Imm); }]>;
 
 def AArch64Base_ANDSIW_immWSizeAsLabel : AArch64Base_ANDSIW_immWSize<OtherVT>;
 
@@ -943,7 +943,7 @@ class AArch64Base_ANDSIX_immXSize<ValueType ty> : Operand<ty>
 
 def AArch64Base_ANDSIX_immXSizeAsInt64
     : AArch64Base_ANDSIX_immXSize<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_ANDSIX_immXSize_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_LogicImmFormat_immXSize_predicate(Imm); }]>;
 
 def AArch64Base_ANDSIX_immXSizeAsLabel : AArch64Base_ANDSIX_immXSize<OtherVT>;
 
@@ -955,7 +955,7 @@ class AArch64Base_ANDSWASR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_ANDSWASR_imm6AsInt32
     : AArch64Base_ANDSWASR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ANDSWASR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_ANDSWASR_imm6AsLabel : AArch64Base_ANDSWASR_imm6<OtherVT>;
 
@@ -967,7 +967,7 @@ class AArch64Base_ANDSWLSL_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_ANDSWLSL_imm6AsInt32
     : AArch64Base_ANDSWLSL_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ANDSWLSL_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_ANDSWLSL_imm6AsLabel : AArch64Base_ANDSWLSL_imm6<OtherVT>;
 
@@ -979,7 +979,7 @@ class AArch64Base_ANDSWLSR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_ANDSWLSR_imm6AsInt32
     : AArch64Base_ANDSWLSR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ANDSWLSR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_ANDSWLSR_imm6AsLabel : AArch64Base_ANDSWLSR_imm6<OtherVT>;
 
@@ -991,7 +991,7 @@ class AArch64Base_ANDSWROR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_ANDSWROR_imm6AsInt32
     : AArch64Base_ANDSWROR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ANDSWROR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_ANDSWROR_imm6AsLabel : AArch64Base_ANDSWROR_imm6<OtherVT>;
 
@@ -1003,7 +1003,7 @@ class AArch64Base_ANDSXASR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_ANDSXASR_imm6AsInt32
     : AArch64Base_ANDSXASR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ANDSXASR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_ANDSXASR_imm6AsLabel : AArch64Base_ANDSXASR_imm6<OtherVT>;
 
@@ -1015,7 +1015,7 @@ class AArch64Base_ANDSXLSL_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_ANDSXLSL_imm6AsInt32
     : AArch64Base_ANDSXLSL_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ANDSXLSL_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_ANDSXLSL_imm6AsLabel : AArch64Base_ANDSXLSL_imm6<OtherVT>;
 
@@ -1027,7 +1027,7 @@ class AArch64Base_ANDSXLSR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_ANDSXLSR_imm6AsInt32
     : AArch64Base_ANDSXLSR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ANDSXLSR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_ANDSXLSR_imm6AsLabel : AArch64Base_ANDSXLSR_imm6<OtherVT>;
 
@@ -1039,7 +1039,7 @@ class AArch64Base_ANDSXROR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_ANDSXROR_imm6AsInt32
     : AArch64Base_ANDSXROR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ANDSXROR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_ANDSXROR_imm6AsLabel : AArch64Base_ANDSXROR_imm6<OtherVT>;
 
@@ -1051,7 +1051,7 @@ class AArch64Base_ANDWASR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_ANDWASR_imm6AsInt32
     : AArch64Base_ANDWASR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ANDWASR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_ANDWASR_imm6AsLabel : AArch64Base_ANDWASR_imm6<OtherVT>;
 
@@ -1063,7 +1063,7 @@ class AArch64Base_ANDWLSL_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_ANDWLSL_imm6AsInt32
     : AArch64Base_ANDWLSL_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ANDWLSL_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_ANDWLSL_imm6AsLabel : AArch64Base_ANDWLSL_imm6<OtherVT>;
 
@@ -1075,7 +1075,7 @@ class AArch64Base_ANDWLSR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_ANDWLSR_imm6AsInt32
     : AArch64Base_ANDWLSR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ANDWLSR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_ANDWLSR_imm6AsLabel : AArch64Base_ANDWLSR_imm6<OtherVT>;
 
@@ -1087,7 +1087,7 @@ class AArch64Base_ANDWROR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_ANDWROR_imm6AsInt32
     : AArch64Base_ANDWROR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ANDWROR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_ANDWROR_imm6AsLabel : AArch64Base_ANDWROR_imm6<OtherVT>;
 
@@ -1099,7 +1099,7 @@ class AArch64Base_ANDXASR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_ANDXASR_imm6AsInt32
     : AArch64Base_ANDXASR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ANDXASR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_ANDXASR_imm6AsLabel : AArch64Base_ANDXASR_imm6<OtherVT>;
 
@@ -1111,7 +1111,7 @@ class AArch64Base_ANDXLSL_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_ANDXLSL_imm6AsInt32
     : AArch64Base_ANDXLSL_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ANDXLSL_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_ANDXLSL_imm6AsLabel : AArch64Base_ANDXLSL_imm6<OtherVT>;
 
@@ -1123,7 +1123,7 @@ class AArch64Base_ANDXLSR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_ANDXLSR_imm6AsInt32
     : AArch64Base_ANDXLSR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ANDXLSR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_ANDXLSR_imm6AsLabel : AArch64Base_ANDXLSR_imm6<OtherVT>;
 
@@ -1135,7 +1135,7 @@ class AArch64Base_ANDXROR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_ANDXROR_imm6AsInt32
     : AArch64Base_ANDXROR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ANDXROR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_ANDXROR_imm6AsLabel : AArch64Base_ANDXROR_imm6<OtherVT>;
 
@@ -1147,7 +1147,7 @@ class AArch64Base_B_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_B_offsetAsInt64
     : AArch64Base_B_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_B_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_BranchFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_B_offsetAsLabel : AArch64Base_B_offset<OtherVT>;
 
@@ -1159,7 +1159,7 @@ class AArch64Base_BFMW_leftWSize<ValueType ty> : Operand<ty>
 
 def AArch64Base_BFMW_leftWSizeAsInt32
     : AArch64Base_BFMW_leftWSize<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_BFMW_leftWSize_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_BitFieldMoveFormat_leftWSize_predicate(Imm); }]>;
 
 def AArch64Base_BFMW_leftWSizeAsLabel : AArch64Base_BFMW_leftWSize<OtherVT>;
 
@@ -1171,7 +1171,7 @@ class AArch64Base_BFMW_rightWSize<ValueType ty> : Operand<ty>
 
 def AArch64Base_BFMW_rightWSizeAsInt32
     : AArch64Base_BFMW_rightWSize<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_BFMW_rightWSize_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_BitFieldMoveFormat_rightWSize_predicate(Imm); }]>;
 
 def AArch64Base_BFMW_rightWSizeAsLabel : AArch64Base_BFMW_rightWSize<OtherVT>;
 
@@ -1183,7 +1183,7 @@ class AArch64Base_BFMX_leftXSize<ValueType ty> : Operand<ty>
 
 def AArch64Base_BFMX_leftXSizeAsInt32
     : AArch64Base_BFMX_leftXSize<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_BFMX_leftXSize_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_BitFieldMoveFormat_leftXSize_predicate(Imm); }]>;
 
 def AArch64Base_BFMX_leftXSizeAsLabel : AArch64Base_BFMX_leftXSize<OtherVT>;
 
@@ -1195,7 +1195,7 @@ class AArch64Base_BFMX_rightXSize<ValueType ty> : Operand<ty>
 
 def AArch64Base_BFMX_rightXSizeAsInt32
     : AArch64Base_BFMX_rightXSize<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_BFMX_rightXSize_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_BitFieldMoveFormat_rightXSize_predicate(Imm); }]>;
 
 def AArch64Base_BFMX_rightXSizeAsLabel : AArch64Base_BFMX_rightXSize<OtherVT>;
 
@@ -1207,7 +1207,7 @@ class AArch64Base_BICSWASR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_BICSWASR_imm6AsInt32
     : AArch64Base_BICSWASR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_BICSWASR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_BICSWASR_imm6AsLabel : AArch64Base_BICSWASR_imm6<OtherVT>;
 
@@ -1219,7 +1219,7 @@ class AArch64Base_BICSWLSL_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_BICSWLSL_imm6AsInt32
     : AArch64Base_BICSWLSL_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_BICSWLSL_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_BICSWLSL_imm6AsLabel : AArch64Base_BICSWLSL_imm6<OtherVT>;
 
@@ -1231,7 +1231,7 @@ class AArch64Base_BICSWLSR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_BICSWLSR_imm6AsInt32
     : AArch64Base_BICSWLSR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_BICSWLSR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_BICSWLSR_imm6AsLabel : AArch64Base_BICSWLSR_imm6<OtherVT>;
 
@@ -1243,7 +1243,7 @@ class AArch64Base_BICSWROR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_BICSWROR_imm6AsInt32
     : AArch64Base_BICSWROR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_BICSWROR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_BICSWROR_imm6AsLabel : AArch64Base_BICSWROR_imm6<OtherVT>;
 
@@ -1255,7 +1255,7 @@ class AArch64Base_BICSXASR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_BICSXASR_imm6AsInt32
     : AArch64Base_BICSXASR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_BICSXASR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_BICSXASR_imm6AsLabel : AArch64Base_BICSXASR_imm6<OtherVT>;
 
@@ -1267,7 +1267,7 @@ class AArch64Base_BICSXLSL_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_BICSXLSL_imm6AsInt32
     : AArch64Base_BICSXLSL_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_BICSXLSL_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_BICSXLSL_imm6AsLabel : AArch64Base_BICSXLSL_imm6<OtherVT>;
 
@@ -1279,7 +1279,7 @@ class AArch64Base_BICSXLSR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_BICSXLSR_imm6AsInt32
     : AArch64Base_BICSXLSR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_BICSXLSR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_BICSXLSR_imm6AsLabel : AArch64Base_BICSXLSR_imm6<OtherVT>;
 
@@ -1291,7 +1291,7 @@ class AArch64Base_BICSXROR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_BICSXROR_imm6AsInt32
     : AArch64Base_BICSXROR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_BICSXROR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_BICSXROR_imm6AsLabel : AArch64Base_BICSXROR_imm6<OtherVT>;
 
@@ -1303,7 +1303,7 @@ class AArch64Base_BICWASR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_BICWASR_imm6AsInt32
     : AArch64Base_BICWASR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_BICWASR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_BICWASR_imm6AsLabel : AArch64Base_BICWASR_imm6<OtherVT>;
 
@@ -1315,7 +1315,7 @@ class AArch64Base_BICWLSL_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_BICWLSL_imm6AsInt32
     : AArch64Base_BICWLSL_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_BICWLSL_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_BICWLSL_imm6AsLabel : AArch64Base_BICWLSL_imm6<OtherVT>;
 
@@ -1327,7 +1327,7 @@ class AArch64Base_BICWLSR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_BICWLSR_imm6AsInt32
     : AArch64Base_BICWLSR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_BICWLSR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_BICWLSR_imm6AsLabel : AArch64Base_BICWLSR_imm6<OtherVT>;
 
@@ -1339,7 +1339,7 @@ class AArch64Base_BICWROR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_BICWROR_imm6AsInt32
     : AArch64Base_BICWROR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_BICWROR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_BICWROR_imm6AsLabel : AArch64Base_BICWROR_imm6<OtherVT>;
 
@@ -1351,7 +1351,7 @@ class AArch64Base_BICXASR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_BICXASR_imm6AsInt32
     : AArch64Base_BICXASR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_BICXASR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_BICXASR_imm6AsLabel : AArch64Base_BICXASR_imm6<OtherVT>;
 
@@ -1363,7 +1363,7 @@ class AArch64Base_BICXLSL_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_BICXLSL_imm6AsInt32
     : AArch64Base_BICXLSL_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_BICXLSL_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_BICXLSL_imm6AsLabel : AArch64Base_BICXLSL_imm6<OtherVT>;
 
@@ -1375,7 +1375,7 @@ class AArch64Base_BICXLSR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_BICXLSR_imm6AsInt32
     : AArch64Base_BICXLSR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_BICXLSR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_BICXLSR_imm6AsLabel : AArch64Base_BICXLSR_imm6<OtherVT>;
 
@@ -1387,7 +1387,7 @@ class AArch64Base_BICXROR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_BICXROR_imm6AsInt32
     : AArch64Base_BICXROR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_BICXROR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_BICXROR_imm6AsLabel : AArch64Base_BICXROR_imm6<OtherVT>;
 
@@ -1399,7 +1399,7 @@ class AArch64Base_BL_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_BL_offsetAsInt64
     : AArch64Base_BL_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_BL_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_BranchFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_BL_offsetAsLabel : AArch64Base_BL_offset<OtherVT>;
 
@@ -1411,7 +1411,7 @@ class AArch64Base_BRK_imm16<ValueType ty> : Operand<ty>
 
 def AArch64Base_BRK_imm16AsInt32
     : AArch64Base_BRK_imm16<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_BRK_imm16_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_SuperVisorCallFormat_imm16_predicate(Imm); }]>;
 
 def AArch64Base_BRK_imm16AsLabel : AArch64Base_BRK_imm16<OtherVT>;
 
@@ -1423,7 +1423,7 @@ class AArch64Base_BTI_bti<ValueType ty> : Operand<ty>
 
 def AArch64Base_BTI_btiAsInt32
     : AArch64Base_BTI_bti<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_BTI_bti_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_BTIFormat_bti_predicate(Imm); }]>;
 
 def AArch64Base_BTI_btiAsLabel : AArch64Base_BTI_bti<OtherVT>;
 
@@ -1435,7 +1435,7 @@ class AArch64Base_B_AL_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_B_AL_offsetAsInt64
     : AArch64Base_B_AL_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_B_AL_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondBranchFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_B_AL_offsetAsLabel : AArch64Base_B_AL_offset<OtherVT>;
 
@@ -1447,7 +1447,7 @@ class AArch64Base_B_CC_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_B_CC_offsetAsInt64
     : AArch64Base_B_CC_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_B_CC_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondBranchFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_B_CC_offsetAsLabel : AArch64Base_B_CC_offset<OtherVT>;
 
@@ -1459,7 +1459,7 @@ class AArch64Base_B_CS_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_B_CS_offsetAsInt64
     : AArch64Base_B_CS_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_B_CS_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondBranchFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_B_CS_offsetAsLabel : AArch64Base_B_CS_offset<OtherVT>;
 
@@ -1471,7 +1471,7 @@ class AArch64Base_B_EQ_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_B_EQ_offsetAsInt64
     : AArch64Base_B_EQ_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_B_EQ_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondBranchFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_B_EQ_offsetAsLabel : AArch64Base_B_EQ_offset<OtherVT>;
 
@@ -1483,7 +1483,7 @@ class AArch64Base_B_GE_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_B_GE_offsetAsInt64
     : AArch64Base_B_GE_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_B_GE_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondBranchFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_B_GE_offsetAsLabel : AArch64Base_B_GE_offset<OtherVT>;
 
@@ -1495,7 +1495,7 @@ class AArch64Base_B_GT_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_B_GT_offsetAsInt64
     : AArch64Base_B_GT_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_B_GT_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondBranchFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_B_GT_offsetAsLabel : AArch64Base_B_GT_offset<OtherVT>;
 
@@ -1507,7 +1507,7 @@ class AArch64Base_B_HI_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_B_HI_offsetAsInt64
     : AArch64Base_B_HI_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_B_HI_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondBranchFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_B_HI_offsetAsLabel : AArch64Base_B_HI_offset<OtherVT>;
 
@@ -1519,7 +1519,7 @@ class AArch64Base_B_LE_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_B_LE_offsetAsInt64
     : AArch64Base_B_LE_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_B_LE_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondBranchFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_B_LE_offsetAsLabel : AArch64Base_B_LE_offset<OtherVT>;
 
@@ -1531,7 +1531,7 @@ class AArch64Base_B_LS_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_B_LS_offsetAsInt64
     : AArch64Base_B_LS_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_B_LS_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondBranchFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_B_LS_offsetAsLabel : AArch64Base_B_LS_offset<OtherVT>;
 
@@ -1543,7 +1543,7 @@ class AArch64Base_B_LT_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_B_LT_offsetAsInt64
     : AArch64Base_B_LT_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_B_LT_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondBranchFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_B_LT_offsetAsLabel : AArch64Base_B_LT_offset<OtherVT>;
 
@@ -1555,7 +1555,7 @@ class AArch64Base_B_MI_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_B_MI_offsetAsInt64
     : AArch64Base_B_MI_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_B_MI_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondBranchFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_B_MI_offsetAsLabel : AArch64Base_B_MI_offset<OtherVT>;
 
@@ -1567,7 +1567,7 @@ class AArch64Base_B_NE_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_B_NE_offsetAsInt64
     : AArch64Base_B_NE_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_B_NE_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondBranchFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_B_NE_offsetAsLabel : AArch64Base_B_NE_offset<OtherVT>;
 
@@ -1579,7 +1579,7 @@ class AArch64Base_B_NV_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_B_NV_offsetAsInt64
     : AArch64Base_B_NV_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_B_NV_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondBranchFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_B_NV_offsetAsLabel : AArch64Base_B_NV_offset<OtherVT>;
 
@@ -1591,7 +1591,7 @@ class AArch64Base_B_PL_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_B_PL_offsetAsInt64
     : AArch64Base_B_PL_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_B_PL_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondBranchFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_B_PL_offsetAsLabel : AArch64Base_B_PL_offset<OtherVT>;
 
@@ -1603,7 +1603,7 @@ class AArch64Base_B_VC_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_B_VC_offsetAsInt64
     : AArch64Base_B_VC_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_B_VC_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondBranchFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_B_VC_offsetAsLabel : AArch64Base_B_VC_offset<OtherVT>;
 
@@ -1615,7 +1615,7 @@ class AArch64Base_B_VS_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_B_VS_offsetAsInt64
     : AArch64Base_B_VS_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_B_VS_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondBranchFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_B_VS_offsetAsLabel : AArch64Base_B_VS_offset<OtherVT>;
 
@@ -1627,7 +1627,7 @@ class AArch64Base_CBNZW_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_CBNZW_offsetAsInt64
     : AArch64Base_CBNZW_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CBNZW_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CompareBranchFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_CBNZW_offsetAsLabel : AArch64Base_CBNZW_offset<OtherVT>;
 
@@ -1639,7 +1639,7 @@ class AArch64Base_CBNZX_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_CBNZX_offsetAsInt64
     : AArch64Base_CBNZX_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CBNZX_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CompareBranchFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_CBNZX_offsetAsLabel : AArch64Base_CBNZX_offset<OtherVT>;
 
@@ -1651,7 +1651,7 @@ class AArch64Base_CBZW_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_CBZW_offsetAsInt64
     : AArch64Base_CBZW_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CBZW_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CompareBranchFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_CBZW_offsetAsLabel : AArch64Base_CBZW_offset<OtherVT>;
 
@@ -1663,7 +1663,7 @@ class AArch64Base_CBZX_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_CBZX_offsetAsInt64
     : AArch64Base_CBZX_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CBZX_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CompareBranchFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_CBZX_offsetAsLabel : AArch64Base_CBZX_offset<OtherVT>;
 
@@ -1675,7 +1675,7 @@ class AArch64Base_CCMNALW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNALW_nzcvAsInt32
     : AArch64Base_CCMNALW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNALW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNALW_nzcvAsLabel : AArch64Base_CCMNALW_nzcv<OtherVT>;
 
@@ -1687,7 +1687,7 @@ class AArch64Base_CCMNALX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNALX_nzcvAsInt32
     : AArch64Base_CCMNALX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNALX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNALX_nzcvAsLabel : AArch64Base_CCMNALX_nzcv<OtherVT>;
 
@@ -1699,7 +1699,7 @@ class AArch64Base_CCMNCCW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNCCW_nzcvAsInt32
     : AArch64Base_CCMNCCW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNCCW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNCCW_nzcvAsLabel : AArch64Base_CCMNCCW_nzcv<OtherVT>;
 
@@ -1711,7 +1711,7 @@ class AArch64Base_CCMNCCX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNCCX_nzcvAsInt32
     : AArch64Base_CCMNCCX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNCCX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNCCX_nzcvAsLabel : AArch64Base_CCMNCCX_nzcv<OtherVT>;
 
@@ -1723,7 +1723,7 @@ class AArch64Base_CCMNCSW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNCSW_nzcvAsInt32
     : AArch64Base_CCMNCSW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNCSW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNCSW_nzcvAsLabel : AArch64Base_CCMNCSW_nzcv<OtherVT>;
 
@@ -1735,7 +1735,7 @@ class AArch64Base_CCMNCSX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNCSX_nzcvAsInt32
     : AArch64Base_CCMNCSX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNCSX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNCSX_nzcvAsLabel : AArch64Base_CCMNCSX_nzcv<OtherVT>;
 
@@ -1747,7 +1747,7 @@ class AArch64Base_CCMNEQW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNEQW_nzcvAsInt32
     : AArch64Base_CCMNEQW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNEQW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNEQW_nzcvAsLabel : AArch64Base_CCMNEQW_nzcv<OtherVT>;
 
@@ -1759,7 +1759,7 @@ class AArch64Base_CCMNEQX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNEQX_nzcvAsInt32
     : AArch64Base_CCMNEQX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNEQX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNEQX_nzcvAsLabel : AArch64Base_CCMNEQX_nzcv<OtherVT>;
 
@@ -1771,7 +1771,7 @@ class AArch64Base_CCMNGEW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNGEW_nzcvAsInt32
     : AArch64Base_CCMNGEW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNGEW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNGEW_nzcvAsLabel : AArch64Base_CCMNGEW_nzcv<OtherVT>;
 
@@ -1783,7 +1783,7 @@ class AArch64Base_CCMNGEX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNGEX_nzcvAsInt32
     : AArch64Base_CCMNGEX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNGEX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNGEX_nzcvAsLabel : AArch64Base_CCMNGEX_nzcv<OtherVT>;
 
@@ -1795,7 +1795,7 @@ class AArch64Base_CCMNGTW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNGTW_nzcvAsInt32
     : AArch64Base_CCMNGTW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNGTW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNGTW_nzcvAsLabel : AArch64Base_CCMNGTW_nzcv<OtherVT>;
 
@@ -1807,7 +1807,7 @@ class AArch64Base_CCMNGTX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNGTX_nzcvAsInt32
     : AArch64Base_CCMNGTX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNGTX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNGTX_nzcvAsLabel : AArch64Base_CCMNGTX_nzcv<OtherVT>;
 
@@ -1819,7 +1819,7 @@ class AArch64Base_CCMNHIW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNHIW_nzcvAsInt32
     : AArch64Base_CCMNHIW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNHIW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNHIW_nzcvAsLabel : AArch64Base_CCMNHIW_nzcv<OtherVT>;
 
@@ -1831,7 +1831,7 @@ class AArch64Base_CCMNHIX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNHIX_nzcvAsInt32
     : AArch64Base_CCMNHIX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNHIX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNHIX_nzcvAsLabel : AArch64Base_CCMNHIX_nzcv<OtherVT>;
 
@@ -1843,7 +1843,7 @@ class AArch64Base_CCMNIALW_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNIALW_immXAsInt64
     : AArch64Base_CCMNIALW_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMNIALW_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMNIALW_immXAsLabel : AArch64Base_CCMNIALW_immX<OtherVT>;
 
@@ -1855,7 +1855,7 @@ class AArch64Base_CCMNIALW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNIALW_nzcvAsInt32
     : AArch64Base_CCMNIALW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNIALW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNIALW_nzcvAsLabel : AArch64Base_CCMNIALW_nzcv<OtherVT>;
 
@@ -1867,7 +1867,7 @@ class AArch64Base_CCMNIALX_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNIALX_immXAsInt64
     : AArch64Base_CCMNIALX_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMNIALX_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMNIALX_immXAsLabel : AArch64Base_CCMNIALX_immX<OtherVT>;
 
@@ -1879,7 +1879,7 @@ class AArch64Base_CCMNIALX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNIALX_nzcvAsInt32
     : AArch64Base_CCMNIALX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNIALX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNIALX_nzcvAsLabel : AArch64Base_CCMNIALX_nzcv<OtherVT>;
 
@@ -1891,7 +1891,7 @@ class AArch64Base_CCMNICCW_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNICCW_immXAsInt64
     : AArch64Base_CCMNICCW_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMNICCW_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMNICCW_immXAsLabel : AArch64Base_CCMNICCW_immX<OtherVT>;
 
@@ -1903,7 +1903,7 @@ class AArch64Base_CCMNICCW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNICCW_nzcvAsInt32
     : AArch64Base_CCMNICCW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNICCW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNICCW_nzcvAsLabel : AArch64Base_CCMNICCW_nzcv<OtherVT>;
 
@@ -1915,7 +1915,7 @@ class AArch64Base_CCMNICCX_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNICCX_immXAsInt64
     : AArch64Base_CCMNICCX_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMNICCX_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMNICCX_immXAsLabel : AArch64Base_CCMNICCX_immX<OtherVT>;
 
@@ -1927,7 +1927,7 @@ class AArch64Base_CCMNICCX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNICCX_nzcvAsInt32
     : AArch64Base_CCMNICCX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNICCX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNICCX_nzcvAsLabel : AArch64Base_CCMNICCX_nzcv<OtherVT>;
 
@@ -1939,7 +1939,7 @@ class AArch64Base_CCMNICSW_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNICSW_immXAsInt64
     : AArch64Base_CCMNICSW_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMNICSW_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMNICSW_immXAsLabel : AArch64Base_CCMNICSW_immX<OtherVT>;
 
@@ -1951,7 +1951,7 @@ class AArch64Base_CCMNICSW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNICSW_nzcvAsInt32
     : AArch64Base_CCMNICSW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNICSW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNICSW_nzcvAsLabel : AArch64Base_CCMNICSW_nzcv<OtherVT>;
 
@@ -1963,7 +1963,7 @@ class AArch64Base_CCMNICSX_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNICSX_immXAsInt64
     : AArch64Base_CCMNICSX_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMNICSX_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMNICSX_immXAsLabel : AArch64Base_CCMNICSX_immX<OtherVT>;
 
@@ -1975,7 +1975,7 @@ class AArch64Base_CCMNICSX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNICSX_nzcvAsInt32
     : AArch64Base_CCMNICSX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNICSX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNICSX_nzcvAsLabel : AArch64Base_CCMNICSX_nzcv<OtherVT>;
 
@@ -1987,7 +1987,7 @@ class AArch64Base_CCMNIEQW_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNIEQW_immXAsInt64
     : AArch64Base_CCMNIEQW_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMNIEQW_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMNIEQW_immXAsLabel : AArch64Base_CCMNIEQW_immX<OtherVT>;
 
@@ -1999,7 +1999,7 @@ class AArch64Base_CCMNIEQW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNIEQW_nzcvAsInt32
     : AArch64Base_CCMNIEQW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNIEQW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNIEQW_nzcvAsLabel : AArch64Base_CCMNIEQW_nzcv<OtherVT>;
 
@@ -2011,7 +2011,7 @@ class AArch64Base_CCMNIEQX_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNIEQX_immXAsInt64
     : AArch64Base_CCMNIEQX_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMNIEQX_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMNIEQX_immXAsLabel : AArch64Base_CCMNIEQX_immX<OtherVT>;
 
@@ -2023,7 +2023,7 @@ class AArch64Base_CCMNIEQX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNIEQX_nzcvAsInt32
     : AArch64Base_CCMNIEQX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNIEQX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNIEQX_nzcvAsLabel : AArch64Base_CCMNIEQX_nzcv<OtherVT>;
 
@@ -2035,7 +2035,7 @@ class AArch64Base_CCMNIGEW_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNIGEW_immXAsInt64
     : AArch64Base_CCMNIGEW_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMNIGEW_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMNIGEW_immXAsLabel : AArch64Base_CCMNIGEW_immX<OtherVT>;
 
@@ -2047,7 +2047,7 @@ class AArch64Base_CCMNIGEW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNIGEW_nzcvAsInt32
     : AArch64Base_CCMNIGEW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNIGEW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNIGEW_nzcvAsLabel : AArch64Base_CCMNIGEW_nzcv<OtherVT>;
 
@@ -2059,7 +2059,7 @@ class AArch64Base_CCMNIGEX_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNIGEX_immXAsInt64
     : AArch64Base_CCMNIGEX_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMNIGEX_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMNIGEX_immXAsLabel : AArch64Base_CCMNIGEX_immX<OtherVT>;
 
@@ -2071,7 +2071,7 @@ class AArch64Base_CCMNIGEX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNIGEX_nzcvAsInt32
     : AArch64Base_CCMNIGEX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNIGEX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNIGEX_nzcvAsLabel : AArch64Base_CCMNIGEX_nzcv<OtherVT>;
 
@@ -2083,7 +2083,7 @@ class AArch64Base_CCMNIGTW_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNIGTW_immXAsInt64
     : AArch64Base_CCMNIGTW_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMNIGTW_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMNIGTW_immXAsLabel : AArch64Base_CCMNIGTW_immX<OtherVT>;
 
@@ -2095,7 +2095,7 @@ class AArch64Base_CCMNIGTW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNIGTW_nzcvAsInt32
     : AArch64Base_CCMNIGTW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNIGTW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNIGTW_nzcvAsLabel : AArch64Base_CCMNIGTW_nzcv<OtherVT>;
 
@@ -2107,7 +2107,7 @@ class AArch64Base_CCMNIGTX_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNIGTX_immXAsInt64
     : AArch64Base_CCMNIGTX_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMNIGTX_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMNIGTX_immXAsLabel : AArch64Base_CCMNIGTX_immX<OtherVT>;
 
@@ -2119,7 +2119,7 @@ class AArch64Base_CCMNIGTX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNIGTX_nzcvAsInt32
     : AArch64Base_CCMNIGTX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNIGTX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNIGTX_nzcvAsLabel : AArch64Base_CCMNIGTX_nzcv<OtherVT>;
 
@@ -2131,7 +2131,7 @@ class AArch64Base_CCMNIHIW_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNIHIW_immXAsInt64
     : AArch64Base_CCMNIHIW_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMNIHIW_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMNIHIW_immXAsLabel : AArch64Base_CCMNIHIW_immX<OtherVT>;
 
@@ -2143,7 +2143,7 @@ class AArch64Base_CCMNIHIW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNIHIW_nzcvAsInt32
     : AArch64Base_CCMNIHIW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNIHIW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNIHIW_nzcvAsLabel : AArch64Base_CCMNIHIW_nzcv<OtherVT>;
 
@@ -2155,7 +2155,7 @@ class AArch64Base_CCMNIHIX_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNIHIX_immXAsInt64
     : AArch64Base_CCMNIHIX_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMNIHIX_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMNIHIX_immXAsLabel : AArch64Base_CCMNIHIX_immX<OtherVT>;
 
@@ -2167,7 +2167,7 @@ class AArch64Base_CCMNIHIX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNIHIX_nzcvAsInt32
     : AArch64Base_CCMNIHIX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNIHIX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNIHIX_nzcvAsLabel : AArch64Base_CCMNIHIX_nzcv<OtherVT>;
 
@@ -2179,7 +2179,7 @@ class AArch64Base_CCMNILEW_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNILEW_immXAsInt64
     : AArch64Base_CCMNILEW_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMNILEW_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMNILEW_immXAsLabel : AArch64Base_CCMNILEW_immX<OtherVT>;
 
@@ -2191,7 +2191,7 @@ class AArch64Base_CCMNILEW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNILEW_nzcvAsInt32
     : AArch64Base_CCMNILEW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNILEW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNILEW_nzcvAsLabel : AArch64Base_CCMNILEW_nzcv<OtherVT>;
 
@@ -2203,7 +2203,7 @@ class AArch64Base_CCMNILEX_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNILEX_immXAsInt64
     : AArch64Base_CCMNILEX_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMNILEX_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMNILEX_immXAsLabel : AArch64Base_CCMNILEX_immX<OtherVT>;
 
@@ -2215,7 +2215,7 @@ class AArch64Base_CCMNILEX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNILEX_nzcvAsInt32
     : AArch64Base_CCMNILEX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNILEX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNILEX_nzcvAsLabel : AArch64Base_CCMNILEX_nzcv<OtherVT>;
 
@@ -2227,7 +2227,7 @@ class AArch64Base_CCMNILSW_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNILSW_immXAsInt64
     : AArch64Base_CCMNILSW_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMNILSW_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMNILSW_immXAsLabel : AArch64Base_CCMNILSW_immX<OtherVT>;
 
@@ -2239,7 +2239,7 @@ class AArch64Base_CCMNILSW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNILSW_nzcvAsInt32
     : AArch64Base_CCMNILSW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNILSW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNILSW_nzcvAsLabel : AArch64Base_CCMNILSW_nzcv<OtherVT>;
 
@@ -2251,7 +2251,7 @@ class AArch64Base_CCMNILSX_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNILSX_immXAsInt64
     : AArch64Base_CCMNILSX_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMNILSX_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMNILSX_immXAsLabel : AArch64Base_CCMNILSX_immX<OtherVT>;
 
@@ -2263,7 +2263,7 @@ class AArch64Base_CCMNILSX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNILSX_nzcvAsInt32
     : AArch64Base_CCMNILSX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNILSX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNILSX_nzcvAsLabel : AArch64Base_CCMNILSX_nzcv<OtherVT>;
 
@@ -2275,7 +2275,7 @@ class AArch64Base_CCMNILTW_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNILTW_immXAsInt64
     : AArch64Base_CCMNILTW_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMNILTW_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMNILTW_immXAsLabel : AArch64Base_CCMNILTW_immX<OtherVT>;
 
@@ -2287,7 +2287,7 @@ class AArch64Base_CCMNILTW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNILTW_nzcvAsInt32
     : AArch64Base_CCMNILTW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNILTW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNILTW_nzcvAsLabel : AArch64Base_CCMNILTW_nzcv<OtherVT>;
 
@@ -2299,7 +2299,7 @@ class AArch64Base_CCMNILTX_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNILTX_immXAsInt64
     : AArch64Base_CCMNILTX_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMNILTX_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMNILTX_immXAsLabel : AArch64Base_CCMNILTX_immX<OtherVT>;
 
@@ -2311,7 +2311,7 @@ class AArch64Base_CCMNILTX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNILTX_nzcvAsInt32
     : AArch64Base_CCMNILTX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNILTX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNILTX_nzcvAsLabel : AArch64Base_CCMNILTX_nzcv<OtherVT>;
 
@@ -2323,7 +2323,7 @@ class AArch64Base_CCMNIMIW_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNIMIW_immXAsInt64
     : AArch64Base_CCMNIMIW_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMNIMIW_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMNIMIW_immXAsLabel : AArch64Base_CCMNIMIW_immX<OtherVT>;
 
@@ -2335,7 +2335,7 @@ class AArch64Base_CCMNIMIW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNIMIW_nzcvAsInt32
     : AArch64Base_CCMNIMIW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNIMIW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNIMIW_nzcvAsLabel : AArch64Base_CCMNIMIW_nzcv<OtherVT>;
 
@@ -2347,7 +2347,7 @@ class AArch64Base_CCMNIMIX_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNIMIX_immXAsInt64
     : AArch64Base_CCMNIMIX_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMNIMIX_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMNIMIX_immXAsLabel : AArch64Base_CCMNIMIX_immX<OtherVT>;
 
@@ -2359,7 +2359,7 @@ class AArch64Base_CCMNIMIX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNIMIX_nzcvAsInt32
     : AArch64Base_CCMNIMIX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNIMIX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNIMIX_nzcvAsLabel : AArch64Base_CCMNIMIX_nzcv<OtherVT>;
 
@@ -2371,7 +2371,7 @@ class AArch64Base_CCMNINEW_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNINEW_immXAsInt64
     : AArch64Base_CCMNINEW_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMNINEW_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMNINEW_immXAsLabel : AArch64Base_CCMNINEW_immX<OtherVT>;
 
@@ -2383,7 +2383,7 @@ class AArch64Base_CCMNINEW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNINEW_nzcvAsInt32
     : AArch64Base_CCMNINEW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNINEW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNINEW_nzcvAsLabel : AArch64Base_CCMNINEW_nzcv<OtherVT>;
 
@@ -2395,7 +2395,7 @@ class AArch64Base_CCMNINEX_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNINEX_immXAsInt64
     : AArch64Base_CCMNINEX_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMNINEX_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMNINEX_immXAsLabel : AArch64Base_CCMNINEX_immX<OtherVT>;
 
@@ -2407,7 +2407,7 @@ class AArch64Base_CCMNINEX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNINEX_nzcvAsInt32
     : AArch64Base_CCMNINEX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNINEX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNINEX_nzcvAsLabel : AArch64Base_CCMNINEX_nzcv<OtherVT>;
 
@@ -2419,7 +2419,7 @@ class AArch64Base_CCMNINVW_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNINVW_immXAsInt64
     : AArch64Base_CCMNINVW_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMNINVW_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMNINVW_immXAsLabel : AArch64Base_CCMNINVW_immX<OtherVT>;
 
@@ -2431,7 +2431,7 @@ class AArch64Base_CCMNINVW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNINVW_nzcvAsInt32
     : AArch64Base_CCMNINVW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNINVW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNINVW_nzcvAsLabel : AArch64Base_CCMNINVW_nzcv<OtherVT>;
 
@@ -2443,7 +2443,7 @@ class AArch64Base_CCMNINVX_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNINVX_immXAsInt64
     : AArch64Base_CCMNINVX_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMNINVX_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMNINVX_immXAsLabel : AArch64Base_CCMNINVX_immX<OtherVT>;
 
@@ -2455,7 +2455,7 @@ class AArch64Base_CCMNINVX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNINVX_nzcvAsInt32
     : AArch64Base_CCMNINVX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNINVX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNINVX_nzcvAsLabel : AArch64Base_CCMNINVX_nzcv<OtherVT>;
 
@@ -2467,7 +2467,7 @@ class AArch64Base_CCMNIPLW_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNIPLW_immXAsInt64
     : AArch64Base_CCMNIPLW_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMNIPLW_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMNIPLW_immXAsLabel : AArch64Base_CCMNIPLW_immX<OtherVT>;
 
@@ -2479,7 +2479,7 @@ class AArch64Base_CCMNIPLW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNIPLW_nzcvAsInt32
     : AArch64Base_CCMNIPLW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNIPLW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNIPLW_nzcvAsLabel : AArch64Base_CCMNIPLW_nzcv<OtherVT>;
 
@@ -2491,7 +2491,7 @@ class AArch64Base_CCMNIPLX_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNIPLX_immXAsInt64
     : AArch64Base_CCMNIPLX_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMNIPLX_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMNIPLX_immXAsLabel : AArch64Base_CCMNIPLX_immX<OtherVT>;
 
@@ -2503,7 +2503,7 @@ class AArch64Base_CCMNIPLX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNIPLX_nzcvAsInt32
     : AArch64Base_CCMNIPLX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNIPLX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNIPLX_nzcvAsLabel : AArch64Base_CCMNIPLX_nzcv<OtherVT>;
 
@@ -2515,7 +2515,7 @@ class AArch64Base_CCMNIVCW_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNIVCW_immXAsInt64
     : AArch64Base_CCMNIVCW_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMNIVCW_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMNIVCW_immXAsLabel : AArch64Base_CCMNIVCW_immX<OtherVT>;
 
@@ -2527,7 +2527,7 @@ class AArch64Base_CCMNIVCW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNIVCW_nzcvAsInt32
     : AArch64Base_CCMNIVCW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNIVCW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNIVCW_nzcvAsLabel : AArch64Base_CCMNIVCW_nzcv<OtherVT>;
 
@@ -2539,7 +2539,7 @@ class AArch64Base_CCMNIVCX_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNIVCX_immXAsInt64
     : AArch64Base_CCMNIVCX_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMNIVCX_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMNIVCX_immXAsLabel : AArch64Base_CCMNIVCX_immX<OtherVT>;
 
@@ -2551,7 +2551,7 @@ class AArch64Base_CCMNIVCX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNIVCX_nzcvAsInt32
     : AArch64Base_CCMNIVCX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNIVCX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNIVCX_nzcvAsLabel : AArch64Base_CCMNIVCX_nzcv<OtherVT>;
 
@@ -2563,7 +2563,7 @@ class AArch64Base_CCMNIVSW_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNIVSW_immXAsInt64
     : AArch64Base_CCMNIVSW_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMNIVSW_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMNIVSW_immXAsLabel : AArch64Base_CCMNIVSW_immX<OtherVT>;
 
@@ -2575,7 +2575,7 @@ class AArch64Base_CCMNIVSW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNIVSW_nzcvAsInt32
     : AArch64Base_CCMNIVSW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNIVSW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNIVSW_nzcvAsLabel : AArch64Base_CCMNIVSW_nzcv<OtherVT>;
 
@@ -2587,7 +2587,7 @@ class AArch64Base_CCMNIVSX_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNIVSX_immXAsInt64
     : AArch64Base_CCMNIVSX_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMNIVSX_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMNIVSX_immXAsLabel : AArch64Base_CCMNIVSX_immX<OtherVT>;
 
@@ -2599,7 +2599,7 @@ class AArch64Base_CCMNIVSX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNIVSX_nzcvAsInt32
     : AArch64Base_CCMNIVSX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNIVSX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNIVSX_nzcvAsLabel : AArch64Base_CCMNIVSX_nzcv<OtherVT>;
 
@@ -2611,7 +2611,7 @@ class AArch64Base_CCMNLEW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNLEW_nzcvAsInt32
     : AArch64Base_CCMNLEW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNLEW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNLEW_nzcvAsLabel : AArch64Base_CCMNLEW_nzcv<OtherVT>;
 
@@ -2623,7 +2623,7 @@ class AArch64Base_CCMNLEX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNLEX_nzcvAsInt32
     : AArch64Base_CCMNLEX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNLEX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNLEX_nzcvAsLabel : AArch64Base_CCMNLEX_nzcv<OtherVT>;
 
@@ -2635,7 +2635,7 @@ class AArch64Base_CCMNLSW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNLSW_nzcvAsInt32
     : AArch64Base_CCMNLSW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNLSW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNLSW_nzcvAsLabel : AArch64Base_CCMNLSW_nzcv<OtherVT>;
 
@@ -2647,7 +2647,7 @@ class AArch64Base_CCMNLSX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNLSX_nzcvAsInt32
     : AArch64Base_CCMNLSX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNLSX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNLSX_nzcvAsLabel : AArch64Base_CCMNLSX_nzcv<OtherVT>;
 
@@ -2659,7 +2659,7 @@ class AArch64Base_CCMNLTW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNLTW_nzcvAsInt32
     : AArch64Base_CCMNLTW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNLTW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNLTW_nzcvAsLabel : AArch64Base_CCMNLTW_nzcv<OtherVT>;
 
@@ -2671,7 +2671,7 @@ class AArch64Base_CCMNLTX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNLTX_nzcvAsInt32
     : AArch64Base_CCMNLTX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNLTX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNLTX_nzcvAsLabel : AArch64Base_CCMNLTX_nzcv<OtherVT>;
 
@@ -2683,7 +2683,7 @@ class AArch64Base_CCMNMIW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNMIW_nzcvAsInt32
     : AArch64Base_CCMNMIW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNMIW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNMIW_nzcvAsLabel : AArch64Base_CCMNMIW_nzcv<OtherVT>;
 
@@ -2695,7 +2695,7 @@ class AArch64Base_CCMNMIX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNMIX_nzcvAsInt32
     : AArch64Base_CCMNMIX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNMIX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNMIX_nzcvAsLabel : AArch64Base_CCMNMIX_nzcv<OtherVT>;
 
@@ -2707,7 +2707,7 @@ class AArch64Base_CCMNNEW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNNEW_nzcvAsInt32
     : AArch64Base_CCMNNEW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNNEW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNNEW_nzcvAsLabel : AArch64Base_CCMNNEW_nzcv<OtherVT>;
 
@@ -2719,7 +2719,7 @@ class AArch64Base_CCMNNEX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNNEX_nzcvAsInt32
     : AArch64Base_CCMNNEX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNNEX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNNEX_nzcvAsLabel : AArch64Base_CCMNNEX_nzcv<OtherVT>;
 
@@ -2731,7 +2731,7 @@ class AArch64Base_CCMNNVW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNNVW_nzcvAsInt32
     : AArch64Base_CCMNNVW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNNVW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNNVW_nzcvAsLabel : AArch64Base_CCMNNVW_nzcv<OtherVT>;
 
@@ -2743,7 +2743,7 @@ class AArch64Base_CCMNNVX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNNVX_nzcvAsInt32
     : AArch64Base_CCMNNVX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNNVX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNNVX_nzcvAsLabel : AArch64Base_CCMNNVX_nzcv<OtherVT>;
 
@@ -2755,7 +2755,7 @@ class AArch64Base_CCMNPLW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNPLW_nzcvAsInt32
     : AArch64Base_CCMNPLW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNPLW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNPLW_nzcvAsLabel : AArch64Base_CCMNPLW_nzcv<OtherVT>;
 
@@ -2767,7 +2767,7 @@ class AArch64Base_CCMNPLX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNPLX_nzcvAsInt32
     : AArch64Base_CCMNPLX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNPLX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNPLX_nzcvAsLabel : AArch64Base_CCMNPLX_nzcv<OtherVT>;
 
@@ -2779,7 +2779,7 @@ class AArch64Base_CCMNVCW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNVCW_nzcvAsInt32
     : AArch64Base_CCMNVCW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNVCW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNVCW_nzcvAsLabel : AArch64Base_CCMNVCW_nzcv<OtherVT>;
 
@@ -2791,7 +2791,7 @@ class AArch64Base_CCMNVCX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNVCX_nzcvAsInt32
     : AArch64Base_CCMNVCX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNVCX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNVCX_nzcvAsLabel : AArch64Base_CCMNVCX_nzcv<OtherVT>;
 
@@ -2803,7 +2803,7 @@ class AArch64Base_CCMNVSW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNVSW_nzcvAsInt32
     : AArch64Base_CCMNVSW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNVSW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNVSW_nzcvAsLabel : AArch64Base_CCMNVSW_nzcv<OtherVT>;
 
@@ -2815,7 +2815,7 @@ class AArch64Base_CCMNVSX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMNVSX_nzcvAsInt32
     : AArch64Base_CCMNVSX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMNVSX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMNVSX_nzcvAsLabel : AArch64Base_CCMNVSX_nzcv<OtherVT>;
 
@@ -2827,7 +2827,7 @@ class AArch64Base_CCMPALW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPALW_nzcvAsInt32
     : AArch64Base_CCMPALW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPALW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPALW_nzcvAsLabel : AArch64Base_CCMPALW_nzcv<OtherVT>;
 
@@ -2839,7 +2839,7 @@ class AArch64Base_CCMPALX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPALX_nzcvAsInt32
     : AArch64Base_CCMPALX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPALX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPALX_nzcvAsLabel : AArch64Base_CCMPALX_nzcv<OtherVT>;
 
@@ -2851,7 +2851,7 @@ class AArch64Base_CCMPCCW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPCCW_nzcvAsInt32
     : AArch64Base_CCMPCCW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPCCW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPCCW_nzcvAsLabel : AArch64Base_CCMPCCW_nzcv<OtherVT>;
 
@@ -2863,7 +2863,7 @@ class AArch64Base_CCMPCCX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPCCX_nzcvAsInt32
     : AArch64Base_CCMPCCX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPCCX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPCCX_nzcvAsLabel : AArch64Base_CCMPCCX_nzcv<OtherVT>;
 
@@ -2875,7 +2875,7 @@ class AArch64Base_CCMPCSW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPCSW_nzcvAsInt32
     : AArch64Base_CCMPCSW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPCSW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPCSW_nzcvAsLabel : AArch64Base_CCMPCSW_nzcv<OtherVT>;
 
@@ -2887,7 +2887,7 @@ class AArch64Base_CCMPCSX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPCSX_nzcvAsInt32
     : AArch64Base_CCMPCSX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPCSX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPCSX_nzcvAsLabel : AArch64Base_CCMPCSX_nzcv<OtherVT>;
 
@@ -2899,7 +2899,7 @@ class AArch64Base_CCMPEQW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPEQW_nzcvAsInt32
     : AArch64Base_CCMPEQW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPEQW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPEQW_nzcvAsLabel : AArch64Base_CCMPEQW_nzcv<OtherVT>;
 
@@ -2911,7 +2911,7 @@ class AArch64Base_CCMPEQX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPEQX_nzcvAsInt32
     : AArch64Base_CCMPEQX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPEQX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPEQX_nzcvAsLabel : AArch64Base_CCMPEQX_nzcv<OtherVT>;
 
@@ -2923,7 +2923,7 @@ class AArch64Base_CCMPGEW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPGEW_nzcvAsInt32
     : AArch64Base_CCMPGEW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPGEW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPGEW_nzcvAsLabel : AArch64Base_CCMPGEW_nzcv<OtherVT>;
 
@@ -2935,7 +2935,7 @@ class AArch64Base_CCMPGEX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPGEX_nzcvAsInt32
     : AArch64Base_CCMPGEX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPGEX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPGEX_nzcvAsLabel : AArch64Base_CCMPGEX_nzcv<OtherVT>;
 
@@ -2947,7 +2947,7 @@ class AArch64Base_CCMPGTW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPGTW_nzcvAsInt32
     : AArch64Base_CCMPGTW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPGTW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPGTW_nzcvAsLabel : AArch64Base_CCMPGTW_nzcv<OtherVT>;
 
@@ -2959,7 +2959,7 @@ class AArch64Base_CCMPGTX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPGTX_nzcvAsInt32
     : AArch64Base_CCMPGTX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPGTX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPGTX_nzcvAsLabel : AArch64Base_CCMPGTX_nzcv<OtherVT>;
 
@@ -2971,7 +2971,7 @@ class AArch64Base_CCMPHIW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPHIW_nzcvAsInt32
     : AArch64Base_CCMPHIW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPHIW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPHIW_nzcvAsLabel : AArch64Base_CCMPHIW_nzcv<OtherVT>;
 
@@ -2983,7 +2983,7 @@ class AArch64Base_CCMPHIX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPHIX_nzcvAsInt32
     : AArch64Base_CCMPHIX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPHIX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPHIX_nzcvAsLabel : AArch64Base_CCMPHIX_nzcv<OtherVT>;
 
@@ -2995,7 +2995,7 @@ class AArch64Base_CCMPIALW_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPIALW_immXAsInt64
     : AArch64Base_CCMPIALW_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMPIALW_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMPIALW_immXAsLabel : AArch64Base_CCMPIALW_immX<OtherVT>;
 
@@ -3007,7 +3007,7 @@ class AArch64Base_CCMPIALW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPIALW_nzcvAsInt32
     : AArch64Base_CCMPIALW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPIALW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPIALW_nzcvAsLabel : AArch64Base_CCMPIALW_nzcv<OtherVT>;
 
@@ -3019,7 +3019,7 @@ class AArch64Base_CCMPIALX_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPIALX_immXAsInt64
     : AArch64Base_CCMPIALX_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMPIALX_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMPIALX_immXAsLabel : AArch64Base_CCMPIALX_immX<OtherVT>;
 
@@ -3031,7 +3031,7 @@ class AArch64Base_CCMPIALX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPIALX_nzcvAsInt32
     : AArch64Base_CCMPIALX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPIALX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPIALX_nzcvAsLabel : AArch64Base_CCMPIALX_nzcv<OtherVT>;
 
@@ -3043,7 +3043,7 @@ class AArch64Base_CCMPICCW_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPICCW_immXAsInt64
     : AArch64Base_CCMPICCW_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMPICCW_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMPICCW_immXAsLabel : AArch64Base_CCMPICCW_immX<OtherVT>;
 
@@ -3055,7 +3055,7 @@ class AArch64Base_CCMPICCW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPICCW_nzcvAsInt32
     : AArch64Base_CCMPICCW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPICCW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPICCW_nzcvAsLabel : AArch64Base_CCMPICCW_nzcv<OtherVT>;
 
@@ -3067,7 +3067,7 @@ class AArch64Base_CCMPICCX_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPICCX_immXAsInt64
     : AArch64Base_CCMPICCX_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMPICCX_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMPICCX_immXAsLabel : AArch64Base_CCMPICCX_immX<OtherVT>;
 
@@ -3079,7 +3079,7 @@ class AArch64Base_CCMPICCX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPICCX_nzcvAsInt32
     : AArch64Base_CCMPICCX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPICCX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPICCX_nzcvAsLabel : AArch64Base_CCMPICCX_nzcv<OtherVT>;
 
@@ -3091,7 +3091,7 @@ class AArch64Base_CCMPICSW_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPICSW_immXAsInt64
     : AArch64Base_CCMPICSW_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMPICSW_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMPICSW_immXAsLabel : AArch64Base_CCMPICSW_immX<OtherVT>;
 
@@ -3103,7 +3103,7 @@ class AArch64Base_CCMPICSW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPICSW_nzcvAsInt32
     : AArch64Base_CCMPICSW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPICSW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPICSW_nzcvAsLabel : AArch64Base_CCMPICSW_nzcv<OtherVT>;
 
@@ -3115,7 +3115,7 @@ class AArch64Base_CCMPICSX_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPICSX_immXAsInt64
     : AArch64Base_CCMPICSX_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMPICSX_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMPICSX_immXAsLabel : AArch64Base_CCMPICSX_immX<OtherVT>;
 
@@ -3127,7 +3127,7 @@ class AArch64Base_CCMPICSX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPICSX_nzcvAsInt32
     : AArch64Base_CCMPICSX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPICSX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPICSX_nzcvAsLabel : AArch64Base_CCMPICSX_nzcv<OtherVT>;
 
@@ -3139,7 +3139,7 @@ class AArch64Base_CCMPIEQW_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPIEQW_immXAsInt64
     : AArch64Base_CCMPIEQW_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMPIEQW_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMPIEQW_immXAsLabel : AArch64Base_CCMPIEQW_immX<OtherVT>;
 
@@ -3151,7 +3151,7 @@ class AArch64Base_CCMPIEQW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPIEQW_nzcvAsInt32
     : AArch64Base_CCMPIEQW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPIEQW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPIEQW_nzcvAsLabel : AArch64Base_CCMPIEQW_nzcv<OtherVT>;
 
@@ -3163,7 +3163,7 @@ class AArch64Base_CCMPIEQX_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPIEQX_immXAsInt64
     : AArch64Base_CCMPIEQX_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMPIEQX_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMPIEQX_immXAsLabel : AArch64Base_CCMPIEQX_immX<OtherVT>;
 
@@ -3175,7 +3175,7 @@ class AArch64Base_CCMPIEQX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPIEQX_nzcvAsInt32
     : AArch64Base_CCMPIEQX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPIEQX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPIEQX_nzcvAsLabel : AArch64Base_CCMPIEQX_nzcv<OtherVT>;
 
@@ -3187,7 +3187,7 @@ class AArch64Base_CCMPIGEW_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPIGEW_immXAsInt64
     : AArch64Base_CCMPIGEW_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMPIGEW_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMPIGEW_immXAsLabel : AArch64Base_CCMPIGEW_immX<OtherVT>;
 
@@ -3199,7 +3199,7 @@ class AArch64Base_CCMPIGEW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPIGEW_nzcvAsInt32
     : AArch64Base_CCMPIGEW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPIGEW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPIGEW_nzcvAsLabel : AArch64Base_CCMPIGEW_nzcv<OtherVT>;
 
@@ -3211,7 +3211,7 @@ class AArch64Base_CCMPIGEX_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPIGEX_immXAsInt64
     : AArch64Base_CCMPIGEX_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMPIGEX_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMPIGEX_immXAsLabel : AArch64Base_CCMPIGEX_immX<OtherVT>;
 
@@ -3223,7 +3223,7 @@ class AArch64Base_CCMPIGEX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPIGEX_nzcvAsInt32
     : AArch64Base_CCMPIGEX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPIGEX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPIGEX_nzcvAsLabel : AArch64Base_CCMPIGEX_nzcv<OtherVT>;
 
@@ -3235,7 +3235,7 @@ class AArch64Base_CCMPIGTW_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPIGTW_immXAsInt64
     : AArch64Base_CCMPIGTW_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMPIGTW_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMPIGTW_immXAsLabel : AArch64Base_CCMPIGTW_immX<OtherVT>;
 
@@ -3247,7 +3247,7 @@ class AArch64Base_CCMPIGTW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPIGTW_nzcvAsInt32
     : AArch64Base_CCMPIGTW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPIGTW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPIGTW_nzcvAsLabel : AArch64Base_CCMPIGTW_nzcv<OtherVT>;
 
@@ -3259,7 +3259,7 @@ class AArch64Base_CCMPIGTX_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPIGTX_immXAsInt64
     : AArch64Base_CCMPIGTX_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMPIGTX_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMPIGTX_immXAsLabel : AArch64Base_CCMPIGTX_immX<OtherVT>;
 
@@ -3271,7 +3271,7 @@ class AArch64Base_CCMPIGTX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPIGTX_nzcvAsInt32
     : AArch64Base_CCMPIGTX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPIGTX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPIGTX_nzcvAsLabel : AArch64Base_CCMPIGTX_nzcv<OtherVT>;
 
@@ -3283,7 +3283,7 @@ class AArch64Base_CCMPIHIW_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPIHIW_immXAsInt64
     : AArch64Base_CCMPIHIW_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMPIHIW_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMPIHIW_immXAsLabel : AArch64Base_CCMPIHIW_immX<OtherVT>;
 
@@ -3295,7 +3295,7 @@ class AArch64Base_CCMPIHIW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPIHIW_nzcvAsInt32
     : AArch64Base_CCMPIHIW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPIHIW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPIHIW_nzcvAsLabel : AArch64Base_CCMPIHIW_nzcv<OtherVT>;
 
@@ -3307,7 +3307,7 @@ class AArch64Base_CCMPIHIX_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPIHIX_immXAsInt64
     : AArch64Base_CCMPIHIX_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMPIHIX_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMPIHIX_immXAsLabel : AArch64Base_CCMPIHIX_immX<OtherVT>;
 
@@ -3319,7 +3319,7 @@ class AArch64Base_CCMPIHIX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPIHIX_nzcvAsInt32
     : AArch64Base_CCMPIHIX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPIHIX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPIHIX_nzcvAsLabel : AArch64Base_CCMPIHIX_nzcv<OtherVT>;
 
@@ -3331,7 +3331,7 @@ class AArch64Base_CCMPILEW_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPILEW_immXAsInt64
     : AArch64Base_CCMPILEW_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMPILEW_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMPILEW_immXAsLabel : AArch64Base_CCMPILEW_immX<OtherVT>;
 
@@ -3343,7 +3343,7 @@ class AArch64Base_CCMPILEW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPILEW_nzcvAsInt32
     : AArch64Base_CCMPILEW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPILEW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPILEW_nzcvAsLabel : AArch64Base_CCMPILEW_nzcv<OtherVT>;
 
@@ -3355,7 +3355,7 @@ class AArch64Base_CCMPILEX_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPILEX_immXAsInt64
     : AArch64Base_CCMPILEX_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMPILEX_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMPILEX_immXAsLabel : AArch64Base_CCMPILEX_immX<OtherVT>;
 
@@ -3367,7 +3367,7 @@ class AArch64Base_CCMPILEX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPILEX_nzcvAsInt32
     : AArch64Base_CCMPILEX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPILEX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPILEX_nzcvAsLabel : AArch64Base_CCMPILEX_nzcv<OtherVT>;
 
@@ -3379,7 +3379,7 @@ class AArch64Base_CCMPILSW_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPILSW_immXAsInt64
     : AArch64Base_CCMPILSW_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMPILSW_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMPILSW_immXAsLabel : AArch64Base_CCMPILSW_immX<OtherVT>;
 
@@ -3391,7 +3391,7 @@ class AArch64Base_CCMPILSW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPILSW_nzcvAsInt32
     : AArch64Base_CCMPILSW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPILSW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPILSW_nzcvAsLabel : AArch64Base_CCMPILSW_nzcv<OtherVT>;
 
@@ -3403,7 +3403,7 @@ class AArch64Base_CCMPILSX_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPILSX_immXAsInt64
     : AArch64Base_CCMPILSX_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMPILSX_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMPILSX_immXAsLabel : AArch64Base_CCMPILSX_immX<OtherVT>;
 
@@ -3415,7 +3415,7 @@ class AArch64Base_CCMPILSX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPILSX_nzcvAsInt32
     : AArch64Base_CCMPILSX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPILSX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPILSX_nzcvAsLabel : AArch64Base_CCMPILSX_nzcv<OtherVT>;
 
@@ -3427,7 +3427,7 @@ class AArch64Base_CCMPILTW_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPILTW_immXAsInt64
     : AArch64Base_CCMPILTW_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMPILTW_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMPILTW_immXAsLabel : AArch64Base_CCMPILTW_immX<OtherVT>;
 
@@ -3439,7 +3439,7 @@ class AArch64Base_CCMPILTW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPILTW_nzcvAsInt32
     : AArch64Base_CCMPILTW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPILTW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPILTW_nzcvAsLabel : AArch64Base_CCMPILTW_nzcv<OtherVT>;
 
@@ -3451,7 +3451,7 @@ class AArch64Base_CCMPILTX_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPILTX_immXAsInt64
     : AArch64Base_CCMPILTX_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMPILTX_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMPILTX_immXAsLabel : AArch64Base_CCMPILTX_immX<OtherVT>;
 
@@ -3463,7 +3463,7 @@ class AArch64Base_CCMPILTX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPILTX_nzcvAsInt32
     : AArch64Base_CCMPILTX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPILTX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPILTX_nzcvAsLabel : AArch64Base_CCMPILTX_nzcv<OtherVT>;
 
@@ -3475,7 +3475,7 @@ class AArch64Base_CCMPIMIW_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPIMIW_immXAsInt64
     : AArch64Base_CCMPIMIW_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMPIMIW_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMPIMIW_immXAsLabel : AArch64Base_CCMPIMIW_immX<OtherVT>;
 
@@ -3487,7 +3487,7 @@ class AArch64Base_CCMPIMIW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPIMIW_nzcvAsInt32
     : AArch64Base_CCMPIMIW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPIMIW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPIMIW_nzcvAsLabel : AArch64Base_CCMPIMIW_nzcv<OtherVT>;
 
@@ -3499,7 +3499,7 @@ class AArch64Base_CCMPIMIX_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPIMIX_immXAsInt64
     : AArch64Base_CCMPIMIX_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMPIMIX_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMPIMIX_immXAsLabel : AArch64Base_CCMPIMIX_immX<OtherVT>;
 
@@ -3511,7 +3511,7 @@ class AArch64Base_CCMPIMIX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPIMIX_nzcvAsInt32
     : AArch64Base_CCMPIMIX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPIMIX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPIMIX_nzcvAsLabel : AArch64Base_CCMPIMIX_nzcv<OtherVT>;
 
@@ -3523,7 +3523,7 @@ class AArch64Base_CCMPINEW_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPINEW_immXAsInt64
     : AArch64Base_CCMPINEW_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMPINEW_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMPINEW_immXAsLabel : AArch64Base_CCMPINEW_immX<OtherVT>;
 
@@ -3535,7 +3535,7 @@ class AArch64Base_CCMPINEW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPINEW_nzcvAsInt32
     : AArch64Base_CCMPINEW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPINEW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPINEW_nzcvAsLabel : AArch64Base_CCMPINEW_nzcv<OtherVT>;
 
@@ -3547,7 +3547,7 @@ class AArch64Base_CCMPINEX_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPINEX_immXAsInt64
     : AArch64Base_CCMPINEX_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMPINEX_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMPINEX_immXAsLabel : AArch64Base_CCMPINEX_immX<OtherVT>;
 
@@ -3559,7 +3559,7 @@ class AArch64Base_CCMPINEX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPINEX_nzcvAsInt32
     : AArch64Base_CCMPINEX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPINEX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPINEX_nzcvAsLabel : AArch64Base_CCMPINEX_nzcv<OtherVT>;
 
@@ -3571,7 +3571,7 @@ class AArch64Base_CCMPINVW_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPINVW_immXAsInt64
     : AArch64Base_CCMPINVW_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMPINVW_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMPINVW_immXAsLabel : AArch64Base_CCMPINVW_immX<OtherVT>;
 
@@ -3583,7 +3583,7 @@ class AArch64Base_CCMPINVW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPINVW_nzcvAsInt32
     : AArch64Base_CCMPINVW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPINVW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPINVW_nzcvAsLabel : AArch64Base_CCMPINVW_nzcv<OtherVT>;
 
@@ -3595,7 +3595,7 @@ class AArch64Base_CCMPINVX_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPINVX_immXAsInt64
     : AArch64Base_CCMPINVX_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMPINVX_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMPINVX_immXAsLabel : AArch64Base_CCMPINVX_immX<OtherVT>;
 
@@ -3607,7 +3607,7 @@ class AArch64Base_CCMPINVX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPINVX_nzcvAsInt32
     : AArch64Base_CCMPINVX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPINVX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPINVX_nzcvAsLabel : AArch64Base_CCMPINVX_nzcv<OtherVT>;
 
@@ -3619,7 +3619,7 @@ class AArch64Base_CCMPIPLW_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPIPLW_immXAsInt64
     : AArch64Base_CCMPIPLW_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMPIPLW_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMPIPLW_immXAsLabel : AArch64Base_CCMPIPLW_immX<OtherVT>;
 
@@ -3631,7 +3631,7 @@ class AArch64Base_CCMPIPLW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPIPLW_nzcvAsInt32
     : AArch64Base_CCMPIPLW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPIPLW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPIPLW_nzcvAsLabel : AArch64Base_CCMPIPLW_nzcv<OtherVT>;
 
@@ -3643,7 +3643,7 @@ class AArch64Base_CCMPIPLX_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPIPLX_immXAsInt64
     : AArch64Base_CCMPIPLX_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMPIPLX_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMPIPLX_immXAsLabel : AArch64Base_CCMPIPLX_immX<OtherVT>;
 
@@ -3655,7 +3655,7 @@ class AArch64Base_CCMPIPLX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPIPLX_nzcvAsInt32
     : AArch64Base_CCMPIPLX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPIPLX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPIPLX_nzcvAsLabel : AArch64Base_CCMPIPLX_nzcv<OtherVT>;
 
@@ -3667,7 +3667,7 @@ class AArch64Base_CCMPIVCW_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPIVCW_immXAsInt64
     : AArch64Base_CCMPIVCW_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMPIVCW_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMPIVCW_immXAsLabel : AArch64Base_CCMPIVCW_immX<OtherVT>;
 
@@ -3679,7 +3679,7 @@ class AArch64Base_CCMPIVCW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPIVCW_nzcvAsInt32
     : AArch64Base_CCMPIVCW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPIVCW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPIVCW_nzcvAsLabel : AArch64Base_CCMPIVCW_nzcv<OtherVT>;
 
@@ -3691,7 +3691,7 @@ class AArch64Base_CCMPIVCX_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPIVCX_immXAsInt64
     : AArch64Base_CCMPIVCX_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMPIVCX_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMPIVCX_immXAsLabel : AArch64Base_CCMPIVCX_immX<OtherVT>;
 
@@ -3703,7 +3703,7 @@ class AArch64Base_CCMPIVCX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPIVCX_nzcvAsInt32
     : AArch64Base_CCMPIVCX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPIVCX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPIVCX_nzcvAsLabel : AArch64Base_CCMPIVCX_nzcv<OtherVT>;
 
@@ -3715,7 +3715,7 @@ class AArch64Base_CCMPIVSW_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPIVSW_immXAsInt64
     : AArch64Base_CCMPIVSW_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMPIVSW_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMPIVSW_immXAsLabel : AArch64Base_CCMPIVSW_immX<OtherVT>;
 
@@ -3727,7 +3727,7 @@ class AArch64Base_CCMPIVSW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPIVSW_nzcvAsInt32
     : AArch64Base_CCMPIVSW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPIVSW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPIVSW_nzcvAsLabel : AArch64Base_CCMPIVSW_nzcv<OtherVT>;
 
@@ -3739,7 +3739,7 @@ class AArch64Base_CCMPIVSX_immX<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPIVSX_immXAsInt64
     : AArch64Base_CCMPIVSX_immX<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_CCMPIVSX_immX_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_CondCompareFormat_immX_predicate(Imm); }]>;
 
 def AArch64Base_CCMPIVSX_immXAsLabel : AArch64Base_CCMPIVSX_immX<OtherVT>;
 
@@ -3751,7 +3751,7 @@ class AArch64Base_CCMPIVSX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPIVSX_nzcvAsInt32
     : AArch64Base_CCMPIVSX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPIVSX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPIVSX_nzcvAsLabel : AArch64Base_CCMPIVSX_nzcv<OtherVT>;
 
@@ -3763,7 +3763,7 @@ class AArch64Base_CCMPLEW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPLEW_nzcvAsInt32
     : AArch64Base_CCMPLEW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPLEW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPLEW_nzcvAsLabel : AArch64Base_CCMPLEW_nzcv<OtherVT>;
 
@@ -3775,7 +3775,7 @@ class AArch64Base_CCMPLEX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPLEX_nzcvAsInt32
     : AArch64Base_CCMPLEX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPLEX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPLEX_nzcvAsLabel : AArch64Base_CCMPLEX_nzcv<OtherVT>;
 
@@ -3787,7 +3787,7 @@ class AArch64Base_CCMPLSW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPLSW_nzcvAsInt32
     : AArch64Base_CCMPLSW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPLSW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPLSW_nzcvAsLabel : AArch64Base_CCMPLSW_nzcv<OtherVT>;
 
@@ -3799,7 +3799,7 @@ class AArch64Base_CCMPLSX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPLSX_nzcvAsInt32
     : AArch64Base_CCMPLSX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPLSX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPLSX_nzcvAsLabel : AArch64Base_CCMPLSX_nzcv<OtherVT>;
 
@@ -3811,7 +3811,7 @@ class AArch64Base_CCMPLTW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPLTW_nzcvAsInt32
     : AArch64Base_CCMPLTW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPLTW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPLTW_nzcvAsLabel : AArch64Base_CCMPLTW_nzcv<OtherVT>;
 
@@ -3823,7 +3823,7 @@ class AArch64Base_CCMPLTX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPLTX_nzcvAsInt32
     : AArch64Base_CCMPLTX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPLTX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPLTX_nzcvAsLabel : AArch64Base_CCMPLTX_nzcv<OtherVT>;
 
@@ -3835,7 +3835,7 @@ class AArch64Base_CCMPMIW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPMIW_nzcvAsInt32
     : AArch64Base_CCMPMIW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPMIW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPMIW_nzcvAsLabel : AArch64Base_CCMPMIW_nzcv<OtherVT>;
 
@@ -3847,7 +3847,7 @@ class AArch64Base_CCMPMIX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPMIX_nzcvAsInt32
     : AArch64Base_CCMPMIX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPMIX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPMIX_nzcvAsLabel : AArch64Base_CCMPMIX_nzcv<OtherVT>;
 
@@ -3859,7 +3859,7 @@ class AArch64Base_CCMPNEW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPNEW_nzcvAsInt32
     : AArch64Base_CCMPNEW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPNEW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPNEW_nzcvAsLabel : AArch64Base_CCMPNEW_nzcv<OtherVT>;
 
@@ -3871,7 +3871,7 @@ class AArch64Base_CCMPNEX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPNEX_nzcvAsInt32
     : AArch64Base_CCMPNEX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPNEX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPNEX_nzcvAsLabel : AArch64Base_CCMPNEX_nzcv<OtherVT>;
 
@@ -3883,7 +3883,7 @@ class AArch64Base_CCMPNVW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPNVW_nzcvAsInt32
     : AArch64Base_CCMPNVW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPNVW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPNVW_nzcvAsLabel : AArch64Base_CCMPNVW_nzcv<OtherVT>;
 
@@ -3895,7 +3895,7 @@ class AArch64Base_CCMPNVX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPNVX_nzcvAsInt32
     : AArch64Base_CCMPNVX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPNVX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPNVX_nzcvAsLabel : AArch64Base_CCMPNVX_nzcv<OtherVT>;
 
@@ -3907,7 +3907,7 @@ class AArch64Base_CCMPPLW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPPLW_nzcvAsInt32
     : AArch64Base_CCMPPLW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPPLW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPPLW_nzcvAsLabel : AArch64Base_CCMPPLW_nzcv<OtherVT>;
 
@@ -3919,7 +3919,7 @@ class AArch64Base_CCMPPLX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPPLX_nzcvAsInt32
     : AArch64Base_CCMPPLX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPPLX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPPLX_nzcvAsLabel : AArch64Base_CCMPPLX_nzcv<OtherVT>;
 
@@ -3931,7 +3931,7 @@ class AArch64Base_CCMPVCW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPVCW_nzcvAsInt32
     : AArch64Base_CCMPVCW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPVCW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPVCW_nzcvAsLabel : AArch64Base_CCMPVCW_nzcv<OtherVT>;
 
@@ -3943,7 +3943,7 @@ class AArch64Base_CCMPVCX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPVCX_nzcvAsInt32
     : AArch64Base_CCMPVCX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPVCX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPVCX_nzcvAsLabel : AArch64Base_CCMPVCX_nzcv<OtherVT>;
 
@@ -3955,7 +3955,7 @@ class AArch64Base_CCMPVSW_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPVSW_nzcvAsInt32
     : AArch64Base_CCMPVSW_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPVSW_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPVSW_nzcvAsLabel : AArch64Base_CCMPVSW_nzcv<OtherVT>;
 
@@ -3967,7 +3967,7 @@ class AArch64Base_CCMPVSX_nzcv<ValueType ty> : Operand<ty>
 
 def AArch64Base_CCMPVSX_nzcvAsInt32
     : AArch64Base_CCMPVSX_nzcv<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_CCMPVSX_nzcv_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_CondCompareFormat_nzcv_predicate(Imm); }]>;
 
 def AArch64Base_CCMPVSX_nzcvAsLabel : AArch64Base_CCMPVSX_nzcv<OtherVT>;
 
@@ -3979,7 +3979,7 @@ class AArch64Base_EONWASR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_EONWASR_imm6AsInt32
     : AArch64Base_EONWASR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_EONWASR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_EONWASR_imm6AsLabel : AArch64Base_EONWASR_imm6<OtherVT>;
 
@@ -3991,7 +3991,7 @@ class AArch64Base_EONWLSL_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_EONWLSL_imm6AsInt32
     : AArch64Base_EONWLSL_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_EONWLSL_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_EONWLSL_imm6AsLabel : AArch64Base_EONWLSL_imm6<OtherVT>;
 
@@ -4003,7 +4003,7 @@ class AArch64Base_EONWLSR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_EONWLSR_imm6AsInt32
     : AArch64Base_EONWLSR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_EONWLSR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_EONWLSR_imm6AsLabel : AArch64Base_EONWLSR_imm6<OtherVT>;
 
@@ -4015,7 +4015,7 @@ class AArch64Base_EONWROR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_EONWROR_imm6AsInt32
     : AArch64Base_EONWROR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_EONWROR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_EONWROR_imm6AsLabel : AArch64Base_EONWROR_imm6<OtherVT>;
 
@@ -4027,7 +4027,7 @@ class AArch64Base_EONXASR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_EONXASR_imm6AsInt32
     : AArch64Base_EONXASR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_EONXASR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_EONXASR_imm6AsLabel : AArch64Base_EONXASR_imm6<OtherVT>;
 
@@ -4039,7 +4039,7 @@ class AArch64Base_EONXLSL_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_EONXLSL_imm6AsInt32
     : AArch64Base_EONXLSL_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_EONXLSL_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_EONXLSL_imm6AsLabel : AArch64Base_EONXLSL_imm6<OtherVT>;
 
@@ -4051,7 +4051,7 @@ class AArch64Base_EONXLSR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_EONXLSR_imm6AsInt32
     : AArch64Base_EONXLSR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_EONXLSR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_EONXLSR_imm6AsLabel : AArch64Base_EONXLSR_imm6<OtherVT>;
 
@@ -4063,7 +4063,7 @@ class AArch64Base_EONXROR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_EONXROR_imm6AsInt32
     : AArch64Base_EONXROR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_EONXROR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_EONXROR_imm6AsLabel : AArch64Base_EONXROR_imm6<OtherVT>;
 
@@ -4075,7 +4075,7 @@ class AArch64Base_EORIW_immWSize<ValueType ty> : Operand<ty>
 
 def AArch64Base_EORIW_immWSizeAsInt32
     : AArch64Base_EORIW_immWSize<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_EORIW_immWSize_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicImmFormat_immWSize_predicate(Imm); }]>;
 
 def AArch64Base_EORIW_immWSizeAsLabel : AArch64Base_EORIW_immWSize<OtherVT>;
 
@@ -4087,7 +4087,7 @@ class AArch64Base_EORIX_immXSize<ValueType ty> : Operand<ty>
 
 def AArch64Base_EORIX_immXSizeAsInt64
     : AArch64Base_EORIX_immXSize<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_EORIX_immXSize_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_LogicImmFormat_immXSize_predicate(Imm); }]>;
 
 def AArch64Base_EORIX_immXSizeAsLabel : AArch64Base_EORIX_immXSize<OtherVT>;
 
@@ -4099,7 +4099,7 @@ class AArch64Base_EORWASR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_EORWASR_imm6AsInt32
     : AArch64Base_EORWASR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_EORWASR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_EORWASR_imm6AsLabel : AArch64Base_EORWASR_imm6<OtherVT>;
 
@@ -4111,7 +4111,7 @@ class AArch64Base_EORWLSL_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_EORWLSL_imm6AsInt32
     : AArch64Base_EORWLSL_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_EORWLSL_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_EORWLSL_imm6AsLabel : AArch64Base_EORWLSL_imm6<OtherVT>;
 
@@ -4123,7 +4123,7 @@ class AArch64Base_EORWLSR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_EORWLSR_imm6AsInt32
     : AArch64Base_EORWLSR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_EORWLSR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_EORWLSR_imm6AsLabel : AArch64Base_EORWLSR_imm6<OtherVT>;
 
@@ -4135,7 +4135,7 @@ class AArch64Base_EORWROR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_EORWROR_imm6AsInt32
     : AArch64Base_EORWROR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_EORWROR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_EORWROR_imm6AsLabel : AArch64Base_EORWROR_imm6<OtherVT>;
 
@@ -4147,7 +4147,7 @@ class AArch64Base_EORXASR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_EORXASR_imm6AsInt32
     : AArch64Base_EORXASR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_EORXASR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_EORXASR_imm6AsLabel : AArch64Base_EORXASR_imm6<OtherVT>;
 
@@ -4159,7 +4159,7 @@ class AArch64Base_EORXLSL_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_EORXLSL_imm6AsInt32
     : AArch64Base_EORXLSL_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_EORXLSL_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_EORXLSL_imm6AsLabel : AArch64Base_EORXLSL_imm6<OtherVT>;
 
@@ -4171,7 +4171,7 @@ class AArch64Base_EORXLSR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_EORXLSR_imm6AsInt32
     : AArch64Base_EORXLSR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_EORXLSR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_EORXLSR_imm6AsLabel : AArch64Base_EORXLSR_imm6<OtherVT>;
 
@@ -4183,7 +4183,7 @@ class AArch64Base_EORXROR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_EORXROR_imm6AsInt32
     : AArch64Base_EORXROR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_EORXROR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_EORXROR_imm6AsLabel : AArch64Base_EORXROR_imm6<OtherVT>;
 
@@ -4195,7 +4195,7 @@ class AArch64Base_EXTRW_shiftWSize<ValueType ty> : Operand<ty>
 
 def AArch64Base_EXTRW_shiftWSizeAsInt32
     : AArch64Base_EXTRW_shiftWSize<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_EXTRW_shiftWSize_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_ExtractRegFormat_shiftWSize_predicate(Imm); }]>;
 
 def AArch64Base_EXTRW_shiftWSizeAsLabel : AArch64Base_EXTRW_shiftWSize<OtherVT>;
 
@@ -4207,7 +4207,7 @@ class AArch64Base_EXTRX_shiftXSize<ValueType ty> : Operand<ty>
 
 def AArch64Base_EXTRX_shiftXSizeAsInt32
     : AArch64Base_EXTRX_shiftXSize<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_EXTRX_shiftXSize_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_ExtractRegFormat_shiftXSize_predicate(Imm); }]>;
 
 def AArch64Base_EXTRX_shiftXSizeAsLabel : AArch64Base_EXTRX_shiftXSize<OtherVT>;
 
@@ -4219,7 +4219,7 @@ class AArch64Base_HLT_imm16<ValueType ty> : Operand<ty>
 
 def AArch64Base_HLT_imm16AsInt32
     : AArch64Base_HLT_imm16<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_HLT_imm16_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_SuperVisorCallFormat_imm16_predicate(Imm); }]>;
 
 def AArch64Base_HLT_imm16AsLabel : AArch64Base_HLT_imm16<OtherVT>;
 
@@ -4231,7 +4231,7 @@ class AArch64Base_LDPS_offWSize<ValueType ty> : Operand<ty>
 
 def AArch64Base_LDPS_offWSizeAsInt64
     : AArch64Base_LDPS_offWSize<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_LDPS_offWSize_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryPairFormat_offWSize_predicate(Imm); }]>;
 
 def AArch64Base_LDPS_offWSizeAsLabel : AArch64Base_LDPS_offWSize<OtherVT>;
 
@@ -4243,7 +4243,7 @@ class AArch64Base_LDPSPre_offWSize<ValueType ty> : Operand<ty>
 
 def AArch64Base_LDPSPre_offWSizeAsInt64
     : AArch64Base_LDPSPre_offWSize<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_LDPSPre_offWSize_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryPairFormat_offWSize_predicate(Imm); }]>;
 
 def AArch64Base_LDPSPre_offWSizeAsLabel : AArch64Base_LDPSPre_offWSize<OtherVT>;
 
@@ -4255,7 +4255,7 @@ class AArch64Base_LDPSPst_offWSize<ValueType ty> : Operand<ty>
 
 def AArch64Base_LDPSPst_offWSizeAsInt64
     : AArch64Base_LDPSPst_offWSize<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_LDPSPst_offWSize_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryPairFormat_offWSize_predicate(Imm); }]>;
 
 def AArch64Base_LDPSPst_offWSizeAsLabel : AArch64Base_LDPSPst_offWSize<OtherVT>;
 
@@ -4267,7 +4267,7 @@ class AArch64Base_LDPW_offWSize<ValueType ty> : Operand<ty>
 
 def AArch64Base_LDPW_offWSizeAsInt64
     : AArch64Base_LDPW_offWSize<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_LDPW_offWSize_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryPairFormat_offWSize_predicate(Imm); }]>;
 
 def AArch64Base_LDPW_offWSizeAsLabel : AArch64Base_LDPW_offWSize<OtherVT>;
 
@@ -4279,7 +4279,7 @@ class AArch64Base_LDPWPre_offWSize<ValueType ty> : Operand<ty>
 
 def AArch64Base_LDPWPre_offWSizeAsInt64
     : AArch64Base_LDPWPre_offWSize<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_LDPWPre_offWSize_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryPairFormat_offWSize_predicate(Imm); }]>;
 
 def AArch64Base_LDPWPre_offWSizeAsLabel : AArch64Base_LDPWPre_offWSize<OtherVT>;
 
@@ -4291,7 +4291,7 @@ class AArch64Base_LDPWPst_offWSize<ValueType ty> : Operand<ty>
 
 def AArch64Base_LDPWPst_offWSizeAsInt64
     : AArch64Base_LDPWPst_offWSize<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_LDPWPst_offWSize_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryPairFormat_offWSize_predicate(Imm); }]>;
 
 def AArch64Base_LDPWPst_offWSizeAsLabel : AArch64Base_LDPWPst_offWSize<OtherVT>;
 
@@ -4303,7 +4303,7 @@ class AArch64Base_LDPX_offXSize<ValueType ty> : Operand<ty>
 
 def AArch64Base_LDPX_offXSizeAsInt64
     : AArch64Base_LDPX_offXSize<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_LDPX_offXSize_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryPairFormat_offXSize_predicate(Imm); }]>;
 
 def AArch64Base_LDPX_offXSizeAsLabel : AArch64Base_LDPX_offXSize<OtherVT>;
 
@@ -4315,7 +4315,7 @@ class AArch64Base_LDPXPre_offXSize<ValueType ty> : Operand<ty>
 
 def AArch64Base_LDPXPre_offXSizeAsInt64
     : AArch64Base_LDPXPre_offXSize<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_LDPXPre_offXSize_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryPairFormat_offXSize_predicate(Imm); }]>;
 
 def AArch64Base_LDPXPre_offXSizeAsLabel : AArch64Base_LDPXPre_offXSize<OtherVT>;
 
@@ -4327,7 +4327,7 @@ class AArch64Base_LDPXPst_offXSize<ValueType ty> : Operand<ty>
 
 def AArch64Base_LDPXPst_offXSizeAsInt64
     : AArch64Base_LDPXPst_offXSize<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_LDPXPst_offXSize_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryPairFormat_offXSize_predicate(Imm); }]>;
 
 def AArch64Base_LDPXPst_offXSizeAsLabel : AArch64Base_LDPXPst_offXSize<OtherVT>;
 
@@ -4339,7 +4339,7 @@ class AArch64Base_LDRB_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_LDRB_offsetAsInt64
     : AArch64Base_LDRB_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_LDRB_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryOffFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_LDRB_offsetAsLabel : AArch64Base_LDRB_offset<OtherVT>;
 
@@ -4351,7 +4351,7 @@ class AArch64Base_LDRH_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_LDRH_offsetAsInt64
     : AArch64Base_LDRH_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_LDRH_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryOffFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_LDRH_offsetAsLabel : AArch64Base_LDRH_offset<OtherVT>;
 
@@ -4363,7 +4363,7 @@ class AArch64Base_LDRLitSWX_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_LDRLitSWX_offsetAsInt64
     : AArch64Base_LDRLitSWX_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_LDRLitSWX_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryLitFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_LDRLitSWX_offsetAsLabel : AArch64Base_LDRLitSWX_offset<OtherVT>;
 
@@ -4375,7 +4375,7 @@ class AArch64Base_LDRLitW_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_LDRLitW_offsetAsInt64
     : AArch64Base_LDRLitW_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_LDRLitW_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryLitFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_LDRLitW_offsetAsLabel : AArch64Base_LDRLitW_offset<OtherVT>;
 
@@ -4387,7 +4387,7 @@ class AArch64Base_LDRLitX_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_LDRLitX_offsetAsInt64
     : AArch64Base_LDRLitX_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_LDRLitX_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryLitFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_LDRLitX_offsetAsLabel : AArch64Base_LDRLitX_offset<OtherVT>;
 
@@ -4399,7 +4399,7 @@ class AArch64Base_LDRPreB_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_LDRPreB_offsetAsInt64
     : AArch64Base_LDRPreB_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_LDRPreB_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryImmFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_LDRPreB_offsetAsLabel : AArch64Base_LDRPreB_offset<OtherVT>;
 
@@ -4411,7 +4411,7 @@ class AArch64Base_LDRPreH_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_LDRPreH_offsetAsInt64
     : AArch64Base_LDRPreH_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_LDRPreH_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryImmFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_LDRPreH_offsetAsLabel : AArch64Base_LDRPreH_offset<OtherVT>;
 
@@ -4423,7 +4423,7 @@ class AArch64Base_LDRPreSBW_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_LDRPreSBW_offsetAsInt64
     : AArch64Base_LDRPreSBW_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_LDRPreSBW_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryImmFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_LDRPreSBW_offsetAsLabel : AArch64Base_LDRPreSBW_offset<OtherVT>;
 
@@ -4435,7 +4435,7 @@ class AArch64Base_LDRPreSBX_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_LDRPreSBX_offsetAsInt64
     : AArch64Base_LDRPreSBX_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_LDRPreSBX_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryImmFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_LDRPreSBX_offsetAsLabel : AArch64Base_LDRPreSBX_offset<OtherVT>;
 
@@ -4447,7 +4447,7 @@ class AArch64Base_LDRPreSHW_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_LDRPreSHW_offsetAsInt64
     : AArch64Base_LDRPreSHW_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_LDRPreSHW_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryImmFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_LDRPreSHW_offsetAsLabel : AArch64Base_LDRPreSHW_offset<OtherVT>;
 
@@ -4459,7 +4459,7 @@ class AArch64Base_LDRPreSHX_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_LDRPreSHX_offsetAsInt64
     : AArch64Base_LDRPreSHX_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_LDRPreSHX_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryImmFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_LDRPreSHX_offsetAsLabel : AArch64Base_LDRPreSHX_offset<OtherVT>;
 
@@ -4471,7 +4471,7 @@ class AArch64Base_LDRPreSWX_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_LDRPreSWX_offsetAsInt64
     : AArch64Base_LDRPreSWX_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_LDRPreSWX_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryImmFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_LDRPreSWX_offsetAsLabel : AArch64Base_LDRPreSWX_offset<OtherVT>;
 
@@ -4483,7 +4483,7 @@ class AArch64Base_LDRPreW_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_LDRPreW_offsetAsInt64
     : AArch64Base_LDRPreW_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_LDRPreW_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryImmFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_LDRPreW_offsetAsLabel : AArch64Base_LDRPreW_offset<OtherVT>;
 
@@ -4495,7 +4495,7 @@ class AArch64Base_LDRPreX_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_LDRPreX_offsetAsInt64
     : AArch64Base_LDRPreX_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_LDRPreX_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryImmFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_LDRPreX_offsetAsLabel : AArch64Base_LDRPreX_offset<OtherVT>;
 
@@ -4507,7 +4507,7 @@ class AArch64Base_LDRPstB_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_LDRPstB_offsetAsInt64
     : AArch64Base_LDRPstB_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_LDRPstB_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryImmFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_LDRPstB_offsetAsLabel : AArch64Base_LDRPstB_offset<OtherVT>;
 
@@ -4519,7 +4519,7 @@ class AArch64Base_LDRPstH_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_LDRPstH_offsetAsInt64
     : AArch64Base_LDRPstH_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_LDRPstH_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryImmFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_LDRPstH_offsetAsLabel : AArch64Base_LDRPstH_offset<OtherVT>;
 
@@ -4531,7 +4531,7 @@ class AArch64Base_LDRPstSBW_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_LDRPstSBW_offsetAsInt64
     : AArch64Base_LDRPstSBW_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_LDRPstSBW_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryImmFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_LDRPstSBW_offsetAsLabel : AArch64Base_LDRPstSBW_offset<OtherVT>;
 
@@ -4543,7 +4543,7 @@ class AArch64Base_LDRPstSBX_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_LDRPstSBX_offsetAsInt64
     : AArch64Base_LDRPstSBX_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_LDRPstSBX_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryImmFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_LDRPstSBX_offsetAsLabel : AArch64Base_LDRPstSBX_offset<OtherVT>;
 
@@ -4555,7 +4555,7 @@ class AArch64Base_LDRPstSHW_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_LDRPstSHW_offsetAsInt64
     : AArch64Base_LDRPstSHW_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_LDRPstSHW_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryImmFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_LDRPstSHW_offsetAsLabel : AArch64Base_LDRPstSHW_offset<OtherVT>;
 
@@ -4567,7 +4567,7 @@ class AArch64Base_LDRPstSHX_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_LDRPstSHX_offsetAsInt64
     : AArch64Base_LDRPstSHX_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_LDRPstSHX_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryImmFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_LDRPstSHX_offsetAsLabel : AArch64Base_LDRPstSHX_offset<OtherVT>;
 
@@ -4579,7 +4579,7 @@ class AArch64Base_LDRPstSWX_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_LDRPstSWX_offsetAsInt64
     : AArch64Base_LDRPstSWX_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_LDRPstSWX_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryImmFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_LDRPstSWX_offsetAsLabel : AArch64Base_LDRPstSWX_offset<OtherVT>;
 
@@ -4591,7 +4591,7 @@ class AArch64Base_LDRPstW_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_LDRPstW_offsetAsInt64
     : AArch64Base_LDRPstW_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_LDRPstW_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryImmFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_LDRPstW_offsetAsLabel : AArch64Base_LDRPstW_offset<OtherVT>;
 
@@ -4603,7 +4603,7 @@ class AArch64Base_LDRPstX_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_LDRPstX_offsetAsInt64
     : AArch64Base_LDRPstX_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_LDRPstX_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryImmFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_LDRPstX_offsetAsLabel : AArch64Base_LDRPstX_offset<OtherVT>;
 
@@ -4615,7 +4615,7 @@ class AArch64Base_LDRSBW_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_LDRSBW_offsetAsInt64
     : AArch64Base_LDRSBW_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_LDRSBW_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryOffFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_LDRSBW_offsetAsLabel : AArch64Base_LDRSBW_offset<OtherVT>;
 
@@ -4627,7 +4627,7 @@ class AArch64Base_LDRSBX_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_LDRSBX_offsetAsInt64
     : AArch64Base_LDRSBX_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_LDRSBX_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryOffFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_LDRSBX_offsetAsLabel : AArch64Base_LDRSBX_offset<OtherVT>;
 
@@ -4639,7 +4639,7 @@ class AArch64Base_LDRSHW_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_LDRSHW_offsetAsInt64
     : AArch64Base_LDRSHW_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_LDRSHW_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryOffFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_LDRSHW_offsetAsLabel : AArch64Base_LDRSHW_offset<OtherVT>;
 
@@ -4651,7 +4651,7 @@ class AArch64Base_LDRSHX_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_LDRSHX_offsetAsInt64
     : AArch64Base_LDRSHX_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_LDRSHX_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryOffFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_LDRSHX_offsetAsLabel : AArch64Base_LDRSHX_offset<OtherVT>;
 
@@ -4663,7 +4663,7 @@ class AArch64Base_LDRSWX_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_LDRSWX_offsetAsInt64
     : AArch64Base_LDRSWX_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_LDRSWX_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryOffFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_LDRSWX_offsetAsLabel : AArch64Base_LDRSWX_offset<OtherVT>;
 
@@ -4675,7 +4675,7 @@ class AArch64Base_LDRW_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_LDRW_offsetAsInt64
     : AArch64Base_LDRW_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_LDRW_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryOffFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_LDRW_offsetAsLabel : AArch64Base_LDRW_offset<OtherVT>;
 
@@ -4687,7 +4687,7 @@ class AArch64Base_LDRX_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_LDRX_offsetAsInt64
     : AArch64Base_LDRX_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_LDRX_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryOffFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_LDRX_offsetAsLabel : AArch64Base_LDRX_offset<OtherVT>;
 
@@ -4699,7 +4699,7 @@ class AArch64Base_LDURB_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_LDURB_offsetAsInt64
     : AArch64Base_LDURB_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_LDURB_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryImmFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_LDURB_offsetAsLabel : AArch64Base_LDURB_offset<OtherVT>;
 
@@ -4711,7 +4711,7 @@ class AArch64Base_LDURH_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_LDURH_offsetAsInt64
     : AArch64Base_LDURH_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_LDURH_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryImmFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_LDURH_offsetAsLabel : AArch64Base_LDURH_offset<OtherVT>;
 
@@ -4723,7 +4723,7 @@ class AArch64Base_LDURSBW_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_LDURSBW_offsetAsInt64
     : AArch64Base_LDURSBW_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_LDURSBW_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryImmFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_LDURSBW_offsetAsLabel : AArch64Base_LDURSBW_offset<OtherVT>;
 
@@ -4735,7 +4735,7 @@ class AArch64Base_LDURSBX_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_LDURSBX_offsetAsInt64
     : AArch64Base_LDURSBX_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_LDURSBX_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryImmFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_LDURSBX_offsetAsLabel : AArch64Base_LDURSBX_offset<OtherVT>;
 
@@ -4747,7 +4747,7 @@ class AArch64Base_LDURSHW_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_LDURSHW_offsetAsInt64
     : AArch64Base_LDURSHW_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_LDURSHW_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryImmFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_LDURSHW_offsetAsLabel : AArch64Base_LDURSHW_offset<OtherVT>;
 
@@ -4759,7 +4759,7 @@ class AArch64Base_LDURSHX_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_LDURSHX_offsetAsInt64
     : AArch64Base_LDURSHX_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_LDURSHX_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryImmFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_LDURSHX_offsetAsLabel : AArch64Base_LDURSHX_offset<OtherVT>;
 
@@ -4771,7 +4771,7 @@ class AArch64Base_LDURSWX_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_LDURSWX_offsetAsInt64
     : AArch64Base_LDURSWX_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_LDURSWX_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryImmFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_LDURSWX_offsetAsLabel : AArch64Base_LDURSWX_offset<OtherVT>;
 
@@ -4783,7 +4783,7 @@ class AArch64Base_LDURW_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_LDURW_offsetAsInt64
     : AArch64Base_LDURW_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_LDURW_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryImmFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_LDURW_offsetAsLabel : AArch64Base_LDURW_offset<OtherVT>;
 
@@ -4795,7 +4795,7 @@ class AArch64Base_LDURX_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_LDURX_offsetAsInt64
     : AArch64Base_LDURX_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_LDURX_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryImmFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_LDURX_offsetAsLabel : AArch64Base_LDURX_offset<OtherVT>;
 
@@ -4807,7 +4807,7 @@ class AArch64Base_MOVKWPos00_imm16<ValueType ty> : Operand<ty>
 
 def AArch64Base_MOVKWPos00_imm16AsInt32
     : AArch64Base_MOVKWPos00_imm16<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_MOVKWPos00_imm16_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_MovFormat_imm16_predicate(Imm); }]>;
 
 def AArch64Base_MOVKWPos00_imm16AsLabel : AArch64Base_MOVKWPos00_imm16<OtherVT>;
 
@@ -4819,7 +4819,7 @@ class AArch64Base_MOVKWPos16_imm16<ValueType ty> : Operand<ty>
 
 def AArch64Base_MOVKWPos16_imm16AsInt32
     : AArch64Base_MOVKWPos16_imm16<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_MOVKWPos16_imm16_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_MovFormat_imm16_predicate(Imm); }]>;
 
 def AArch64Base_MOVKWPos16_imm16AsLabel : AArch64Base_MOVKWPos16_imm16<OtherVT>;
 
@@ -4831,7 +4831,7 @@ class AArch64Base_MOVKXPos00_imm16<ValueType ty> : Operand<ty>
 
 def AArch64Base_MOVKXPos00_imm16AsInt32
     : AArch64Base_MOVKXPos00_imm16<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_MOVKXPos00_imm16_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_MovFormat_imm16_predicate(Imm); }]>;
 
 def AArch64Base_MOVKXPos00_imm16AsLabel : AArch64Base_MOVKXPos00_imm16<OtherVT>;
 
@@ -4843,7 +4843,7 @@ class AArch64Base_MOVKXPos16_imm16<ValueType ty> : Operand<ty>
 
 def AArch64Base_MOVKXPos16_imm16AsInt32
     : AArch64Base_MOVKXPos16_imm16<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_MOVKXPos16_imm16_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_MovFormat_imm16_predicate(Imm); }]>;
 
 def AArch64Base_MOVKXPos16_imm16AsLabel : AArch64Base_MOVKXPos16_imm16<OtherVT>;
 
@@ -4855,7 +4855,7 @@ class AArch64Base_MOVKXPos32_imm16<ValueType ty> : Operand<ty>
 
 def AArch64Base_MOVKXPos32_imm16AsInt32
     : AArch64Base_MOVKXPos32_imm16<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_MOVKXPos32_imm16_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_MovFormat_imm16_predicate(Imm); }]>;
 
 def AArch64Base_MOVKXPos32_imm16AsLabel : AArch64Base_MOVKXPos32_imm16<OtherVT>;
 
@@ -4867,7 +4867,7 @@ class AArch64Base_MOVKXPos48_imm16<ValueType ty> : Operand<ty>
 
 def AArch64Base_MOVKXPos48_imm16AsInt32
     : AArch64Base_MOVKXPos48_imm16<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_MOVKXPos48_imm16_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_MovFormat_imm16_predicate(Imm); }]>;
 
 def AArch64Base_MOVKXPos48_imm16AsLabel : AArch64Base_MOVKXPos48_imm16<OtherVT>;
 
@@ -4879,7 +4879,7 @@ class AArch64Base_MOVNWPos00_imm16<ValueType ty> : Operand<ty>
 
 def AArch64Base_MOVNWPos00_imm16AsInt32
     : AArch64Base_MOVNWPos00_imm16<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_MOVNWPos00_imm16_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_MovFormat_imm16_predicate(Imm); }]>;
 
 def AArch64Base_MOVNWPos00_imm16AsLabel : AArch64Base_MOVNWPos00_imm16<OtherVT>;
 
@@ -4891,7 +4891,7 @@ class AArch64Base_MOVNWPos16_imm16<ValueType ty> : Operand<ty>
 
 def AArch64Base_MOVNWPos16_imm16AsInt32
     : AArch64Base_MOVNWPos16_imm16<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_MOVNWPos16_imm16_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_MovFormat_imm16_predicate(Imm); }]>;
 
 def AArch64Base_MOVNWPos16_imm16AsLabel : AArch64Base_MOVNWPos16_imm16<OtherVT>;
 
@@ -4903,7 +4903,7 @@ class AArch64Base_MOVNXPos00_imm16<ValueType ty> : Operand<ty>
 
 def AArch64Base_MOVNXPos00_imm16AsInt32
     : AArch64Base_MOVNXPos00_imm16<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_MOVNXPos00_imm16_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_MovFormat_imm16_predicate(Imm); }]>;
 
 def AArch64Base_MOVNXPos00_imm16AsLabel : AArch64Base_MOVNXPos00_imm16<OtherVT>;
 
@@ -4915,7 +4915,7 @@ class AArch64Base_MOVNXPos16_imm16<ValueType ty> : Operand<ty>
 
 def AArch64Base_MOVNXPos16_imm16AsInt32
     : AArch64Base_MOVNXPos16_imm16<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_MOVNXPos16_imm16_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_MovFormat_imm16_predicate(Imm); }]>;
 
 def AArch64Base_MOVNXPos16_imm16AsLabel : AArch64Base_MOVNXPos16_imm16<OtherVT>;
 
@@ -4927,7 +4927,7 @@ class AArch64Base_MOVNXPos32_imm16<ValueType ty> : Operand<ty>
 
 def AArch64Base_MOVNXPos32_imm16AsInt32
     : AArch64Base_MOVNXPos32_imm16<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_MOVNXPos32_imm16_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_MovFormat_imm16_predicate(Imm); }]>;
 
 def AArch64Base_MOVNXPos32_imm16AsLabel : AArch64Base_MOVNXPos32_imm16<OtherVT>;
 
@@ -4939,7 +4939,7 @@ class AArch64Base_MOVNXPos48_imm16<ValueType ty> : Operand<ty>
 
 def AArch64Base_MOVNXPos48_imm16AsInt32
     : AArch64Base_MOVNXPos48_imm16<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_MOVNXPos48_imm16_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_MovFormat_imm16_predicate(Imm); }]>;
 
 def AArch64Base_MOVNXPos48_imm16AsLabel : AArch64Base_MOVNXPos48_imm16<OtherVT>;
 
@@ -4951,7 +4951,7 @@ class AArch64Base_MOVZWPos00_imm16<ValueType ty> : Operand<ty>
 
 def AArch64Base_MOVZWPos00_imm16AsInt32
     : AArch64Base_MOVZWPos00_imm16<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_MOVZWPos00_imm16_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_MovFormat_imm16_predicate(Imm); }]>;
 
 def AArch64Base_MOVZWPos00_imm16AsLabel : AArch64Base_MOVZWPos00_imm16<OtherVT>;
 
@@ -4963,7 +4963,7 @@ class AArch64Base_MOVZWPos16_imm16<ValueType ty> : Operand<ty>
 
 def AArch64Base_MOVZWPos16_imm16AsInt32
     : AArch64Base_MOVZWPos16_imm16<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_MOVZWPos16_imm16_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_MovFormat_imm16_predicate(Imm); }]>;
 
 def AArch64Base_MOVZWPos16_imm16AsLabel : AArch64Base_MOVZWPos16_imm16<OtherVT>;
 
@@ -4975,7 +4975,7 @@ class AArch64Base_MOVZXPos00_imm16<ValueType ty> : Operand<ty>
 
 def AArch64Base_MOVZXPos00_imm16AsInt32
     : AArch64Base_MOVZXPos00_imm16<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_MOVZXPos00_imm16_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_MovFormat_imm16_predicate(Imm); }]>;
 
 def AArch64Base_MOVZXPos00_imm16AsLabel : AArch64Base_MOVZXPos00_imm16<OtherVT>;
 
@@ -4987,7 +4987,7 @@ class AArch64Base_MOVZXPos16_imm16<ValueType ty> : Operand<ty>
 
 def AArch64Base_MOVZXPos16_imm16AsInt32
     : AArch64Base_MOVZXPos16_imm16<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_MOVZXPos16_imm16_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_MovFormat_imm16_predicate(Imm); }]>;
 
 def AArch64Base_MOVZXPos16_imm16AsLabel : AArch64Base_MOVZXPos16_imm16<OtherVT>;
 
@@ -4999,7 +4999,7 @@ class AArch64Base_MOVZXPos32_imm16<ValueType ty> : Operand<ty>
 
 def AArch64Base_MOVZXPos32_imm16AsInt32
     : AArch64Base_MOVZXPos32_imm16<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_MOVZXPos32_imm16_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_MovFormat_imm16_predicate(Imm); }]>;
 
 def AArch64Base_MOVZXPos32_imm16AsLabel : AArch64Base_MOVZXPos32_imm16<OtherVT>;
 
@@ -5011,7 +5011,7 @@ class AArch64Base_MOVZXPos48_imm16<ValueType ty> : Operand<ty>
 
 def AArch64Base_MOVZXPos48_imm16AsInt32
     : AArch64Base_MOVZXPos48_imm16<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_MOVZXPos48_imm16_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_MovFormat_imm16_predicate(Imm); }]>;
 
 def AArch64Base_MOVZXPos48_imm16AsLabel : AArch64Base_MOVZXPos48_imm16<OtherVT>;
 
@@ -5023,7 +5023,7 @@ class AArch64Base_MRS_sysreg<ValueType ty> : Operand<ty>
 
 def AArch64Base_MRS_sysregAsInt32
     : AArch64Base_MRS_sysreg<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_MRS_sysreg_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_MoveSystemRegFormat_sysreg_predicate(Imm); }]>;
 
 def AArch64Base_MRS_sysregAsLabel : AArch64Base_MRS_sysreg<OtherVT>;
 
@@ -5035,7 +5035,7 @@ class AArch64Base_MSR_sysreg<ValueType ty> : Operand<ty>
 
 def AArch64Base_MSR_sysregAsInt32
     : AArch64Base_MSR_sysreg<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_MSR_sysreg_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_MoveSystemRegFormat_sysreg_predicate(Imm); }]>;
 
 def AArch64Base_MSR_sysregAsLabel : AArch64Base_MSR_sysreg<OtherVT>;
 
@@ -5047,7 +5047,7 @@ class AArch64Base_ORNWASR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_ORNWASR_imm6AsInt32
     : AArch64Base_ORNWASR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ORNWASR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_ORNWASR_imm6AsLabel : AArch64Base_ORNWASR_imm6<OtherVT>;
 
@@ -5059,7 +5059,7 @@ class AArch64Base_ORNWLSL_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_ORNWLSL_imm6AsInt32
     : AArch64Base_ORNWLSL_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ORNWLSL_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_ORNWLSL_imm6AsLabel : AArch64Base_ORNWLSL_imm6<OtherVT>;
 
@@ -5071,7 +5071,7 @@ class AArch64Base_ORNWLSR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_ORNWLSR_imm6AsInt32
     : AArch64Base_ORNWLSR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ORNWLSR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_ORNWLSR_imm6AsLabel : AArch64Base_ORNWLSR_imm6<OtherVT>;
 
@@ -5083,7 +5083,7 @@ class AArch64Base_ORNWROR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_ORNWROR_imm6AsInt32
     : AArch64Base_ORNWROR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ORNWROR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_ORNWROR_imm6AsLabel : AArch64Base_ORNWROR_imm6<OtherVT>;
 
@@ -5095,7 +5095,7 @@ class AArch64Base_ORNXASR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_ORNXASR_imm6AsInt32
     : AArch64Base_ORNXASR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ORNXASR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_ORNXASR_imm6AsLabel : AArch64Base_ORNXASR_imm6<OtherVT>;
 
@@ -5107,7 +5107,7 @@ class AArch64Base_ORNXLSL_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_ORNXLSL_imm6AsInt32
     : AArch64Base_ORNXLSL_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ORNXLSL_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_ORNXLSL_imm6AsLabel : AArch64Base_ORNXLSL_imm6<OtherVT>;
 
@@ -5119,7 +5119,7 @@ class AArch64Base_ORNXLSR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_ORNXLSR_imm6AsInt32
     : AArch64Base_ORNXLSR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ORNXLSR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_ORNXLSR_imm6AsLabel : AArch64Base_ORNXLSR_imm6<OtherVT>;
 
@@ -5131,7 +5131,7 @@ class AArch64Base_ORNXROR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_ORNXROR_imm6AsInt32
     : AArch64Base_ORNXROR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ORNXROR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_ORNXROR_imm6AsLabel : AArch64Base_ORNXROR_imm6<OtherVT>;
 
@@ -5143,7 +5143,7 @@ class AArch64Base_ORRIW_immWSize<ValueType ty> : Operand<ty>
 
 def AArch64Base_ORRIW_immWSizeAsInt32
     : AArch64Base_ORRIW_immWSize<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ORRIW_immWSize_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicImmFormat_immWSize_predicate(Imm); }]>;
 
 def AArch64Base_ORRIW_immWSizeAsLabel : AArch64Base_ORRIW_immWSize<OtherVT>;
 
@@ -5155,7 +5155,7 @@ class AArch64Base_ORRIX_immXSize<ValueType ty> : Operand<ty>
 
 def AArch64Base_ORRIX_immXSizeAsInt64
     : AArch64Base_ORRIX_immXSize<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_ORRIX_immXSize_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_LogicImmFormat_immXSize_predicate(Imm); }]>;
 
 def AArch64Base_ORRIX_immXSizeAsLabel : AArch64Base_ORRIX_immXSize<OtherVT>;
 
@@ -5167,7 +5167,7 @@ class AArch64Base_ORRWASR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_ORRWASR_imm6AsInt32
     : AArch64Base_ORRWASR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ORRWASR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_ORRWASR_imm6AsLabel : AArch64Base_ORRWASR_imm6<OtherVT>;
 
@@ -5179,7 +5179,7 @@ class AArch64Base_ORRWLSL_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_ORRWLSL_imm6AsInt32
     : AArch64Base_ORRWLSL_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ORRWLSL_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_ORRWLSL_imm6AsLabel : AArch64Base_ORRWLSL_imm6<OtherVT>;
 
@@ -5191,7 +5191,7 @@ class AArch64Base_ORRWLSR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_ORRWLSR_imm6AsInt32
     : AArch64Base_ORRWLSR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ORRWLSR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_ORRWLSR_imm6AsLabel : AArch64Base_ORRWLSR_imm6<OtherVT>;
 
@@ -5203,7 +5203,7 @@ class AArch64Base_ORRWROR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_ORRWROR_imm6AsInt32
     : AArch64Base_ORRWROR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ORRWROR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_ORRWROR_imm6AsLabel : AArch64Base_ORRWROR_imm6<OtherVT>;
 
@@ -5215,7 +5215,7 @@ class AArch64Base_ORRXASR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_ORRXASR_imm6AsInt32
     : AArch64Base_ORRXASR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ORRXASR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_ORRXASR_imm6AsLabel : AArch64Base_ORRXASR_imm6<OtherVT>;
 
@@ -5227,7 +5227,7 @@ class AArch64Base_ORRXLSL_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_ORRXLSL_imm6AsInt32
     : AArch64Base_ORRXLSL_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ORRXLSL_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_ORRXLSL_imm6AsLabel : AArch64Base_ORRXLSL_imm6<OtherVT>;
 
@@ -5239,7 +5239,7 @@ class AArch64Base_ORRXLSR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_ORRXLSR_imm6AsInt32
     : AArch64Base_ORRXLSR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ORRXLSR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_ORRXLSR_imm6AsLabel : AArch64Base_ORRXLSR_imm6<OtherVT>;
 
@@ -5251,7 +5251,7 @@ class AArch64Base_ORRXROR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_ORRXROR_imm6AsInt32
     : AArch64Base_ORRXROR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_ORRXROR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_LogicRegShiftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_ORRXROR_imm6AsLabel : AArch64Base_ORRXROR_imm6<OtherVT>;
 
@@ -5263,7 +5263,7 @@ class AArch64Base_SBFMW_leftWSize<ValueType ty> : Operand<ty>
 
 def AArch64Base_SBFMW_leftWSizeAsInt32
     : AArch64Base_SBFMW_leftWSize<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_SBFMW_leftWSize_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_BitFieldMoveFormat_leftWSize_predicate(Imm); }]>;
 
 def AArch64Base_SBFMW_leftWSizeAsLabel : AArch64Base_SBFMW_leftWSize<OtherVT>;
 
@@ -5275,7 +5275,7 @@ class AArch64Base_SBFMW_rightWSize<ValueType ty> : Operand<ty>
 
 def AArch64Base_SBFMW_rightWSizeAsInt32
     : AArch64Base_SBFMW_rightWSize<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_SBFMW_rightWSize_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_BitFieldMoveFormat_rightWSize_predicate(Imm); }]>;
 
 def AArch64Base_SBFMW_rightWSizeAsLabel : AArch64Base_SBFMW_rightWSize<OtherVT>;
 
@@ -5287,7 +5287,7 @@ class AArch64Base_SBFMX_leftXSize<ValueType ty> : Operand<ty>
 
 def AArch64Base_SBFMX_leftXSizeAsInt32
     : AArch64Base_SBFMX_leftXSize<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_SBFMX_leftXSize_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_BitFieldMoveFormat_leftXSize_predicate(Imm); }]>;
 
 def AArch64Base_SBFMX_leftXSizeAsLabel : AArch64Base_SBFMX_leftXSize<OtherVT>;
 
@@ -5299,7 +5299,7 @@ class AArch64Base_SBFMX_rightXSize<ValueType ty> : Operand<ty>
 
 def AArch64Base_SBFMX_rightXSizeAsInt32
     : AArch64Base_SBFMX_rightXSize<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_SBFMX_rightXSize_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_BitFieldMoveFormat_rightXSize_predicate(Imm); }]>;
 
 def AArch64Base_SBFMX_rightXSizeAsLabel : AArch64Base_SBFMX_rightXSize<OtherVT>;
 
@@ -5311,7 +5311,7 @@ class AArch64Base_STPW_offWSize<ValueType ty> : Operand<ty>
 
 def AArch64Base_STPW_offWSizeAsInt64
     : AArch64Base_STPW_offWSize<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_STPW_offWSize_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryPairFormat_offWSize_predicate(Imm); }]>;
 
 def AArch64Base_STPW_offWSizeAsLabel : AArch64Base_STPW_offWSize<OtherVT>;
 
@@ -5323,7 +5323,7 @@ class AArch64Base_STPWPre_offWSize<ValueType ty> : Operand<ty>
 
 def AArch64Base_STPWPre_offWSizeAsInt64
     : AArch64Base_STPWPre_offWSize<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_STPWPre_offWSize_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryPairFormat_offWSize_predicate(Imm); }]>;
 
 def AArch64Base_STPWPre_offWSizeAsLabel : AArch64Base_STPWPre_offWSize<OtherVT>;
 
@@ -5335,7 +5335,7 @@ class AArch64Base_STPWPst_offWSize<ValueType ty> : Operand<ty>
 
 def AArch64Base_STPWPst_offWSizeAsInt64
     : AArch64Base_STPWPst_offWSize<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_STPWPst_offWSize_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryPairFormat_offWSize_predicate(Imm); }]>;
 
 def AArch64Base_STPWPst_offWSizeAsLabel : AArch64Base_STPWPst_offWSize<OtherVT>;
 
@@ -5347,7 +5347,7 @@ class AArch64Base_STPX_offXSize<ValueType ty> : Operand<ty>
 
 def AArch64Base_STPX_offXSizeAsInt64
     : AArch64Base_STPX_offXSize<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_STPX_offXSize_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryPairFormat_offXSize_predicate(Imm); }]>;
 
 def AArch64Base_STPX_offXSizeAsLabel : AArch64Base_STPX_offXSize<OtherVT>;
 
@@ -5359,7 +5359,7 @@ class AArch64Base_STPXPre_offXSize<ValueType ty> : Operand<ty>
 
 def AArch64Base_STPXPre_offXSizeAsInt64
     : AArch64Base_STPXPre_offXSize<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_STPXPre_offXSize_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryPairFormat_offXSize_predicate(Imm); }]>;
 
 def AArch64Base_STPXPre_offXSizeAsLabel : AArch64Base_STPXPre_offXSize<OtherVT>;
 
@@ -5371,7 +5371,7 @@ class AArch64Base_STPXPst_offXSize<ValueType ty> : Operand<ty>
 
 def AArch64Base_STPXPst_offXSizeAsInt64
     : AArch64Base_STPXPst_offXSize<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_STPXPst_offXSize_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryPairFormat_offXSize_predicate(Imm); }]>;
 
 def AArch64Base_STPXPst_offXSizeAsLabel : AArch64Base_STPXPst_offXSize<OtherVT>;
 
@@ -5383,7 +5383,7 @@ class AArch64Base_STRB_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_STRB_offsetAsInt64
     : AArch64Base_STRB_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_STRB_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryOffFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_STRB_offsetAsLabel : AArch64Base_STRB_offset<OtherVT>;
 
@@ -5395,7 +5395,7 @@ class AArch64Base_STRH_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_STRH_offsetAsInt64
     : AArch64Base_STRH_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_STRH_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryOffFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_STRH_offsetAsLabel : AArch64Base_STRH_offset<OtherVT>;
 
@@ -5407,7 +5407,7 @@ class AArch64Base_STRPreB_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_STRPreB_offsetAsInt64
     : AArch64Base_STRPreB_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_STRPreB_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryImmFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_STRPreB_offsetAsLabel : AArch64Base_STRPreB_offset<OtherVT>;
 
@@ -5419,7 +5419,7 @@ class AArch64Base_STRPreH_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_STRPreH_offsetAsInt64
     : AArch64Base_STRPreH_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_STRPreH_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryImmFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_STRPreH_offsetAsLabel : AArch64Base_STRPreH_offset<OtherVT>;
 
@@ -5431,7 +5431,7 @@ class AArch64Base_STRPreW_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_STRPreW_offsetAsInt64
     : AArch64Base_STRPreW_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_STRPreW_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryImmFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_STRPreW_offsetAsLabel : AArch64Base_STRPreW_offset<OtherVT>;
 
@@ -5443,7 +5443,7 @@ class AArch64Base_STRPreX_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_STRPreX_offsetAsInt64
     : AArch64Base_STRPreX_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_STRPreX_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryImmFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_STRPreX_offsetAsLabel : AArch64Base_STRPreX_offset<OtherVT>;
 
@@ -5455,7 +5455,7 @@ class AArch64Base_STRPstB_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_STRPstB_offsetAsInt64
     : AArch64Base_STRPstB_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_STRPstB_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryImmFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_STRPstB_offsetAsLabel : AArch64Base_STRPstB_offset<OtherVT>;
 
@@ -5467,7 +5467,7 @@ class AArch64Base_STRPstH_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_STRPstH_offsetAsInt64
     : AArch64Base_STRPstH_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_STRPstH_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryImmFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_STRPstH_offsetAsLabel : AArch64Base_STRPstH_offset<OtherVT>;
 
@@ -5479,7 +5479,7 @@ class AArch64Base_STRPstW_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_STRPstW_offsetAsInt64
     : AArch64Base_STRPstW_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_STRPstW_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryImmFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_STRPstW_offsetAsLabel : AArch64Base_STRPstW_offset<OtherVT>;
 
@@ -5491,7 +5491,7 @@ class AArch64Base_STRPstX_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_STRPstX_offsetAsInt64
     : AArch64Base_STRPstX_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_STRPstX_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryImmFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_STRPstX_offsetAsLabel : AArch64Base_STRPstX_offset<OtherVT>;
 
@@ -5503,7 +5503,7 @@ class AArch64Base_STRW_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_STRW_offsetAsInt64
     : AArch64Base_STRW_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_STRW_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryOffFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_STRW_offsetAsLabel : AArch64Base_STRW_offset<OtherVT>;
 
@@ -5515,7 +5515,7 @@ class AArch64Base_STRX_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_STRX_offsetAsInt64
     : AArch64Base_STRX_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_STRX_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryOffFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_STRX_offsetAsLabel : AArch64Base_STRX_offset<OtherVT>;
 
@@ -5527,7 +5527,7 @@ class AArch64Base_STURB_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_STURB_offsetAsInt64
     : AArch64Base_STURB_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_STURB_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryImmFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_STURB_offsetAsLabel : AArch64Base_STURB_offset<OtherVT>;
 
@@ -5539,7 +5539,7 @@ class AArch64Base_STURH_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_STURH_offsetAsInt64
     : AArch64Base_STURH_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_STURH_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryImmFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_STURH_offsetAsLabel : AArch64Base_STURH_offset<OtherVT>;
 
@@ -5551,7 +5551,7 @@ class AArch64Base_STURW_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_STURW_offsetAsInt64
     : AArch64Base_STURW_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_STURW_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryImmFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_STURW_offsetAsLabel : AArch64Base_STURW_offset<OtherVT>;
 
@@ -5563,7 +5563,7 @@ class AArch64Base_STURX_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_STURX_offsetAsInt64
     : AArch64Base_STURX_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_STURX_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_MemoryImmFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_STURX_offsetAsLabel : AArch64Base_STURX_offset<OtherVT>;
 
@@ -5575,7 +5575,7 @@ class AArch64Base_SUBWASR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_SUBWASR_imm6AsInt32
     : AArch64Base_SUBWASR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_SUBWASR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubSftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_SUBWASR_imm6AsLabel : AArch64Base_SUBWASR_imm6<OtherVT>;
 
@@ -5587,7 +5587,7 @@ class AArch64Base_SUBWI_imm12X<ValueType ty> : Operand<ty>
 
 def AArch64Base_SUBWI_imm12XAsInt64
     : AArch64Base_SUBWI_imm12X<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_SUBWI_imm12X_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_AddSubImmFormat_imm12X_predicate(Imm); }]>;
 
 def AArch64Base_SUBWI_imm12XAsLabel : AArch64Base_SUBWI_imm12X<OtherVT>;
 
@@ -5599,7 +5599,7 @@ class AArch64Base_SUBWI12_imm12S<ValueType ty> : Operand<ty>
 
 def AArch64Base_SUBWI12_imm12SAsInt64
     : AArch64Base_SUBWI12_imm12S<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_SUBWI12_imm12S_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_AddSubImmFormat_imm12S_predicate(Imm); }]>;
 
 def AArch64Base_SUBWI12_imm12SAsLabel : AArch64Base_SUBWI12_imm12S<OtherVT>;
 
@@ -5611,7 +5611,7 @@ class AArch64Base_SUBWLSL_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_SUBWLSL_imm6AsInt32
     : AArch64Base_SUBWLSL_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_SUBWLSL_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubSftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_SUBWLSL_imm6AsLabel : AArch64Base_SUBWLSL_imm6<OtherVT>;
 
@@ -5623,7 +5623,7 @@ class AArch64Base_SUBWLSR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_SUBWLSR_imm6AsInt32
     : AArch64Base_SUBWLSR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_SUBWLSR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubSftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_SUBWLSR_imm6AsLabel : AArch64Base_SUBWLSR_imm6<OtherVT>;
 
@@ -5635,7 +5635,7 @@ class AArch64Base_SUBWSASR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_SUBWSASR_imm6AsInt32
     : AArch64Base_SUBWSASR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_SUBWSASR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubSftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_SUBWSASR_imm6AsLabel : AArch64Base_SUBWSASR_imm6<OtherVT>;
 
@@ -5647,7 +5647,7 @@ class AArch64Base_SUBWSI_imm12X<ValueType ty> : Operand<ty>
 
 def AArch64Base_SUBWSI_imm12XAsInt64
     : AArch64Base_SUBWSI_imm12X<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_SUBWSI_imm12X_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_AddSubImmFormat_imm12X_predicate(Imm); }]>;
 
 def AArch64Base_SUBWSI_imm12XAsLabel : AArch64Base_SUBWSI_imm12X<OtherVT>;
 
@@ -5659,7 +5659,7 @@ class AArch64Base_SUBWSI12_imm12S<ValueType ty> : Operand<ty>
 
 def AArch64Base_SUBWSI12_imm12SAsInt64
     : AArch64Base_SUBWSI12_imm12S<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_SUBWSI12_imm12S_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_AddSubImmFormat_imm12S_predicate(Imm); }]>;
 
 def AArch64Base_SUBWSI12_imm12SAsLabel : AArch64Base_SUBWSI12_imm12S<OtherVT>;
 
@@ -5671,7 +5671,7 @@ class AArch64Base_SUBWSLSL_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_SUBWSLSL_imm6AsInt32
     : AArch64Base_SUBWSLSL_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_SUBWSLSL_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubSftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_SUBWSLSL_imm6AsLabel : AArch64Base_SUBWSLSL_imm6<OtherVT>;
 
@@ -5683,7 +5683,7 @@ class AArch64Base_SUBWSLSR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_SUBWSLSR_imm6AsInt32
     : AArch64Base_SUBWSLSR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_SUBWSLSR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubSftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_SUBWSLSR_imm6AsLabel : AArch64Base_SUBWSLSR_imm6<OtherVT>;
 
@@ -5695,7 +5695,7 @@ class AArch64Base_SUBWSSXSB_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_SUBWSSXSB_imm3AsInt32
     : AArch64Base_SUBWSSXSB_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_SUBWSSXSB_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_SUBWSSXSB_imm3AsLabel : AArch64Base_SUBWSSXSB_imm3<OtherVT>;
 
@@ -5707,7 +5707,7 @@ class AArch64Base_SUBWSSXSH_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_SUBWSSXSH_imm3AsInt32
     : AArch64Base_SUBWSSXSH_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_SUBWSSXSH_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_SUBWSSXSH_imm3AsLabel : AArch64Base_SUBWSSXSH_imm3<OtherVT>;
 
@@ -5719,7 +5719,7 @@ class AArch64Base_SUBWSSXSW_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_SUBWSSXSW_imm3AsInt32
     : AArch64Base_SUBWSSXSW_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_SUBWSSXSW_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_SUBWSSXSW_imm3AsLabel : AArch64Base_SUBWSSXSW_imm3<OtherVT>;
 
@@ -5731,7 +5731,7 @@ class AArch64Base_SUBWSSXSX_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_SUBWSSXSX_imm3AsInt32
     : AArch64Base_SUBWSSXSX_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_SUBWSSXSX_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_SUBWSSXSX_imm3AsLabel : AArch64Base_SUBWSSXSX_imm3<OtherVT>;
 
@@ -5743,7 +5743,7 @@ class AArch64Base_SUBWSUXSB_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_SUBWSUXSB_imm3AsInt32
     : AArch64Base_SUBWSUXSB_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_SUBWSUXSB_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_SUBWSUXSB_imm3AsLabel : AArch64Base_SUBWSUXSB_imm3<OtherVT>;
 
@@ -5755,7 +5755,7 @@ class AArch64Base_SUBWSUXSH_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_SUBWSUXSH_imm3AsInt32
     : AArch64Base_SUBWSUXSH_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_SUBWSUXSH_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_SUBWSUXSH_imm3AsLabel : AArch64Base_SUBWSUXSH_imm3<OtherVT>;
 
@@ -5767,7 +5767,7 @@ class AArch64Base_SUBWSUXSW_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_SUBWSUXSW_imm3AsInt32
     : AArch64Base_SUBWSUXSW_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_SUBWSUXSW_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_SUBWSUXSW_imm3AsLabel : AArch64Base_SUBWSUXSW_imm3<OtherVT>;
 
@@ -5779,7 +5779,7 @@ class AArch64Base_SUBWSUXSX_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_SUBWSUXSX_imm3AsInt32
     : AArch64Base_SUBWSUXSX_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_SUBWSUXSX_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_SUBWSUXSX_imm3AsLabel : AArch64Base_SUBWSUXSX_imm3<OtherVT>;
 
@@ -5791,7 +5791,7 @@ class AArch64Base_SUBWSXSB_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_SUBWSXSB_imm3AsInt32
     : AArch64Base_SUBWSXSB_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_SUBWSXSB_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_SUBWSXSB_imm3AsLabel : AArch64Base_SUBWSXSB_imm3<OtherVT>;
 
@@ -5803,7 +5803,7 @@ class AArch64Base_SUBWSXSH_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_SUBWSXSH_imm3AsInt32
     : AArch64Base_SUBWSXSH_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_SUBWSXSH_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_SUBWSXSH_imm3AsLabel : AArch64Base_SUBWSXSH_imm3<OtherVT>;
 
@@ -5815,7 +5815,7 @@ class AArch64Base_SUBWSXSW_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_SUBWSXSW_imm3AsInt32
     : AArch64Base_SUBWSXSW_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_SUBWSXSW_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_SUBWSXSW_imm3AsLabel : AArch64Base_SUBWSXSW_imm3<OtherVT>;
 
@@ -5827,7 +5827,7 @@ class AArch64Base_SUBWSXSX_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_SUBWSXSX_imm3AsInt32
     : AArch64Base_SUBWSXSX_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_SUBWSXSX_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_SUBWSXSX_imm3AsLabel : AArch64Base_SUBWSXSX_imm3<OtherVT>;
 
@@ -5839,7 +5839,7 @@ class AArch64Base_SUBWUXSB_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_SUBWUXSB_imm3AsInt32
     : AArch64Base_SUBWUXSB_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_SUBWUXSB_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_SUBWUXSB_imm3AsLabel : AArch64Base_SUBWUXSB_imm3<OtherVT>;
 
@@ -5851,7 +5851,7 @@ class AArch64Base_SUBWUXSH_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_SUBWUXSH_imm3AsInt32
     : AArch64Base_SUBWUXSH_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_SUBWUXSH_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_SUBWUXSH_imm3AsLabel : AArch64Base_SUBWUXSH_imm3<OtherVT>;
 
@@ -5863,7 +5863,7 @@ class AArch64Base_SUBWUXSW_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_SUBWUXSW_imm3AsInt32
     : AArch64Base_SUBWUXSW_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_SUBWUXSW_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_SUBWUXSW_imm3AsLabel : AArch64Base_SUBWUXSW_imm3<OtherVT>;
 
@@ -5875,7 +5875,7 @@ class AArch64Base_SUBWUXSX_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_SUBWUXSX_imm3AsInt32
     : AArch64Base_SUBWUXSX_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_SUBWUXSX_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_SUBWUXSX_imm3AsLabel : AArch64Base_SUBWUXSX_imm3<OtherVT>;
 
@@ -5887,7 +5887,7 @@ class AArch64Base_SUBXASR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_SUBXASR_imm6AsInt32
     : AArch64Base_SUBXASR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_SUBXASR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubSftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_SUBXASR_imm6AsLabel : AArch64Base_SUBXASR_imm6<OtherVT>;
 
@@ -5899,7 +5899,7 @@ class AArch64Base_SUBXI_imm12X<ValueType ty> : Operand<ty>
 
 def AArch64Base_SUBXI_imm12XAsInt64
     : AArch64Base_SUBXI_imm12X<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_SUBXI_imm12X_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_AddSubImmFormat_imm12X_predicate(Imm); }]>;
 
 def AArch64Base_SUBXI_imm12XAsLabel : AArch64Base_SUBXI_imm12X<OtherVT>;
 
@@ -5911,7 +5911,7 @@ class AArch64Base_SUBXI12_imm12S<ValueType ty> : Operand<ty>
 
 def AArch64Base_SUBXI12_imm12SAsInt64
     : AArch64Base_SUBXI12_imm12S<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_SUBXI12_imm12S_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_AddSubImmFormat_imm12S_predicate(Imm); }]>;
 
 def AArch64Base_SUBXI12_imm12SAsLabel : AArch64Base_SUBXI12_imm12S<OtherVT>;
 
@@ -5923,7 +5923,7 @@ class AArch64Base_SUBXLSL_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_SUBXLSL_imm6AsInt32
     : AArch64Base_SUBXLSL_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_SUBXLSL_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubSftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_SUBXLSL_imm6AsLabel : AArch64Base_SUBXLSL_imm6<OtherVT>;
 
@@ -5935,7 +5935,7 @@ class AArch64Base_SUBXLSR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_SUBXLSR_imm6AsInt32
     : AArch64Base_SUBXLSR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_SUBXLSR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubSftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_SUBXLSR_imm6AsLabel : AArch64Base_SUBXLSR_imm6<OtherVT>;
 
@@ -5947,7 +5947,7 @@ class AArch64Base_SUBXSASR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_SUBXSASR_imm6AsInt32
     : AArch64Base_SUBXSASR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_SUBXSASR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubSftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_SUBXSASR_imm6AsLabel : AArch64Base_SUBXSASR_imm6<OtherVT>;
 
@@ -5959,7 +5959,7 @@ class AArch64Base_SUBXSI_imm12X<ValueType ty> : Operand<ty>
 
 def AArch64Base_SUBXSI_imm12XAsInt64
     : AArch64Base_SUBXSI_imm12X<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_SUBXSI_imm12X_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_AddSubImmFormat_imm12X_predicate(Imm); }]>;
 
 def AArch64Base_SUBXSI_imm12XAsLabel : AArch64Base_SUBXSI_imm12X<OtherVT>;
 
@@ -5971,7 +5971,7 @@ class AArch64Base_SUBXSI12_imm12S<ValueType ty> : Operand<ty>
 
 def AArch64Base_SUBXSI12_imm12SAsInt64
     : AArch64Base_SUBXSI12_imm12S<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_SUBXSI12_imm12S_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_AddSubImmFormat_imm12S_predicate(Imm); }]>;
 
 def AArch64Base_SUBXSI12_imm12SAsLabel : AArch64Base_SUBXSI12_imm12S<OtherVT>;
 
@@ -5983,7 +5983,7 @@ class AArch64Base_SUBXSLSL_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_SUBXSLSL_imm6AsInt32
     : AArch64Base_SUBXSLSL_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_SUBXSLSL_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubSftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_SUBXSLSL_imm6AsLabel : AArch64Base_SUBXSLSL_imm6<OtherVT>;
 
@@ -5995,7 +5995,7 @@ class AArch64Base_SUBXSLSR_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_SUBXSLSR_imm6AsInt32
     : AArch64Base_SUBXSLSR_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_SUBXSLSR_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubSftFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_SUBXSLSR_imm6AsLabel : AArch64Base_SUBXSLSR_imm6<OtherVT>;
 
@@ -6007,7 +6007,7 @@ class AArch64Base_SUBXSSXSB_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_SUBXSSXSB_imm3AsInt32
     : AArch64Base_SUBXSSXSB_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_SUBXSSXSB_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_SUBXSSXSB_imm3AsLabel : AArch64Base_SUBXSSXSB_imm3<OtherVT>;
 
@@ -6019,7 +6019,7 @@ class AArch64Base_SUBXSSXSH_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_SUBXSSXSH_imm3AsInt32
     : AArch64Base_SUBXSSXSH_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_SUBXSSXSH_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_SUBXSSXSH_imm3AsLabel : AArch64Base_SUBXSSXSH_imm3<OtherVT>;
 
@@ -6031,7 +6031,7 @@ class AArch64Base_SUBXSSXSW_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_SUBXSSXSW_imm3AsInt32
     : AArch64Base_SUBXSSXSW_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_SUBXSSXSW_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_SUBXSSXSW_imm3AsLabel : AArch64Base_SUBXSSXSW_imm3<OtherVT>;
 
@@ -6043,7 +6043,7 @@ class AArch64Base_SUBXSSXSX_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_SUBXSSXSX_imm3AsInt32
     : AArch64Base_SUBXSSXSX_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_SUBXSSXSX_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_SUBXSSXSX_imm3AsLabel : AArch64Base_SUBXSSXSX_imm3<OtherVT>;
 
@@ -6055,7 +6055,7 @@ class AArch64Base_SUBXSUXSB_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_SUBXSUXSB_imm3AsInt32
     : AArch64Base_SUBXSUXSB_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_SUBXSUXSB_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_SUBXSUXSB_imm3AsLabel : AArch64Base_SUBXSUXSB_imm3<OtherVT>;
 
@@ -6067,7 +6067,7 @@ class AArch64Base_SUBXSUXSH_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_SUBXSUXSH_imm3AsInt32
     : AArch64Base_SUBXSUXSH_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_SUBXSUXSH_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_SUBXSUXSH_imm3AsLabel : AArch64Base_SUBXSUXSH_imm3<OtherVT>;
 
@@ -6079,7 +6079,7 @@ class AArch64Base_SUBXSUXSW_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_SUBXSUXSW_imm3AsInt32
     : AArch64Base_SUBXSUXSW_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_SUBXSUXSW_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_SUBXSUXSW_imm3AsLabel : AArch64Base_SUBXSUXSW_imm3<OtherVT>;
 
@@ -6091,7 +6091,7 @@ class AArch64Base_SUBXSUXSX_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_SUBXSUXSX_imm3AsInt32
     : AArch64Base_SUBXSUXSX_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_SUBXSUXSX_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_SUBXSUXSX_imm3AsLabel : AArch64Base_SUBXSUXSX_imm3<OtherVT>;
 
@@ -6103,7 +6103,7 @@ class AArch64Base_SUBXSXSB_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_SUBXSXSB_imm3AsInt32
     : AArch64Base_SUBXSXSB_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_SUBXSXSB_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_SUBXSXSB_imm3AsLabel : AArch64Base_SUBXSXSB_imm3<OtherVT>;
 
@@ -6115,7 +6115,7 @@ class AArch64Base_SUBXSXSH_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_SUBXSXSH_imm3AsInt32
     : AArch64Base_SUBXSXSH_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_SUBXSXSH_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_SUBXSXSH_imm3AsLabel : AArch64Base_SUBXSXSH_imm3<OtherVT>;
 
@@ -6127,7 +6127,7 @@ class AArch64Base_SUBXSXSW_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_SUBXSXSW_imm3AsInt32
     : AArch64Base_SUBXSXSW_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_SUBXSXSW_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_SUBXSXSW_imm3AsLabel : AArch64Base_SUBXSXSW_imm3<OtherVT>;
 
@@ -6139,7 +6139,7 @@ class AArch64Base_SUBXSXSX_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_SUBXSXSX_imm3AsInt32
     : AArch64Base_SUBXSXSX_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_SUBXSXSX_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_SUBXSXSX_imm3AsLabel : AArch64Base_SUBXSXSX_imm3<OtherVT>;
 
@@ -6151,7 +6151,7 @@ class AArch64Base_SUBXUXSB_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_SUBXUXSB_imm3AsInt32
     : AArch64Base_SUBXUXSB_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_SUBXUXSB_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_SUBXUXSB_imm3AsLabel : AArch64Base_SUBXUXSB_imm3<OtherVT>;
 
@@ -6163,7 +6163,7 @@ class AArch64Base_SUBXUXSH_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_SUBXUXSH_imm3AsInt32
     : AArch64Base_SUBXUXSH_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_SUBXUXSH_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_SUBXUXSH_imm3AsLabel : AArch64Base_SUBXUXSH_imm3<OtherVT>;
 
@@ -6175,7 +6175,7 @@ class AArch64Base_SUBXUXSW_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_SUBXUXSW_imm3AsInt32
     : AArch64Base_SUBXUXSW_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_SUBXUXSW_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_SUBXUXSW_imm3AsLabel : AArch64Base_SUBXUXSW_imm3<OtherVT>;
 
@@ -6187,7 +6187,7 @@ class AArch64Base_SUBXUXSX_imm3<ValueType ty> : Operand<ty>
 
 def AArch64Base_SUBXUXSX_imm3AsInt32
     : AArch64Base_SUBXUXSX_imm3<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_SUBXUXSX_imm3_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_AddSubExtFormat_imm3_predicate(Imm); }]>;
 
 def AArch64Base_SUBXUXSX_imm3AsLabel : AArch64Base_SUBXUXSX_imm3<OtherVT>;
 
@@ -6199,7 +6199,7 @@ class AArch64Base_SVC_imm16<ValueType ty> : Operand<ty>
 
 def AArch64Base_SVC_imm16AsInt32
     : AArch64Base_SVC_imm16<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_SVC_imm16_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_SuperVisorCallFormat_imm16_predicate(Imm); }]>;
 
 def AArch64Base_SVC_imm16AsLabel : AArch64Base_SVC_imm16<OtherVT>;
 
@@ -6211,7 +6211,7 @@ class AArch64Base_TBNZ_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_TBNZ_offsetAsInt64
     : AArch64Base_TBNZ_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_TBNZ_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_TestBitBranchFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_TBNZ_offsetAsLabel : AArch64Base_TBNZ_offset<OtherVT>;
 
@@ -6223,7 +6223,7 @@ class AArch64Base_TBNZ_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_TBNZ_imm6AsInt32
     : AArch64Base_TBNZ_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_TBNZ_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_TestBitBranchFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_TBNZ_imm6AsLabel : AArch64Base_TBNZ_imm6<OtherVT>;
 
@@ -6235,7 +6235,7 @@ class AArch64Base_TBZ_offset<ValueType ty> : Operand<ty>
 
 def AArch64Base_TBZ_offsetAsInt64
     : AArch64Base_TBZ_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Base_TBZ_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_TestBitBranchFormat_offset_predicate(Imm); }]>;
 
 def AArch64Base_TBZ_offsetAsLabel : AArch64Base_TBZ_offset<OtherVT>;
 
@@ -6247,7 +6247,7 @@ class AArch64Base_TBZ_imm6<ValueType ty> : Operand<ty>
 
 def AArch64Base_TBZ_imm6AsInt32
     : AArch64Base_TBZ_imm6<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_TBZ_imm6_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_TestBitBranchFormat_imm6_predicate(Imm); }]>;
 
 def AArch64Base_TBZ_imm6AsLabel : AArch64Base_TBZ_imm6<OtherVT>;
 
@@ -6259,7 +6259,7 @@ class AArch64Base_UBFMW_leftWSize<ValueType ty> : Operand<ty>
 
 def AArch64Base_UBFMW_leftWSizeAsInt32
     : AArch64Base_UBFMW_leftWSize<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_UBFMW_leftWSize_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_BitFieldMoveFormat_leftWSize_predicate(Imm); }]>;
 
 def AArch64Base_UBFMW_leftWSizeAsLabel : AArch64Base_UBFMW_leftWSize<OtherVT>;
 
@@ -6271,7 +6271,7 @@ class AArch64Base_UBFMW_rightWSize<ValueType ty> : Operand<ty>
 
 def AArch64Base_UBFMW_rightWSizeAsInt32
     : AArch64Base_UBFMW_rightWSize<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_UBFMW_rightWSize_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_BitFieldMoveFormat_rightWSize_predicate(Imm); }]>;
 
 def AArch64Base_UBFMW_rightWSizeAsLabel : AArch64Base_UBFMW_rightWSize<OtherVT>;
 
@@ -6283,7 +6283,7 @@ class AArch64Base_UBFMX_leftXSize<ValueType ty> : Operand<ty>
 
 def AArch64Base_UBFMX_leftXSizeAsInt32
     : AArch64Base_UBFMX_leftXSize<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_UBFMX_leftXSize_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_BitFieldMoveFormat_leftXSize_predicate(Imm); }]>;
 
 def AArch64Base_UBFMX_leftXSizeAsLabel : AArch64Base_UBFMX_leftXSize<OtherVT>;
 
@@ -6295,7 +6295,7 @@ class AArch64Base_UBFMX_rightXSize<ValueType ty> : Operand<ty>
 
 def AArch64Base_UBFMX_rightXSizeAsInt32
     : AArch64Base_UBFMX_rightXSize<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_UBFMX_rightXSize_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_BitFieldMoveFormat_rightXSize_predicate(Imm); }]>;
 
 def AArch64Base_UBFMX_rightXSizeAsLabel : AArch64Base_UBFMX_rightXSize<OtherVT>;
 
@@ -6307,7 +6307,7 @@ class AArch64Base_UDF_imm16<ValueType ty> : Operand<ty>
 
 def AArch64Base_UDF_imm16AsInt32
     : AArch64Base_UDF_imm16<i32>
-    , ImmLeaf<i32, [{ return AArch64Base_UDF_imm16_predicate(Imm); }]>;
+    , ImmLeaf<i32, [{ return AArch64Base_UndefinedInstrFormat_imm16_predicate(Imm); }]>;
 
 def AArch64Base_UDF_imm16AsLabel : AArch64Base_UDF_imm16<OtherVT>;
 
@@ -6319,7 +6319,7 @@ class AArch64Temp_PLDR_offset<ValueType ty> : Operand<ty>
 
 def AArch64Temp_PLDR_offsetAsInt64
     : AArch64Temp_PLDR_offset<i64>
-    , ImmLeaf<i64, [{ return AArch64Temp_PLDR_offset_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_RelAddressFormat_offset_predicate(Imm); }]>;
 
 def AArch64Temp_PLDR_offsetAsLabel : AArch64Temp_PLDR_offset<OtherVT>;
 
@@ -6331,7 +6331,7 @@ class AArch64Temp_PLDR_imm12X<ValueType ty> : Operand<ty>
 
 def AArch64Temp_PLDR_imm12XAsInt64
     : AArch64Temp_PLDR_imm12X<i64>
-    , ImmLeaf<i64, [{ return AArch64Temp_PLDR_imm12X_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return AArch64Base_AddSubImmFormat_imm12X_predicate(Imm); }]>;
 
 def AArch64Temp_PLDR_imm12XAsLabel : AArch64Temp_PLDR_imm12X<OtherVT>;
 

--- a/vadl/test/resources/snapshots/aarch64/RegisterInfo.cpp
+++ b/vadl/test/resources/snapshots/aarch64/RegisterInfo.cpp
@@ -80,7 +80,7 @@ int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 // try to inline the offset into the instruction
 //
 
-if(Offset >= 0 && Offset <= 4096 && AArch64Base_ADDXI_imm12X_predicate(Offset))
+if(Offset >= 0 && Offset <= 4096 && AArch64Base_AddSubImmFormat_imm12X_predicate(Offset))
 {
 // immediate can be encoded and instruction can be inlined.
 FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
@@ -132,7 +132,7 @@ int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 // try to inline the offset into the instruction
 //
 
-if(Offset >= 0 && Offset <= 4096 && AArch64Base_LDRB_offset_predicate(Offset))
+if(Offset >= 0 && Offset <= 4096 && AArch64Base_MemoryOffFormat_offset_predicate(Offset))
 {
 // immediate can be encoded and instruction can be inlined.
 FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
@@ -184,7 +184,7 @@ int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 // try to inline the offset into the instruction
 //
 
-if(Offset >= 0 && Offset <= 4096 && AArch64Base_LDRH_offset_predicate(Offset))
+if(Offset >= 0 && Offset <= 4096 && AArch64Base_MemoryOffFormat_offset_predicate(Offset))
 {
 // immediate can be encoded and instruction can be inlined.
 FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
@@ -236,7 +236,7 @@ int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 // try to inline the offset into the instruction
 //
 
-if(Offset >= 0 && Offset <= 4096 && AArch64Base_LDRSBW_offset_predicate(Offset))
+if(Offset >= 0 && Offset <= 4096 && AArch64Base_MemoryOffFormat_offset_predicate(Offset))
 {
 // immediate can be encoded and instruction can be inlined.
 FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
@@ -288,7 +288,7 @@ int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 // try to inline the offset into the instruction
 //
 
-if(Offset >= 0 && Offset <= 4096 && AArch64Base_LDRSBX_offset_predicate(Offset))
+if(Offset >= 0 && Offset <= 4096 && AArch64Base_MemoryOffFormat_offset_predicate(Offset))
 {
 // immediate can be encoded and instruction can be inlined.
 FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
@@ -340,7 +340,7 @@ int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 // try to inline the offset into the instruction
 //
 
-if(Offset >= 0 && Offset <= 4096 && AArch64Base_LDRSHW_offset_predicate(Offset))
+if(Offset >= 0 && Offset <= 4096 && AArch64Base_MemoryOffFormat_offset_predicate(Offset))
 {
 // immediate can be encoded and instruction can be inlined.
 FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
@@ -392,7 +392,7 @@ int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 // try to inline the offset into the instruction
 //
 
-if(Offset >= 0 && Offset <= 4096 && AArch64Base_LDRSHX_offset_predicate(Offset))
+if(Offset >= 0 && Offset <= 4096 && AArch64Base_MemoryOffFormat_offset_predicate(Offset))
 {
 // immediate can be encoded and instruction can be inlined.
 FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
@@ -444,7 +444,7 @@ int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 // try to inline the offset into the instruction
 //
 
-if(Offset >= 0 && Offset <= 4096 && AArch64Base_LDRSWX_offset_predicate(Offset))
+if(Offset >= 0 && Offset <= 4096 && AArch64Base_MemoryOffFormat_offset_predicate(Offset))
 {
 // immediate can be encoded and instruction can be inlined.
 FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
@@ -496,7 +496,7 @@ int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 // try to inline the offset into the instruction
 //
 
-if(Offset >= 0 && Offset <= 4096 && AArch64Base_LDRW_offset_predicate(Offset))
+if(Offset >= 0 && Offset <= 4096 && AArch64Base_MemoryOffFormat_offset_predicate(Offset))
 {
 // immediate can be encoded and instruction can be inlined.
 FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
@@ -548,7 +548,7 @@ int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 // try to inline the offset into the instruction
 //
 
-if(Offset >= 0 && Offset <= 4096 && AArch64Base_LDRX_offset_predicate(Offset))
+if(Offset >= 0 && Offset <= 4096 && AArch64Base_MemoryOffFormat_offset_predicate(Offset))
 {
 // immediate can be encoded and instruction can be inlined.
 FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
@@ -600,7 +600,7 @@ int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 // try to inline the offset into the instruction
 //
 
-if(Offset >= -256 && Offset <= 255 && AArch64Base_LDURB_offset_predicate(Offset))
+if(Offset >= -256 && Offset <= 255 && AArch64Base_MemoryImmFormat_offset_predicate(Offset))
 {
 // immediate can be encoded and instruction can be inlined.
 FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
@@ -652,7 +652,7 @@ int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 // try to inline the offset into the instruction
 //
 
-if(Offset >= -256 && Offset <= 255 && AArch64Base_LDURH_offset_predicate(Offset))
+if(Offset >= -256 && Offset <= 255 && AArch64Base_MemoryImmFormat_offset_predicate(Offset))
 {
 // immediate can be encoded and instruction can be inlined.
 FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
@@ -704,7 +704,7 @@ int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 // try to inline the offset into the instruction
 //
 
-if(Offset >= -256 && Offset <= 255 && AArch64Base_LDURSBW_offset_predicate(Offset))
+if(Offset >= -256 && Offset <= 255 && AArch64Base_MemoryImmFormat_offset_predicate(Offset))
 {
 // immediate can be encoded and instruction can be inlined.
 FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
@@ -756,7 +756,7 @@ int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 // try to inline the offset into the instruction
 //
 
-if(Offset >= -256 && Offset <= 255 && AArch64Base_LDURSBX_offset_predicate(Offset))
+if(Offset >= -256 && Offset <= 255 && AArch64Base_MemoryImmFormat_offset_predicate(Offset))
 {
 // immediate can be encoded and instruction can be inlined.
 FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
@@ -808,7 +808,7 @@ int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 // try to inline the offset into the instruction
 //
 
-if(Offset >= -256 && Offset <= 255 && AArch64Base_LDURSHW_offset_predicate(Offset))
+if(Offset >= -256 && Offset <= 255 && AArch64Base_MemoryImmFormat_offset_predicate(Offset))
 {
 // immediate can be encoded and instruction can be inlined.
 FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
@@ -860,7 +860,7 @@ int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 // try to inline the offset into the instruction
 //
 
-if(Offset >= -256 && Offset <= 255 && AArch64Base_LDURSHX_offset_predicate(Offset))
+if(Offset >= -256 && Offset <= 255 && AArch64Base_MemoryImmFormat_offset_predicate(Offset))
 {
 // immediate can be encoded and instruction can be inlined.
 FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
@@ -912,7 +912,7 @@ int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 // try to inline the offset into the instruction
 //
 
-if(Offset >= -256 && Offset <= 255 && AArch64Base_LDURSWX_offset_predicate(Offset))
+if(Offset >= -256 && Offset <= 255 && AArch64Base_MemoryImmFormat_offset_predicate(Offset))
 {
 // immediate can be encoded and instruction can be inlined.
 FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
@@ -964,7 +964,7 @@ int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 // try to inline the offset into the instruction
 //
 
-if(Offset >= -256 && Offset <= 255 && AArch64Base_LDURW_offset_predicate(Offset))
+if(Offset >= -256 && Offset <= 255 && AArch64Base_MemoryImmFormat_offset_predicate(Offset))
 {
 // immediate can be encoded and instruction can be inlined.
 FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
@@ -1016,7 +1016,7 @@ int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 // try to inline the offset into the instruction
 //
 
-if(Offset >= -256 && Offset <= 255 && AArch64Base_LDURX_offset_predicate(Offset))
+if(Offset >= -256 && Offset <= 255 && AArch64Base_MemoryImmFormat_offset_predicate(Offset))
 {
 // immediate can be encoded and instruction can be inlined.
 FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
@@ -1068,7 +1068,7 @@ int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 // try to inline the offset into the instruction
 //
 
-if(Offset >= 0 && Offset <= 4096 && AArch64Base_STRB_offset_predicate(Offset))
+if(Offset >= 0 && Offset <= 4096 && AArch64Base_MemoryOffFormat_offset_predicate(Offset))
 {
 // immediate can be encoded and instruction can be inlined.
 FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
@@ -1120,7 +1120,7 @@ int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 // try to inline the offset into the instruction
 //
 
-if(Offset >= 0 && Offset <= 4096 && AArch64Base_STRH_offset_predicate(Offset))
+if(Offset >= 0 && Offset <= 4096 && AArch64Base_MemoryOffFormat_offset_predicate(Offset))
 {
 // immediate can be encoded and instruction can be inlined.
 FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
@@ -1172,7 +1172,7 @@ int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 // try to inline the offset into the instruction
 //
 
-if(Offset >= 0 && Offset <= 4096 && AArch64Base_STRW_offset_predicate(Offset))
+if(Offset >= 0 && Offset <= 4096 && AArch64Base_MemoryOffFormat_offset_predicate(Offset))
 {
 // immediate can be encoded and instruction can be inlined.
 FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
@@ -1224,7 +1224,7 @@ int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 // try to inline the offset into the instruction
 //
 
-if(Offset >= 0 && Offset <= 4096 && AArch64Base_STRX_offset_predicate(Offset))
+if(Offset >= 0 && Offset <= 4096 && AArch64Base_MemoryOffFormat_offset_predicate(Offset))
 {
 // immediate can be encoded and instruction can be inlined.
 FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
@@ -1276,7 +1276,7 @@ int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 // try to inline the offset into the instruction
 //
 
-if(Offset >= -256 && Offset <= 255 && AArch64Base_STURB_offset_predicate(Offset))
+if(Offset >= -256 && Offset <= 255 && AArch64Base_MemoryImmFormat_offset_predicate(Offset))
 {
 // immediate can be encoded and instruction can be inlined.
 FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
@@ -1328,7 +1328,7 @@ int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 // try to inline the offset into the instruction
 //
 
-if(Offset >= -256 && Offset <= 255 && AArch64Base_STURH_offset_predicate(Offset))
+if(Offset >= -256 && Offset <= 255 && AArch64Base_MemoryImmFormat_offset_predicate(Offset))
 {
 // immediate can be encoded and instruction can be inlined.
 FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
@@ -1380,7 +1380,7 @@ int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 // try to inline the offset into the instruction
 //
 
-if(Offset >= -256 && Offset <= 255 && AArch64Base_STURW_offset_predicate(Offset))
+if(Offset >= -256 && Offset <= 255 && AArch64Base_MemoryImmFormat_offset_predicate(Offset))
 {
 // immediate can be encoded and instruction can be inlined.
 FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
@@ -1432,7 +1432,7 @@ int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 // try to inline the offset into the instruction
 //
 
-if(Offset >= -256 && Offset <= 255 && AArch64Base_STURX_offset_predicate(Offset))
+if(Offset >= -256 && Offset <= 255 && AArch64Base_MemoryImmFormat_offset_predicate(Offset))
 {
 // immediate can be encoded and instruction can be inlined.
 FIOp.ChangeToRegister( FrameReg, false /* isDef */ );

--- a/vadl/test/resources/snapshots/rv64im/InstrInfoTableGen.td
+++ b/vadl/test/resources/snapshots/rv64im/InstrInfoTableGen.td
@@ -195,7 +195,7 @@ class RV3264Base_ADDI_immS<ValueType ty> : Operand<ty>
 
 def RV3264Base_ADDI_immSAsInt64
     : RV3264Base_ADDI_immS<i64>
-    , ImmLeaf<i64, [{ return RV3264Base_ADDI_immS_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return RV3264Base_Itype_immS_predicate(Imm); }]>;
 
 def RV3264Base_ADDI_immSAsLabel : RV3264Base_ADDI_immS<OtherVT>;
 
@@ -207,7 +207,7 @@ class RV3264Base_ADDIW_immS<ValueType ty> : Operand<ty>
 
 def RV3264Base_ADDIW_immSAsInt64
     : RV3264Base_ADDIW_immS<i64>
-    , ImmLeaf<i64, [{ return RV3264Base_ADDIW_immS_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return RV3264Base_Itype_immS_predicate(Imm); }]>;
 
 def RV3264Base_ADDIW_immSAsLabel : RV3264Base_ADDIW_immS<OtherVT>;
 
@@ -219,7 +219,7 @@ class RV3264Base_ANDI_immS<ValueType ty> : Operand<ty>
 
 def RV3264Base_ANDI_immSAsInt64
     : RV3264Base_ANDI_immS<i64>
-    , ImmLeaf<i64, [{ return RV3264Base_ANDI_immS_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return RV3264Base_Itype_immS_predicate(Imm); }]>;
 
 def RV3264Base_ANDI_immSAsLabel : RV3264Base_ANDI_immS<OtherVT>;
 
@@ -231,7 +231,7 @@ class RV3264Base_AUIPC_immUp<ValueType ty> : Operand<ty>
 
 def RV3264Base_AUIPC_immUpAsInt64
     : RV3264Base_AUIPC_immUp<i64>
-    , ImmLeaf<i64, [{ return RV3264Base_AUIPC_immUp_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return RV3264Base_Utype_immUp_predicate(Imm); }]>;
 
 def RV3264Base_AUIPC_immUpAsLabel : RV3264Base_AUIPC_immUp<OtherVT>;
 
@@ -243,7 +243,7 @@ class RV3264Base_BEQ_immS<ValueType ty> : Operand<ty>
 
 def RV3264Base_BEQ_immSAsInt64
     : RV3264Base_BEQ_immS<i64>
-    , ImmLeaf<i64, [{ return RV3264Base_BEQ_immS_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return RV3264Base_Btype_immS_predicate(Imm); }]>;
 
 def RV3264Base_BEQ_immSAsLabel : RV3264Base_BEQ_immS<OtherVT>;
 
@@ -255,7 +255,7 @@ class RV3264Base_BGE_immS<ValueType ty> : Operand<ty>
 
 def RV3264Base_BGE_immSAsInt64
     : RV3264Base_BGE_immS<i64>
-    , ImmLeaf<i64, [{ return RV3264Base_BGE_immS_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return RV3264Base_Btype_immS_predicate(Imm); }]>;
 
 def RV3264Base_BGE_immSAsLabel : RV3264Base_BGE_immS<OtherVT>;
 
@@ -267,7 +267,7 @@ class RV3264Base_BGEU_immS<ValueType ty> : Operand<ty>
 
 def RV3264Base_BGEU_immSAsInt64
     : RV3264Base_BGEU_immS<i64>
-    , ImmLeaf<i64, [{ return RV3264Base_BGEU_immS_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return RV3264Base_Btype_immS_predicate(Imm); }]>;
 
 def RV3264Base_BGEU_immSAsLabel : RV3264Base_BGEU_immS<OtherVT>;
 
@@ -279,7 +279,7 @@ class RV3264Base_BLT_immS<ValueType ty> : Operand<ty>
 
 def RV3264Base_BLT_immSAsInt64
     : RV3264Base_BLT_immS<i64>
-    , ImmLeaf<i64, [{ return RV3264Base_BLT_immS_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return RV3264Base_Btype_immS_predicate(Imm); }]>;
 
 def RV3264Base_BLT_immSAsLabel : RV3264Base_BLT_immS<OtherVT>;
 
@@ -291,7 +291,7 @@ class RV3264Base_BLTU_immS<ValueType ty> : Operand<ty>
 
 def RV3264Base_BLTU_immSAsInt64
     : RV3264Base_BLTU_immS<i64>
-    , ImmLeaf<i64, [{ return RV3264Base_BLTU_immS_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return RV3264Base_Btype_immS_predicate(Imm); }]>;
 
 def RV3264Base_BLTU_immSAsLabel : RV3264Base_BLTU_immS<OtherVT>;
 
@@ -303,7 +303,7 @@ class RV3264Base_BNE_immS<ValueType ty> : Operand<ty>
 
 def RV3264Base_BNE_immSAsInt64
     : RV3264Base_BNE_immS<i64>
-    , ImmLeaf<i64, [{ return RV3264Base_BNE_immS_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return RV3264Base_Btype_immS_predicate(Imm); }]>;
 
 def RV3264Base_BNE_immSAsLabel : RV3264Base_BNE_immS<OtherVT>;
 
@@ -315,7 +315,7 @@ class RV3264Base_JAL_immS<ValueType ty> : Operand<ty>
 
 def RV3264Base_JAL_immSAsInt64
     : RV3264Base_JAL_immS<i64>
-    , ImmLeaf<i64, [{ return RV3264Base_JAL_immS_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return RV3264Base_Jtype_immS_predicate(Imm); }]>;
 
 def RV3264Base_JAL_immSAsLabel : RV3264Base_JAL_immS<OtherVT>;
 
@@ -327,7 +327,7 @@ class RV3264Base_JALR_immS<ValueType ty> : Operand<ty>
 
 def RV3264Base_JALR_immSAsInt64
     : RV3264Base_JALR_immS<i64>
-    , ImmLeaf<i64, [{ return RV3264Base_JALR_immS_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return RV3264Base_Itype_immS_predicate(Imm); }]>;
 
 def RV3264Base_JALR_immSAsLabel : RV3264Base_JALR_immS<OtherVT>;
 
@@ -339,7 +339,7 @@ class RV3264Base_LB_immS<ValueType ty> : Operand<ty>
 
 def RV3264Base_LB_immSAsInt64
     : RV3264Base_LB_immS<i64>
-    , ImmLeaf<i64, [{ return RV3264Base_LB_immS_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return RV3264Base_Itype_immS_predicate(Imm); }]>;
 
 def RV3264Base_LB_immSAsLabel : RV3264Base_LB_immS<OtherVT>;
 
@@ -351,7 +351,7 @@ class RV3264Base_LBU_immS<ValueType ty> : Operand<ty>
 
 def RV3264Base_LBU_immSAsInt64
     : RV3264Base_LBU_immS<i64>
-    , ImmLeaf<i64, [{ return RV3264Base_LBU_immS_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return RV3264Base_Itype_immS_predicate(Imm); }]>;
 
 def RV3264Base_LBU_immSAsLabel : RV3264Base_LBU_immS<OtherVT>;
 
@@ -363,7 +363,7 @@ class RV3264Base_LD_immS<ValueType ty> : Operand<ty>
 
 def RV3264Base_LD_immSAsInt64
     : RV3264Base_LD_immS<i64>
-    , ImmLeaf<i64, [{ return RV3264Base_LD_immS_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return RV3264Base_Itype_immS_predicate(Imm); }]>;
 
 def RV3264Base_LD_immSAsLabel : RV3264Base_LD_immS<OtherVT>;
 
@@ -375,7 +375,7 @@ class RV3264Base_LH_immS<ValueType ty> : Operand<ty>
 
 def RV3264Base_LH_immSAsInt64
     : RV3264Base_LH_immS<i64>
-    , ImmLeaf<i64, [{ return RV3264Base_LH_immS_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return RV3264Base_Itype_immS_predicate(Imm); }]>;
 
 def RV3264Base_LH_immSAsLabel : RV3264Base_LH_immS<OtherVT>;
 
@@ -387,7 +387,7 @@ class RV3264Base_LHU_immS<ValueType ty> : Operand<ty>
 
 def RV3264Base_LHU_immSAsInt64
     : RV3264Base_LHU_immS<i64>
-    , ImmLeaf<i64, [{ return RV3264Base_LHU_immS_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return RV3264Base_Itype_immS_predicate(Imm); }]>;
 
 def RV3264Base_LHU_immSAsLabel : RV3264Base_LHU_immS<OtherVT>;
 
@@ -399,7 +399,7 @@ class RV3264Base_LUI_immUp<ValueType ty> : Operand<ty>
 
 def RV3264Base_LUI_immUpAsInt64
     : RV3264Base_LUI_immUp<i64>
-    , ImmLeaf<i64, [{ return RV3264Base_LUI_immUp_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return RV3264Base_Utype_immUp_predicate(Imm); }]>;
 
 def RV3264Base_LUI_immUpAsLabel : RV3264Base_LUI_immUp<OtherVT>;
 
@@ -411,7 +411,7 @@ class RV3264Base_LW_immS<ValueType ty> : Operand<ty>
 
 def RV3264Base_LW_immSAsInt64
     : RV3264Base_LW_immS<i64>
-    , ImmLeaf<i64, [{ return RV3264Base_LW_immS_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return RV3264Base_Itype_immS_predicate(Imm); }]>;
 
 def RV3264Base_LW_immSAsLabel : RV3264Base_LW_immS<OtherVT>;
 
@@ -423,7 +423,7 @@ class RV3264Base_LWU_immS<ValueType ty> : Operand<ty>
 
 def RV3264Base_LWU_immSAsInt64
     : RV3264Base_LWU_immS<i64>
-    , ImmLeaf<i64, [{ return RV3264Base_LWU_immS_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return RV3264Base_Itype_immS_predicate(Imm); }]>;
 
 def RV3264Base_LWU_immSAsLabel : RV3264Base_LWU_immS<OtherVT>;
 
@@ -435,7 +435,7 @@ class RV3264Base_ORI_immS<ValueType ty> : Operand<ty>
 
 def RV3264Base_ORI_immSAsInt64
     : RV3264Base_ORI_immS<i64>
-    , ImmLeaf<i64, [{ return RV3264Base_ORI_immS_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return RV3264Base_Itype_immS_predicate(Imm); }]>;
 
 def RV3264Base_ORI_immSAsLabel : RV3264Base_ORI_immS<OtherVT>;
 
@@ -447,7 +447,7 @@ class RV3264Base_SB_immS<ValueType ty> : Operand<ty>
 
 def RV3264Base_SB_immSAsInt64
     : RV3264Base_SB_immS<i64>
-    , ImmLeaf<i64, [{ return RV3264Base_SB_immS_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return RV3264Base_Stype_immS_predicate(Imm); }]>;
 
 def RV3264Base_SB_immSAsLabel : RV3264Base_SB_immS<OtherVT>;
 
@@ -459,7 +459,7 @@ class RV3264Base_SD_immS<ValueType ty> : Operand<ty>
 
 def RV3264Base_SD_immSAsInt64
     : RV3264Base_SD_immS<i64>
-    , ImmLeaf<i64, [{ return RV3264Base_SD_immS_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return RV3264Base_Stype_immS_predicate(Imm); }]>;
 
 def RV3264Base_SD_immSAsLabel : RV3264Base_SD_immS<OtherVT>;
 
@@ -471,7 +471,7 @@ class RV3264Base_SH_immS<ValueType ty> : Operand<ty>
 
 def RV3264Base_SH_immSAsInt64
     : RV3264Base_SH_immS<i64>
-    , ImmLeaf<i64, [{ return RV3264Base_SH_immS_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return RV3264Base_Stype_immS_predicate(Imm); }]>;
 
 def RV3264Base_SH_immSAsLabel : RV3264Base_SH_immS<OtherVT>;
 
@@ -483,7 +483,7 @@ class RV3264Base_SLLI_shamt<ValueType ty> : Operand<ty>
 
 def RV3264Base_SLLI_shamtAsInt64
     : RV3264Base_SLLI_shamt<i64>
-    , ImmLeaf<i64, [{ return RV3264Base_SLLI_shamt_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return RV3264Base_Ftype_shamt_predicate(Imm); }]>;
 
 def RV3264Base_SLLI_shamtAsLabel : RV3264Base_SLLI_shamt<OtherVT>;
 
@@ -495,7 +495,7 @@ class RV3264Base_SLLIW_shamt<ValueType ty> : Operand<ty>
 
 def RV3264Base_SLLIW_shamtAsInt64
     : RV3264Base_SLLIW_shamt<i64>
-    , ImmLeaf<i64, [{ return RV3264Base_SLLIW_shamt_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return RV3264Base_Rtype_shamt_predicate(Imm); }]>;
 
 def RV3264Base_SLLIW_shamtAsLabel : RV3264Base_SLLIW_shamt<OtherVT>;
 
@@ -507,7 +507,7 @@ class RV3264Base_SLTI_immS<ValueType ty> : Operand<ty>
 
 def RV3264Base_SLTI_immSAsInt64
     : RV3264Base_SLTI_immS<i64>
-    , ImmLeaf<i64, [{ return RV3264Base_SLTI_immS_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return RV3264Base_Itype_immS_predicate(Imm); }]>;
 
 def RV3264Base_SLTI_immSAsLabel : RV3264Base_SLTI_immS<OtherVT>;
 
@@ -519,7 +519,7 @@ class RV3264Base_SLTIU_immS<ValueType ty> : Operand<ty>
 
 def RV3264Base_SLTIU_immSAsInt64
     : RV3264Base_SLTIU_immS<i64>
-    , ImmLeaf<i64, [{ return RV3264Base_SLTIU_immS_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return RV3264Base_Itype_immS_predicate(Imm); }]>;
 
 def RV3264Base_SLTIU_immSAsLabel : RV3264Base_SLTIU_immS<OtherVT>;
 
@@ -531,7 +531,7 @@ class RV3264Base_SRAI_shamt<ValueType ty> : Operand<ty>
 
 def RV3264Base_SRAI_shamtAsInt64
     : RV3264Base_SRAI_shamt<i64>
-    , ImmLeaf<i64, [{ return RV3264Base_SRAI_shamt_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return RV3264Base_Ftype_shamt_predicate(Imm); }]>;
 
 def RV3264Base_SRAI_shamtAsLabel : RV3264Base_SRAI_shamt<OtherVT>;
 
@@ -543,7 +543,7 @@ class RV3264Base_SRAIW_shamt<ValueType ty> : Operand<ty>
 
 def RV3264Base_SRAIW_shamtAsInt64
     : RV3264Base_SRAIW_shamt<i64>
-    , ImmLeaf<i64, [{ return RV3264Base_SRAIW_shamt_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return RV3264Base_Rtype_shamt_predicate(Imm); }]>;
 
 def RV3264Base_SRAIW_shamtAsLabel : RV3264Base_SRAIW_shamt<OtherVT>;
 
@@ -555,7 +555,7 @@ class RV3264Base_SRLI_shamt<ValueType ty> : Operand<ty>
 
 def RV3264Base_SRLI_shamtAsInt64
     : RV3264Base_SRLI_shamt<i64>
-    , ImmLeaf<i64, [{ return RV3264Base_SRLI_shamt_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return RV3264Base_Ftype_shamt_predicate(Imm); }]>;
 
 def RV3264Base_SRLI_shamtAsLabel : RV3264Base_SRLI_shamt<OtherVT>;
 
@@ -567,7 +567,7 @@ class RV3264Base_SRLIW_shamt<ValueType ty> : Operand<ty>
 
 def RV3264Base_SRLIW_shamtAsInt64
     : RV3264Base_SRLIW_shamt<i64>
-    , ImmLeaf<i64, [{ return RV3264Base_SRLIW_shamt_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return RV3264Base_Rtype_shamt_predicate(Imm); }]>;
 
 def RV3264Base_SRLIW_shamtAsLabel : RV3264Base_SRLIW_shamt<OtherVT>;
 
@@ -579,7 +579,7 @@ class RV3264Base_SW_immS<ValueType ty> : Operand<ty>
 
 def RV3264Base_SW_immSAsInt64
     : RV3264Base_SW_immS<i64>
-    , ImmLeaf<i64, [{ return RV3264Base_SW_immS_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return RV3264Base_Stype_immS_predicate(Imm); }]>;
 
 def RV3264Base_SW_immSAsLabel : RV3264Base_SW_immS<OtherVT>;
 
@@ -591,7 +591,7 @@ class RV3264Base_XORI_immS<ValueType ty> : Operand<ty>
 
 def RV3264Base_XORI_immSAsInt64
     : RV3264Base_XORI_immS<i64>
-    , ImmLeaf<i64, [{ return RV3264Base_XORI_immS_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return RV3264Base_Itype_immS_predicate(Imm); }]>;
 
 def RV3264Base_XORI_immSAsLabel : RV3264Base_XORI_immS<OtherVT>;
 
@@ -603,7 +603,7 @@ class RV3264Base_J_immS<ValueType ty> : Operand<ty>
 
 def RV3264Base_J_immSAsInt64
     : RV3264Base_J_immS<i64>
-    , ImmLeaf<i64, [{ return RV3264Base_J_immS_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return RV3264Base_Jtype_immS_predicate(Imm); }]>;
 
 def RV3264Base_J_immSAsLabel : RV3264Base_J_immS<OtherVT>;
 
@@ -615,7 +615,7 @@ class RV3264Base_BEQZ_immS<ValueType ty> : Operand<ty>
 
 def RV3264Base_BEQZ_immSAsInt64
     : RV3264Base_BEQZ_immS<i64>
-    , ImmLeaf<i64, [{ return RV3264Base_BEQZ_immS_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return RV3264Base_Btype_immS_predicate(Imm); }]>;
 
 def RV3264Base_BEQZ_immSAsLabel : RV3264Base_BEQZ_immS<OtherVT>;
 
@@ -627,7 +627,7 @@ class RV3264Base_BNEZ_immS<ValueType ty> : Operand<ty>
 
 def RV3264Base_BNEZ_immSAsInt64
     : RV3264Base_BNEZ_immS<i64>
-    , ImmLeaf<i64, [{ return RV3264Base_BNEZ_immS_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return RV3264Base_Btype_immS_predicate(Imm); }]>;
 
 def RV3264Base_BNEZ_immSAsLabel : RV3264Base_BNEZ_immS<OtherVT>;
 
@@ -639,7 +639,7 @@ class RV3264Base_BLEZ_immS<ValueType ty> : Operand<ty>
 
 def RV3264Base_BLEZ_immSAsInt64
     : RV3264Base_BLEZ_immS<i64>
-    , ImmLeaf<i64, [{ return RV3264Base_BLEZ_immS_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return RV3264Base_Btype_immS_predicate(Imm); }]>;
 
 def RV3264Base_BLEZ_immSAsLabel : RV3264Base_BLEZ_immS<OtherVT>;
 
@@ -651,7 +651,7 @@ class RV3264Base_BGEZ_immS<ValueType ty> : Operand<ty>
 
 def RV3264Base_BGEZ_immSAsInt64
     : RV3264Base_BGEZ_immS<i64>
-    , ImmLeaf<i64, [{ return RV3264Base_BGEZ_immS_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return RV3264Base_Btype_immS_predicate(Imm); }]>;
 
 def RV3264Base_BGEZ_immSAsLabel : RV3264Base_BGEZ_immS<OtherVT>;
 
@@ -663,7 +663,7 @@ class RV3264Base_BLTZ_immS<ValueType ty> : Operand<ty>
 
 def RV3264Base_BLTZ_immSAsInt64
     : RV3264Base_BLTZ_immS<i64>
-    , ImmLeaf<i64, [{ return RV3264Base_BLTZ_immS_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return RV3264Base_Btype_immS_predicate(Imm); }]>;
 
 def RV3264Base_BLTZ_immSAsLabel : RV3264Base_BLTZ_immS<OtherVT>;
 
@@ -675,7 +675,7 @@ class RV3264Base_BGTZ_immS<ValueType ty> : Operand<ty>
 
 def RV3264Base_BGTZ_immSAsInt64
     : RV3264Base_BGTZ_immS<i64>
-    , ImmLeaf<i64, [{ return RV3264Base_BGTZ_immS_predicate(Imm); }]>;
+    , ImmLeaf<i64, [{ return RV3264Base_Btype_immS_predicate(Imm); }]>;
 
 def RV3264Base_BGTZ_immSAsLabel : RV3264Base_BGTZ_immS<OtherVT>;
 

--- a/vadl/test/vadl/lcb/riscv/riscv64/template/EmitImmediateFilePassTest.java
+++ b/vadl/test/vadl/lcb/riscv/riscv64/template/EmitImmediateFilePassTest.java
@@ -288,109 +288,28 @@ public class EmitImmediateFilePassTest extends AbstractLcbTest {
         
         
         
-        static bool RV3264Base_ADDIW_immS_predicate(uint64_t immS) {
-        return (VADL_and(VADL_sgeq(immS, 64, ((int64_t) 0xfffffffffffff800 ), 64), 1, VADL_sleq(immS, 64, ((int64_t) 0x7ff ), 64), 1) ? ((bool) 0x1 ): ((bool) 0x0 ));
+        static bool RV3264Base_Btype_immS_predicate(uint64_t immS) {
+           return (VADL_and(VADL_equ(VADL_and(immS, 64, ((int64_t) 0x1 ), 64), 64, ((uint64_t) 0x0 ), 64), 1, VADL_and(VADL_sleq(immS, 64, ((int64_t) 0xfff ), 64), 1, VADL_sgeq(immS, 64, ((int64_t) 0xfffffffffffff000 ), 64), 1), 1) ? ((bool) 0x1 ): ((bool) 0x0 ));
         }
-        static bool RV3264Base_ADDI_immS_predicate(uint64_t immS) {
-        return (VADL_and(VADL_sgeq(immS, 64, ((int64_t) 0xfffffffffffff800 ), 64), 1, VADL_sleq(immS, 64, ((int64_t) 0x7ff ), 64), 1) ? ((bool) 0x1 ): ((bool) 0x0 ));
+        static bool RV3264Base_Ftype_shamt_predicate(uint64_t shamt) {
+           return (VADL_and(VADL_sgeq(shamt, 6, ((int64_t) 0xffffffffffffffe0 ), 64), 1, VADL_sleq(shamt, 6, ((int64_t) 0x1f ), 64), 1) ? ((bool) 0x1 ): ((bool) 0x0 ));
         }
-        static bool RV3264Base_ANDI_immS_predicate(uint64_t immS) {
-        return (VADL_and(VADL_sgeq(immS, 64, ((int64_t) 0xfffffffffffff800 ), 64), 1, VADL_sleq(immS, 64, ((int64_t) 0x7ff ), 64), 1) ? ((bool) 0x1 ): ((bool) 0x0 ));
+        static bool RV3264Base_Itype_immS_predicate(uint64_t immS) {
+           return (VADL_and(VADL_sgeq(immS, 64, ((int64_t) 0xfffffffffffff800 ), 64), 1, VADL_sleq(immS, 64, ((int64_t) 0x7ff ), 64), 1) ? ((bool) 0x1 ): ((bool) 0x0 ));
         }
-        static bool RV3264Base_AUIPC_immUp_predicate(uint64_t immUp) {
-        return (VADL_and(VADL_equ(VADL_and(immUp, 64, ((int64_t) 0x800 ), 64), 64, ((uint64_t) 0x0 ), 64), 1, VADL_and(VADL_sleq(immUp, 64, ((int64_t) 0x7fffffff ), 64), 1, VADL_sgeq(immUp, 64, ((int64_t) 0xffffffff80000000 ), 64), 1), 1) ? ((bool) 0x1 ): ((bool) 0x0 ));
+        static bool RV3264Base_Jtype_immS_predicate(uint64_t immS) {
+           return (VADL_and(VADL_equ(VADL_and(immS, 64, ((int64_t) 0x1 ), 64), 64, ((uint64_t) 0x0 ), 64), 1, VADL_and(VADL_sleq(immS, 64, ((int64_t) 0xfffff ), 64), 1, VADL_sgeq(immS, 64, ((int64_t) 0xfffffffffff00000 ), 64), 1), 1) ? ((bool) 0x1 ): ((bool) 0x0 ));
         }
-        static bool RV3264Base_BEQ_immS_predicate(uint64_t immS) {
-        return (VADL_and(VADL_equ(VADL_and(immS, 64, ((int64_t) 0x1 ), 64), 64, ((uint64_t) 0x0 ), 64), 1, VADL_and(VADL_sleq(immS, 64, ((int64_t) 0xfff ), 64), 1, VADL_sgeq(immS, 64, ((int64_t) 0xfffffffffffff000 ), 64), 1), 1) ? ((bool) 0x1 ): ((bool) 0x0 ));
+        static bool RV3264Base_Rtype_shamt_predicate(uint64_t shamt) {
+           return (VADL_and(VADL_sgeq(shamt, 5, ((int64_t) 0xfffffffffffffff0 ), 64), 1, VADL_sleq(shamt, 5, ((int64_t) 0xf ), 64), 1) ? ((bool) 0x1 ): ((bool) 0x0 ));
         }
-        static bool RV3264Base_BGEU_immS_predicate(uint64_t immS) {
-        return (VADL_and(VADL_equ(VADL_and(immS, 64, ((int64_t) 0x1 ), 64), 64, ((uint64_t) 0x0 ), 64), 1, VADL_and(VADL_sleq(immS, 64, ((int64_t) 0xfff ), 64), 1, VADL_sgeq(immS, 64, ((int64_t) 0xfffffffffffff000 ), 64), 1), 1) ? ((bool) 0x1 ): ((bool) 0x0 ));
+        static bool RV3264Base_Stype_immS_predicate(uint64_t immS) {
+           return (VADL_and(VADL_sgeq(immS, 64, ((int64_t) 0xfffffffffffff800 ), 64), 1, VADL_sleq(immS, 64, ((int64_t) 0x7ff ), 64), 1) ? ((bool) 0x1 ): ((bool) 0x0 ));
         }
-        static bool RV3264Base_BGE_immS_predicate(uint64_t immS) {
-        return (VADL_and(VADL_equ(VADL_and(immS, 64, ((int64_t) 0x1 ), 64), 64, ((uint64_t) 0x0 ), 64), 1, VADL_and(VADL_sleq(immS, 64, ((int64_t) 0xfff ), 64), 1, VADL_sgeq(immS, 64, ((int64_t) 0xfffffffffffff000 ), 64), 1), 1) ? ((bool) 0x1 ): ((bool) 0x0 ));
+        static bool RV3264Base_Utype_immUp_predicate(uint64_t immUp) {
+           return (VADL_and(VADL_equ(VADL_and(immUp, 64, ((int64_t) 0x800 ), 64), 64, ((uint64_t) 0x0 ), 64), 1, VADL_and(VADL_sleq(immUp, 64, ((int64_t) 0x7fffffff ), 64), 1, VADL_sgeq(immUp, 64, ((int64_t) 0xffffffff80000000 ), 64), 1), 1) ? ((bool) 0x1 ): ((bool) 0x0 ));
         }
-        static bool RV3264Base_BLTU_immS_predicate(uint64_t immS) {
-        return (VADL_and(VADL_equ(VADL_and(immS, 64, ((int64_t) 0x1 ), 64), 64, ((uint64_t) 0x0 ), 64), 1, VADL_and(VADL_sleq(immS, 64, ((int64_t) 0xfff ), 64), 1, VADL_sgeq(immS, 64, ((int64_t) 0xfffffffffffff000 ), 64), 1), 1) ? ((bool) 0x1 ): ((bool) 0x0 ));
-        }
-        static bool RV3264Base_BLT_immS_predicate(uint64_t immS) {
-        return (VADL_and(VADL_equ(VADL_and(immS, 64, ((int64_t) 0x1 ), 64), 64, ((uint64_t) 0x0 ), 64), 1, VADL_and(VADL_sleq(immS, 64, ((int64_t) 0xfff ), 64), 1, VADL_sgeq(immS, 64, ((int64_t) 0xfffffffffffff000 ), 64), 1), 1) ? ((bool) 0x1 ): ((bool) 0x0 ));
-        }
-        static bool RV3264Base_BNE_immS_predicate(uint64_t immS) {
-        return (VADL_and(VADL_equ(VADL_and(immS, 64, ((int64_t) 0x1 ), 64), 64, ((uint64_t) 0x0 ), 64), 1, VADL_and(VADL_sleq(immS, 64, ((int64_t) 0xfff ), 64), 1, VADL_sgeq(immS, 64, ((int64_t) 0xfffffffffffff000 ), 64), 1), 1) ? ((bool) 0x1 ): ((bool) 0x0 ));
-        }
-        static bool RV3264Base_JALR_immS_predicate(uint64_t immS) {
-        return (VADL_and(VADL_sgeq(immS, 64, ((int64_t) 0xfffffffffffff800 ), 64), 1, VADL_sleq(immS, 64, ((int64_t) 0x7ff ), 64), 1) ? ((bool) 0x1 ): ((bool) 0x0 ));
-        }
-        static bool RV3264Base_JAL_immS_predicate(uint64_t immS) {
-        return (VADL_and(VADL_equ(VADL_and(immS, 64, ((int64_t) 0x1 ), 64), 64, ((uint64_t) 0x0 ), 64), 1, VADL_and(VADL_sleq(immS, 64, ((int64_t) 0xfffff ), 64), 1, VADL_sgeq(immS, 64, ((int64_t) 0xfffffffffff00000 ), 64), 1), 1) ? ((bool) 0x1 ): ((bool) 0x0 ));
-        }
-        static bool RV3264Base_LBU_immS_predicate(uint64_t immS) {
-        return (VADL_and(VADL_sgeq(immS, 64, ((int64_t) 0xfffffffffffff800 ), 64), 1, VADL_sleq(immS, 64, ((int64_t) 0x7ff ), 64), 1) ? ((bool) 0x1 ): ((bool) 0x0 ));
-        }
-        static bool RV3264Base_LB_immS_predicate(uint64_t immS) {
-        return (VADL_and(VADL_sgeq(immS, 64, ((int64_t) 0xfffffffffffff800 ), 64), 1, VADL_sleq(immS, 64, ((int64_t) 0x7ff ), 64), 1) ? ((bool) 0x1 ): ((bool) 0x0 ));
-        }
-        static bool RV3264Base_LD_immS_predicate(uint64_t immS) {
-        return (VADL_and(VADL_sgeq(immS, 64, ((int64_t) 0xfffffffffffff800 ), 64), 1, VADL_sleq(immS, 64, ((int64_t) 0x7ff ), 64), 1) ? ((bool) 0x1 ): ((bool) 0x0 ));
-        }
-        static bool RV3264Base_LHU_immS_predicate(uint64_t immS) {
-        return (VADL_and(VADL_sgeq(immS, 64, ((int64_t) 0xfffffffffffff800 ), 64), 1, VADL_sleq(immS, 64, ((int64_t) 0x7ff ), 64), 1) ? ((bool) 0x1 ): ((bool) 0x0 ));
-        }
-        static bool RV3264Base_LH_immS_predicate(uint64_t immS) {
-        return (VADL_and(VADL_sgeq(immS, 64, ((int64_t) 0xfffffffffffff800 ), 64), 1, VADL_sleq(immS, 64, ((int64_t) 0x7ff ), 64), 1) ? ((bool) 0x1 ): ((bool) 0x0 ));
-        }
-        static bool RV3264Base_LUI_immUp_predicate(uint64_t immUp) {
-        return (VADL_and(VADL_equ(VADL_and(immUp, 64, ((int64_t) 0x800 ), 64), 64, ((uint64_t) 0x0 ), 64), 1, VADL_and(VADL_sleq(immUp, 64, ((int64_t) 0x7fffffff ), 64), 1, VADL_sgeq(immUp, 64, ((int64_t) 0xffffffff80000000 ), 64), 1), 1) ? ((bool) 0x1 ): ((bool) 0x0 ));
-        }
-        static bool RV3264Base_LWU_immS_predicate(uint64_t immS) {
-        return (VADL_and(VADL_sgeq(immS, 64, ((int64_t) 0xfffffffffffff800 ), 64), 1, VADL_sleq(immS, 64, ((int64_t) 0x7ff ), 64), 1) ? ((bool) 0x1 ): ((bool) 0x0 ));
-        }
-        static bool RV3264Base_LW_immS_predicate(uint64_t immS) {
-        return (VADL_and(VADL_sgeq(immS, 64, ((int64_t) 0xfffffffffffff800 ), 64), 1, VADL_sleq(immS, 64, ((int64_t) 0x7ff ), 64), 1) ? ((bool) 0x1 ): ((bool) 0x0 ));
-        }
-        static bool RV3264Base_ORI_immS_predicate(uint64_t immS) {
-        return (VADL_and(VADL_sgeq(immS, 64, ((int64_t) 0xfffffffffffff800 ), 64), 1, VADL_sleq(immS, 64, ((int64_t) 0x7ff ), 64), 1) ? ((bool) 0x1 ): ((bool) 0x0 ));
-        }
-        static bool RV3264Base_SB_immS_predicate(uint64_t immS) {
-        return (VADL_and(VADL_sgeq(immS, 64, ((int64_t) 0xfffffffffffff800 ), 64), 1, VADL_sleq(immS, 64, ((int64_t) 0x7ff ), 64), 1) ? ((bool) 0x1 ): ((bool) 0x0 ));
-        }
-        static bool RV3264Base_SD_immS_predicate(uint64_t immS) {
-        return (VADL_and(VADL_sgeq(immS, 64, ((int64_t) 0xfffffffffffff800 ), 64), 1, VADL_sleq(immS, 64, ((int64_t) 0x7ff ), 64), 1) ? ((bool) 0x1 ): ((bool) 0x0 ));
-        }
-        static bool RV3264Base_SH_immS_predicate(uint64_t immS) {
-        return (VADL_and(VADL_sgeq(immS, 64, ((int64_t) 0xfffffffffffff800 ), 64), 1, VADL_sleq(immS, 64, ((int64_t) 0x7ff ), 64), 1) ? ((bool) 0x1 ): ((bool) 0x0 ));
-        }
-        static bool RV3264Base_SLLIW_shamt_predicate(uint64_t shamt) {
-        return (VADL_and(VADL_sgeq(shamt, 5, ((int64_t) 0xfffffffffffffff0 ), 64), 1, VADL_sleq(shamt, 5, ((int64_t) 0xf ), 64), 1) ? ((bool) 0x1 ): ((bool) 0x0 ));
-        }
-        static bool RV3264Base_SLLI_shamt_predicate(uint64_t shamt) {
-        return (VADL_and(VADL_sgeq(shamt, 6, ((int64_t) 0xffffffffffffffe0 ), 64), 1, VADL_sleq(shamt, 6, ((int64_t) 0x1f ), 64), 1) ? ((bool) 0x1 ): ((bool) 0x0 ));
-        }
-        static bool RV3264Base_SLTIU_immS_predicate(uint64_t immS) {
-        return (VADL_and(VADL_sgeq(immS, 64, ((int64_t) 0xfffffffffffff800 ), 64), 1, VADL_sleq(immS, 64, ((int64_t) 0x7ff ), 64), 1) ? ((bool) 0x1 ): ((bool) 0x0 ));
-        }
-        static bool RV3264Base_SLTI_immS_predicate(uint64_t immS) {
-        return (VADL_and(VADL_sgeq(immS, 64, ((int64_t) 0xfffffffffffff800 ), 64), 1, VADL_sleq(immS, 64, ((int64_t) 0x7ff ), 64), 1) ? ((bool) 0x1 ): ((bool) 0x0 ));
-        }
-        static bool RV3264Base_SRAIW_shamt_predicate(uint64_t shamt) {
-        return (VADL_and(VADL_sgeq(shamt, 5, ((int64_t) 0xfffffffffffffff0 ), 64), 1, VADL_sleq(shamt, 5, ((int64_t) 0xf ), 64), 1) ? ((bool) 0x1 ): ((bool) 0x0 ));
-        }
-        static bool RV3264Base_SRAI_shamt_predicate(uint64_t shamt) {
-        return (VADL_and(VADL_sgeq(shamt, 6, ((int64_t) 0xffffffffffffffe0 ), 64), 1, VADL_sleq(shamt, 6, ((int64_t) 0x1f ), 64), 1) ? ((bool) 0x1 ): ((bool) 0x0 ));
-        }
-        static bool RV3264Base_SRLIW_shamt_predicate(uint64_t shamt) {
-        return (VADL_and(VADL_sgeq(shamt, 5, ((int64_t) 0xfffffffffffffff0 ), 64), 1, VADL_sleq(shamt, 5, ((int64_t) 0xf ), 64), 1) ? ((bool) 0x1 ): ((bool) 0x0 ));
-        }
-        static bool RV3264Base_SRLI_shamt_predicate(uint64_t shamt) {
-        return (VADL_and(VADL_sgeq(shamt, 6, ((int64_t) 0xffffffffffffffe0 ), 64), 1, VADL_sleq(shamt, 6, ((int64_t) 0x1f ), 64), 1) ? ((bool) 0x1 ): ((bool) 0x0 ));
-        }
-        static bool RV3264Base_SW_immS_predicate(uint64_t immS) {
-        return (VADL_and(VADL_sgeq(immS, 64, ((int64_t) 0xfffffffffffff800 ), 64), 1, VADL_sleq(immS, 64, ((int64_t) 0x7ff ), 64), 1) ? ((bool) 0x1 ): ((bool) 0x0 ));
-        }
-        static bool RV3264Base_XORI_immS_predicate(uint64_t immS) {
-        return (VADL_and(VADL_sgeq(immS, 64, ((int64_t) 0xfffffffffffff800 ), 64), 1, VADL_sleq(immS, 64, ((int64_t) 0x7ff ), 64), 1) ? ((bool) 0x1 ): ((bool) 0x0 ));
-        }
-        
+              
         
         namespace
         {

--- a/vadl/test/vadl/lcb/riscv/riscv64/template/EmitRegisterInfoCppFilePassTest.java
+++ b/vadl/test/vadl/lcb/riscv/riscv64/template/EmitRegisterInfoCppFilePassTest.java
@@ -134,7 +134,7 @@ public class EmitRegisterInfoCppFilePassTest extends AbstractLcbTest {
         // try to inline the offset into the instruction
         //
         
-        if(Offset >= -2048 && Offset <= 2047 && RV3264Base_ADDI_immS_predicate(Offset))
+        if(Offset >= -2048 && Offset <= 2047 && RV3264Base_Itype_immS_predicate(Offset))
         {
         // immediate can be encoded and instruction can be inlined.
         FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
@@ -186,7 +186,7 @@ public class EmitRegisterInfoCppFilePassTest extends AbstractLcbTest {
         // try to inline the offset into the instruction
         //
         
-        if(Offset >= -2048 && Offset <= 2047 && RV3264Base_LB_immS_predicate(Offset))
+        if(Offset >= -2048 && Offset <= 2047 && RV3264Base_Itype_immS_predicate(Offset))
         {
         // immediate can be encoded and instruction can be inlined.
         FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
@@ -238,7 +238,7 @@ public class EmitRegisterInfoCppFilePassTest extends AbstractLcbTest {
         // try to inline the offset into the instruction
         //
         
-        if(Offset >= -2048 && Offset <= 2047 && RV3264Base_LBU_immS_predicate(Offset))
+        if(Offset >= -2048 && Offset <= 2047 && RV3264Base_Itype_immS_predicate(Offset))
         {
         // immediate can be encoded and instruction can be inlined.
         FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
@@ -290,7 +290,7 @@ public class EmitRegisterInfoCppFilePassTest extends AbstractLcbTest {
         // try to inline the offset into the instruction
         //
         
-        if(Offset >= -2048 && Offset <= 2047 && RV3264Base_LD_immS_predicate(Offset))
+        if(Offset >= -2048 && Offset <= 2047 && RV3264Base_Itype_immS_predicate(Offset))
         {
         // immediate can be encoded and instruction can be inlined.
         FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
@@ -342,7 +342,7 @@ public class EmitRegisterInfoCppFilePassTest extends AbstractLcbTest {
         // try to inline the offset into the instruction
         //
         
-        if(Offset >= -2048 && Offset <= 2047 && RV3264Base_LH_immS_predicate(Offset))
+        if(Offset >= -2048 && Offset <= 2047 && RV3264Base_Itype_immS_predicate(Offset))
         {
         // immediate can be encoded and instruction can be inlined.
         FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
@@ -394,7 +394,7 @@ public class EmitRegisterInfoCppFilePassTest extends AbstractLcbTest {
         // try to inline the offset into the instruction
         //
         
-        if(Offset >= -2048 && Offset <= 2047 && RV3264Base_LHU_immS_predicate(Offset))
+        if(Offset >= -2048 && Offset <= 2047 && RV3264Base_Itype_immS_predicate(Offset))
         {
         // immediate can be encoded and instruction can be inlined.
         FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
@@ -446,7 +446,7 @@ public class EmitRegisterInfoCppFilePassTest extends AbstractLcbTest {
         // try to inline the offset into the instruction
         //
         
-        if(Offset >= -2048 && Offset <= 2047 && RV3264Base_LW_immS_predicate(Offset))
+        if(Offset >= -2048 && Offset <= 2047 && RV3264Base_Itype_immS_predicate(Offset))
         {
         // immediate can be encoded and instruction can be inlined.
         FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
@@ -498,7 +498,7 @@ public class EmitRegisterInfoCppFilePassTest extends AbstractLcbTest {
         // try to inline the offset into the instruction
         //
         
-        if(Offset >= -2048 && Offset <= 2047 && RV3264Base_LWU_immS_predicate(Offset))
+        if(Offset >= -2048 && Offset <= 2047 && RV3264Base_Itype_immS_predicate(Offset))
         {
         // immediate can be encoded and instruction can be inlined.
         FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
@@ -550,7 +550,7 @@ public class EmitRegisterInfoCppFilePassTest extends AbstractLcbTest {
         // try to inline the offset into the instruction
         //
         
-        if(Offset >= -2048 && Offset <= 2047 && RV3264Base_SB_immS_predicate(Offset))
+        if(Offset >= -2048 && Offset <= 2047 && RV3264Base_Stype_immS_predicate(Offset))
         {
         // immediate can be encoded and instruction can be inlined.
         FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
@@ -602,7 +602,7 @@ public class EmitRegisterInfoCppFilePassTest extends AbstractLcbTest {
         // try to inline the offset into the instruction
         //
         
-        if(Offset >= -2048 && Offset <= 2047 && RV3264Base_SD_immS_predicate(Offset))
+        if(Offset >= -2048 && Offset <= 2047 && RV3264Base_Stype_immS_predicate(Offset))
         {
         // immediate can be encoded and instruction can be inlined.
         FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
@@ -654,7 +654,7 @@ public class EmitRegisterInfoCppFilePassTest extends AbstractLcbTest {
         // try to inline the offset into the instruction
         //
         
-        if(Offset >= -2048 && Offset <= 2047 && RV3264Base_SH_immS_predicate(Offset))
+        if(Offset >= -2048 && Offset <= 2047 && RV3264Base_Stype_immS_predicate(Offset))
         {
         // immediate can be encoded and instruction can be inlined.
         FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
@@ -706,7 +706,7 @@ public class EmitRegisterInfoCppFilePassTest extends AbstractLcbTest {
         // try to inline the offset into the instruction
         //
         
-        if(Offset >= -2048 && Offset <= 2047 && RV3264Base_SW_immS_predicate(Offset))
+        if(Offset >= -2048 && Offset <= 2047 && RV3264Base_Stype_immS_predicate(Offset))
         {
         // immediate can be encoded and instruction can be inlined.
         FIOp.ChangeToRegister( FrameReg, false /* isDef */ );


### PR DESCRIPTION
The goal of this PR is to reduce the number of generated c++ predicate functions, by only generating predicate functions for each format (and associated field accesses), instead of for every instruction (and associated field accesses).

This enables the generated aarch64 compiler to be compilable. See [here](https://github.com/OpenVADL/openvadl/pull/905#issue-4309743409) for a brief explanation.

Changes to the implementation:

- The identifier used for predicate functions is now constructed from the field-access and associated format identifier, instead of field-access and instruction identifier
- "CreateFunctionsFromImmediatePass" reuses generated predicate functions of the format of each instruction