### PR TITLE
cli: Disable semantic encoding verification by default

### DIFF
--- a/vadl-cli/main/vadl/cli/decoder/DecoderOptsConverter.java
+++ b/vadl-cli/main/vadl/cli/decoder/DecoderOptsConverter.java
@@ -23,7 +23,7 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import picocli.CommandLine;
 import vadl.cli.decoder.mixin.DecoderMixin.DecoderOpt;
-import vadl.cli.decoder.mixin.DecoderMixin.DecoderSkipOption;
+import vadl.cli.decoder.mixin.DecoderMixin.DecoderStep;
 import vadl.cli.decoder.mixin.DecoderMixin.DecoderStrategy;
 import vadl.configuration.DecoderOptions;
 
@@ -34,13 +34,14 @@ public abstract class DecoderOptsConverter
     implements Iterable<String>, CommandLine.ITypeConverter<DecoderOpt> {
 
   private static final String KEY_STRATEGY = "strategy";
-  private static final String KEY_SKIP = "skip";
+  private static final String KEY_STEP_INCLUDE = "with";
+  private static final String KEY_STEP_EXCLUDE = "skip";
 
   /**
    * Allow subclasses to override the available options.
    */
   protected DecoderOptions.Generator[] strategies = DecoderOptions.Generator.values();
-  protected DecoderOptions.OptionToSkip[] skipOptions = DecoderOptions.OptionToSkip.values();
+  protected DecoderOptions.OptionalStep[] steps = DecoderOptions.OptionalStep.values();
 
   @Override
   public DecoderOpt convert(String value) {
@@ -63,22 +64,35 @@ public abstract class DecoderOptsConverter
                   .map(DecoderOptions.Generator::getSelector).toList()));
     }
 
-    if (KEY_SKIP.equals(fragments[0].trim())) {
+    if (KEY_STEP_EXCLUDE.equals(fragments[0].trim())) {
       var val = fragments[1].trim();
-      var skipOpt = DecoderOptions.OptionToSkip.fromSelector(val, skipOptions);
-      if (skipOpt != null) {
-        return new DecoderSkipOption(skipOpt);
+      var step = DecoderOptions.OptionalStep.fromSelector(val, steps);
+      if (step != null) {
+        return new DecoderStep(step, false);
       }
 
       throw new CommandLine.TypeConversionException(
-          "Unable to parse decoder option to skip: '%s'. Available options are: %s".formatted(val,
-              Arrays.stream(skipOptions)
-                  .map(DecoderOptions.OptionToSkip::getSelector).toList()));
+          "Unable to parse decoder step to disable: '%s'. Available options are: %s".formatted(val,
+              Arrays.stream(steps)
+                  .map(DecoderOptions.OptionalStep::getSelector).toList()));
+    }
+
+    if (KEY_STEP_INCLUDE.equals(fragments[0].trim())) {
+      var val = fragments[1].trim();
+      var step = DecoderOptions.OptionalStep.fromSelector(val, steps);
+      if (step != null) {
+        return new DecoderStep(step, true);
+      }
+
+      throw new CommandLine.TypeConversionException(
+          "Unable to parse decoder step to enable: '%s'. Available options are: %s".formatted(val,
+              Arrays.stream(steps)
+                  .map(DecoderOptions.OptionalStep::getSelector).toList()));
     }
 
     throw new CommandLine.TypeConversionException(
-        "Illegal decoder option '%s'. Available options are: %s".formatted(value,
-            List.of(KEY_SKIP, KEY_STRATEGY)));
+        "Illegal decoder step '%s'. Available options are: %s".formatted(value,
+            List.of(KEY_STEP_INCLUDE, KEY_STEP_EXCLUDE, KEY_STRATEGY)));
   }
 
   /**
@@ -93,9 +107,10 @@ public abstract class DecoderOptsConverter
       options.add(
           "%n%s=%s (%s)".formatted(KEY_STRATEGY, generator.getSelector(), generator.getDesc()));
     }
-    for (DecoderOptions.OptionToSkip skipOption : skipOptions) {
+    for (DecoderOptions.OptionalStep step : steps) {
       options.add(
-          "%n%s=%s (%s)".formatted(KEY_SKIP, skipOption.getSelector(), skipOption.getDesc()));
+          "%n[%s|%s]=%s (%s)".formatted(KEY_STEP_INCLUDE, KEY_STEP_EXCLUDE,
+              step.getSelector(), step.getDesc()));
     }
     return options;
   }

--- a/vadl-cli/main/vadl/cli/decoder/mixin/CheckDecoderOptions.java
+++ b/vadl-cli/main/vadl/cli/decoder/mixin/CheckDecoderOptions.java
@@ -45,7 +45,7 @@ public class CheckDecoderOptions extends DecoderMixin {
 
     public CheckDecoderOptsContributor() {
       strategies = DecoderOptions.Generator.values();
-      skipOptions = DecoderOptions.OptionToSkip.values();
+      steps = DecoderOptions.OptionalStep.values();
     }
   }
 

--- a/vadl-cli/main/vadl/cli/decoder/mixin/DecoderMixin.java
+++ b/vadl-cli/main/vadl/cli/decoder/mixin/DecoderMixin.java
@@ -21,7 +21,7 @@ import picocli.CommandLine;
 import picocli.CommandLine.MaxValuesExceededException;
 import vadl.configuration.DecoderOptions;
 import vadl.configuration.DecoderOptions.Generator;
-import vadl.configuration.DecoderOptions.OptionToSkip;
+import vadl.configuration.DecoderOptions.OptionalStep;
 
 /**
  * Base functionality for the decoder option mixins.
@@ -60,15 +60,10 @@ public abstract class DecoderMixin {
       result.setGenerator(strategies.getFirst().generator());
     }
 
-    var skipOpts = decoderOptions.stream()
-        .filter(DecoderSkipOption.class::isInstance)
-        .map(DecoderSkipOption.class::cast)
-        .map(DecoderSkipOption::option)
-        .toList();
-
-    if (!skipOpts.isEmpty()) {
-      result.setOptsToSkip(skipOpts.toArray(new OptionToSkip[0]));
-    }
+    decoderOptions.stream()
+        .filter(DecoderStep.class::isInstance)
+        .map(DecoderStep.class::cast)
+        .forEach(step -> result.getOpts().put(step.step(), step.enabled()));
 
     return result;
   }
@@ -88,11 +83,11 @@ public abstract class DecoderMixin {
   }
 
   /**
-   * Skip options.
+   * Optional step option.
    *
-   * @param option The option to skip.
+   * @param step The step to skip.
    */
