### PR TITLE
iss: Save common expressions in helper instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,8 @@ bin/
 
 ### Python ###
 .venv
+**/__pycache__/
+*.pyc
 
 ### OTHER ###
 .swp

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -6,6 +6,12 @@
         <option name="TAB_SIZE" value="2" />
       </value>
     </option>
+    <option name="DO_NOT_FORMAT">
+      <list>
+        <fileSet type="globPattern" pattern="docs/**/*.md" />
+        <fileSet type="globPattern" pattern="vadl/test/resources/**/*" />
+      </list>
+    </option>
     <JavaCodeStyleSettings>
       <option name="SPACE_INSIDE_ONE_LINE_ENUM_BRACES" value="true" />
       <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />

--- a/docs/refman/tutorial.md
+++ b/docs/refman/tutorial.md
@@ -933,6 +933,9 @@ instruction set architecture ISA = {
   alias register ZR : Word = X(31)        // zero register
   register        Y : Word<32>            // alternative specification instead of arrow syntax
   alias register  Z : Bits<32><2><16> = Y // Y is interpreted as 32 registers with two 16 bit parts
+  [ overwrite source : zero ]             // fills the upper 32 bits of the S(*) register with zeros
+  [ overwrite source : sign ]             // sign extends the upper 32 bits of the S(*) register
+  alias register  V = S(*)(30..0)         // slices the lower 32 bits of the S(*) register
 }
 ~~~
 \endlisting
@@ -949,6 +952,22 @@ The only requirement is that both registers have the same number of bits.
 It is allowed that the alias register has other annotations than the aliased register as demonstrated with the registers `X` and `S`.
 The alias register inherits all attributes from the aliased register.
 It is possible to make the \ac{PC} an alias of a register using the keywords `alias program counter`.
+
+When an alias refers only to a slice of its source register, reads always access only that slice.
+Writes need additional care because the alias value is smaller than the underlying source register.
+If no `[ overwrite source : ... ]` annotation is given, writing the alias performs a partial update:
+the written value replaces only the aliased slice, while all bits outside that slice are preserved
+from the original source register.
+This is the default merge behavior for sliced register aliases.
+
+The annotation `[ overwrite source : zero ]` changes this behavior by zero extending the written
+alias value to the full width of the source register before writing it back.
+Accordingly, all bits outside the aliased slice are set to zero.
+The annotation `[ overwrite source : sign ]` sign extends the written alias value to the full
+width of the source register before writing it back.
+This is useful when the alias models a narrower architectural view whose write semantics define the
+complete source register, for example by zero extension or sign extension, instead of preserving the
+remaining high bits.
 
 Listing \r{partial_register_access} shows the declaration of a status register with some bit fields.
 It is possible that these bit fields can be accessed directly (partial read and write) or the register can be accessed only as a whole (full read and write).

--- a/sys/aarch64/aarch64.vadl
+++ b/sys/aarch64/aarch64.vadl
@@ -1655,6 +1655,7 @@ model MovNZInstr (i: InstrWithFunct, size: Id): IsaDefs = {
     , ESR_EL1   = 0b11'000'0101'0010'000     // exception syndrome register exception level 1
     , SPSR_EL1  = 0b11'000'0100'0000'000     // saved program state register exception level 1
     , CPACR_EL1 = 0b11'000'0001'0000'010     // architectural feature access control register exception level 1
+    , ZCR_EL1   = 0b11'000'0001'0010'000     // SVE control register exception level 1
     }
 
   constant SysRegNZCV15 = SysRegEncode::NZCV as Bits15
