### PR TITLE
parser: Fix crashes with invalid record invocations

### DIFF
--- a/sys/aarch64/aarch64.vadl
+++ b/sys/aarch64/aarch64.vadl
@@ -1831,7 +1831,7 @@ model MovNZInstr (i: InstrWithFunct, size: Id): IsaDefs = {
     assembly $i.id = ($i.mnemo, ' ', SysRegName(sysreg), ', ', XSize(rt))
     }
 
-  model ExceptionCallEncAsm (i: InstrWithFunct): IsaDefs = {
+  model ExceptionCallEncAsm (i: InstrNoFunct): IsaDefs = {
     encoding $i.id = {op = $i.opcode}
     assembly $i.id = ($i.mnemo, ' #', udec(imm16))
     }
@@ -1841,10 +1841,12 @@ model MovNZInstr (i: InstrWithFunct, size: Id): IsaDefs = {
     instruction $i.id: SuperVisorCallFormat = {
       raise GeneralException (ExceptionClass::$i.funct, 0, PC.next, 0)
       }
-    $ExceptionCallEncAsm ($i)
+    $ExceptionCallEncAsm (($i.id; $i.mnemo; $i.opcode))
     }
 
-  model HaltInstr (i: InstrWithFunct): IsaDefs = {
+
+
+  model HaltInstr (i: InstrNoFunct): IsaDefs = {
     [add operands : imm16]
     instruction $i.id: SuperVisorCallFormat = {}
     $ExceptionCallEncAsm ($i)

--- a/vadl/main/vadl/ast/ParserUtils.java
+++ b/vadl/main/vadl/ast/ParserUtils.java
@@ -321,6 +321,17 @@ class ParserUtils {
     }
   }
 
+  static RecordInstance createRecordInstance(RecordType recordType, List<Node> entries,
+                                             SourceLocation location) {
+    if (recordType.entries.size() != entries.size()) {
+      throw error("Invalid Record Invocation", location)
+          .locationDescription(location, "Record `%s` expected %d arguments but got %d.",
+              recordType.name, recordType.entries.size(), entries.size())
+          .build();
+    }
+    return new RecordInstance(recordType, entries, location);
+  }
+
   static SyntaxType paramSyntaxType(Parser parser, String name) {
     for (List<MacroParam> params : parser.macroContext) {
       for (MacroParam param : params) {
@@ -549,6 +560,16 @@ class ParserUtils {
           argCount, argCount + 1);
     }
     return builder.build();
+  }
+
+  static Diagnostic tooManyRecordArgumentsError(RecordType recordType, SourceLocation location) {
+    // Unfortunately, we don't know how many arguments actually were provided because we cannot
+    // continue parsing to find out.
+    return error("Invalid Record Invocation", location)
+        .locationDescription(location,
+          "The record `%s` only expected %d arguments but, you provided at least %d.",
+          recordType.name, recordType.entries.size(), recordType.entries.size() + 1)
+    .build();
   }
 
   private static boolean isPlaceholder(Node n) {

--- a/vadl/main/vadl/ast/vadl.ATG
+++ b/vadl/main/vadl/ast/vadl.ATG
@@ -2227,8 +2227,8 @@ A micro architecture definition (#microArchitectureDefinition) is shown in line 
   .
 
   /// Parses the longest macro expression (either instance or placeholder) from the parser.
-  maximumMacroExpr<out Node node>                 (. node = null; var startLoc = nextTokenLoc(); .)
-  = SYM_DOLLAR                                    (. var segments = new ArrayList<String>(); .)
+  maximumMacroExpr<out Node node>                 (. node = null; var startLoc = nextTokenLoc(); var segments = new ArrayList<String>(); .)
+  = SYM_DOLLAR
     identifier<out Identifier id>                 (. var macro = macroTable.getMacro(id.name);
                                                      var paramType = paramSyntaxType(this, id.name);
                                                      segments.add(id.name); .)
@@ -2353,13 +2353,20 @@ A micro architecture definition (#microArchitectureDefinition) is shown in line 
   | IF (type == BasicSyntaxType.UN_OP)
     unaryOperator<out IsUnOp op>                            (. body = (Node) op; .)
   | IF (type instanceof RecordType recordType)
-    ( SYM_PAREN_OPEN                                        (. var entries = new ArrayList<Node>(recordType.entries.size()); var nextEntry = recordType.entries.iterator(); .)
-      macroBody<out Node entry, nextEntry.next().type()>    (. entries.add(entry); .)
+    ( SYM_PAREN_OPEN                                        (. var entries = new ArrayList<Node>(recordType.entries.size());
+                                                               var syntaxTypeIterator = recordType.entries.iterator();
+                                                               if (!syntaxTypeIterator.hasNext()) {throw tooManyRecordArgumentsError(recordType, nextTokenLoc());}
+                                                               var nextEntry = syntaxTypeIterator.next();
+                                                            .)
+      macroBody<out Node entry, nextEntry.type()>    (. entries.add(entry); .)
       {
-        SYM_SEMICOLON
-        macroBody<out entry, nextEntry.next().type()>       (. entries.add(entry); .)
+        SYM_SEMICOLON                                (.  if (!syntaxTypeIterator.hasNext()) {throw tooManyRecordArgumentsError(recordType, nextTokenLoc());}
+                                                         nextEntry = syntaxTypeIterator.next();
+                                                     .)
+        macroBody<out entry, nextEntry.type()>       (. entries.add(entry); .)
       }
-      SYM_PAREN_CLOSE                                       (. body = new RecordInstance(recordType, entries, start.join(lastTokenLoc())); .)
+      SYM_PAREN_CLOSE                                       (.
+                                                               body = createRecordInstance(recordType, entries, start.join(lastTokenLoc())); .)
     | macroReplacement<out body>
     )
   | IF (type instanceof ProjectionType projection)

--- a/vadl/test/resources/frontend-snapshots/macro/invalidHigherOrderMacroWithTooManyArguments.vadl
+++ b/vadl/test/resources/frontend-snapshots/macro/invalidHigherOrderMacroWithTooManyArguments.vadl
@@ -15,7 +15,7 @@ model InstrBHSD (modelid: InstrWithFunctElemSize, i: InstrWithFunct): IsaDefs = 
 //  Reported Diagnostics:
 //
 //  error: Invalid Model Invocation
-//       ╭── test/resources/frontend-snapshots/parser/invalidHigherOrderMacroWithTooManyArguments.vadl:11:35
+//       ╭── test/resources/frontend-snapshots/macro/invalidHigherOrderMacroWithTooManyArguments.vadl:11:35
 //       │
 //    11 │   $modelid ($i; ElementsB; SizeB; ".B")
 //       │                                   ^^^^ The model only expected 3 arguments but, you provided at least 4.

--- a/vadl/test/resources/frontend-snapshots/macro/invalidHigherOrderModelWrongArgumentCount.vadl
+++ b/vadl/test/resources/frontend-snapshots/macro/invalidHigherOrderModelWrongArgumentCount.vadl
@@ -161,14 +161,14 @@ model-type SVEWhileStatModel = (WhileRec, Id) -> Stat
 //  Reported Diagnostics:
 //
 //  error: The macro `SVEWhileCondInstr` expects 4 arguments but 1 were provided.
-//       ╭── test/resources/frontend-snapshots/parser/invalidHigherOrderModelWrongArgumentCount.vadl:147:5
+//       ╭── test/resources/frontend-snapshots/macro/invalidHigherOrderModelWrongArgumentCount.vadl:147:5
 //       │
 //   147 │     $SVEWhileCondInstr ($ExtInstrStr ($i;  "W"); WSize ; $elements ; $elSize ; $elStr)
 //       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //       │
 //
 //  error: SyntaxType Mismatch
-//       ╭── test/resources/frontend-snapshots/parser/invalidHigherOrderModelWrongArgumentCount.vadl:142:148
+//       ╭── test/resources/frontend-snapshots/macro/invalidHigherOrderModelWrongArgumentCount.vadl:142:148
 //       │
 //   142 │     $SVEWhileBaseInstr (WhileStatLSLE ; $ExtInstrIdStr($i ; LS ; "ls"); (LS ; $UMax($regSize) ; $PtrueBHSD($elSize) ; ugth ; $elements ; $elSize ; $elStr) ; $regSize)
 //       │                                                                                                                                                    ^^^^^^
@@ -176,7 +176,7 @@ model-type SVEWhileStatModel = (WhileRec, Id) -> Stat
 //       Mismatched node type: Required `STR`, but got `INVALID`
 //
 //  error: SyntaxType Mismatch
-//       ╭── test/resources/frontend-snapshots/parser/invalidHigherOrderModelWrongArgumentCount.vadl:147:25
+//       ╭── test/resources/frontend-snapshots/macro/invalidHigherOrderModelWrongArgumentCount.vadl:147:25
 //       │
 //   147 │     $SVEWhileCondInstr ($ExtInstrStr ($i;  "W"); WSize ; $elements ; $elSize ; $elStr)
 //       │                         ^^^^^^^^^^^^
@@ -184,7 +184,7 @@ model-type SVEWhileStatModel = (WhileRec, Id) -> Stat
 //       Mismatched node type: Required `InstrWithFunct (ID,STR,EX,ID)`, but got `INVALID`
 //
 //  error: Parsing Error
-//       ╭── test/resources/frontend-snapshots/parser/invalidHigherOrderModelWrongArgumentCount.vadl:147:38
+//       ╭── test/resources/frontend-snapshots/macro/invalidHigherOrderModelWrongArgumentCount.vadl:147:38
 //       │
 //   147 │     $SVEWhileCondInstr ($ExtInstrStr ($i;  "W"); WSize ; $elements ; $elSize ; $elStr)
 //       │                                      ^ The parser expected `)` here.

--- a/vadl/test/resources/frontend-snapshots/macro/invalidModelInvocationUsesRightLocation.vadl
+++ b/vadl/test/resources/frontend-snapshots/macro/invalidModelInvocationUsesRightLocation.vadl
@@ -16,7 +16,7 @@ constant second = false + $apfelstrudel()
 //  Reported Diagnostics:
 //
 //  error: Type Mismatch
-//       ╭── test/resources/frontend-snapshots/parser/invalidModelInvocationUsesRightLocation.vadl:13:19
+//       ╭── test/resources/frontend-snapshots/macro/invalidModelInvocationUsesRightLocation.vadl:13:19
 //       │
 //    13 │ constant second = false + $apfelstrudel()
 //       │                   ^^^^^^^^^^^^^^^^^^^^^^^ note: The left type is `Bits<1>` while right is `Bits<6>`

--- a/vadl/test/resources/frontend-snapshots/macro/invalidModelMissingReturnType.vadl
+++ b/vadl/test/resources/frontend-snapshots/macro/invalidModelMissingReturnType.vadl
@@ -8,7 +8,7 @@ model XYZ() = { }
 //  Reported Diagnostics:
 //
 //  error: Parsing Error
-//       ╭── test/resources/frontend-snapshots/parser/invalidModelMissingReturnType.vadl:5:13
+//       ╭── test/resources/frontend-snapshots/macro/invalidModelMissingReturnType.vadl:5:13
 //       │
 //     5 │ model XYZ() = { }
 //       │             ^ The parser expected `:` here.

--- a/vadl/test/resources/frontend-snapshots/macro/invalidModelWithErrorInModel.vadl
+++ b/vadl/test/resources/frontend-snapshots/macro/invalidModelWithErrorInModel.vadl
@@ -12,13 +12,13 @@ constant second = $apfelstrudel
 //  Reported Diagnostics:
 //
 //  error: Type Mismatch
-//       ╭── test/resources/frontend-snapshots/parser/invalidModelWithErrorInModel.vadl:4:3
+//       ╭── test/resources/frontend-snapshots/macro/invalidModelWithErrorInModel.vadl:4:3
 //       │
 //     4 │   false + 42
 //       │   ^^^^^^^^^^ note: The left type is `Bits<1>` while right is `Bits<6>`
 //       │
 //       ├─ From this model invocation (outermost call first):
-//       │       test/resources/frontend-snapshots/parser/invalidModelWithErrorInModel.vadl:9:19
+//       │       test/resources/frontend-snapshots/macro/invalidModelWithErrorInModel.vadl:9:19
 //       │
 //       Both types on the left and right side of an binary operation should be equal.
 //

--- a/vadl/test/resources/frontend-snapshots/macro/invalidModelWithTooManyArguments.vadl
+++ b/vadl/test/resources/frontend-snapshots/macro/invalidModelWithTooManyArguments.vadl
@@ -8,7 +8,7 @@ constant x = $flo(y; z)
 //  Reported Diagnostics:
 //
 //  error: Invalid Model Invocation
-//       ╭── test/resources/frontend-snapshots/parser/invalidModelWithTooManyArguments.vadl:5:22
+//       ╭── test/resources/frontend-snapshots/macro/invalidModelWithTooManyArguments.vadl:5:22
 //       │
 //     5 │ constant x = $flo(y; z)
 //       │                      ^ Model `flo` only expected 1 arguments but, you provided at least 2.

--- a/vadl/test/resources/frontend-snapshots/macro/tooFewRecordArguments.vadl
+++ b/vadl/test/resources/frontend-snapshots/macro/tooFewRecordArguments.vadl
@@ -1,0 +1,22 @@
+// Previously this would crash the parser.
+
+record Person ( name: Id, age: Ex )
+
+model constModel (info: Person) : Defs = {
+  constant $info.name = $info.age
+}
+
+$constModel((flo))
+
+
+//  Reported Diagnostics:
+//
+//  error: Invalid Record Invocation
+//       ╭── test/resources/frontend-snapshots/macro/tooFewRecordArguments.vadl:9:13
+//       │
+//     9 │ $constModel((flo))
+//       │             ^^^^^ Record `Person` expected 2 arguments but got 1.
+//       │
+//
+//
+// Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl/test/resources/frontend-snapshots/macro/tooManyRecordArguments.vadl
+++ b/vadl/test/resources/frontend-snapshots/macro/tooManyRecordArguments.vadl
@@ -1,0 +1,22 @@
+// Previously this would crash the parser.
+
+record Person ( name: Id, age: Ex )
+
+model constModel (info: Person) : Defs = {
+  constant $info.name = $info.age
+}
+
+$constModel((flo; 27; 104))
+
+
+//  Reported Diagnostics:
+//
+//  error: Invalid Record Invocation
+//       ╭── test/resources/frontend-snapshots/macro/tooManyRecordArguments.vadl:9:23
+//       │
+//     9 │ $constModel((flo; 27; 104))
+//       │                       ^^^ The record `Person` only expected 2 arguments but, you provided at least 3.
+//       │
+//
+//
+// Part of the class vadl.ast.FrontendSnapshotTests


### PR DESCRIPTION
I've also moved 4 tests from the parser directory to the macro one. Otherwise they are unchanged.

@AndreasKrall this fixes the crash you sent me by mail.