-  public record DecoderSkipOption(OptionToSkip option) implements DecoderOpt {
+  public record DecoderStep(OptionalStep step, boolean enabled) implements DecoderOpt {
   }
 
 }

--- a/vadl-cli/main/vadl/cli/decoder/mixin/IssDecoderOptions.java
+++ b/vadl-cli/main/vadl/cli/decoder/mixin/IssDecoderOptions.java
@@ -22,7 +22,7 @@ import java.util.Set;
 import picocli.CommandLine;
 import vadl.cli.decoder.DecoderOptsConverter;
 import vadl.configuration.DecoderOptions.Generator;
-import vadl.configuration.DecoderOptions.OptionToSkip;
+import vadl.configuration.DecoderOptions.OptionalStep;
 
 /**
  * Decoder options available to the {@link vadl.cli.IssCommand}.
@@ -49,9 +49,9 @@ public class IssDecoderOptions extends DecoderMixin {
       strategies = Arrays.stream(Generator.values())
           .filter(g -> g != Generator.RTL_TABLE)
           .toArray(Generator[]::new);
-      skipOptions = Arrays.stream(OptionToSkip.values())
-          .filter(s -> s != OptionToSkip.OPT_ALL)
-          .toArray(OptionToSkip[]::new);
+      steps = Arrays.stream(OptionalStep.values())
+          .filter(s -> s != OptionalStep.OPT_ALL)
+          .toArray(OptionalStep[]::new);
     }
 
   }

--- a/vadl-cli/main/vadl/cli/decoder/mixin/RtlDecoderOptions.java
+++ b/vadl-cli/main/vadl/cli/decoder/mixin/RtlDecoderOptions.java
@@ -22,7 +22,7 @@ import java.util.Set;
 import picocli.CommandLine;
 import vadl.cli.decoder.DecoderOptsConverter;
 import vadl.configuration.DecoderOptions.Generator;
-import vadl.configuration.DecoderOptions.OptionToSkip;
+import vadl.configuration.DecoderOptions.OptionalStep;
 
 /**
  * Decoder options available to the {@link vadl.cli.RtlCommand}.
@@ -47,9 +47,9 @@ public class RtlDecoderOptions extends DecoderMixin {
 
     public RtlDecoderOptsContributor() {
       strategies = Generator.values();
-      skipOptions = Arrays.stream(OptionToSkip.values())
-          .filter(s -> s != OptionToSkip.OPT_ALL)
-          .toArray(OptionToSkip[]::new);
+      steps = Arrays.stream(OptionalStep.values())
+          .filter(s -> s != OptionalStep.OPT_ALL)
+          .toArray(OptionalStep[]::new);
     }
   }
 

--- a/vadl/main/vadl/configuration/DecoderOptions.java
+++ b/vadl/main/vadl/configuration/DecoderOptions.java
@@ -16,7 +16,8 @@
 
 package vadl.configuration;
 
-import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
@@ -74,24 +75,24 @@ public class DecoderOptions {
   /**
    * The options for decoder generation which can be disabled.
    */