@@ -1668,6 +1669,7 @@ model MovNZInstr (i: InstrWithFunct, size: Id): IsaDefs = {
   register ESR_EL1:  ExceptionSyndromeFormat // exception syndrome register exception level level 1
   register SPSR_EL1: SavedProgramStateFormat // saved program state register exception level level 1
   register CPACR_EL1:CPACRFormat             // architectural feature access control register exception level 1
+  register ZCR_EL1:  BitsX                   // SVE control register exception level 1
 
   model SaveProgramState (): Stats = {
     SPSR_EL1 := (SPSR_EL1(63..32), NZCV_N, NZCV_Z, NZCV_C, NZCV_V, SPSR_EL1(27..4), SPSel as Bits4 | 0b0100)
@@ -1751,6 +1753,7 @@ model MovNZInstr (i: InstrWithFunct, size: Id): IsaDefs = {
       , SysRegEncode::SPSR_EL1  => "spsr_el1"
       , SysRegEncode::VBAR_EL1  => "vbar_el1"
       , SysRegEncode::CPACR_EL1 => "cpacr_el1"
+      , SysRegEncode::ZCR_EL1   => "zcr_el1"
       , _ => ("S", udec(sysreg(15..14)), "_",
                    udec(sysreg(13..11)), "_",
                    udec(sysreg(10.. 7)), "_",
@@ -1786,6 +1789,7 @@ model MovNZInstr (i: InstrWithFunct, size: Id): IsaDefs = {
                                          }
           , SysRegEncode::ELR_EL1   => X(rt) := ELR_EL1
           , SysRegEncode::VBAR_EL1  => X(rt) := VBAR_EL1
+          , SysRegEncode::ZCR_EL1   => X(rt) := ZCR_EL1
           , _                       => raise $UndefinedException ()
           }
     [select when : rs != SysRegNZCV15]
@@ -1825,6 +1829,7 @@ model MovNZInstr (i: InstrWithFunct, size: Id): IsaDefs = {
           , SysRegEncode::ELR_EL1   => ELR_EL1 := X(rt)
           , SysRegEncode::VBAR_EL1  => VBAR_EL1 := X(rt)
           , SysRegEncode::CPACR_EL1 => CPACR_EL1 := X(rt)
+          , SysRegEncode::ZCR_EL1   => ZCR_EL1 := X(rt)
           , _                       => raise $UndefinedException ()
           }
     encoding $i.id = {op = $i.opcode}

--- a/sys/aarch64/sve.vadl
+++ b/sys/aarch64/sve.vadl
@@ -59,6 +59,7 @@ instruction set architecture AArch64SVEandSME extending AArch64Base = {
   alias register ZH : BitsZH<NumZ> = Z    // half   vector register file
   alias register ZS : BitsZS<NumZ> = Z    // single vector register file
   alias register ZD : BitsZD<NumZ> = Z    // double vector register file
+  [ overwrite source : zero ]
   alias register V = Z(*)(VSize-1..0)     // scalar view of the vector registers
 
   enumeration ElSize =                    // element size encoding

--- a/vadl/build.gradle.kts
+++ b/vadl/build.gradle.kts
@@ -89,6 +89,10 @@ tasks.processResources {
     from(createProperties)
 }
 
+tasks.processTestResources {
+    exclude("**/__pycache__/**", "**/*.pyc")
+}
+
 tasks.withType<Test>().configureEach {
     environment("PROJECT_ROOT", rootDir.absolutePath)
     useJUnitPlatform {

--- a/vadl/main/vadl/iss/codegen/IssProcGen.java
+++ b/vadl/main/vadl/iss/codegen/IssProcGen.java
@@ -29,16 +29,20 @@ import vadl.iss.passes.extensions.IssAccessorRegistry;
 import vadl.iss.passes.safeResourceRead.nodes.ExprSaveNode;
 import vadl.javaannotations.DispatchFor;
 import vadl.javaannotations.Handler;
+import vadl.utils.GraphUtils;
 import vadl.utils.functionInterfaces.TriConsumer;
 import vadl.viam.graph.Graph;
 import vadl.viam.graph.Node;
 import vadl.viam.graph.control.InstrCallNode;
 import vadl.viam.graph.control.ScheduledNode;
 import vadl.viam.graph.dependency.AsmBuiltInCall;
+import vadl.viam.graph.dependency.ConstantNode;
 import vadl.viam.graph.dependency.FieldAccessRefNode;
 import vadl.viam.graph.dependency.FieldRefNode;
 import vadl.viam.graph.dependency.FoldNode;
 import vadl.viam.graph.dependency.ForIdxNode;
+import vadl.viam.graph.dependency.LetNode;
+import vadl.viam.graph.dependency.ParamNode;
 import vadl.viam.graph.dependency.ReadRegTensorNode;
 import vadl.viam.passes.sideEffectScheduling.nodes.InstrExitNode;
 
@@ -146,23 +150,17 @@ abstract class IssProcGen implements CDefaultMixins.All,
   }
 
   private boolean dependsOnForallIndex(Node node) {
-    return dependsOnForallIndex(node, new HashSet<>());
-  }
-
-  private boolean dependsOnForallIndex(Node node, Set<Node> visited) {
-    if (!visited.add(node)) {
-      return false;
-    }
-    if (node instanceof ForIdxNode) {
-      return true;
-    }
-    return node.inputs().anyMatch(input -> dependsOnForallIndex(input, visited));
+    return GraphUtils.isOrHasDependencies(node, ForIdxNode.class::isInstance);
   }
 
   @Handler
   @Override
   public void handle(CGenContext<Node> ctx, ScheduledNode node) {
     if (node.node() instanceof ExprSaveNode save) {
+      if (shouldInlineExprSave(save)) {
+        ctx.gen(node.next());
+        return;
+      }
       var type = CppTypeMap.nextFittingUInt(save.type().asDataType());
       ctx.wr(type + " " + exprSaveVariable(save) + " = ")
           .gen(save.value())
@@ -176,6 +174,10 @@ abstract class IssProcGen implements CDefaultMixins.All,
 
   @Handler
   public void handle(CGenContext<Node> ctx, ExprSaveNode toHandle) {
+    if (shouldInlineExprSave(toHandle)) {
+      ctx.gen(toHandle.value());
+      return;
+    }
     ctx.wr(exprSaveVariable(toHandle));
   }
 
@@ -207,6 +209,32 @@ abstract class IssProcGen implements CDefaultMixins.All,
   @Handler
   void handle(CGenContext<Node> ctx, FoldNode toHandle) {
     throwNotAllowed(toHandle, "forall fold expressions");
+  }
+
+  private boolean shouldInlineExprSave(ExprSaveNode save) {
+    return isIdentifierLike(save.value(), new HashSet<>());
+  }
+
+  private boolean isIdentifierLike(Node node, Set<Node> visited) {
+    if (!visited.add(node)) {
+      return false;
+    }
+    if (node instanceof ReadRegTensorNode read && preloadedReadRegs.contains(read)) {
+      return true;
+    }
+    if (node instanceof ParamNode
+        || node instanceof FieldRefNode
+        || node instanceof FieldAccessRefNode
+        || node instanceof ConstantNode) {
+      return true;
+    }
+    if (node instanceof LetNode letNode) {
+      return isIdentifierLike(letNode.expression(), visited);
+    }
+    if (node instanceof ExprSaveNode saveNode) {
+      return isIdentifierLike(saveNode.value(), visited);
+    }
+    return false;
   }
 
 }

--- a/vadl/main/vadl/iss/passes/IssCommonExprSavePass.java
+++ b/vadl/main/vadl/iss/passes/IssCommonExprSavePass.java
@@ -1,0 +1,217 @@
+// SPDX-FileCopyrightText : © 2026 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.iss.passes;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+import javax.annotation.Nullable;
+import vadl.configuration.IssConfiguration;
+import vadl.iss.passes.safeResourceRead.nodes.ExprSaveNode;
+import vadl.iss.passes.utils.IssDominatorAnalysis;
+import vadl.pass.PassName;
+import vadl.pass.PassResults;
+import vadl.utils.GraphUtils;
+import vadl.viam.Instruction;
+import vadl.viam.Specification;
+import vadl.viam.graph.Node;
+import vadl.viam.graph.control.AbstractBeginNode;
+import vadl.viam.graph.control.ControlNode;
+import vadl.viam.graph.control.DirectionalNode;
+import vadl.viam.graph.control.ScheduledNode;
+import vadl.viam.graph.dependency.ConstantNode;
+import vadl.viam.graph.dependency.ExpressionNode;
+import vadl.viam.graph.dependency.ForIdxNode;
+import vadl.viam.graph.dependency.FuncCallNode;
+import vadl.viam.graph.dependency.LetNode;
+import vadl.viam.graph.dependency.ParamNode;
+import vadl.viam.graph.dependency.ReadMemNode;
+import vadl.viam.graph.dependency.ReadRegTensorNode;
+
+/**
+ * Materializes helper-side common scalar subexpressions as {@link ExprSaveNode}s.
+ *
+ * <p>The helper path emits expression trees directly as C code. After ISS decomposition,
+ * normalization, and resource-read securing, expensive helper expressions often appear as repeated
+ * scalar subtrees. This pass stores such subtrees once at the latest control location that
+ * dominates all uses, so helper code generation can reuse the existing {@link ExprSaveNode}
+ * support without introducing codegen-local placement logic.</p>
+ */
+public class IssCommonExprSavePass extends AbstractIssPass {
+
+  public IssCommonExprSavePass(IssConfiguration configuration) {
+    super(configuration);
+  }
+
+  @Override
+  public PassName getName() {
+    return PassName.of("ISS Common Expr Save Pass");
+  }
+
+  @Override
+  public @Nullable Object execute(PassResults passResults, Specification viam) throws IOException {
+    if (viam.isa().isEmpty()) {
+      return null;
+    }
+
+    helperInstrs(viam).forEach(this::saveCommonExpressions);
+    return null;
+  }
+
+  private void saveCommonExpressions(Instruction instruction) {
+    var graph = instruction.behavior();
+    var dominatorAnalysis = IssDominatorAnalysis.analyze(graph);
+
+    // Process from consumers back toward leaves so once a parent expression is materialized,
+    // its children can see that reduced fanout and avoid redundant saves.
+    var topo = new java.util.ArrayList<>(GraphUtils.topologyOrderOfDependencyNodes(graph));
+    java.util.Collections.reverse(topo);
+
+    topo.stream()
+        .filter(ExpressionNode.class::isInstance)
+        .map(ExpressionNode.class::cast)
+        .filter(this::isCandidate)
+        .forEach(expr -> materialize(expr, dominatorAnalysis));
+  }
+
+  private boolean isCandidate(ExpressionNode expr) {
+    if (expr instanceof ExprSaveNode) {
+      return false;
+    }
+    if (!expr.type().isDataType()) {
+      return false;
+    }
+    if (expr.type().asDataType().bitWidth() > 64) {
+      return false;
+    }
+    if (expr.inputs().findAny().isEmpty()) {
+      return false;
+    }
+    if (expr.usages().count() <= 1) {
+      return false;
+    }
+    if (dependsOnForallIndex(expr)) {
+      return false;
+    }
+    if (hasPreloadedReadUsage(expr, new HashSet<>())) {
+      return false;
+    }
+    if (isTrivialAlias(expr)) {
+      return false;
+    }
+    return !containsDisallowedSubtree(expr, new HashSet<>());
+  }
+
+  private void materialize(ExpressionNode expr,
+                           IssDominatorAnalysis dominatorAnalysis) {
+    // Map all transitively reachable control users back onto stable CFG nodes that participate
+    // in the dominator analysis, then save once at their latest common dominator.
+    var controlUsages = GraphUtils.getTransientUsages(expr)
+        .filter(ControlNode.class::isInstance)
+        .map(ControlNode.class::cast)
+        .map(node -> normalizeControlUsage(node, dominatorAnalysis))
+        .filter(java.util.Objects::nonNull)
+        .collect(java.util.stream.Collectors.toSet());
+    if (controlUsages.isEmpty()) {
+      return;
+    }
+
+    var saveLocation = dominatorAnalysis.latestCommonDominator(controlUsages);
+    var saveNode = new ExprSaveNode(expr);
+    saveNode = expr.replace(saveNode);
+    insertScheduledSave(saveNode, saveLocation);
+  }
+
+  private void insertScheduledSave(ExprSaveNode saveNode, ControlNode location) {
+    // Expr saves behave like other scheduled dependency nodes: they must be inserted into the
+    // directional CFG edge that dominates all later uses.
+    var scheduledSaveNode = new ScheduledNode(saveNode);
+    if (location instanceof AbstractBeginNode beginNode) {
+      beginNode.addAfter(scheduledSaveNode);
+      return;
+    }
+
+    var predecessor = location.predecessor();
+    location.ensure(predecessor instanceof DirectionalNode,
+        "Expected control save location predecessor to be directional, got %s",
+        location.predecessor());
+    ((DirectionalNode) predecessor).addAfter(scheduledSaveNode);
+  }
+
+  private boolean dependsOnForallIndex(Node node) {
+    return GraphUtils.isOrHasDependencies(node, ForIdxNode.class::isInstance);
+  }
+
+  private boolean containsDisallowedSubtree(Node node, Set<Node> visited) {
+    // Keep the pass conservative: helper-only repeated scalar arithmetic is fine to save,
+    // but memory reads and function calls may imply extra evaluation constraints or side effects.
+    if (!visited.add(node)) {
+      return false;
+    }
+    if (node instanceof ReadMemNode || node instanceof FuncCallNode) {
+      return true;
+    }
+    return node.inputs().anyMatch(input -> containsDisallowedSubtree(input, visited));
+  }
+
+  private boolean hasPreloadedReadUsage(Node node, Set<Node> visited) {
+    // Helper register-read preloads are emitted before scheduled ExprSave statements, so any
+    // expression feeding such a preload must remain directly printable and cannot depend on a save.
+    if (!visited.add(node)) {
+      return false;
+    }
+    return node.usages().anyMatch(usage -> {
+      if (usage instanceof ReadRegTensorNode read) {
+        return isPreloadedHelperRead(read);
+      }
+      return hasPreloadedReadUsage(usage, visited);
+    });
+  }
+
+  private boolean isPreloadedHelperRead(ReadRegTensorNode read) {
+    return !dependsOnForallIndex(read) && read.type().isDataType()
+        && read.type().asDataType().bitWidth() <= 64;
+  }
+
+  private boolean isTrivialAlias(ExpressionNode expr) {
+    // Do not create save temporaries that merely rename an already variable-like value.
+    if (!(expr instanceof LetNode letNode)) {
+      return false;
+    }
+    var value = letNode.expression();
+    return value instanceof ConstantNode || value instanceof ParamNode
+        || value instanceof ReadRegTensorNode || value instanceof ExprSaveNode;
+  }
+
+  private static @Nullable ControlNode normalizeControlUsage(
+      ControlNode node,
+      IssDominatorAnalysis dominatorAnalysis) {
+    // Newly inserted ScheduledNodes are not part of the precomputed dominator map; use their
+    // successor as the stable CFG location they conceptually belong to.
+    if (dominatorAnalysis.contains(node)) {
+      return node;
+    }
+    if (node instanceof DirectionalNode directionalNode && directionalNode.next() != null) {
+      var next = directionalNode.next();
+      if (dominatorAnalysis.contains(next)) {
+        return next;
+      }
+    }
+    return null;
+  }
+
+}

--- a/vadl/main/vadl/iss/passes/safeResourceRead/IssSafeResourceReadPass.java
+++ b/vadl/main/vadl/iss/passes/safeResourceRead/IssSafeResourceReadPass.java
@@ -16,17 +16,12 @@
 
 package vadl.iss.passes.safeResourceRead;
 
-import static java.util.Objects.requireNonNull;
-import static vadl.utils.GraphUtils.getSingleNode;
-
 import java.io.IOException;
-import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
@@ -35,28 +30,23 @@ import vadl.iss.passes.AbstractIssPass;
 import vadl.iss.passes.nodes.IssReadRegNode;
 import vadl.iss.passes.nodes.IssWriteRegNode;
 import vadl.iss.passes.safeResourceRead.nodes.ExprSaveNode;
+import vadl.iss.passes.utils.IssDominatorAnalysis;
 import vadl.pass.PassName;
 import vadl.pass.PassResults;
 import vadl.viam.Instruction;
 import vadl.viam.Resource;
 import vadl.viam.Specification;
-import vadl.viam.graph.Graph;
 import vadl.viam.graph.Node;
 import vadl.viam.graph.control.AbstractBeginNode;
 import vadl.viam.graph.control.AbstractEndNode;
-import vadl.viam.graph.control.BranchEndNode;
 import vadl.viam.graph.control.ControlNode;
-import vadl.viam.graph.control.ControlSplitNode;
 import vadl.viam.graph.control.DirectionalNode;
-import vadl.viam.graph.control.MergeNode;
 import vadl.viam.graph.control.ScheduledNode;
-import vadl.viam.graph.control.StartNode;
 import vadl.viam.graph.dependency.ConstantNode;
 import vadl.viam.graph.dependency.DependencyNode;
 import vadl.viam.graph.dependency.ExpressionNode;
 import vadl.viam.graph.dependency.ReadResourceNode;
 import vadl.viam.graph.dependency.WriteResourceNode;
-import vadl.viam.passes.CfgTraverser;
 import vadl.viam.passes.sideEffectScheduling.nodes.InstrExitNode;
 
 /**
@@ -133,7 +123,7 @@ class IssResourceReadSecurer {
   Instruction instruction;
   IssSafeResourceReadPass.Result result;
 
-  Map<ControlNode, List<ControlNode>> dominatorSets;
+  IssDominatorAnalysis dominatorAnalysis;
 
   /**
    * Constructs an IssResourceReadSecurer for the given instruction and pass result.
@@ -144,7 +134,7 @@ class IssResourceReadSecurer {
   IssResourceReadSecurer(Instruction instruction, IssSafeResourceReadPass.Result result) {
     this.instruction = instruction;
     this.result = result;
-    dominatorSets = IssDominatorAnalysis.getDominatorSets(instruction.behavior());
+    dominatorAnalysis = IssDominatorAnalysis.analyze(instruction.behavior());
   }
 
   /**
@@ -339,7 +329,7 @@ class IssResourceReadSecurer {
         continue;
       }
       for (var writeSchedule : scheduledWrites) {
-        var writeDominators = requireNonNull(dominatorSets.get(writeSchedule));
+        var writeDominators = dominatorAnalysis.dominatorsOf(writeSchedule);
         if (!writeDominators.contains(conflictNode)) {
           allDominators = false;
           break;
@@ -360,7 +350,7 @@ class IssResourceReadSecurer {
       return null;
     }
 
-    return findLatestCommonNode(conflictNodes, dominatorSets);
+    return dominatorAnalysis.latestCommonDominator(conflictNodes);
 
   }
 
@@ -408,91 +398,4 @@ class IssResourceReadSecurer {
     return Stream.concat(s1, s2);
   }
 
-  /**
-   * Finds the control node that is the latest common dominator of all nodes in the given set.
-   *
-   * @param set           The set of control nodes.
-   * @param dominatorSets The map of dominator sets for each control node.
-   * @return The control node that is the latest common dominator.
-   */
-  @SuppressWarnings("LineLength")
-  private static ControlNode findLatestCommonNode(Set<ControlNode> set,
-                                                  Map<ControlNode, List<ControlNode>> dominatorSets) {
-
-    var domSets = new ArrayList<List<ControlNode>>();
-    for (ControlNode node : set) {
-      domSets.add(new ArrayList<>(dominatorSets.get(node)));
-    }
-
-    // Start node is always common
-    var lastCommon = domSets.get(0).get(0);
-
-    // Remove first from all (as first is always the start node)
-    for (var s : domSets) {
-      s.remove(0);
-    }
-
-    while (true) {
-      @Nullable ControlNode nextCommon = null;
-
-      for (var dominators : domSets) {
-        if (dominators.isEmpty()) {
-          return lastCommon;
-        }
-
-        var thisNext = dominators.remove(0);
-        if (lastCommon != null && thisNext != lastCommon) {
-          return lastCommon;
-        }
-        nextCommon = thisNext;
-      }
-
-      lastCommon = requireNonNull(nextCommon);
-    }
-
-  }
-}
-
-/**
- * Performs dominator analysis on a control flow graph (CFG)
- * to compute dominator sets for control nodes.
- */
-class IssDominatorAnalysis implements CfgTraverser {
-
-  Map<ControlNode, List<ControlNode>> dominatorSets = new HashMap<>();
-  ArrayDeque<Integer> splitDominatorIndexStack = new ArrayDeque<>();
-
-  // The current dominators during traversal
-  List<ControlNode> dominators = new ArrayList<>();
-
-  /**
-   * Computes the dominator sets for the given control flow graph.
-   *
-   * @param cfg The control flow graph to compute dominator sets for.
-   * @return A map of control nodes to their dominator sets.
-   */
-  static Map<ControlNode, List<ControlNode>> getDominatorSets(Graph cfg) {
-    var analysis = new IssDominatorAnalysis();
-    var start = getSingleNode(cfg, StartNode.class);
-    analysis.traverseBranch(start);
-    return analysis.dominatorSets;
-  }
-
-  @Override
-  public ControlNode onControlNode(ControlNode n) {
-    if (n instanceof ControlSplitNode) {
-      // Push index of splitNode
-      splitDominatorIndexStack.push(dominators.size() - 1);
-    } else if (n instanceof BranchEndNode || n instanceof MergeNode) {
-      // Reset sub-branch dominators
-      dominators = dominators.subList(0, requireNonNull(splitDominatorIndexStack.peek()) + 1);
-    }
-
-    // Add itself to dominator list
-    dominators.add(n);
-
-    // Copy to dominator sets
-    dominatorSets.put(n, new ArrayList<>(dominators));
-    return n;
-  }
 }

--- a/vadl/main/vadl/iss/passes/utils/IssDominatorAnalysis.java
+++ b/vadl/main/vadl/iss/passes/utils/IssDominatorAnalysis.java
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText : © 2026 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.iss.passes.utils;
+
+import static java.util.Objects.requireNonNull;
+import static vadl.utils.GraphUtils.getSingleNode;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+import vadl.viam.graph.Graph;
+import vadl.viam.graph.control.BranchEndNode;
+import vadl.viam.graph.control.ControlNode;
+import vadl.viam.graph.control.ControlSplitNode;
+import vadl.viam.graph.control.MergeNode;
+import vadl.viam.graph.control.StartNode;
+import vadl.viam.passes.CfgTraverser;
+
+/**
+ * Utilities for computing and querying CFG dominator information for ISS passes.
+ */
+public final class IssDominatorAnalysis {
+
+  private final Map<ControlNode, List<ControlNode>> dominatorSets;
+
+  private IssDominatorAnalysis(Map<ControlNode, List<ControlNode>> dominatorSets) {
+    this.dominatorSets = dominatorSets;
+  }
+
+  /**
+   * Analyzes the given control flow graph and captures its dominator information.
+   *
+   * <p>Each list is ordered from entry toward the node itself, so shared-prefix scans can be used
+   * to derive a latest common dominator.</p>
+   */
+  public static IssDominatorAnalysis analyze(Graph cfg) {
+    var traversal = new Traversal();
+    var start = getSingleNode(cfg, StartNode.class);
+    traversal.traverseBranch(start);
+    return new IssDominatorAnalysis(traversal.dominatorSets);
+  }
+
+  /**
+   * Returns the ordered dominator list for the given control node.
+   */
+  public List<ControlNode> dominatorsOf(ControlNode node) {
+    return requireNonNull(dominatorSets.get(node));
+  }
+
+  /**
+   * Returns whether the given control node was part of the analyzed CFG.
+   */
+  public boolean contains(ControlNode node) {
+    return dominatorSets.containsKey(node);
+  }
+
+  /**
+   * Finds the latest control node that dominates every node in the given set.
+   */
+  public ControlNode latestCommonDominator(Set<ControlNode> nodes) {
+    var domSets = new ArrayList<List<ControlNode>>();
+    for (var node : nodes) {
+      domSets.add(new ArrayList<>(dominatorsOf(node)));
+    }
+
+    // Start node is always common; the last shared prefix element is the answer.
+    var lastCommon = domSets.getFirst().getFirst();
+    for (var dominators : domSets) {
+      dominators.removeFirst();
+    }
+
+    while (true) {
+      @Nullable ControlNode nextCommon = null;
+      for (var dominators : domSets) {
+        if (dominators.isEmpty()) {
+          return lastCommon;
+        }
+
+        var next = dominators.removeFirst();
+        if (next != lastCommon) {
+          return lastCommon;
+        }
+        nextCommon = next;
+      }
+      lastCommon = requireNonNull(nextCommon);
+    }
+  }
+
+  /**
+   * Traverses the CFG while maintaining the active dominator stack for each branch.
+   */
+  private static final class Traversal implements CfgTraverser {
+    private final Map<ControlNode, List<ControlNode>> dominatorSets = new HashMap<>();
+    private final ArrayDeque<Integer> splitDominatorIndexStack = new ArrayDeque<>();
+    private List<ControlNode> dominators = new ArrayList<>();
+
+    @Override
+    public ControlNode onControlNode(ControlNode node) {
+      if (node instanceof ControlSplitNode) {
+        splitDominatorIndexStack.push(dominators.size() - 1);
+      } else if (node instanceof BranchEndNode || node instanceof MergeNode) {
+        dominators = dominators.subList(0, requireNonNull(splitDominatorIndexStack.peek()) + 1);
+      }
+
+      dominators.add(node);
+      dominatorSets.put(node, new ArrayList<>(dominators));
+      return node;
+    }
+  }
+}

--- a/vadl/main/vadl/pass/PassOrders.java
+++ b/vadl/main/vadl/pass/PassOrders.java
@@ -54,6 +54,7 @@ import vadl.gcb.passes.operands.GenerateInstructionOperandsPass;
 import vadl.iss.passes.IssBitfieldWriteLoweringPass;
 import vadl.iss.passes.IssBuiltInArgTruncOptPass;
 import vadl.iss.passes.IssCFunctionExtractionPass;
+import vadl.iss.passes.IssCommonExprSavePass;
 import vadl.iss.passes.IssConfigurationPass;
 import vadl.iss.passes.IssExecStrategyPass;
 import vadl.iss.passes.IssExtractOptimizationPass;
@@ -535,6 +536,7 @@ public class PassOrders {
         .add(new IssLoopUnrollPass(config))
         .add(new SideEffectSchedulingPass(config))
         .add(new IssSafeResourceReadPass(config))
+        .add(new IssCommonExprSavePass(config))
         .add(new IssPcAccessConversionPass(config))
         .add(new IssTcgContextPass(config))
         .add(new IssSelectLoweringPass(config))

--- a/vadl/main/vadl/utils/GraphUtils.java
+++ b/vadl/main/vadl/utils/GraphUtils.java
@@ -19,12 +19,15 @@ package vadl.utils;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
+import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -149,7 +152,7 @@ public class GraphUtils {
    * <p>Copied nodes are canonicalized when they implement {@link Canonicalizable}. The substituted
    * replacement itself is returned as provided and is not copied.</p>
    *
-   * @param root the expression root to copy
+   * @param root         the expression root to copy
    * @param substitution function returning a replacement expression, or {@code null} to keep
    *                     copying
    * @return the copied expression root with substitutions applied
@@ -265,38 +268,38 @@ public class GraphUtils {
   }
 
   /**
-   * Determines if a specified filter applies to the given node or at least one of its dependencies.
+   * Determines if the given node itself or any node in its transitive input subtree matches the
+   * provided predicate.
    *
-   * @param node   The starting node to check.
-   * @param filter A function that applies a condition to each node,
-   *               returning true if the node has a dependency and should be considered.
-   * @return true if itself or any dependency satisfies the filter condition; false otherwise.
+   * @param node      the root node whose dependency subtree should be searched
+   * @param predicate the condition to test on the root and all transitive inputs
+   * @return true if the root or any transitive input matches the predicate; false otherwise
    */
-  public static boolean isOrhasDependencies(Node node, Function<Node, Boolean> filter) {
-    return filter.apply((Node) node) || hasDependencies(node, filter);
+  public static boolean isOrHasDependencies(Node node, Predicate<Node> predicate) {
+    return isOrHasDependencies(node, predicate, new HashSet<>());
   }
 
+  private static boolean isOrHasDependencies(Node node,
+                                             Predicate<Node> predicate,
+                                             Set<Node> visited) {
+    if (!visited.add(node)) {
+      return false;
+    }
+    if (predicate.test(node)) {
+      return true;
+    }
+    return node.inputs().anyMatch(input -> isOrHasDependencies(input, predicate, visited));
+  }
 
   /**
-   * Determines if a given node has dependencies based on a provided filter function.
+   * Determines if any transitive input of the given node matches the provided predicate.
    *
-   * @param node   The starting node to check for dependencies.
-   * @param filter A function that applies a condition to each node,
-   *               returning true if the node has a dependency and should be considered.
-   * @return true if any dependency satisfies the filter condition; false otherwise.
+   * @param node      the root node whose input subtree should be searched, excluding the root
+   * @param predicate the condition to test on transitive inputs
+   * @return true if any transitive input matches the predicate; false otherwise
    */
-  public static boolean hasDependencies(Node node, Function<Node, Boolean> filter) {
-    GraphVisitor<Boolean> visitor = new GraphVisitor<>() {
-      @Override
-      public @Nonnull Boolean visit(Node from, @Nullable Node to) {
-        if (to == null || filter.apply(to)) {
-          return filter.apply(to);
-        }
-        return to.inputs().anyMatch(input -> visit(node, input));
-      }
-    };
-
-    return node.inputs().anyMatch(input -> visitor.visit(node, input));
+  public static boolean hasDependencies(Node node, Predicate<Node> predicate) {
+    return node.inputs().anyMatch(input -> isOrHasDependencies(input, predicate));
   }
 
   /**
@@ -635,10 +638,11 @@ public class GraphUtils {
    * Finds the end node of the branch the given node is on.
    *
    * @param node the node from which to search from
-   * @return     the branch end node
+   * @return the branch end node
    */
   public static AbstractEndNode branchEnd(DirectionalNode node) {
-    return new CfgTraverser() {}.traverseBranch(node);
+    return new CfgTraverser() {
+    }.traverseBranch(node);
   }
 
 

--- a/vadl/test/resources/snapshots/aarch64/InstrInfoTableGen.td
+++ b/vadl/test/resources/snapshots/aarch64/InstrInfoTableGen.td
@@ -40065,7 +40065,7 @@ let AddedComplexity = 0;
 let Pattern = [];
 
 let Uses = [  ];
-let Defs = [ NZCV_N,NZCV_Z,NZCV_C,NZCV_V,CPACR_EL1,VBAR_EL1,ELR_EL1,SP_EL1,SP_EL0,SPSel,ESR_EL1,SPSR_EL1,SP ];
+let Defs = [ NZCV_N,NZCV_Z,NZCV_C,NZCV_V,ZCR_EL1,CPACR_EL1,VBAR_EL1,ELR_EL1,SP_EL1,SP_EL0,SPSel,ESR_EL1,SPSR_EL1,SP ];
 }
 
 def MSUBW : Instruction

--- a/vadl/test/resources/snapshots/aarch64/RegisterInfo.cpp
+++ b/vadl/test/resources/snapshots/aarch64/RegisterInfo.cpp
@@ -30,1726 +30,1726 @@ using namespace llvm;
 void processornamevalueRegisterInfo::anchor() {}
 
 processornamevalueRegisterInfo::processornamevalueRegisterInfo()
-: processornamevalueGenRegisterInfo( processornamevalue::S30 )
+    : processornamevalueGenRegisterInfo( processornamevalue::S30 )
 {
 }
 
 const uint16_t * processornamevalueRegisterInfo::getCalleeSavedRegs(const MachineFunction * /*MF*/
 ) const
 {
-// defined in calling convention tablegen
-return CSR_processornamevalue_SaveList;
+    // defined in calling convention tablegen
+    return CSR_processornamevalue_SaveList;
 }
 
 BitVector processornamevalueRegisterInfo::getReservedRegs(const MachineFunction &MF) const
 {
-BitVector Reserved(getNumRegs());
+    BitVector Reserved(getNumRegs());
 
-markSuperRegs(Reserved, processornamevalue::X29); // frame pointer
-markSuperRegs(Reserved, processornamevalue::S31); // stack pointer
-
-
+    markSuperRegs(Reserved, processornamevalue::X29); // frame pointer
+    markSuperRegs(Reserved, processornamevalue::S31); // stack pointer
 
 
 
-assert(checkAllSuperRegsMarked(Reserved));
 
-return Reserved;
+
+    assert(checkAllSuperRegsMarked(Reserved));
+
+    return Reserved;
 }
 
 
 bool eliminateFrameIndexADDXI
-( MachineBasicBlock::iterator II
-, int SPAdj
-, unsigned FIOperandNum
-, unsigned FrameReg
-, StackOffset FrameIndexOffset
-, RegScavenger *RS
-)
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
 {
-MachineInstr &MI = *II;
-assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
 
-MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
 
-int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-//
-// try to inline the offset into the instruction
-//
+    //
+    // try to inline the offset into the instruction
+    //
 
-if(Offset >= 0 && Offset <= 4096 && AArch64Base_AddSubImmFormat_imm12X_predicate(Offset))
-{
-// immediate can be encoded and instruction can be inlined.
-FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-ImmOp.setImm( Offset );
-return false; // success
-}
+    if(Offset >= 0 && Offset <= 4096 && AArch64Base_AddSubImmFormat_imm12X_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
 
 
-DebugLoc DL = MI.getDebugLoc();
-MachineBasicBlock &MBB = *MI.getParent();
-MachineFunction *MF = MBB.getParent();
-MachineRegisterInfo &MRI = MF->getRegInfo();
-const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-//
-// try to generate a scratch register and adjust frame register with given offset
-//
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
 
-Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-{
-// the scratch register can properly be manipulated and used as address register.
-FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-ImmOp.setImm( 0 );
-return false; // success
-}
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
 
-return true; // failure
+    return true; // failure
 }
 bool eliminateFrameIndexLDRB
-( MachineBasicBlock::iterator II
-, int SPAdj
-, unsigned FIOperandNum
-, unsigned FrameReg
-, StackOffset FrameIndexOffset
-, RegScavenger *RS
-)
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
 {
-MachineInstr &MI = *II;
-assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
 
-MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
 
-int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-//
-// try to inline the offset into the instruction
-//
+    //
+    // try to inline the offset into the instruction
+    //
 
-if(Offset >= 0 && Offset <= 4096 && AArch64Base_MemoryOffFormat_offset_predicate(Offset))
-{
-// immediate can be encoded and instruction can be inlined.
-FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-ImmOp.setImm( Offset );
-return false; // success
-}
+    if(Offset >= 0 && Offset <= 4096 && AArch64Base_MemoryOffFormat_offset_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
 
 
-DebugLoc DL = MI.getDebugLoc();
-MachineBasicBlock &MBB = *MI.getParent();
-MachineFunction *MF = MBB.getParent();
-MachineRegisterInfo &MRI = MF->getRegInfo();
-const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-//
-// try to generate a scratch register and adjust frame register with given offset
-//
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
 
-Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-{
-// the scratch register can properly be manipulated and used as address register.
-FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-ImmOp.setImm( 0 );
-return false; // success
-}
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
 
-return true; // failure
+    return true; // failure
 }
 bool eliminateFrameIndexLDRH
-( MachineBasicBlock::iterator II
-, int SPAdj
-, unsigned FIOperandNum
-, unsigned FrameReg
-, StackOffset FrameIndexOffset
-, RegScavenger *RS
-)
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
 {
-MachineInstr &MI = *II;
-assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
 
-MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
 
-int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-//
-// try to inline the offset into the instruction
-//
+    //
+    // try to inline the offset into the instruction
+    //
 
-if(Offset >= 0 && Offset <= 4096 && AArch64Base_MemoryOffFormat_offset_predicate(Offset))
-{
-// immediate can be encoded and instruction can be inlined.
-FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-ImmOp.setImm( Offset );
-return false; // success
-}
+    if(Offset >= 0 && Offset <= 4096 && AArch64Base_MemoryOffFormat_offset_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
 
 
-DebugLoc DL = MI.getDebugLoc();
-MachineBasicBlock &MBB = *MI.getParent();
-MachineFunction *MF = MBB.getParent();
-MachineRegisterInfo &MRI = MF->getRegInfo();
-const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-//
-// try to generate a scratch register and adjust frame register with given offset
-//
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
 
-Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-{
-// the scratch register can properly be manipulated and used as address register.
-FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-ImmOp.setImm( 0 );
-return false; // success
-}
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
 
-return true; // failure
+    return true; // failure
 }
 bool eliminateFrameIndexLDRSBW
-( MachineBasicBlock::iterator II
-, int SPAdj
-, unsigned FIOperandNum
-, unsigned FrameReg
-, StackOffset FrameIndexOffset
-, RegScavenger *RS
-)
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
 {
-MachineInstr &MI = *II;
-assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
 
-MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
 
-int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-//
-// try to inline the offset into the instruction
-//
+    //
+    // try to inline the offset into the instruction
+    //
 
-if(Offset >= 0 && Offset <= 4096 && AArch64Base_MemoryOffFormat_offset_predicate(Offset))
-{
-// immediate can be encoded and instruction can be inlined.
-FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-ImmOp.setImm( Offset );
-return false; // success
-}
+    if(Offset >= 0 && Offset <= 4096 && AArch64Base_MemoryOffFormat_offset_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
 
 
-DebugLoc DL = MI.getDebugLoc();
-MachineBasicBlock &MBB = *MI.getParent();
-MachineFunction *MF = MBB.getParent();
-MachineRegisterInfo &MRI = MF->getRegInfo();
-const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-//
-// try to generate a scratch register and adjust frame register with given offset
-//
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
 
-Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-{
-// the scratch register can properly be manipulated and used as address register.
-FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-ImmOp.setImm( 0 );
-return false; // success
-}
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
 
-return true; // failure
+    return true; // failure
 }
 bool eliminateFrameIndexLDRSBX
-( MachineBasicBlock::iterator II
-, int SPAdj
-, unsigned FIOperandNum
-, unsigned FrameReg
-, StackOffset FrameIndexOffset
-, RegScavenger *RS
-)
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
 {
-MachineInstr &MI = *II;
-assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
 
-MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
 
-int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-//
-// try to inline the offset into the instruction
-//
+    //
+    // try to inline the offset into the instruction
+    //
 
-if(Offset >= 0 && Offset <= 4096 && AArch64Base_MemoryOffFormat_offset_predicate(Offset))
-{
-// immediate can be encoded and instruction can be inlined.
-FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-ImmOp.setImm( Offset );
-return false; // success
-}
+    if(Offset >= 0 && Offset <= 4096 && AArch64Base_MemoryOffFormat_offset_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
 
 
-DebugLoc DL = MI.getDebugLoc();
-MachineBasicBlock &MBB = *MI.getParent();
-MachineFunction *MF = MBB.getParent();
-MachineRegisterInfo &MRI = MF->getRegInfo();
-const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-//
-// try to generate a scratch register and adjust frame register with given offset
-//
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
 
-Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-{
-// the scratch register can properly be manipulated and used as address register.
-FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-ImmOp.setImm( 0 );
-return false; // success
-}
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
 
-return true; // failure
+    return true; // failure
 }
 bool eliminateFrameIndexLDRSHW
-( MachineBasicBlock::iterator II
-, int SPAdj
-, unsigned FIOperandNum
-, unsigned FrameReg
-, StackOffset FrameIndexOffset
-, RegScavenger *RS
-)
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
 {
-MachineInstr &MI = *II;
-assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
 
-MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
 
-int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-//
-// try to inline the offset into the instruction
-//
+    //
+    // try to inline the offset into the instruction
+    //
 
-if(Offset >= 0 && Offset <= 4096 && AArch64Base_MemoryOffFormat_offset_predicate(Offset))
-{
-// immediate can be encoded and instruction can be inlined.
-FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-ImmOp.setImm( Offset );
-return false; // success
-}
+    if(Offset >= 0 && Offset <= 4096 && AArch64Base_MemoryOffFormat_offset_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
 
 
-DebugLoc DL = MI.getDebugLoc();
-MachineBasicBlock &MBB = *MI.getParent();
-MachineFunction *MF = MBB.getParent();
-MachineRegisterInfo &MRI = MF->getRegInfo();
-const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-//
-// try to generate a scratch register and adjust frame register with given offset
-//
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
 
-Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-{
-// the scratch register can properly be manipulated and used as address register.
-FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-ImmOp.setImm( 0 );
-return false; // success
-}
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
 
-return true; // failure
+    return true; // failure
 }
 bool eliminateFrameIndexLDRSHX
-( MachineBasicBlock::iterator II
-, int SPAdj
-, unsigned FIOperandNum
-, unsigned FrameReg
-, StackOffset FrameIndexOffset
-, RegScavenger *RS
-)
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
 {
-MachineInstr &MI = *II;
-assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
 
-MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
 
-int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-//
-// try to inline the offset into the instruction
-//
+    //
+    // try to inline the offset into the instruction
+    //
 
-if(Offset >= 0 && Offset <= 4096 && AArch64Base_MemoryOffFormat_offset_predicate(Offset))
-{
-// immediate can be encoded and instruction can be inlined.
-FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-ImmOp.setImm( Offset );
-return false; // success
-}
+    if(Offset >= 0 && Offset <= 4096 && AArch64Base_MemoryOffFormat_offset_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
 
 
-DebugLoc DL = MI.getDebugLoc();
-MachineBasicBlock &MBB = *MI.getParent();
-MachineFunction *MF = MBB.getParent();
-MachineRegisterInfo &MRI = MF->getRegInfo();
-const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-//
-// try to generate a scratch register and adjust frame register with given offset
-//
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
 
-Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-{
-// the scratch register can properly be manipulated and used as address register.
-FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-ImmOp.setImm( 0 );
-return false; // success
-}
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
 
-return true; // failure
+    return true; // failure
 }
 bool eliminateFrameIndexLDRSWX
-( MachineBasicBlock::iterator II
-, int SPAdj
-, unsigned FIOperandNum
-, unsigned FrameReg
-, StackOffset FrameIndexOffset
-, RegScavenger *RS
-)
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
 {
-MachineInstr &MI = *II;
-assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
 
-MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
 
-int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-//
-// try to inline the offset into the instruction
-//
+    //
+    // try to inline the offset into the instruction
+    //
 
-if(Offset >= 0 && Offset <= 4096 && AArch64Base_MemoryOffFormat_offset_predicate(Offset))
-{
-// immediate can be encoded and instruction can be inlined.
-FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-ImmOp.setImm( Offset );
-return false; // success
-}
+    if(Offset >= 0 && Offset <= 4096 && AArch64Base_MemoryOffFormat_offset_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
 
 
-DebugLoc DL = MI.getDebugLoc();
-MachineBasicBlock &MBB = *MI.getParent();
-MachineFunction *MF = MBB.getParent();
-MachineRegisterInfo &MRI = MF->getRegInfo();
-const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-//
-// try to generate a scratch register and adjust frame register with given offset
-//
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
 
-Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-{
-// the scratch register can properly be manipulated and used as address register.
-FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-ImmOp.setImm( 0 );
-return false; // success
-}
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
 
-return true; // failure
+    return true; // failure
 }
 bool eliminateFrameIndexLDRW
-( MachineBasicBlock::iterator II
-, int SPAdj
-, unsigned FIOperandNum
-, unsigned FrameReg
-, StackOffset FrameIndexOffset
-, RegScavenger *RS
-)
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
 {
-MachineInstr &MI = *II;
-assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
 
-MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
 
-int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-//
-// try to inline the offset into the instruction
-//
+    //
+    // try to inline the offset into the instruction
+    //
 
-if(Offset >= 0 && Offset <= 4096 && AArch64Base_MemoryOffFormat_offset_predicate(Offset))
-{
-// immediate can be encoded and instruction can be inlined.
-FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-ImmOp.setImm( Offset );
-return false; // success
-}
+    if(Offset >= 0 && Offset <= 4096 && AArch64Base_MemoryOffFormat_offset_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
 
 
-DebugLoc DL = MI.getDebugLoc();
-MachineBasicBlock &MBB = *MI.getParent();
-MachineFunction *MF = MBB.getParent();
-MachineRegisterInfo &MRI = MF->getRegInfo();
-const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-//
-// try to generate a scratch register and adjust frame register with given offset
-//
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
 
-Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-{
-// the scratch register can properly be manipulated and used as address register.
-FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-ImmOp.setImm( 0 );
-return false; // success
-}
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
 
-return true; // failure
+    return true; // failure
 }
 bool eliminateFrameIndexLDRX
-( MachineBasicBlock::iterator II
-, int SPAdj
-, unsigned FIOperandNum
-, unsigned FrameReg
-, StackOffset FrameIndexOffset
-, RegScavenger *RS
-)
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
 {
-MachineInstr &MI = *II;
-assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
 
-MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
 
-int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-//
-// try to inline the offset into the instruction
-//
+    //
+    // try to inline the offset into the instruction
+    //
 
-if(Offset >= 0 && Offset <= 4096 && AArch64Base_MemoryOffFormat_offset_predicate(Offset))
-{
-// immediate can be encoded and instruction can be inlined.
-FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-ImmOp.setImm( Offset );
-return false; // success
-}
+    if(Offset >= 0 && Offset <= 4096 && AArch64Base_MemoryOffFormat_offset_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
 
 
-DebugLoc DL = MI.getDebugLoc();
-MachineBasicBlock &MBB = *MI.getParent();
-MachineFunction *MF = MBB.getParent();
-MachineRegisterInfo &MRI = MF->getRegInfo();
-const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-//
-// try to generate a scratch register and adjust frame register with given offset
-//
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
 
-Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-{
-// the scratch register can properly be manipulated and used as address register.
-FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-ImmOp.setImm( 0 );
-return false; // success
-}
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
 
-return true; // failure
+    return true; // failure
 }
 bool eliminateFrameIndexLDURB
-( MachineBasicBlock::iterator II
-, int SPAdj
-, unsigned FIOperandNum
-, unsigned FrameReg
-, StackOffset FrameIndexOffset
-, RegScavenger *RS
-)
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
 {
-MachineInstr &MI = *II;
-assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
 
-MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
 
-int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-//
-// try to inline the offset into the instruction
-//
+    //
+    // try to inline the offset into the instruction
+    //
 
-if(Offset >= -256 && Offset <= 255 && AArch64Base_MemoryImmFormat_offset_predicate(Offset))
-{
-// immediate can be encoded and instruction can be inlined.
-FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-ImmOp.setImm( Offset );
-return false; // success
-}
+    if(Offset >= -256 && Offset <= 255 && AArch64Base_MemoryImmFormat_offset_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
 
 
-DebugLoc DL = MI.getDebugLoc();
-MachineBasicBlock &MBB = *MI.getParent();
-MachineFunction *MF = MBB.getParent();
-MachineRegisterInfo &MRI = MF->getRegInfo();
-const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-//
-// try to generate a scratch register and adjust frame register with given offset
-//
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
 
-Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-{
-// the scratch register can properly be manipulated and used as address register.
-FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-ImmOp.setImm( 0 );
-return false; // success
-}
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
 
-return true; // failure
+    return true; // failure
 }
 bool eliminateFrameIndexLDURH
-( MachineBasicBlock::iterator II
-, int SPAdj
-, unsigned FIOperandNum
-, unsigned FrameReg
-, StackOffset FrameIndexOffset
-, RegScavenger *RS
-)
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
 {
-MachineInstr &MI = *II;
-assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
 
-MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
 
-int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-//
-// try to inline the offset into the instruction
-//
+    //
+    // try to inline the offset into the instruction
+    //
 
-if(Offset >= -256 && Offset <= 255 && AArch64Base_MemoryImmFormat_offset_predicate(Offset))
-{
-// immediate can be encoded and instruction can be inlined.
-FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-ImmOp.setImm( Offset );
-return false; // success
-}
+    if(Offset >= -256 && Offset <= 255 && AArch64Base_MemoryImmFormat_offset_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
 
 
-DebugLoc DL = MI.getDebugLoc();
-MachineBasicBlock &MBB = *MI.getParent();
-MachineFunction *MF = MBB.getParent();
-MachineRegisterInfo &MRI = MF->getRegInfo();
-const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-//
-// try to generate a scratch register and adjust frame register with given offset
-//
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
 
-Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-{
-// the scratch register can properly be manipulated and used as address register.
-FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-ImmOp.setImm( 0 );
-return false; // success
-}
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
 
-return true; // failure
+    return true; // failure
 }
 bool eliminateFrameIndexLDURSBW
-( MachineBasicBlock::iterator II
-, int SPAdj
-, unsigned FIOperandNum
-, unsigned FrameReg
-, StackOffset FrameIndexOffset
-, RegScavenger *RS
-)
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
 {
-MachineInstr &MI = *II;
-assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
 
-MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
 
-int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-//
-// try to inline the offset into the instruction
-//
+    //
+    // try to inline the offset into the instruction
+    //
 
-if(Offset >= -256 && Offset <= 255 && AArch64Base_MemoryImmFormat_offset_predicate(Offset))
-{
-// immediate can be encoded and instruction can be inlined.
-FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-ImmOp.setImm( Offset );
-return false; // success
-}
+    if(Offset >= -256 && Offset <= 255 && AArch64Base_MemoryImmFormat_offset_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
 
 
-DebugLoc DL = MI.getDebugLoc();
-MachineBasicBlock &MBB = *MI.getParent();
-MachineFunction *MF = MBB.getParent();
-MachineRegisterInfo &MRI = MF->getRegInfo();
-const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-//
-// try to generate a scratch register and adjust frame register with given offset
-//
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
 
-Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-{
-// the scratch register can properly be manipulated and used as address register.
-FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-ImmOp.setImm( 0 );
-return false; // success
-}
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
 
-return true; // failure
+    return true; // failure
 }
 bool eliminateFrameIndexLDURSBX
-( MachineBasicBlock::iterator II
-, int SPAdj
-, unsigned FIOperandNum
-, unsigned FrameReg
-, StackOffset FrameIndexOffset
-, RegScavenger *RS
-)
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
 {
-MachineInstr &MI = *II;
-assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
 
-MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
 
-int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-//
-// try to inline the offset into the instruction
-//
+    //
+    // try to inline the offset into the instruction
+    //
 
-if(Offset >= -256 && Offset <= 255 && AArch64Base_MemoryImmFormat_offset_predicate(Offset))
-{
-// immediate can be encoded and instruction can be inlined.
-FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-ImmOp.setImm( Offset );
-return false; // success
-}
+    if(Offset >= -256 && Offset <= 255 && AArch64Base_MemoryImmFormat_offset_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
 
 
-DebugLoc DL = MI.getDebugLoc();
-MachineBasicBlock &MBB = *MI.getParent();
-MachineFunction *MF = MBB.getParent();
-MachineRegisterInfo &MRI = MF->getRegInfo();
-const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-//
-// try to generate a scratch register and adjust frame register with given offset
-//
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
 
-Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-{
-// the scratch register can properly be manipulated and used as address register.
-FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-ImmOp.setImm( 0 );
-return false; // success
-}
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
 
-return true; // failure
+    return true; // failure
 }
 bool eliminateFrameIndexLDURSHW
-( MachineBasicBlock::iterator II
-, int SPAdj
-, unsigned FIOperandNum
-, unsigned FrameReg
-, StackOffset FrameIndexOffset
-, RegScavenger *RS
-)
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
 {
-MachineInstr &MI = *II;
-assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
 
-MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
 
-int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-//
-// try to inline the offset into the instruction
-//
+    //
+    // try to inline the offset into the instruction
+    //
 
-if(Offset >= -256 && Offset <= 255 && AArch64Base_MemoryImmFormat_offset_predicate(Offset))
-{
-// immediate can be encoded and instruction can be inlined.
-FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-ImmOp.setImm( Offset );
-return false; // success
-}
+    if(Offset >= -256 && Offset <= 255 && AArch64Base_MemoryImmFormat_offset_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
 
 
-DebugLoc DL = MI.getDebugLoc();
-MachineBasicBlock &MBB = *MI.getParent();
-MachineFunction *MF = MBB.getParent();
-MachineRegisterInfo &MRI = MF->getRegInfo();
-const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-//
-// try to generate a scratch register and adjust frame register with given offset
-//
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
 
-Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-{
-// the scratch register can properly be manipulated and used as address register.
-FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-ImmOp.setImm( 0 );
-return false; // success
-}
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
 
-return true; // failure
+    return true; // failure
 }
 bool eliminateFrameIndexLDURSHX
-( MachineBasicBlock::iterator II
-, int SPAdj
-, unsigned FIOperandNum
-, unsigned FrameReg
-, StackOffset FrameIndexOffset
-, RegScavenger *RS
-)
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
 {
-MachineInstr &MI = *II;
-assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
 
-MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
 
-int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-//
-// try to inline the offset into the instruction
-//
+    //
+    // try to inline the offset into the instruction
+    //
 
-if(Offset >= -256 && Offset <= 255 && AArch64Base_MemoryImmFormat_offset_predicate(Offset))
-{
-// immediate can be encoded and instruction can be inlined.
-FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-ImmOp.setImm( Offset );
-return false; // success
-}
+    if(Offset >= -256 && Offset <= 255 && AArch64Base_MemoryImmFormat_offset_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
 
 
-DebugLoc DL = MI.getDebugLoc();
-MachineBasicBlock &MBB = *MI.getParent();
-MachineFunction *MF = MBB.getParent();
-MachineRegisterInfo &MRI = MF->getRegInfo();
-const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-//
-// try to generate a scratch register and adjust frame register with given offset
-//
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
 
-Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-{
-// the scratch register can properly be manipulated and used as address register.
-FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-ImmOp.setImm( 0 );
-return false; // success
-}
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
 
-return true; // failure
+    return true; // failure
 }
 bool eliminateFrameIndexLDURSWX
-( MachineBasicBlock::iterator II
-, int SPAdj
-, unsigned FIOperandNum
-, unsigned FrameReg
-, StackOffset FrameIndexOffset
-, RegScavenger *RS
-)
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
 {
-MachineInstr &MI = *II;
-assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
 
-MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
 
-int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-//
-// try to inline the offset into the instruction
-//
+    //
+    // try to inline the offset into the instruction
+    //
 
-if(Offset >= -256 && Offset <= 255 && AArch64Base_MemoryImmFormat_offset_predicate(Offset))
-{
-// immediate can be encoded and instruction can be inlined.
-FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-ImmOp.setImm( Offset );
-return false; // success
-}
+    if(Offset >= -256 && Offset <= 255 && AArch64Base_MemoryImmFormat_offset_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
 
 
-DebugLoc DL = MI.getDebugLoc();
-MachineBasicBlock &MBB = *MI.getParent();
-MachineFunction *MF = MBB.getParent();
-MachineRegisterInfo &MRI = MF->getRegInfo();
-const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-//
-// try to generate a scratch register and adjust frame register with given offset
-//
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
 
-Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-{
-// the scratch register can properly be manipulated and used as address register.
-FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-ImmOp.setImm( 0 );
-return false; // success
-}
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
 
-return true; // failure
+    return true; // failure
 }
 bool eliminateFrameIndexLDURW
-( MachineBasicBlock::iterator II
-, int SPAdj
-, unsigned FIOperandNum
-, unsigned FrameReg
-, StackOffset FrameIndexOffset
-, RegScavenger *RS
-)
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
 {
-MachineInstr &MI = *II;
-assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
 
-MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
 
-int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-//
-// try to inline the offset into the instruction
-//
+    //
+    // try to inline the offset into the instruction
+    //
 
-if(Offset >= -256 && Offset <= 255 && AArch64Base_MemoryImmFormat_offset_predicate(Offset))
-{
-// immediate can be encoded and instruction can be inlined.
-FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-ImmOp.setImm( Offset );
-return false; // success
-}
+    if(Offset >= -256 && Offset <= 255 && AArch64Base_MemoryImmFormat_offset_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
 
 
-DebugLoc DL = MI.getDebugLoc();
-MachineBasicBlock &MBB = *MI.getParent();
-MachineFunction *MF = MBB.getParent();
-MachineRegisterInfo &MRI = MF->getRegInfo();
-const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-//
-// try to generate a scratch register and adjust frame register with given offset
-//
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
 
-Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-{
-// the scratch register can properly be manipulated and used as address register.
-FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-ImmOp.setImm( 0 );
-return false; // success
-}
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
 
-return true; // failure
+    return true; // failure
 }
 bool eliminateFrameIndexLDURX
-( MachineBasicBlock::iterator II
-, int SPAdj
-, unsigned FIOperandNum
-, unsigned FrameReg
-, StackOffset FrameIndexOffset
-, RegScavenger *RS
-)
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
 {
-MachineInstr &MI = *II;
-assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 1).isImm() && "Immediate operand position does not match expected position!" );
 
-MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 1);
 
-int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-//
-// try to inline the offset into the instruction
-//
+    //
+    // try to inline the offset into the instruction
+    //
 
-if(Offset >= -256 && Offset <= 255 && AArch64Base_MemoryImmFormat_offset_predicate(Offset))
-{
-// immediate can be encoded and instruction can be inlined.
-FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-ImmOp.setImm( Offset );
-return false; // success
-}
+    if(Offset >= -256 && Offset <= 255 && AArch64Base_MemoryImmFormat_offset_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
 
 
-DebugLoc DL = MI.getDebugLoc();
-MachineBasicBlock &MBB = *MI.getParent();
-MachineFunction *MF = MBB.getParent();
-MachineRegisterInfo &MRI = MF->getRegInfo();
-const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-//
-// try to generate a scratch register and adjust frame register with given offset
-//
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
 
-Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-{
-// the scratch register can properly be manipulated and used as address register.
-FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-ImmOp.setImm( 0 );
-return false; // success
-}
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
 
-return true; // failure
+    return true; // failure
 }
 bool eliminateFrameIndexSTRB
-( MachineBasicBlock::iterator II
-, int SPAdj
-, unsigned FIOperandNum
-, unsigned FrameReg
-, StackOffset FrameIndexOffset
-, RegScavenger *RS
-)
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
 {
-MachineInstr &MI = *II;
-assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-assert(  MI.getOperand(FIOperandNum + 2).isImm() && "Immediate operand position does not match expected position!" );
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 2).isImm() && "Immediate operand position does not match expected position!" );
 
-MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 2);
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 2);
 
-int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-//
-// try to inline the offset into the instruction
-//
+    //
+    // try to inline the offset into the instruction
+    //
 
-if(Offset >= 0 && Offset <= 4096 && AArch64Base_MemoryOffFormat_offset_predicate(Offset))
-{
-// immediate can be encoded and instruction can be inlined.
-FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-ImmOp.setImm( Offset );
-return false; // success
-}
+    if(Offset >= 0 && Offset <= 4096 && AArch64Base_MemoryOffFormat_offset_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
 
 
-DebugLoc DL = MI.getDebugLoc();
-MachineBasicBlock &MBB = *MI.getParent();
-MachineFunction *MF = MBB.getParent();
-MachineRegisterInfo &MRI = MF->getRegInfo();
-const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-//
-// try to generate a scratch register and adjust frame register with given offset
-//
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
 
-Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-{
-// the scratch register can properly be manipulated and used as address register.
-FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-ImmOp.setImm( 0 );
-return false; // success
-}
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
 
-return true; // failure
+    return true; // failure
 }
 bool eliminateFrameIndexSTRH
-( MachineBasicBlock::iterator II
-, int SPAdj
-, unsigned FIOperandNum
-, unsigned FrameReg
-, StackOffset FrameIndexOffset
-, RegScavenger *RS
-)
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
 {
-MachineInstr &MI = *II;
-assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-assert(  MI.getOperand(FIOperandNum + 2).isImm() && "Immediate operand position does not match expected position!" );
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 2).isImm() && "Immediate operand position does not match expected position!" );
 
-MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 2);
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 2);
 
-int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-//
-// try to inline the offset into the instruction
-//
+    //
+    // try to inline the offset into the instruction
+    //
 
-if(Offset >= 0 && Offset <= 4096 && AArch64Base_MemoryOffFormat_offset_predicate(Offset))
-{
-// immediate can be encoded and instruction can be inlined.
-FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-ImmOp.setImm( Offset );
-return false; // success
-}
+    if(Offset >= 0 && Offset <= 4096 && AArch64Base_MemoryOffFormat_offset_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
 
 
-DebugLoc DL = MI.getDebugLoc();
-MachineBasicBlock &MBB = *MI.getParent();
-MachineFunction *MF = MBB.getParent();
-MachineRegisterInfo &MRI = MF->getRegInfo();
-const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-//
-// try to generate a scratch register and adjust frame register with given offset
-//
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
 
-Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-{
-// the scratch register can properly be manipulated and used as address register.
-FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-ImmOp.setImm( 0 );
-return false; // success
-}
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
 
-return true; // failure
+    return true; // failure
 }
 bool eliminateFrameIndexSTRW
-( MachineBasicBlock::iterator II
-, int SPAdj
-, unsigned FIOperandNum
-, unsigned FrameReg
-, StackOffset FrameIndexOffset
-, RegScavenger *RS
-)
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
 {
-MachineInstr &MI = *II;
-assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-assert(  MI.getOperand(FIOperandNum + 2).isImm() && "Immediate operand position does not match expected position!" );
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 2).isImm() && "Immediate operand position does not match expected position!" );
 
-MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 2);
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 2);
 
-int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-//
-// try to inline the offset into the instruction
-//
+    //
+    // try to inline the offset into the instruction
+    //
 
-if(Offset >= 0 && Offset <= 4096 && AArch64Base_MemoryOffFormat_offset_predicate(Offset))
-{
-// immediate can be encoded and instruction can be inlined.
-FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-ImmOp.setImm( Offset );
-return false; // success
-}
+    if(Offset >= 0 && Offset <= 4096 && AArch64Base_MemoryOffFormat_offset_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
 
 
-DebugLoc DL = MI.getDebugLoc();
-MachineBasicBlock &MBB = *MI.getParent();
-MachineFunction *MF = MBB.getParent();
-MachineRegisterInfo &MRI = MF->getRegInfo();
-const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-//
-// try to generate a scratch register and adjust frame register with given offset
-//
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
 
-Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-{
-// the scratch register can properly be manipulated and used as address register.
-FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-ImmOp.setImm( 0 );
-return false; // success
-}
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
 
-return true; // failure
+    return true; // failure
 }
 bool eliminateFrameIndexSTRX
-( MachineBasicBlock::iterator II
-, int SPAdj
-, unsigned FIOperandNum
-, unsigned FrameReg
-, StackOffset FrameIndexOffset
-, RegScavenger *RS
-)
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
 {
-MachineInstr &MI = *II;
-assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-assert(  MI.getOperand(FIOperandNum + 2).isImm() && "Immediate operand position does not match expected position!" );
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 2).isImm() && "Immediate operand position does not match expected position!" );
 
-MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 2);
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 2);
 
-int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-//
-// try to inline the offset into the instruction
-//
+    //
+    // try to inline the offset into the instruction
+    //
 
-if(Offset >= 0 && Offset <= 4096 && AArch64Base_MemoryOffFormat_offset_predicate(Offset))
-{
-// immediate can be encoded and instruction can be inlined.
-FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-ImmOp.setImm( Offset );
-return false; // success
-}
+    if(Offset >= 0 && Offset <= 4096 && AArch64Base_MemoryOffFormat_offset_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
 
 
-DebugLoc DL = MI.getDebugLoc();
-MachineBasicBlock &MBB = *MI.getParent();
-MachineFunction *MF = MBB.getParent();
-MachineRegisterInfo &MRI = MF->getRegInfo();
-const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-//
-// try to generate a scratch register and adjust frame register with given offset
-//
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
 
-Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-{
-// the scratch register can properly be manipulated and used as address register.
-FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-ImmOp.setImm( 0 );
-return false; // success
-}
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
 
-return true; // failure
+    return true; // failure
 }
 bool eliminateFrameIndexSTURB
-( MachineBasicBlock::iterator II
-, int SPAdj
-, unsigned FIOperandNum
-, unsigned FrameReg
-, StackOffset FrameIndexOffset
-, RegScavenger *RS
-)
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
 {
-MachineInstr &MI = *II;
-assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-assert(  MI.getOperand(FIOperandNum + 2).isImm() && "Immediate operand position does not match expected position!" );
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 2).isImm() && "Immediate operand position does not match expected position!" );
 
-MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 2);
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 2);
 
-int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-//
-// try to inline the offset into the instruction
-//
+    //
+    // try to inline the offset into the instruction
+    //
 
-if(Offset >= -256 && Offset <= 255 && AArch64Base_MemoryImmFormat_offset_predicate(Offset))
-{
-// immediate can be encoded and instruction can be inlined.
-FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-ImmOp.setImm( Offset );
-return false; // success
-}
+    if(Offset >= -256 && Offset <= 255 && AArch64Base_MemoryImmFormat_offset_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
 
 
-DebugLoc DL = MI.getDebugLoc();
-MachineBasicBlock &MBB = *MI.getParent();
-MachineFunction *MF = MBB.getParent();
-MachineRegisterInfo &MRI = MF->getRegInfo();
-const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-//
-// try to generate a scratch register and adjust frame register with given offset
-//
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
 
-Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-{
-// the scratch register can properly be manipulated and used as address register.
-FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-ImmOp.setImm( 0 );
-return false; // success
-}
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
 
-return true; // failure
+    return true; // failure
 }
 bool eliminateFrameIndexSTURH
-( MachineBasicBlock::iterator II
-, int SPAdj
-, unsigned FIOperandNum
-, unsigned FrameReg
-, StackOffset FrameIndexOffset
-, RegScavenger *RS
-)
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
 {
-MachineInstr &MI = *II;
-assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-assert(  MI.getOperand(FIOperandNum + 2).isImm() && "Immediate operand position does not match expected position!" );
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 2).isImm() && "Immediate operand position does not match expected position!" );
 
-MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 2);
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 2);
 
-int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-//
-// try to inline the offset into the instruction
-//
+    //
+    // try to inline the offset into the instruction
+    //
 
-if(Offset >= -256 && Offset <= 255 && AArch64Base_MemoryImmFormat_offset_predicate(Offset))
-{
-// immediate can be encoded and instruction can be inlined.
-FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-ImmOp.setImm( Offset );
-return false; // success
-}
+    if(Offset >= -256 && Offset <= 255 && AArch64Base_MemoryImmFormat_offset_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
 
 
-DebugLoc DL = MI.getDebugLoc();
-MachineBasicBlock &MBB = *MI.getParent();
-MachineFunction *MF = MBB.getParent();
-MachineRegisterInfo &MRI = MF->getRegInfo();
-const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-//
-// try to generate a scratch register and adjust frame register with given offset
-//
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
 
-Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-{
-// the scratch register can properly be manipulated and used as address register.
-FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-ImmOp.setImm( 0 );
-return false; // success
-}
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
 
-return true; // failure
+    return true; // failure
 }
 bool eliminateFrameIndexSTURW
-( MachineBasicBlock::iterator II
-, int SPAdj
-, unsigned FIOperandNum
-, unsigned FrameReg
-, StackOffset FrameIndexOffset
-, RegScavenger *RS
-)
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
 {
-MachineInstr &MI = *II;
-assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-assert(  MI.getOperand(FIOperandNum + 2).isImm() && "Immediate operand position does not match expected position!" );
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 2).isImm() && "Immediate operand position does not match expected position!" );
 
-MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 2);
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 2);
 
-int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-//
-// try to inline the offset into the instruction
-//
+    //
+    // try to inline the offset into the instruction
+    //
 
-if(Offset >= -256 && Offset <= 255 && AArch64Base_MemoryImmFormat_offset_predicate(Offset))
-{
-// immediate can be encoded and instruction can be inlined.
-FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-ImmOp.setImm( Offset );
-return false; // success
-}
+    if(Offset >= -256 && Offset <= 255 && AArch64Base_MemoryImmFormat_offset_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
 
 
-DebugLoc DL = MI.getDebugLoc();
-MachineBasicBlock &MBB = *MI.getParent();
-MachineFunction *MF = MBB.getParent();
-MachineRegisterInfo &MRI = MF->getRegInfo();
-const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-//
-// try to generate a scratch register and adjust frame register with given offset
-//
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
 
-Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-{
-// the scratch register can properly be manipulated and used as address register.
-FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-ImmOp.setImm( 0 );
-return false; // success
-}
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
 
-return true; // failure
+    return true; // failure
 }
 bool eliminateFrameIndexSTURX
-( MachineBasicBlock::iterator II
-, int SPAdj
-, unsigned FIOperandNum
-, unsigned FrameReg
-, StackOffset FrameIndexOffset
-, RegScavenger *RS
-)
+    ( MachineBasicBlock::iterator II
+    , int SPAdj
+    , unsigned FIOperandNum
+    , unsigned FrameReg
+    , StackOffset FrameIndexOffset
+    , RegScavenger *RS
+    )
 {
-MachineInstr &MI = *II;
-assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
-assert(  MI.getOperand(FIOperandNum + 2).isImm() && "Immediate operand position does not match expected position!" );
+    MachineInstr &MI = *II;
+    assert(  MI.getOperand(FIOperandNum).isFI() && "Frame Index operand position does not match expected position!" );
+    assert(  MI.getOperand(FIOperandNum + 2).isImm() && "Immediate operand position does not match expected position!" );
 
-MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 2);
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    MachineOperand &ImmOp = MI.getOperand(FIOperandNum + 2);
 
-int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
+    int Offset = FrameIndexOffset.getFixed() + ImmOp.getImm();
 
-//
-// try to inline the offset into the instruction
-//
+    //
+    // try to inline the offset into the instruction
+    //
 
-if(Offset >= -256 && Offset <= 255 && AArch64Base_MemoryImmFormat_offset_predicate(Offset))
-{
-// immediate can be encoded and instruction can be inlined.
-FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
-ImmOp.setImm( Offset );
-return false; // success
-}
+    if(Offset >= -256 && Offset <= 255 && AArch64Base_MemoryImmFormat_offset_predicate(Offset))
+    {
+        // immediate can be encoded and instruction can be inlined.
+        FIOp.ChangeToRegister( FrameReg, false /* isDef */ );
+        ImmOp.setImm( Offset );
+        return false; // success
+    }
 
 
-DebugLoc DL = MI.getDebugLoc();
-MachineBasicBlock &MBB = *MI.getParent();
-MachineFunction *MF = MBB.getParent();
-MachineRegisterInfo &MRI = MF->getRegInfo();
-const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
+    DebugLoc DL = MI.getDebugLoc();
+    MachineBasicBlock &MBB = *MI.getParent();
+    MachineFunction *MF = MBB.getParent();
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+    const processornamevalueInstrInfo *TII = MF->getSubtarget<processornamevalueSubtarget>().getInstrInfo();
 
-//
-// try to generate a scratch register and adjust frame register with given offset
-//
+    //
+    // try to generate a scratch register and adjust frame register with given offset
+    //
 
-Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
-if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
-{
-// the scratch register can properly be manipulated and used as address register.
-FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
-ImmOp.setImm( 0 );
-return false; // success
-}
+    Register ScratchReg = MRI.createVirtualRegister(&processornamevalue::SRegClass);
+    if(TII->adjustReg(MBB, II, DL, ScratchReg, FrameReg, Offset) == false) // MachineInstr::MIFlag Flag
+    {
+        // the scratch register can properly be manipulated and used as address register.
+        FIOp.ChangeToRegister( ScratchReg, false /*isDef*/, false /*isImpl*/, true /*isKill*/ );
+        ImmOp.setImm( 0 );
+        return false; // success
+    }
 
-return true; // failure
+    return true; // failure
 }
 
 
 /**
-* This method calls its own replacement class for each allowed instruction.
-* Inside the special instruction the following steps or tries to remove the FI are done.
-*
-*     1. try to inline the frame index calculation into the current instruction.
-*     2. check if we can move the immediate materialization and frame index addition
-*        into a separate instruction with scratch register. The scratch register must be
-*        useable with our current instruction.
-*     3. replace the current instruction with
-*        3.1 a more specific instruction that can load the offset
-*        3.2 a very general instruction that uses a scratch register for computing the
-*            desired frame index.
-*
-* If an instruction is not supported, an llvm_fatal_error is emitted as it should be impossible
-* for a frame index to be an operand.
-*/
+ * This method calls its own replacement class for each allowed instruction.
+ * Inside the special instruction the following steps or tries to remove the FI are done.
+ *
+ *     1. try to inline the frame index calculation into the current instruction.
+ *     2. check if we can move the immediate materialization and frame index addition
+ *        into a separate instruction with scratch register. The scratch register must be
+ *        useable with our current instruction.
+ *     3. replace the current instruction with
+ *        3.1 a more specific instruction that can load the offset
+ *        3.2 a very general instruction that uses a scratch register for computing the
+ *            desired frame index.
+ *
+ * If an instruction is not supported, an llvm_fatal_error is emitted as it should be impossible
+ * for a frame index to be an operand.
+ */
 bool processornamevalueRegisterInfo::eliminateFrameIndex(MachineBasicBlock::iterator II, int SPAdj, unsigned FIOperandNum, RegScavenger *RS) const
 {
-MachineInstr &MI = *II;
-const MachineFunction &MF = *MI.getParent()->getParent();
+    MachineInstr &MI = *II;
+    const MachineFunction &MF = *MI.getParent()->getParent();
 
-const TargetInstrInfo *TII = MF.getSubtarget().getInstrInfo();
-const std::string mnemonic = TII->getName(MI.getOpcode()).str(); // for debug purposes
+    const TargetInstrInfo *TII = MF.getSubtarget().getInstrInfo();
+    const std::string mnemonic = TII->getName(MI.getOpcode()).str(); // for debug purposes
 
-MachineOperand &FIOp = MI.getOperand(FIOperandNum);
-unsigned FI = FIOp.getIndex();
-Register FrameReg;
-StackOffset FrameIndexOffset = getFrameLowering(MF)->getFrameIndexReference(MF, FI, FrameReg);
+    MachineOperand &FIOp = MI.getOperand(FIOperandNum);
+    unsigned FI = FIOp.getIndex();
+    Register FrameReg;
+    StackOffset FrameIndexOffset = getFrameLowering(MF)->getFrameIndexReference(MF, FI, FrameReg);
 
-bool error = true;
-switch (MI.getOpcode())
-{
+    bool error = true;
+    switch (MI.getOpcode())
+    {
 
-case processornamevalue::ADDXI:
-{
-error = eliminateFrameIndexADDXI(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-break;
-}
-case processornamevalue::LDRB:
-{
-error = eliminateFrameIndexLDRB(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-break;
-}
-case processornamevalue::LDRH:
-{
-error = eliminateFrameIndexLDRH(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-break;
-}
-case processornamevalue::LDRSBW:
-{
-error = eliminateFrameIndexLDRSBW(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-break;
-}
-case processornamevalue::LDRSBX:
-{
-error = eliminateFrameIndexLDRSBX(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-break;
-}
-case processornamevalue::LDRSHW:
-{
-error = eliminateFrameIndexLDRSHW(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-break;
-}
-case processornamevalue::LDRSHX:
-{
-error = eliminateFrameIndexLDRSHX(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-break;
-}
-case processornamevalue::LDRSWX:
-{
-error = eliminateFrameIndexLDRSWX(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-break;
-}
-case processornamevalue::LDRW:
-{
-error = eliminateFrameIndexLDRW(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-break;
-}
-case processornamevalue::LDRX:
-{
-error = eliminateFrameIndexLDRX(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-break;
-}
-case processornamevalue::LDURB:
-{
-error = eliminateFrameIndexLDURB(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-break;
-}
-case processornamevalue::LDURH:
-{
-error = eliminateFrameIndexLDURH(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-break;
-}
-case processornamevalue::LDURSBW:
-{
-error = eliminateFrameIndexLDURSBW(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-break;
-}
-case processornamevalue::LDURSBX:
-{
-error = eliminateFrameIndexLDURSBX(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-break;
-}
-case processornamevalue::LDURSHW:
-{
-error = eliminateFrameIndexLDURSHW(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-break;
-}
-case processornamevalue::LDURSHX:
-{
-error = eliminateFrameIndexLDURSHX(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-break;
-}
-case processornamevalue::LDURSWX:
-{
-error = eliminateFrameIndexLDURSWX(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-break;
-}
-case processornamevalue::LDURW:
-{
-error = eliminateFrameIndexLDURW(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-break;
-}
-case processornamevalue::LDURX:
-{
-error = eliminateFrameIndexLDURX(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-break;
-}
-case processornamevalue::STRB:
-{
-error = eliminateFrameIndexSTRB(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-break;
-}
-case processornamevalue::STRH:
-{
-error = eliminateFrameIndexSTRH(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-break;
-}
-case processornamevalue::STRW:
-{
-error = eliminateFrameIndexSTRW(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-break;
-}
-case processornamevalue::STRX:
-{
-error = eliminateFrameIndexSTRX(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-break;
-}
-case processornamevalue::STURB:
-{
-error = eliminateFrameIndexSTURB(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-break;
-}
-case processornamevalue::STURH:
-{
-error = eliminateFrameIndexSTURH(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-break;
-}
-case processornamevalue::STURW:
-{
-error = eliminateFrameIndexSTURW(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-break;
-}
-case processornamevalue::STURX:
-{
-error = eliminateFrameIndexSTURX(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
-break;
-}
+        case processornamevalue::ADDXI:
+        {
+          error = eliminateFrameIndexADDXI(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::LDRB:
+        {
+          error = eliminateFrameIndexLDRB(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::LDRH:
+        {
+          error = eliminateFrameIndexLDRH(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::LDRSBW:
+        {
+          error = eliminateFrameIndexLDRSBW(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::LDRSBX:
+        {
+          error = eliminateFrameIndexLDRSBX(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::LDRSHW:
+        {
+          error = eliminateFrameIndexLDRSHW(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::LDRSHX:
+        {
+          error = eliminateFrameIndexLDRSHX(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::LDRSWX:
+        {
+          error = eliminateFrameIndexLDRSWX(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::LDRW:
+        {
+          error = eliminateFrameIndexLDRW(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::LDRX:
+        {
+          error = eliminateFrameIndexLDRX(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::LDURB:
+        {
+          error = eliminateFrameIndexLDURB(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::LDURH:
+        {
+          error = eliminateFrameIndexLDURH(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::LDURSBW:
+        {
+          error = eliminateFrameIndexLDURSBW(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::LDURSBX:
+        {
+          error = eliminateFrameIndexLDURSBX(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::LDURSHW:
+        {
+          error = eliminateFrameIndexLDURSHW(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::LDURSHX:
+        {
+          error = eliminateFrameIndexLDURSHX(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::LDURSWX:
+        {
+          error = eliminateFrameIndexLDURSWX(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::LDURW:
+        {
+          error = eliminateFrameIndexLDURW(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::LDURX:
+        {
+          error = eliminateFrameIndexLDURX(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::STRB:
+        {
+          error = eliminateFrameIndexSTRB(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::STRH:
+        {
+          error = eliminateFrameIndexSTRH(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::STRW:
+        {
+          error = eliminateFrameIndexSTRW(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::STRX:
+        {
+          error = eliminateFrameIndexSTRX(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::STURB:
+        {
+          error = eliminateFrameIndexSTURB(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::STURH:
+        {
+          error = eliminateFrameIndexSTURH(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::STURW:
+        {
+          error = eliminateFrameIndexSTURW(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
+        case processornamevalue::STURX:
+        {
+          error = eliminateFrameIndexSTURX(II, SPAdj, FIOperandNum, FrameReg, FrameIndexOffset, RS);
+          break;
+        }
 
-default:
-{
-/* This should be unreachable! */
-std::string errMsg;
-std::stringstream errMsgStream;
-errMsgStream << "Unexpected frame index for instruction '" << mnemonic << "'";
-errMsg = errMsgStream.str();
-llvm_unreachable(errMsg.c_str());
-}
-}
+        default:
+        {
+            /* This should be unreachable! */
+            std::string errMsg;
+            std::stringstream errMsgStream;
+            errMsgStream << "Unexpected frame index for instruction '" << mnemonic << "'";
+            errMsg = errMsgStream.str();
+            llvm_unreachable(errMsg.c_str());
+        }
+    }
 
-if (error) // something went wrong
-{
-std::string errMsg;
-std::stringstream errMsgStream;
-errMsgStream << "Unable to eliminate frame index ('FrameIndex<" << FrameIndexOffset.getFixed() << ">')";
-errMsgStream << " for instruction '" << mnemonic << "'";
-errMsg = errMsgStream.str();
-report_fatal_error(errMsg.c_str()); // if we cannot eliminate the frame index abort!
-}
+    if (error) // something went wrong
+    {
+        std::string errMsg;
+        std::stringstream errMsgStream;
+        errMsgStream << "Unable to eliminate frame index ('FrameIndex<" << FrameIndexOffset.getFixed() << ">')";
+        errMsgStream << " for instruction '" << mnemonic << "'";
+        errMsg = errMsgStream.str();
+        report_fatal_error(errMsg.c_str()); // if we cannot eliminate the frame index abort!
+    }
 
-return true;
+    return true;
 }
 
 Register processornamevalueRegisterInfo::getFrameRegister(const MachineFunction &MF) const
 {
-const TargetFrameLowering *TFI = getFrameLowering(MF);
-return TFI->hasFP(MF) ? processornamevalue::X29 /* FP */ : processornamevalue::S31 /* SP */;
+    const TargetFrameLowering *TFI = getFrameLowering(MF);
+    return TFI->hasFP(MF) ? processornamevalue::X29 /* FP */ : processornamevalue::S31 /* SP */;
 }
 
 const uint32_t * processornamevalueRegisterInfo::getCallPreservedMask(const MachineFunction & /*MF*/
-, CallingConv::ID /*CC*/
+                                                                   , CallingConv::ID /*CC*/
 ) const
 {
-// defined in calling convention tablegen
-return CSR_processornamevalue_RegMask;
+    // defined in calling convention tablegen
+    return CSR_processornamevalue_RegMask;
 }
 
 
 /*static*/ unsigned processornamevalueRegisterInfo::S(unsigned index)
 {
-switch (index)
-{
+  switch (index)
+  {
 
-case 0:
-return processornamevalue::S0;
-case 1:
-return processornamevalue::S1;
-case 2:
-return processornamevalue::S2;
-case 3:
-return processornamevalue::S3;
-case 4:
-return processornamevalue::S4;
-case 5:
-return processornamevalue::S5;
-case 6:
-return processornamevalue::S6;
-case 7:
-return processornamevalue::S7;
-case 8:
-return processornamevalue::S8;
-case 9:
-return processornamevalue::S9;
-case 10:
-return processornamevalue::S10;
-case 11:
-return processornamevalue::S11;
-case 12:
-return processornamevalue::S12;
-case 13:
-return processornamevalue::S13;
-case 14:
-return processornamevalue::S14;
-case 15:
-return processornamevalue::S15;
-case 16:
-return processornamevalue::S16;
-case 17:
-return processornamevalue::S17;
-case 18:
-return processornamevalue::S18;
-case 19:
-return processornamevalue::S19;
-case 20:
-return processornamevalue::S20;
-case 21:
-return processornamevalue::S21;
-case 22:
-return processornamevalue::S22;
-case 23:
-return processornamevalue::S23;
-case 24:
-return processornamevalue::S24;
-case 25:
-return processornamevalue::S25;
-case 26:
-return processornamevalue::S26;
-case 27:
-return processornamevalue::S27;
-case 28:
-return processornamevalue::S28;
-case 29:
-return processornamevalue::S29;
-case 30:
-return processornamevalue::S30;
-case 31:
-return processornamevalue::S31;
+    case 0:
+        return processornamevalue::S0;
+    case 1:
+        return processornamevalue::S1;
+    case 2:
+        return processornamevalue::S2;
+    case 3:
+        return processornamevalue::S3;
+    case 4:
+        return processornamevalue::S4;
+    case 5:
+        return processornamevalue::S5;
+    case 6:
+        return processornamevalue::S6;
+    case 7:
+        return processornamevalue::S7;
+    case 8:
+        return processornamevalue::S8;
+    case 9:
+        return processornamevalue::S9;
+    case 10:
+        return processornamevalue::S10;
+    case 11:
+        return processornamevalue::S11;
+    case 12:
+        return processornamevalue::S12;
+    case 13:
+        return processornamevalue::S13;
+    case 14:
+        return processornamevalue::S14;
+    case 15:
+        return processornamevalue::S15;
+    case 16:
+        return processornamevalue::S16;
+    case 17:
+        return processornamevalue::S17;
+    case 18:
+        return processornamevalue::S18;
+    case 19:
+        return processornamevalue::S19;
+    case 20:
+        return processornamevalue::S20;
+    case 21:
+        return processornamevalue::S21;
+    case 22:
+        return processornamevalue::S22;
+    case 23:
+        return processornamevalue::S23;
+    case 24:
+        return processornamevalue::S24;
+    case 25:
+        return processornamevalue::S25;
+    case 26:
+        return processornamevalue::S26;
+    case 27:
+        return processornamevalue::S27;
+    case 28:
+        return processornamevalue::S28;
+    case 29:
+        return processornamevalue::S29;
+    case 30:
+        return processornamevalue::S30;
+    case 31:
+        return processornamevalue::S31;
 
-default:
-{
-std::string errMsg;
-std::stringstream errMsgStream;
-errMsgStream << "Unable to find index " << "'" << index << "'";
-errMsgStream << " with name '«registerClass.simpleName»' !\n";
-errMsg = errMsgStream.str();
-report_fatal_error(errMsg.c_str());
-}
-}
+    default:
+    {
+        std::string errMsg;
+        std::stringstream errMsgStream;
+        errMsgStream << "Unable to find index " << "'" << index << "'";
+        errMsgStream << " with name '«registerClass.simpleName»' !\n";
+        errMsg = errMsgStream.str();
+        report_fatal_error(errMsg.c_str());
+    }
+  }
 }

--- a/vadl/test/resources/snapshots/aarch64/RegisterInfo.td
+++ b/vadl/test/resources/snapshots/aarch64/RegisterInfo.td
@@ -1,3 +1,4 @@
+
 def SUB_32  : SubRegIndex<32>;
 def SUB_32_1  : SubRegIndex<32>;
 
@@ -9,2608 +10,2626 @@ def FULL_64    : SubRegIndex<64>;
 
 def SP : Register<"SP">
 {
-let Namespace = "aarch64temp";
-let AsmName = "SP";
-let AltNames = [   ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 14 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
-let HWEncoding = 31;
-let isArtificial = 1;
+    let Namespace = "aarch64temp";
+    let AsmName = "SP";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 15 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
+    let HWEncoding = 31;
+    let isArtificial = 1;
 }
 def LR : Register<"LR">
 {
-let Namespace = "aarch64temp";
-let AsmName = "LR";
-let AltNames = [   ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 15 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
-let HWEncoding = 30;
-let isArtificial = 1;
+    let Namespace = "aarch64temp";
+    let AsmName = "LR";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 16 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
+    let HWEncoding = 30;
+    let isArtificial = 1;
 }
 
 
 
 def NZCV_N : Register<"NZCV_N">
 {
-let Namespace = "aarch64temp";
-let AsmName = "NZCV_N";
-let AltNames = [   ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 0 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "NZCV_N";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 0 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
 
-let HWEncoding = 0;
+    let HWEncoding = 0;
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def NZCV_Z : Register<"NZCV_Z">
 {
-let Namespace = "aarch64temp";
-let AsmName = "NZCV_Z";
-let AltNames = [   ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 1 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "NZCV_Z";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 1 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
 
-let HWEncoding = 0;
+    let HWEncoding = 0;
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def NZCV_C : Register<"NZCV_C">
 {
-let Namespace = "aarch64temp";
-let AsmName = "NZCV_C";
-let AltNames = [   ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 2 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "NZCV_C";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 2 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
 
-let HWEncoding = 0;
+    let HWEncoding = 0;
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def NZCV_V : Register<"NZCV_V">
 {
-let Namespace = "aarch64temp";
-let AsmName = "NZCV_V";
-let AltNames = [   ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 3 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "NZCV_V";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 3 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
 
-let HWEncoding = 0;
+    let HWEncoding = 0;
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def CurrentEL : Register<"CurrentEL">
 {
-let Namespace = "aarch64temp";
-let AsmName = "CurrentEL";
-let AltNames = [   ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 4 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "CurrentEL";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 4 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
 
-let HWEncoding = 0;
+    let HWEncoding = 0;
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def SPSel : Register<"SPSel">
 {
-let Namespace = "aarch64temp";
-let AsmName = "SPSel";
-let AltNames = [   ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 5 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "SPSel";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 5 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
 
-let HWEncoding = 0;
+    let HWEncoding = 0;
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def SP_EL0 : Register<"SP_EL0">
 {
-let Namespace = "aarch64temp";
-let AsmName = "SP_EL0";
-let AltNames = [   ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 6 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "SP_EL0";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 6 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
 
-let HWEncoding = 0;
+    let HWEncoding = 0;
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def SP_EL1 : Register<"SP_EL1">
 {
-let Namespace = "aarch64temp";
-let AsmName = "SP_EL1";
-let AltNames = [   ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 7 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "SP_EL1";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 7 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
 
-let HWEncoding = 0;
+    let HWEncoding = 0;
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def ELR_EL1 : Register<"ELR_EL1">
 {
-let Namespace = "aarch64temp";
-let AsmName = "ELR_EL1";
-let AltNames = [   ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 8 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "ELR_EL1";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 8 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
 
-let HWEncoding = 0;
+    let HWEncoding = 0;
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def VBAR_EL1 : Register<"VBAR_EL1">
 {
-let Namespace = "aarch64temp";
-let AsmName = "VBAR_EL1";
-let AltNames = [   ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 9 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "VBAR_EL1";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 9 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
 
-let HWEncoding = 0;
+    let HWEncoding = 0;
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def ESR_EL1 : Register<"ESR_EL1">
 {
-let Namespace = "aarch64temp";
-let AsmName = "ESR_EL1";
-let AltNames = [   ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 10 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "ESR_EL1";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 10 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
 
-let HWEncoding = 0;
+    let HWEncoding = 0;
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def SPSR_EL1 : Register<"SPSR_EL1">
 {
-let Namespace = "aarch64temp";
-let AsmName = "SPSR_EL1";
-let AltNames = [   ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 11 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "SPSR_EL1";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 11 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
 
-let HWEncoding = 0;
+    let HWEncoding = 0;
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def CPACR_EL1 : Register<"CPACR_EL1">
 {
-let Namespace = "aarch64temp";
-let AsmName = "CPACR_EL1";
-let AltNames = [   ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 12 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "CPACR_EL1";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 12 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
 
-let HWEncoding = 0;
+    let HWEncoding = 0;
 
-let isArtificial = false;
+    let isArtificial = false;
+}
+def ZCR_EL1 : Register<"ZCR_EL1">
+{
+    let Namespace = "aarch64temp";
+    let AsmName = "ZCR_EL1";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 13 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
+
+
+    let HWEncoding = 0;
+
+    let isArtificial = false;
 }
 def PC : Register<"PC">
 {
-let Namespace = "aarch64temp";
-let AsmName = "PC";
-let AltNames = [   ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 13 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "PC";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 14 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
 
-let HWEncoding = 0;
+    let HWEncoding = 0;
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def R0 : Register<"R0">
 {
-let Namespace = "aarch64temp";
-let AsmName = "R0";
-let AltNames = [   ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 48 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "R0";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 49 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 0;
+    let HWEncoding{4-0} = 0;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def R1 : Register<"R1">
 {
-let Namespace = "aarch64temp";
-let AsmName = "R1";
-let AltNames = [   ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 49 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "R1";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 50 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 1;
+    let HWEncoding{4-0} = 1;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def R2 : Register<"R2">
 {
-let Namespace = "aarch64temp";
-let AsmName = "R2";
-let AltNames = [   ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 50 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "R2";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 51 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 2;
+    let HWEncoding{4-0} = 2;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def R3 : Register<"R3">
 {
-let Namespace = "aarch64temp";
-let AsmName = "R3";
-let AltNames = [   ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 51 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "R3";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 52 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 3;
+    let HWEncoding{4-0} = 3;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def R4 : Register<"R4">
 {
-let Namespace = "aarch64temp";
-let AsmName = "R4";
-let AltNames = [   ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 52 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "R4";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 53 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 4;
+    let HWEncoding{4-0} = 4;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def R5 : Register<"R5">
 {
-let Namespace = "aarch64temp";
-let AsmName = "R5";
-let AltNames = [   ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 53 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "R5";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 54 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 5;
+    let HWEncoding{4-0} = 5;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def R6 : Register<"R6">
 {
-let Namespace = "aarch64temp";
-let AsmName = "R6";
-let AltNames = [   ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 54 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "R6";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 55 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 6;
+    let HWEncoding{4-0} = 6;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def R7 : Register<"R7">
 {
-let Namespace = "aarch64temp";
-let AsmName = "R7";
-let AltNames = [   ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 55 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "R7";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 56 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 7;
+    let HWEncoding{4-0} = 7;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def R8 : Register<"R8">
 {
-let Namespace = "aarch64temp";
-let AsmName = "R8";
-let AltNames = [   ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 56 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "R8";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 57 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 8;
+    let HWEncoding{4-0} = 8;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def R9 : Register<"R9">
 {
-let Namespace = "aarch64temp";
-let AsmName = "R9";
-let AltNames = [   ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 57 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "R9";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 58 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 9;
+    let HWEncoding{4-0} = 9;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def R10 : Register<"R10">
 {
-let Namespace = "aarch64temp";
-let AsmName = "R10";
-let AltNames = [   ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 58 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "R10";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 59 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 10;
+    let HWEncoding{4-0} = 10;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def R11 : Register<"R11">
 {
-let Namespace = "aarch64temp";
-let AsmName = "R11";
-let AltNames = [   ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 59 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "R11";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 60 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 11;
+    let HWEncoding{4-0} = 11;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def R12 : Register<"R12">
 {
-let Namespace = "aarch64temp";
-let AsmName = "R12";
-let AltNames = [   ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 60 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "R12";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 61 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 12;
+    let HWEncoding{4-0} = 12;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def R13 : Register<"R13">
 {
-let Namespace = "aarch64temp";
-let AsmName = "R13";
-let AltNames = [   ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 61 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "R13";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 62 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 13;
+    let HWEncoding{4-0} = 13;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def R14 : Register<"R14">
 {
-let Namespace = "aarch64temp";
-let AsmName = "R14";
-let AltNames = [   ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 62 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "R14";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 63 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 14;
+    let HWEncoding{4-0} = 14;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def R15 : Register<"R15">
 {
-let Namespace = "aarch64temp";
-let AsmName = "R15";
-let AltNames = [   ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 63 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "R15";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 64 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 15;
+    let HWEncoding{4-0} = 15;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def R16 : Register<"R16">
 {
-let Namespace = "aarch64temp";
-let AsmName = "R16";
-let AltNames = [   ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 64 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "R16";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 65 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 16;
+    let HWEncoding{4-0} = 16;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def R17 : Register<"R17">
 {
-let Namespace = "aarch64temp";
-let AsmName = "R17";
-let AltNames = [   ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 65 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "R17";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 66 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 17;
+    let HWEncoding{4-0} = 17;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def R18 : Register<"R18">
 {
-let Namespace = "aarch64temp";
-let AsmName = "R18";
-let AltNames = [   ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 66 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "R18";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 67 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 18;
+    let HWEncoding{4-0} = 18;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def R19 : Register<"R19">
 {
-let Namespace = "aarch64temp";
-let AsmName = "R19";
-let AltNames = [   ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 67 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "R19";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 68 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 19;
+    let HWEncoding{4-0} = 19;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def R20 : Register<"R20">
 {
-let Namespace = "aarch64temp";
-let AsmName = "R20";
-let AltNames = [   ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 68 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "R20";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 69 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 20;
+    let HWEncoding{4-0} = 20;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def R21 : Register<"R21">
 {
-let Namespace = "aarch64temp";
-let AsmName = "R21";
-let AltNames = [   ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 69 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "R21";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 70 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 21;
+    let HWEncoding{4-0} = 21;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def R22 : Register<"R22">
 {
-let Namespace = "aarch64temp";
-let AsmName = "R22";
-let AltNames = [   ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 70 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "R22";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 71 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 22;
+    let HWEncoding{4-0} = 22;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def R23 : Register<"R23">
 {
-let Namespace = "aarch64temp";
-let AsmName = "R23";
-let AltNames = [   ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 71 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "R23";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 72 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 23;
+    let HWEncoding{4-0} = 23;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def R24 : Register<"R24">
 {
-let Namespace = "aarch64temp";
-let AsmName = "R24";
-let AltNames = [   ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 72 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "R24";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 73 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 24;
+    let HWEncoding{4-0} = 24;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def R25 : Register<"R25">
 {
-let Namespace = "aarch64temp";
-let AsmName = "R25";
-let AltNames = [   ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 73 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "R25";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 74 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 25;
+    let HWEncoding{4-0} = 25;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def R26 : Register<"R26">
 {
-let Namespace = "aarch64temp";
-let AsmName = "R26";
-let AltNames = [   ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 74 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "R26";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 75 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 26;
+    let HWEncoding{4-0} = 26;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def R27 : Register<"R27">
 {
-let Namespace = "aarch64temp";
-let AsmName = "R27";
-let AltNames = [   ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 75 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "R27";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 76 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 27;
+    let HWEncoding{4-0} = 27;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def R28 : Register<"R28">
 {
-let Namespace = "aarch64temp";
-let AsmName = "R28";
-let AltNames = [   ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 76 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "R28";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 77 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 28;
+    let HWEncoding{4-0} = 28;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def R29 : Register<"R29">
 {
-let Namespace = "aarch64temp";
-let AsmName = "R29";
-let AltNames = [   ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 77 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "R29";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 78 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 29;
+    let HWEncoding{4-0} = 29;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def R30 : Register<"R30">
 {
-let Namespace = "aarch64temp";
-let AsmName = "R30";
-let AltNames = [   ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 78 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "R30";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 79 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 30;
+    let HWEncoding{4-0} = 30;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def R31 : Register<"R31">
 {
-let Namespace = "aarch64temp";
-let AsmName = "R31";
-let AltNames = [   ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 79 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "R31";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 80 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 31;
+    let HWEncoding{4-0} = 31;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def X0 : Register<"X0">
 {
-let Namespace = "aarch64temp";
-let AsmName = "X0";
-let AltNames = [ "X0"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 80 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "X0";
+    let AltNames = [ "X0"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 81 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 0;
+    let HWEncoding{4-0} = 0;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def X1 : Register<"X1">
 {
-let Namespace = "aarch64temp";
-let AsmName = "X1";
-let AltNames = [ "X1"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 81 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "X1";
+    let AltNames = [ "X1"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 82 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 1;
+    let HWEncoding{4-0} = 1;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def X2 : Register<"X2">
 {
-let Namespace = "aarch64temp";
-let AsmName = "X2";
-let AltNames = [ "X2"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 82 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "X2";
+    let AltNames = [ "X2"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 83 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 2;
+    let HWEncoding{4-0} = 2;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def X3 : Register<"X3">
 {
-let Namespace = "aarch64temp";
-let AsmName = "X3";
-let AltNames = [ "X3"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 83 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "X3";
+    let AltNames = [ "X3"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 84 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 3;
+    let HWEncoding{4-0} = 3;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def X4 : Register<"X4">
 {
-let Namespace = "aarch64temp";
-let AsmName = "X4";
-let AltNames = [ "X4"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 84 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "X4";
+    let AltNames = [ "X4"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 85 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 4;
+    let HWEncoding{4-0} = 4;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def X5 : Register<"X5">
 {
-let Namespace = "aarch64temp";
-let AsmName = "X5";
-let AltNames = [ "X5"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 85 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "X5";
+    let AltNames = [ "X5"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 86 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 5;
+    let HWEncoding{4-0} = 5;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def X6 : Register<"X6">
 {
-let Namespace = "aarch64temp";
-let AsmName = "X6";
-let AltNames = [ "X6"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 86 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "X6";
+    let AltNames = [ "X6"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 87 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 6;
+    let HWEncoding{4-0} = 6;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def X7 : Register<"X7">
 {
-let Namespace = "aarch64temp";
-let AsmName = "X7";
-let AltNames = [ "X7"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 87 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "X7";
+    let AltNames = [ "X7"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 88 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 7;
+    let HWEncoding{4-0} = 7;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def X8 : Register<"X8">
 {
-let Namespace = "aarch64temp";
-let AsmName = "X8";
-let AltNames = [ "X8"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 88 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "X8";
+    let AltNames = [ "X8"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 89 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 8;
+    let HWEncoding{4-0} = 8;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def X9 : Register<"X9">
 {
-let Namespace = "aarch64temp";
-let AsmName = "X9";
-let AltNames = [ "X9"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 89 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "X9";
+    let AltNames = [ "X9"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 90 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 9;
+    let HWEncoding{4-0} = 9;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def X10 : Register<"X10">
 {
-let Namespace = "aarch64temp";
-let AsmName = "X10";
-let AltNames = [ "X10"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 90 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "X10";
+    let AltNames = [ "X10"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 91 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 10;
+    let HWEncoding{4-0} = 10;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def X11 : Register<"X11">
 {
-let Namespace = "aarch64temp";
-let AsmName = "X11";
-let AltNames = [ "X11"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 91 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "X11";
+    let AltNames = [ "X11"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 92 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 11;
+    let HWEncoding{4-0} = 11;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def X12 : Register<"X12">
 {
-let Namespace = "aarch64temp";
-let AsmName = "X12";
-let AltNames = [ "X12"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 92 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "X12";
+    let AltNames = [ "X12"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 93 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 12;
+    let HWEncoding{4-0} = 12;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def X13 : Register<"X13">
 {
-let Namespace = "aarch64temp";
-let AsmName = "X13";
-let AltNames = [ "X13"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 93 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "X13";
+    let AltNames = [ "X13"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 94 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 13;
+    let HWEncoding{4-0} = 13;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def X14 : Register<"X14">
 {
-let Namespace = "aarch64temp";
-let AsmName = "X14";
-let AltNames = [ "X14"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 94 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "X14";
+    let AltNames = [ "X14"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 95 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 14;
+    let HWEncoding{4-0} = 14;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def X15 : Register<"X15">
 {
-let Namespace = "aarch64temp";
-let AsmName = "X15";
-let AltNames = [ "X15"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 95 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "X15";
+    let AltNames = [ "X15"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 96 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 15;
+    let HWEncoding{4-0} = 15;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def X16 : Register<"X16">
 {
-let Namespace = "aarch64temp";
-let AsmName = "X16";
-let AltNames = [ "X16"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 96 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "X16";
+    let AltNames = [ "X16"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 97 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 16;
+    let HWEncoding{4-0} = 16;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def X17 : Register<"X17">
 {
-let Namespace = "aarch64temp";
-let AsmName = "X17";
-let AltNames = [ "X17"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 97 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "X17";
+    let AltNames = [ "X17"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 98 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 17;
+    let HWEncoding{4-0} = 17;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def X18 : Register<"X18">
 {
-let Namespace = "aarch64temp";
-let AsmName = "X18";
-let AltNames = [ "X18"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 98 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "X18";
+    let AltNames = [ "X18"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 99 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 18;
+    let HWEncoding{4-0} = 18;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def X19 : Register<"X19">
 {
-let Namespace = "aarch64temp";
-let AsmName = "X19";
-let AltNames = [ "X19"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 99 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "X19";
+    let AltNames = [ "X19"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 100 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 19;
+    let HWEncoding{4-0} = 19;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def X20 : Register<"X20">
 {
-let Namespace = "aarch64temp";
-let AsmName = "X20";
-let AltNames = [ "X20"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 100 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "X20";
+    let AltNames = [ "X20"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 101 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 20;
+    let HWEncoding{4-0} = 20;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def X21 : Register<"X21">
 {
-let Namespace = "aarch64temp";
-let AsmName = "X21";
-let AltNames = [ "X21"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 101 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "X21";
+    let AltNames = [ "X21"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 102 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 21;
+    let HWEncoding{4-0} = 21;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def X22 : Register<"X22">
 {
-let Namespace = "aarch64temp";
-let AsmName = "X22";
-let AltNames = [ "X22"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 102 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "X22";
+    let AltNames = [ "X22"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 103 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 22;
+    let HWEncoding{4-0} = 22;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def X23 : Register<"X23">
 {
-let Namespace = "aarch64temp";
-let AsmName = "X23";
-let AltNames = [ "X23"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 103 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "X23";
+    let AltNames = [ "X23"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 104 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 23;
+    let HWEncoding{4-0} = 23;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def X24 : Register<"X24">
 {
-let Namespace = "aarch64temp";
-let AsmName = "X24";
-let AltNames = [ "X24"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 104 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "X24";
+    let AltNames = [ "X24"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 105 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 24;
+    let HWEncoding{4-0} = 24;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def X25 : Register<"X25">
 {
-let Namespace = "aarch64temp";
-let AsmName = "X25";
-let AltNames = [ "X25"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 105 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "X25";
+    let AltNames = [ "X25"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 106 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 25;
+    let HWEncoding{4-0} = 25;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def X26 : Register<"X26">
 {
-let Namespace = "aarch64temp";
-let AsmName = "X26";
-let AltNames = [ "X26"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 106 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "X26";
+    let AltNames = [ "X26"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 107 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 26;
+    let HWEncoding{4-0} = 26;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def X27 : Register<"X27">
 {
-let Namespace = "aarch64temp";
-let AsmName = "X27";
-let AltNames = [ "X27"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 107 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "X27";
+    let AltNames = [ "X27"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 108 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 27;
+    let HWEncoding{4-0} = 27;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def X28 : Register<"X28">
 {
-let Namespace = "aarch64temp";
-let AsmName = "X28";
-let AltNames = [ "X28"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 108 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "X28";
+    let AltNames = [ "X28"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 109 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 28;
+    let HWEncoding{4-0} = 28;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def X29 : Register<"X29">
 {
-let Namespace = "aarch64temp";
-let AsmName = "A_FP";
-let AltNames = [ "A_FP"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 109 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "A_FP";
+    let AltNames = [ "A_FP"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 110 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 29;
+    let HWEncoding{4-0} = 29;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def X30 : Register<"X30">
 {
-let Namespace = "aarch64temp";
-let AsmName = "X30";
-let AltNames = [   ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 110 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "X30";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 111 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 30;
+    let HWEncoding{4-0} = 30;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def X31 : Register<"X31">
 {
-let Namespace = "aarch64temp";
-let AsmName = "X31";
-let AltNames = [   ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 111 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "X31";
+    let AltNames = [   ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 112 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 31;
+    let HWEncoding{4-0} = 31;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def W0 : Register<"W0">
 {
-let Namespace = "aarch64temp";
-let AsmName = "W0";
-let AltNames = [ "W0"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 112 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "W0";
+    let AltNames = [ "W0"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 113 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 0;
+    let HWEncoding{4-0} = 0;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def W1 : Register<"W1">
 {
-let Namespace = "aarch64temp";
-let AsmName = "W1";
-let AltNames = [ "W1"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 113 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "W1";
+    let AltNames = [ "W1"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 114 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 1;
+    let HWEncoding{4-0} = 1;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def W2 : Register<"W2">
 {
-let Namespace = "aarch64temp";
-let AsmName = "W2";
-let AltNames = [ "W2"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 114 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "W2";
+    let AltNames = [ "W2"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 115 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 2;
+    let HWEncoding{4-0} = 2;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def W3 : Register<"W3">
 {
-let Namespace = "aarch64temp";
-let AsmName = "W3";
-let AltNames = [ "W3"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 115 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "W3";
+    let AltNames = [ "W3"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 116 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 3;
+    let HWEncoding{4-0} = 3;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def W4 : Register<"W4">
 {
-let Namespace = "aarch64temp";
-let AsmName = "W4";
-let AltNames = [ "W4"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 116 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "W4";
+    let AltNames = [ "W4"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 117 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 4;
+    let HWEncoding{4-0} = 4;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def W5 : Register<"W5">
 {
-let Namespace = "aarch64temp";
-let AsmName = "W5";
-let AltNames = [ "W5"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 117 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "W5";
+    let AltNames = [ "W5"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 118 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 5;
+    let HWEncoding{4-0} = 5;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def W6 : Register<"W6">
 {
-let Namespace = "aarch64temp";
-let AsmName = "W6";
-let AltNames = [ "W6"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 118 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "W6";
+    let AltNames = [ "W6"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 119 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 6;
+    let HWEncoding{4-0} = 6;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def W7 : Register<"W7">
 {
-let Namespace = "aarch64temp";
-let AsmName = "W7";
-let AltNames = [ "W7"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 119 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "W7";
+    let AltNames = [ "W7"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 120 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 7;
+    let HWEncoding{4-0} = 7;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def W8 : Register<"W8">
 {
-let Namespace = "aarch64temp";
-let AsmName = "W8";
-let AltNames = [ "W8"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 120 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "W8";
+    let AltNames = [ "W8"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 121 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 8;
+    let HWEncoding{4-0} = 8;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def W9 : Register<"W9">
 {
-let Namespace = "aarch64temp";
-let AsmName = "W9";
-let AltNames = [ "W9"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 121 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "W9";
+    let AltNames = [ "W9"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 122 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 9;
+    let HWEncoding{4-0} = 9;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def W10 : Register<"W10">
 {
-let Namespace = "aarch64temp";
-let AsmName = "W10";
-let AltNames = [ "W10"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 122 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "W10";
+    let AltNames = [ "W10"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 123 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 10;
+    let HWEncoding{4-0} = 10;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def W11 : Register<"W11">
 {
-let Namespace = "aarch64temp";
-let AsmName = "W11";
-let AltNames = [ "W11"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 123 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "W11";
+    let AltNames = [ "W11"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 124 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 11;
+    let HWEncoding{4-0} = 11;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def W12 : Register<"W12">
 {
-let Namespace = "aarch64temp";
-let AsmName = "W12";
-let AltNames = [ "W12"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 124 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "W12";
+    let AltNames = [ "W12"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 125 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 12;
+    let HWEncoding{4-0} = 12;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def W13 : Register<"W13">
 {
-let Namespace = "aarch64temp";
-let AsmName = "W13";
-let AltNames = [ "W13"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 125 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "W13";
+    let AltNames = [ "W13"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 126 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 13;
+    let HWEncoding{4-0} = 13;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def W14 : Register<"W14">
 {
-let Namespace = "aarch64temp";
-let AsmName = "W14";
-let AltNames = [ "W14"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 126 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "W14";
+    let AltNames = [ "W14"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 127 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 14;
+    let HWEncoding{4-0} = 14;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def W15 : Register<"W15">
 {
-let Namespace = "aarch64temp";
-let AsmName = "W15";
-let AltNames = [ "W15"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 127 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "W15";
+    let AltNames = [ "W15"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 128 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 15;
+    let HWEncoding{4-0} = 15;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def W16 : Register<"W16">
 {
-let Namespace = "aarch64temp";
-let AsmName = "W16";
-let AltNames = [ "W16"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 128 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "W16";
+    let AltNames = [ "W16"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 129 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 16;
+    let HWEncoding{4-0} = 16;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def W17 : Register<"W17">
 {
-let Namespace = "aarch64temp";
-let AsmName = "W17";
-let AltNames = [ "W17"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 129 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "W17";
+    let AltNames = [ "W17"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 130 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 17;
+    let HWEncoding{4-0} = 17;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def W18 : Register<"W18">
 {
-let Namespace = "aarch64temp";
-let AsmName = "W18";
-let AltNames = [ "W18"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 130 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "W18";
+    let AltNames = [ "W18"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 131 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 18;
+    let HWEncoding{4-0} = 18;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def W19 : Register<"W19">
 {
-let Namespace = "aarch64temp";
-let AsmName = "W19";
-let AltNames = [ "W19"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 131 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "W19";
+    let AltNames = [ "W19"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 132 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 19;
+    let HWEncoding{4-0} = 19;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def W20 : Register<"W20">
 {
-let Namespace = "aarch64temp";
-let AsmName = "W20";
-let AltNames = [ "W20"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 132 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "W20";
+    let AltNames = [ "W20"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 133 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 20;
+    let HWEncoding{4-0} = 20;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def W21 : Register<"W21">
 {
-let Namespace = "aarch64temp";
-let AsmName = "W21";
-let AltNames = [ "W21"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 133 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "W21";
+    let AltNames = [ "W21"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 134 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 21;
+    let HWEncoding{4-0} = 21;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def W22 : Register<"W22">
 {
-let Namespace = "aarch64temp";
-let AsmName = "W22";
-let AltNames = [ "W22"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 134 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "W22";
+    let AltNames = [ "W22"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 135 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 22;
+    let HWEncoding{4-0} = 22;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def W23 : Register<"W23">
 {
-let Namespace = "aarch64temp";
-let AsmName = "W23";
-let AltNames = [ "W23"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 135 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "W23";
+    let AltNames = [ "W23"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 136 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 23;
+    let HWEncoding{4-0} = 23;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def W24 : Register<"W24">
 {
-let Namespace = "aarch64temp";
-let AsmName = "W24";
-let AltNames = [ "W24"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 136 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "W24";
+    let AltNames = [ "W24"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 137 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 24;
+    let HWEncoding{4-0} = 24;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def W25 : Register<"W25">
 {
-let Namespace = "aarch64temp";
-let AsmName = "W25";
-let AltNames = [ "W25"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 137 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "W25";
+    let AltNames = [ "W25"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 138 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 25;
+    let HWEncoding{4-0} = 25;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def W26 : Register<"W26">
 {
-let Namespace = "aarch64temp";
-let AsmName = "W26";
-let AltNames = [ "W26"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 138 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "W26";
+    let AltNames = [ "W26"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 139 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 26;
+    let HWEncoding{4-0} = 26;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def W27 : Register<"W27">
 {
-let Namespace = "aarch64temp";
-let AsmName = "W27";
-let AltNames = [ "W27"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 139 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "W27";
+    let AltNames = [ "W27"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 140 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 27;
+    let HWEncoding{4-0} = 27;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def W28 : Register<"W28">
 {
-let Namespace = "aarch64temp";
-let AsmName = "W28";
-let AltNames = [ "W28"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 140 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "W28";
+    let AltNames = [ "W28"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 141 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 28;
+    let HWEncoding{4-0} = 28;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def W29 : Register<"W29">
 {
-let Namespace = "aarch64temp";
-let AsmName = "W29";
-let AltNames = [ "W29"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 141 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "W29";
+    let AltNames = [ "W29"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 142 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 29;
+    let HWEncoding{4-0} = 29;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def W30 : Register<"W30">
 {
-let Namespace = "aarch64temp";
-let AsmName = "W30";
-let AltNames = [ "W30"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 142 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "W30";
+    let AltNames = [ "W30"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 143 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 30;
+    let HWEncoding{4-0} = 30;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def W31 : Register<"W31">
 {
-let Namespace = "aarch64temp";
-let AsmName = "W31";
-let AltNames = [ "W31"  ];
-let Aliases = [ ];
-let SubRegs = [  ];
-let SubRegIndices = [  ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 143 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "W31";
+    let AltNames = [ "W31"  ];
+    let Aliases = [ ];
+    let SubRegs = [  ];
+    let SubRegIndices = [  ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 144 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 31;
+    let HWEncoding{4-0} = 31;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def S0 : Register<"S0">
 {
-let Namespace = "aarch64temp";
-let AsmName = "S0";
-let AltNames = [ "S0"  ];
-let Aliases = [ ];
-let SubRegs = [ R0, X0, W0 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 16 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "S0";
+    let AltNames = [ "S0"  ];
+    let Aliases = [ ];
+    let SubRegs = [ R0, X0, W0 ];
+    let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 17 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 0;
+    let HWEncoding{4-0} = 0;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def S1 : Register<"S1">
 {
-let Namespace = "aarch64temp";
-let AsmName = "S1";
-let AltNames = [ "S1"  ];
-let Aliases = [ ];
-let SubRegs = [ R1, X1, W1 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 17 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "S1";
+    let AltNames = [ "S1"  ];
+    let Aliases = [ ];
+    let SubRegs = [ R1, X1, W1 ];
+    let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 18 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 1;
+    let HWEncoding{4-0} = 1;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def S2 : Register<"S2">
 {
-let Namespace = "aarch64temp";
-let AsmName = "S2";
-let AltNames = [ "S2"  ];
-let Aliases = [ ];
-let SubRegs = [ R2, X2, W2 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 18 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "S2";
+    let AltNames = [ "S2"  ];
+    let Aliases = [ ];
+    let SubRegs = [ R2, X2, W2 ];
+    let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 19 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 2;
+    let HWEncoding{4-0} = 2;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def S3 : Register<"S3">
 {
-let Namespace = "aarch64temp";
-let AsmName = "S3";
-let AltNames = [ "S3"  ];
-let Aliases = [ ];
-let SubRegs = [ R3, X3, W3 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 19 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "S3";
+    let AltNames = [ "S3"  ];
+    let Aliases = [ ];
+    let SubRegs = [ R3, X3, W3 ];
+    let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 20 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 3;
+    let HWEncoding{4-0} = 3;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def S4 : Register<"S4">
 {
-let Namespace = "aarch64temp";
-let AsmName = "S4";
-let AltNames = [ "S4"  ];
-let Aliases = [ ];
-let SubRegs = [ R4, X4, W4 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 20 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "S4";
+    let AltNames = [ "S4"  ];
+    let Aliases = [ ];
+    let SubRegs = [ R4, X4, W4 ];
+    let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 21 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 4;
+    let HWEncoding{4-0} = 4;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def S5 : Register<"S5">
 {
-let Namespace = "aarch64temp";
-let AsmName = "S5";
-let AltNames = [ "S5"  ];
-let Aliases = [ ];
-let SubRegs = [ R5, X5, W5 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 21 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "S5";
+    let AltNames = [ "S5"  ];
+    let Aliases = [ ];
+    let SubRegs = [ R5, X5, W5 ];
+    let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 22 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 5;
+    let HWEncoding{4-0} = 5;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def S6 : Register<"S6">
 {
-let Namespace = "aarch64temp";
-let AsmName = "S6";
-let AltNames = [ "S6"  ];
-let Aliases = [ ];
-let SubRegs = [ R6, X6, W6 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 22 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "S6";
+    let AltNames = [ "S6"  ];
+    let Aliases = [ ];
+    let SubRegs = [ R6, X6, W6 ];
+    let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 23 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 6;
+    let HWEncoding{4-0} = 6;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def S7 : Register<"S7">
 {
-let Namespace = "aarch64temp";
-let AsmName = "S7";
-let AltNames = [ "S7"  ];
-let Aliases = [ ];
-let SubRegs = [ R7, X7, W7 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 23 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "S7";
+    let AltNames = [ "S7"  ];
+    let Aliases = [ ];
+    let SubRegs = [ R7, X7, W7 ];
+    let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 24 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 7;
+    let HWEncoding{4-0} = 7;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def S8 : Register<"S8">
 {
-let Namespace = "aarch64temp";
-let AsmName = "S8";
-let AltNames = [ "S8"  ];
-let Aliases = [ ];
-let SubRegs = [ R8, X8, W8 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 24 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "S8";
+    let AltNames = [ "S8"  ];
+    let Aliases = [ ];
+    let SubRegs = [ R8, X8, W8 ];
+    let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 25 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 8;
+    let HWEncoding{4-0} = 8;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def S9 : Register<"S9">
 {
-let Namespace = "aarch64temp";
-let AsmName = "S9";
-let AltNames = [ "S9"  ];
-let Aliases = [ ];
-let SubRegs = [ R9, X9, W9 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 25 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "S9";
+    let AltNames = [ "S9"  ];
+    let Aliases = [ ];
+    let SubRegs = [ R9, X9, W9 ];
+    let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 26 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 9;
+    let HWEncoding{4-0} = 9;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def S10 : Register<"S10">
 {
-let Namespace = "aarch64temp";
-let AsmName = "S10";
-let AltNames = [ "S10"  ];
-let Aliases = [ ];
-let SubRegs = [ R10, X10, W10 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 26 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "S10";
+    let AltNames = [ "S10"  ];
+    let Aliases = [ ];
+    let SubRegs = [ R10, X10, W10 ];
+    let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 27 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 10;
+    let HWEncoding{4-0} = 10;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def S11 : Register<"S11">
 {
-let Namespace = "aarch64temp";
-let AsmName = "S11";
-let AltNames = [ "S11"  ];
-let Aliases = [ ];
-let SubRegs = [ R11, X11, W11 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 27 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "S11";
+    let AltNames = [ "S11"  ];
+    let Aliases = [ ];
+    let SubRegs = [ R11, X11, W11 ];
+    let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 28 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 11;
+    let HWEncoding{4-0} = 11;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def S12 : Register<"S12">
 {
-let Namespace = "aarch64temp";
-let AsmName = "S12";
-let AltNames = [ "S12"  ];
-let Aliases = [ ];
-let SubRegs = [ R12, X12, W12 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 28 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "S12";
+    let AltNames = [ "S12"  ];
+    let Aliases = [ ];
+    let SubRegs = [ R12, X12, W12 ];
+    let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 29 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 12;
+    let HWEncoding{4-0} = 12;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def S13 : Register<"S13">
 {
-let Namespace = "aarch64temp";
-let AsmName = "S13";
-let AltNames = [ "S13"  ];
-let Aliases = [ ];
-let SubRegs = [ R13, X13, W13 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 29 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "S13";
+    let AltNames = [ "S13"  ];
+    let Aliases = [ ];
+    let SubRegs = [ R13, X13, W13 ];
+    let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 30 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 13;
+    let HWEncoding{4-0} = 13;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def S14 : Register<"S14">
 {
-let Namespace = "aarch64temp";
-let AsmName = "S14";
-let AltNames = [ "S14"  ];
-let Aliases = [ ];
-let SubRegs = [ R14, X14, W14 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 30 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "S14";
+    let AltNames = [ "S14"  ];
+    let Aliases = [ ];
+    let SubRegs = [ R14, X14, W14 ];
+    let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 31 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 14;
+    let HWEncoding{4-0} = 14;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def S15 : Register<"S15">
 {
-let Namespace = "aarch64temp";
-let AsmName = "S15";
-let AltNames = [ "S15"  ];
-let Aliases = [ ];
-let SubRegs = [ R15, X15, W15 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 31 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "S15";
+    let AltNames = [ "S15"  ];
+    let Aliases = [ ];
+    let SubRegs = [ R15, X15, W15 ];
+    let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 32 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 15;
+    let HWEncoding{4-0} = 15;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def S16 : Register<"S16">
 {
-let Namespace = "aarch64temp";
-let AsmName = "S16";
-let AltNames = [ "S16"  ];
-let Aliases = [ ];
-let SubRegs = [ R16, X16, W16 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 32 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "S16";
+    let AltNames = [ "S16"  ];
+    let Aliases = [ ];
+    let SubRegs = [ R16, X16, W16 ];
+    let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 33 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 16;
+    let HWEncoding{4-0} = 16;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def S17 : Register<"S17">
 {
-let Namespace = "aarch64temp";
-let AsmName = "S17";
-let AltNames = [ "S17"  ];
-let Aliases = [ ];
-let SubRegs = [ R17, X17, W17 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 33 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "S17";
+    let AltNames = [ "S17"  ];
+    let Aliases = [ ];
+    let SubRegs = [ R17, X17, W17 ];
+    let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 34 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 17;
+    let HWEncoding{4-0} = 17;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def S18 : Register<"S18">
 {
-let Namespace = "aarch64temp";
-let AsmName = "S18";
-let AltNames = [ "S18"  ];
-let Aliases = [ ];
-let SubRegs = [ R18, X18, W18 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 34 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "S18";
+    let AltNames = [ "S18"  ];
+    let Aliases = [ ];
+    let SubRegs = [ R18, X18, W18 ];
+    let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 35 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 18;
+    let HWEncoding{4-0} = 18;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def S19 : Register<"S19">
 {
-let Namespace = "aarch64temp";
-let AsmName = "S19";
-let AltNames = [ "S19"  ];
-let Aliases = [ ];
-let SubRegs = [ R19, X19, W19 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 35 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "S19";
+    let AltNames = [ "S19"  ];
+    let Aliases = [ ];
+    let SubRegs = [ R19, X19, W19 ];
+    let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 36 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 19;
+    let HWEncoding{4-0} = 19;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def S20 : Register<"S20">
 {
-let Namespace = "aarch64temp";
-let AsmName = "S20";
-let AltNames = [ "S20"  ];
-let Aliases = [ ];
-let SubRegs = [ R20, X20, W20 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 36 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "S20";
+    let AltNames = [ "S20"  ];
+    let Aliases = [ ];
+    let SubRegs = [ R20, X20, W20 ];
+    let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 37 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 20;
+    let HWEncoding{4-0} = 20;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def S21 : Register<"S21">
 {
-let Namespace = "aarch64temp";
-let AsmName = "S21";
-let AltNames = [ "S21"  ];
-let Aliases = [ ];
-let SubRegs = [ R21, X21, W21 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 37 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "S21";
+    let AltNames = [ "S21"  ];
+    let Aliases = [ ];
+    let SubRegs = [ R21, X21, W21 ];
+    let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 38 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 21;
+    let HWEncoding{4-0} = 21;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def S22 : Register<"S22">
 {
-let Namespace = "aarch64temp";
-let AsmName = "S22";
-let AltNames = [ "S22"  ];
-let Aliases = [ ];
-let SubRegs = [ R22, X22, W22 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 38 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "S22";
+    let AltNames = [ "S22"  ];
+    let Aliases = [ ];
+    let SubRegs = [ R22, X22, W22 ];
+    let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 39 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 22;
+    let HWEncoding{4-0} = 22;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def S23 : Register<"S23">
 {
-let Namespace = "aarch64temp";
-let AsmName = "S23";
-let AltNames = [ "S23"  ];
-let Aliases = [ ];
-let SubRegs = [ R23, X23, W23 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 39 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "S23";
+    let AltNames = [ "S23"  ];
+    let Aliases = [ ];
+    let SubRegs = [ R23, X23, W23 ];
+    let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 40 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 23;
+    let HWEncoding{4-0} = 23;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def S24 : Register<"S24">
 {
-let Namespace = "aarch64temp";
-let AsmName = "S24";
-let AltNames = [ "S24"  ];
-let Aliases = [ ];
-let SubRegs = [ R24, X24, W24 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 40 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "S24";
+    let AltNames = [ "S24"  ];
+    let Aliases = [ ];
+    let SubRegs = [ R24, X24, W24 ];
+    let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 41 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 24;
+    let HWEncoding{4-0} = 24;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def S25 : Register<"S25">
 {
-let Namespace = "aarch64temp";
-let AsmName = "S25";
-let AltNames = [ "S25"  ];
-let Aliases = [ ];
-let SubRegs = [ R25, X25, W25 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 41 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "S25";
+    let AltNames = [ "S25"  ];
+    let Aliases = [ ];
+    let SubRegs = [ R25, X25, W25 ];
+    let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 42 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 25;
+    let HWEncoding{4-0} = 25;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def S26 : Register<"S26">
 {
-let Namespace = "aarch64temp";
-let AsmName = "S26";
-let AltNames = [ "S26"  ];
-let Aliases = [ ];
-let SubRegs = [ R26, X26, W26 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 42 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "S26";
+    let AltNames = [ "S26"  ];
+    let Aliases = [ ];
+    let SubRegs = [ R26, X26, W26 ];
+    let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 43 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 26;
+    let HWEncoding{4-0} = 26;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def S27 : Register<"S27">
 {
-let Namespace = "aarch64temp";
-let AsmName = "S27";
-let AltNames = [ "S27"  ];
-let Aliases = [ ];
-let SubRegs = [ R27, X27, W27 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 43 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "S27";
+    let AltNames = [ "S27"  ];
+    let Aliases = [ ];
+    let SubRegs = [ R27, X27, W27 ];
+    let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 44 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 27;
+    let HWEncoding{4-0} = 27;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def S28 : Register<"S28">
 {
-let Namespace = "aarch64temp";
-let AsmName = "S28";
-let AltNames = [ "S28"  ];
-let Aliases = [ ];
-let SubRegs = [ R28, X28, W28 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 44 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "S28";
+    let AltNames = [ "S28"  ];
+    let Aliases = [ ];
+    let SubRegs = [ R28, X28, W28 ];
+    let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 45 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 28;
+    let HWEncoding{4-0} = 28;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def S29 : Register<"S29">
 {
-let Namespace = "aarch64temp";
-let AsmName = "S29";
-let AltNames = [ "S29"  ];
-let Aliases = [ ];
-let SubRegs = [ R29, X29, W29 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 45 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "S29";
+    let AltNames = [ "S29"  ];
+    let Aliases = [ ];
+    let SubRegs = [ R29, X29, W29 ];
+    let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 46 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 29;
+    let HWEncoding{4-0} = 29;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def S30 : Register<"S30">
 {
-let Namespace = "aarch64temp";
-let AsmName = "A_LR";
-let AltNames = [ "A_LR", "S30"  ];
-let Aliases = [ ];
-let SubRegs = [ R30, X30, W30 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 46 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "A_LR";
+    let AltNames = [ "A_LR", "S30"  ];
+    let Aliases = [ ];
+    let SubRegs = [ R30, X30, W30 ];
+    let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 47 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 30;
+    let HWEncoding{4-0} = 30;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 def S31 : Register<"S31">
 {
-let Namespace = "aarch64temp";
-let AsmName = "A_SP";
-let AltNames = [ "A_SP", "S31"  ];
-let Aliases = [ ];
-let SubRegs = [ R31, X31, W31 ];
-let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
-let RegAltNameIndices = [];
-let DwarfNumbers = [ 47 ];
-list<int> CostPerUse = [0];
-let CoveredBySubRegs = 0;
+    let Namespace = "aarch64temp";
+    let AsmName = "A_SP";
+    let AltNames = [ "A_SP", "S31"  ];
+    let Aliases = [ ];
+    let SubRegs = [ R31, X31, W31 ];
+    let SubRegIndices = [ SUB_32, FULL_64, SUB_32_1 ];
+    let RegAltNameIndices = [];
+    let DwarfNumbers = [ 48 ];
+    list<int> CostPerUse = [0];
+    let CoveredBySubRegs = 0;
 
-let HWEncoding{4-0} = 31;
+    let HWEncoding{4-0} = 31;
 
 
-let isArtificial = false;
+    let isArtificial = false;
 }
 
 
 defvar aarch64temp = DefaultMode;
 
 def SLenRI : RegInfoByHwMode<
-[ aarch64temp ],
-[RegInfo<64,64,64>]>;
+      [ aarch64temp ],
+      [RegInfo<64,64,64>]>;
 def S : RegisterClass
 < /* namespace = */ "aarch64temp"
 , /* regTypes  = */  [  i64 ]
 , /* alignment = */ 32
 , /* regList   = */
-( add S9, S10, S11, S12, S13, S14, S15, S19, S20, S21, S22, S23, S24, S25, S26, S27, S28, S0, S1, S2, S3, S4, S5, S6, S7, S8, S16, S17, S18, S29, S30, S31 )
+  ( add S9, S10, S11, S12, S13, S14, S15, S19, S20, S21, S22, S23, S24, S25, S26, S27, S28, S0, S1, S2, S3, S4, S5, S6, S7, S8, S16, S17, S18, S29, S30, S31 )
 > {
-let RegInfos = SLenRI;
+  let RegInfos = SLenRI;
 }
 
 
@@ -2620,7 +2639,7 @@ def R : RegisterClass
 , /* regTypes  = */  [  i32 ]
 , /* alignment = */ 32
 , /* regList   = */
-( add R0, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17, R18, R19, R20, R21, R22, R23, R24, R25, R26, R27, R28, R29, R30, R31 )
+  ( add R0, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17, R18, R19, R20, R21, R22, R23, R24, R25, R26, R27, R28, R29, R30, R31 )
 > {
 }
 def X : RegisterClass
@@ -2628,7 +2647,7 @@ def X : RegisterClass
 , /* regTypes  = */  [  i64 ]
 , /* alignment = */ 32
 , /* regList   = */
-( add X0, X1, X2, X3, X4, X5, X6, X7, X8, X9, X10, X11, X12, X13, X14, X15, X16, X17, X18, X19, X20, X21, X22, X23, X24, X25, X26, X27, X28, X29, X30, X31 )
+  ( add X0, X1, X2, X3, X4, X5, X6, X7, X8, X9, X10, X11, X12, X13, X14, X15, X16, X17, X18, X19, X20, X21, X22, X23, X24, X25, X26, X27, X28, X29, X30, X31 )
 > {
 }
 def W : RegisterClass
@@ -2636,6 +2655,6 @@ def W : RegisterClass
 , /* regTypes  = */  [  i32 ]
 , /* alignment = */ 32
 , /* regList   = */
-( add W0, W1, W2, W3, W4, W5, W6, W7, W8, W9, W10, W11, W12, W13, W14, W15, W16, W17, W18, W19, W20, W21, W22, W23, W24, W25, W26, W27, W28, W29, W30, W31 )
+  ( add W0, W1, W2, W3, W4, W5, W6, W7, W8, W9, W10, W11, W12, W13, W14, W15, W16, W17, W18, W19, W20, W21, W22, W23, W24, W25, W26, W27, W28, W29, W30, W31 )
 > {
 }

--- a/vadl/test/vadl/iss/aarch64/A64SVETestBuilder.java
+++ b/vadl/test/vadl/iss/aarch64/A64SVETestBuilder.java
@@ -30,9 +30,16 @@ public class A64SVETestBuilder extends A64TestBuilder {
     if (vlBits <= 0) {
       throw new IllegalArgumentException("SVE VL must be > 0, got " + vlBits);
     }
+    if (vlBits % 128 != 0) {
+      throw new IllegalArgumentException("SVE VL must be a multiple of 128, got " + vlBits);
+    }
+    var zcrLen = (vlBits / 128) - 1;
     add("# configure CPACR to enable SIMD/SVE access in reference QEMU");
     add("mov %s, #0x330000", tmpReg);
     add("msr cpacr_el1, %s", tmpReg);
+    add("# match reference QEMU's runtime SVE vector length to the fixed VADL test VL");
+    add("mov %s, #%d", tmpReg, zcrLen);
+    add("msr zcr_el1, %s", tmpReg);
   }
 
   public void fillMemory64(long addr, int words, String addrReg, String dataReg) {

--- a/vadl/test/vadl/lcb/aarch64/template/EmitInstrInfoTableGenFilePassTest.java
+++ b/vadl/test/vadl/lcb/aarch64/template/EmitInstrInfoTableGenFilePassTest.java
@@ -16,13 +16,12 @@
 
 package vadl.lcb.aarch64.template;
 
-import java.io.File;
+import static vadl.TestUtils.assertEqualsFileLines;
+
 import java.io.IOException;
-import java.nio.charset.Charset;
+import java.nio.file.Path;
 import org.apache.commons.io.FileUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.shaded.com.google.common.io.Files;
 import vadl.lcb.AbstractLcbTest;
 import vadl.lcb.template.lib.Target.EmitInstrInfoTableGenFilePass;
 import vadl.pass.PassKey;
@@ -43,14 +42,10 @@ public class EmitInstrInfoTableGenFilePassTest extends AbstractLcbTest {
             .lastResultOf(EmitInstrInfoTableGenFilePass.class);
 
     // Then
-    var resultFile = passResult.emittedFile().toFile();
-    var trimmed = Files.asCharSource(resultFile, Charset.defaultCharset()).read().trim();
-    var output = trimmed.lines();
+    var resultFile = passResult.emittedFile();
+    var actual = FileUtils.readFileToString(resultFile.toFile(), "UTF-8");
+    var fs = Path.of("test/resources/snapshots/aarch64/InstrInfoTableGen.td");
 
-    var fs = new File(
-        "test/resources/snapshots/aarch64/InstrInfoTableGen.td");
-    var expected = FileUtils.readFileToString(fs, "UTF-8");
-
-    Assertions.assertLinesMatch(expected.trim().lines(), output);
+    assertEqualsFileLines(fs, actual);
   }
 }

--- a/vadl/test/vadl/lcb/aarch64/template/EmitRegisterInfoCppFilePassTest.java
+++ b/vadl/test/vadl/lcb/aarch64/template/EmitRegisterInfoCppFilePassTest.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -16,13 +16,13 @@
 
 package vadl.lcb.aarch64.template;
 
-import java.io.File;
+import static vadl.TestUtils.assertEqualsFileLines;
+
 import java.io.IOException;
-import java.nio.charset.Charset;
+import java.nio.file.Path;
+import java.util.stream.Collectors;
 import org.apache.commons.io.FileUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.shaded.com.google.common.io.Files;
 import vadl.lcb.AbstractLcbTest;
 import vadl.lcb.template.lib.Target.EmitRegisterInfoCppFilePass;
 import vadl.pass.PassKey;
@@ -44,13 +44,14 @@ public class EmitRegisterInfoCppFilePassTest extends AbstractLcbTest {
 
     // Then
     var resultFile = passResult.emittedFile().toFile();
-    var trimmed = Files.asCharSource(resultFile, Charset.defaultCharset()).read().trim();
-    var output = trimmed.lines().map(String::trim);
+    var actual = FileUtils.readFileToString(resultFile, "UTF-8")
+        .lines()
+        .map(String::stripTrailing)
+        .collect(Collectors.joining("\n"));
 
-    var fs = new File(
+    var fs = Path.of(
         "test/resources/snapshots/aarch64/RegisterInfo.cpp");
-    var expected = FileUtils.readFileToString(fs, "UTF-8");
 
-    Assertions.assertLinesMatch(expected.trim().lines().map(String::trim), output);
+    assertEqualsFileLines(fs, actual);
   }
 }

--- a/vadl/test/vadl/lcb/aarch64/template/EmitRegisterInfoTableGenFilePassTest.java
+++ b/vadl/test/vadl/lcb/aarch64/template/EmitRegisterInfoTableGenFilePassTest.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -16,16 +16,15 @@
 
 package vadl.lcb.aarch64.template;
 
-import java.io.File;
+import static vadl.TestUtils.assertEqualsFileLines;
+
 import java.io.IOException;
-import java.nio.charset.Charset;
+import java.nio.file.Path;
+import java.util.stream.Collectors;
 import org.apache.commons.io.FileUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.shaded.com.google.common.io.Files;
 import vadl.gcb.valuetypes.TargetName;
 import vadl.lcb.AbstractLcbTest;
-import vadl.lcb.template.lib.Target.EmitRegisterInfoCppFilePass;
 import vadl.lcb.template.lib.Target.EmitRegisterInfoTableGenFilePass;
 import vadl.pass.PassKey;
 import vadl.pass.exception.DuplicatedPassKeyException;
@@ -47,13 +46,14 @@ public class EmitRegisterInfoTableGenFilePassTest extends AbstractLcbTest {
 
     // Then
     var resultFile = passResult.emittedFile().toFile();
-    var trimmed = Files.asCharSource(resultFile, Charset.defaultCharset()).read().trim();
-    var output = trimmed.lines().map(String::trim);
+    var actual = FileUtils.readFileToString(resultFile, "UTF-8")
+        .lines()
+        .map(String::stripTrailing)
+        .collect(Collectors.joining("\n"));
 
-    var fs = new File(
+    var fs = Path.of(
         "test/resources/snapshots/aarch64/RegisterInfo.td");
-    var expected = FileUtils.readFileToString(fs, "UTF-8");
 
-    Assertions.assertLinesMatch(expected.trim().lines().map(String::trim), output);
+    assertEqualsFileLines(fs, actual);
   }
 }


### PR DESCRIPTION
This PR reduces helper-code explosion for repeated helper-side expressions by materializing reused scalar subexpressions as `ExprSaveNode` temporaries before C emission.

It adds an ISS pass that identifies repeated helper-only scalar expressions, places a save at the latest dominating control location, and reuses that value instead of regenerating the same subtree at every use site. The pass stays conservative: it skips loop-index-dependent expressions, helper-preload-fed expressions, memory reads, function calls, and trivial aliases.

The change also cleans up the supporting infrastructure around it: dominator analysis was extracted into a shared ISS utility, helper codegen now avoids emitting pointless alias saves for already identifier-like values, and graph traversal helpers were centralized so the save pass and helper codegen use the same dependency-query logic.

The AArch64 SVE spec now works for all VL (128 - 2048 bits).