-  public enum OptionToSkip {
+  public enum OptionalStep {
 
-    OPT_ALL("Skip all decoder related verification and generation passes, default: enabled",
+    OPT_ALL("All decoder related verification and generation passes, default: enabled",
         "all"),
 
-    OPT_CONSTRAINT_SYNTHESIS("Skip constraint synthesis for decoder generation, default: enabled",
+    OPT_CONSTRAINT_SYNTHESIS("Constraint synthesis for decoder generation, default: enabled",
         "constraint-synthesis"),
 
-    OPT_ENCODING_VERIFICATION("Skip the encoding verification, default: enabled",
+    OPT_ENCODING_VERIFICATION("Encoding verification, default: disabled",
         "encoding-verification"),
 
-    OPT_DECODER_VERIFICATION("Skip the correctness verification of the decode tree, default: "
+    OPT_DECODER_VERIFICATION("correctness verification of the decode tree, default: "
         + "enabled", "decoder-verification");
 
     private final String selector;
     private final String desc;
 
-    OptionToSkip(String desc, String selector) {
+    OptionalStep(String desc, String selector) {
       this.desc = desc;
       this.selector = selector;
     }
@@ -112,12 +113,12 @@ public class DecoderOptions {
      * @return The skipped option, or null if no match was found.
      */
     @Nullable
-    public static OptionToSkip fromSelector(String selector, OptionToSkip... options) {
+    public static OptionalStep fromSelector(String selector, OptionalStep... options) {
       if (selector == null || selector.isBlank()) {
         return null;
       }
-      final var opts = options.length == 0 ? OptionToSkip.values() : options;
-      for (OptionToSkip opt : opts) {
+      final var opts = options.length == 0 ? OptionalStep.values() : options;
+      for (OptionalStep opt : opts) {
         if (opt.getSelector().equals(selector)) {
           return opt;
         }
@@ -126,20 +127,33 @@ public class DecoderOptions {
     }
   }
 
-  private OptionToSkip[] optsToSkip;
+  private Map<OptionalStep, Boolean> opts;
   private Generator generator;
 
   public DecoderOptions() {
-    optsToSkip = new OptionToSkip[0];
+    opts = new HashMap<>(Map.of(
+        OptionalStep.OPT_ALL, true,
+        OptionalStep.OPT_CONSTRAINT_SYNTHESIS, true,
+        OptionalStep.OPT_ENCODING_VERIFICATION, false,
+        OptionalStep.OPT_DECODER_VERIFICATION, true
+    ));
     generator = Generator.IRREGULAR;
   }
 
-  public OptionToSkip[] getOptsToSkip() {
-    return optsToSkip;
+  public Map<OptionalStep, Boolean> getOpts() {
+    return opts;
   }
 
-  public void setOptsToSkip(OptionToSkip[] optsToSkip) {
-    this.optsToSkip = optsToSkip;
+  public void setOpts(Map<OptionalStep, Boolean> opts) {
+    this.opts = opts;
+  }
+
+  public boolean isEnabled(OptionalStep opt) {
+    return opts.getOrDefault(opt, true);
+  }
+
+  public boolean isDisabled(OptionalStep opt) {
+    return !isEnabled(opt);
   }
 
   public Generator getGenerator() {
@@ -153,7 +167,7 @@ public class DecoderOptions {
   @Override
   public String toString() {
     return "DecoderOptions{"
-        + "optsToSkip=" + Arrays.toString(optsToSkip)
+        + "steps=" + opts
         + ", generator=" + generator
         + '}';
   }

--- a/vadl/main/vadl/configuration/DecoderOptions.java
+++ b/vadl/main/vadl/configuration/DecoderOptions.java
@@ -130,6 +130,9 @@ public class DecoderOptions {
   private Map<OptionalStep, Boolean> opts;
   private Generator generator;
 
+  /**
+   * Default constructor.
+   */
   public DecoderOptions() {
     opts = new HashMap<>(Map.of(
         OptionalStep.OPT_ALL, true,

--- a/vadl/main/vadl/pass/PassOrders.java
+++ b/vadl/main/vadl/pass/PassOrders.java
@@ -17,10 +17,10 @@
 package vadl.pass;
 
 import static vadl.configuration.DecoderOptions.Generator.RTL_TABLE;
-import static vadl.configuration.DecoderOptions.OptionToSkip.OPT_ALL;
-import static vadl.configuration.DecoderOptions.OptionToSkip.OPT_CONSTRAINT_SYNTHESIS;
-import static vadl.configuration.DecoderOptions.OptionToSkip.OPT_DECODER_VERIFICATION;
-import static vadl.configuration.DecoderOptions.OptionToSkip.OPT_ENCODING_VERIFICATION;
+import static vadl.configuration.DecoderOptions.OptionalStep.OPT_ALL;
+import static vadl.configuration.DecoderOptions.OptionalStep.OPT_CONSTRAINT_SYNTHESIS;
+import static vadl.configuration.DecoderOptions.OptionalStep.OPT_DECODER_VERIFICATION;
+import static vadl.configuration.DecoderOptions.OptionalStep.OPT_ENCODING_VERIFICATION;
 import static vadl.iss.template.IssDefaultRenderingPass.issDefault;
 
 import com.google.common.collect.Streams;
@@ -671,10 +671,7 @@ public class PassOrders {
    */
   private static void addDecodePasses(PassOrder order, GeneralConfiguration config) {
 
-    var skipAll = Stream.of(config.getDecoderOptions().getOptsToSkip())
-        .anyMatch(o -> o == OPT_ALL);
-
-    if (skipAll) {
+    if (config.getDecoderOptions().isDisabled(OPT_ALL)) {
       return;
     }
 
@@ -683,23 +680,17 @@ public class PassOrders {
         .add(new VdtEncodingConstraintValidationPass(config))
         .add(new VdtInputPreparationPass(config));
 
-    var skipSynthesis = Stream.of(config.getDecoderOptions().getOptsToSkip())
-        .anyMatch(o -> o == OPT_CONSTRAINT_SYNTHESIS);
-    if (!skipSynthesis) {
+    if (config.getDecoderOptions().isEnabled(OPT_CONSTRAINT_SYNTHESIS)) {
       order.add(new VdtConstraintSynthesisPass(config));
     }
 
-    var skipEncodingVerification = Stream.of(config.getDecoderOptions().getOptsToSkip())
-        .anyMatch(o -> o == OPT_ENCODING_VERIFICATION);
-    if (!skipEncodingVerification) {
+    if (config.getDecoderOptions().isEnabled(OPT_ENCODING_VERIFICATION)) {
       order.add(new VdtEncodingSemanticVerificationPass(config));
     }
 
     order.add(new VdtLoweringPass(config));
 
-    var skipDecoderVerification = Stream.of(config.getDecoderOptions().getOptsToSkip())
-        .anyMatch(o -> o == OPT_DECODER_VERIFICATION);
-    if (!skipDecoderVerification) {
+    if (config.getDecoderOptions().isEnabled(OPT_DECODER_VERIFICATION)) {
       order.add(new VdtVerificationPass(config));
     }
   }


### PR DESCRIPTION
Refactors the CLI options for the optional decoder steps to en- or disable options, with a certain default. It disables the semantic encoding verification pass by default, and allows to optionally include it like this:

```sh
openvadl check sys/spec.vadl --decoder with=encoding-verification
```