### PR TITLE
iss: Update test VADL paths for AArch64 and RISC-V simulators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ docs/obj
 out/
 !vadl/src/main/**/out/
 !vadl/src/test/**/out/
+.output.txt
 
 ### Eclipse ###
 .apt_generated

--- a/vadl/test/resources/scripts/iss_qemu/main.py
+++ b/vadl/test/resources/scripts/iss_qemu/main.py
@@ -1,14 +1,12 @@
 import argparse
 import asyncio
+from concurrent.futures import ProcessPoolExecutor, as_completed
 import os
 import shutil
+import subprocess
+import sys
 import time
 import traceback
-import yaml
-import sys
-import subprocess
-from dataclasses import dataclass
-from typing import List
 
 from config_loader import load_config
 from test_case_plugin_executor import TestCasePluginExecutor
@@ -22,47 +20,77 @@ def reset_terminal():
         except subprocess.CalledProcessError as e:
           pass
 
-async def main(testsuite_path: argparse.FileType):
+
+def report_progress(completed: int, total: int):
+    width = 30
+    filled = width if total == 0 else int(width * completed / total)
+    bar = "#" * filled + "-" * (width - filled)
+    print(f"[{bar}] {completed}/{total}", file=sys.stderr, flush=True)
+
+
+def get_num_jobs():
+    configured_jobs = os.environ.get("VADL_ISS_JOBS")
+    if configured_jobs is not None:
+        try:
+            jobs = int(configured_jobs)
+            if jobs > 0:
+                return jobs
+        except ValueError:
+            pass
+
+    num_cores = os.cpu_count()
+    if num_cores is None:
+        return 1
+    return num_cores
+
+async def run_test_case(test_case):
+    test_start_time = time.time()
+    try:
+        await test_case.compile_and_link()
+        await test_case.exec()
+    except Exception as e:
+        test_case.test_result.status = 'FAIL'
+        test_case.test_result.errors.append(str(e))
+        print(traceback.format_exc())
+    finally:
+        reset_terminal()
+        test_end_time = time.time()
+        test_case.test_result.duration = f"{(test_end_time - test_start_time) * 1000:.2f}ms"
+        # status = test_case.test_result.status == 'PASS' and "✅ PASS" or "❌ FAIL"
+        # print(f"[{status}] Finish test case {test_case.test.id} in {test_case.test_result.duration}")
+        await test_case.emit_result(dir="results", prefix="result-")
+
+
+def run_test(test, test_config):
+    test_case = TestCasePluginExecutor(test, test_config)
+    asyncio.run(run_test_case(test_case))
+
+
+def main(testsuite_path: str):
     test_config = load_config(testsuite_path)
+    tests = test_config.tests
+    total_tests = len(tests)
 
-
-    # produces testcases
-    # test_cases = [TestCaseExecutor2(spec) for (i, spec) in enumerate(test_config.tests)]
-    # test_cases = [QMPTestCaseExecutor(qemu_exec, spec) for spec in test_config.tests]
-    test_cases = [TestCasePluginExecutor(test, test_config) for test in test_config.tests]
+    if total_tests == 0:
+        report_progress(0, 0)
+        return
 
     start_time = time.time()
+    num_jobs = get_num_jobs()
 
-    # Get the number of cores available
-    num_cores = os.cpu_count()
-    # Create a semaphore to limit concurrent test cases
-    semaphore = asyncio.Semaphore(num_cores)
+    with ProcessPoolExecutor(num_jobs) as executor:
+        futures = [
+            executor.submit(run_test, test, test_config)
+            for test in tests
+        ]
 
-
-    # define how tests should be executed
-    async def run_test(test_case):
-        async with semaphore:
-            test_start_time = time.time()
-            try:
-                await test_case.compile_and_link()
-                await test_case.exec()
-            except Exception as e:
-                test_case.test_result.status = 'FAIL'
-                test_case.test_result.errors.append(str(e))
-                print(traceback.format_exc())
-            finally:
-                reset_terminal()
-                test_end_time = time.time()
-                test_case.test_result.duration = f"{(test_end_time - test_start_time) * 1000:.2f}ms"
-                status = test_case.test_result.status == 'PASS' and "✅ PASS" or "❌ FAIL"
-                print(f"[{status}] Finish test case {test_case.test.id} in {test_case.test_result.duration}")
-                await test_case.emit_result(dir="results", prefix="result-")
-
-    # Create tasks with semaphore-controlled concurrency
-    tasks = [asyncio.create_task(run_test(test_case)) for test_case in test_cases]
-
-    # Wait for all tasks to complete
-    await asyncio.gather(*tasks)
+        report_progress(0, total_tests)
+        completed = 0
+        for future in as_completed(futures):
+            future.result()
+            completed += 1
+            if completed % 100 == 0 or completed == total_tests:
+                report_progress(completed, total_tests)
 
     end_time = time.time()
     print(f"Total time: {end_time - start_time:.3f}s")
@@ -73,4 +101,4 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("config", type=str)
     args = parser.parse_args()
-    asyncio.run(main(args.config))
+    main(args.config)

--- a/vadl/test/resources/scripts/iss_qemu/test_case_plugin_executor.py
+++ b/vadl/test/resources/scripts/iss_qemu/test_case_plugin_executor.py
@@ -83,15 +83,16 @@ class TestCasePluginExecutor:
     filename = output_dir / f"{prefix}{self.test.id}.yaml"
 
     # Prepare the data to be written
+    should_emit_details = self.test_result.status != 'PASS'
     data = {
         'id': self.test.id,
         'status': self.test_result.status,
         'duration': self.test_result.duration,
         'completedStages': self.test_result.completed_stages,
         'errors': self.test_result.errors,
-        'regTests': self.test_result.reg_tests,
-        'simLogs': self.test_result.sim_logs,
-        'refLogs': self.test_result.ref_logs,
+        'regTests': should_emit_details and self.test_result.reg_tests or {},
+        'simLogs': should_emit_details and self.test_result.sim_logs or {},
+        'refLogs': should_emit_details and self.test_result.ref_logs or {},
     }
 
     # Write data to the YAML file asynchronously

--- a/vadl/test/resources/testSource/iss/riscv/custom/Makefile
+++ b/vadl/test/resources/testSource/iss/riscv/custom/Makefile
@@ -13,7 +13,7 @@ ABI = lp64
 ASFLAGS = -march=$(ARCH) -mabi=$(ABI)
 LDFLAGS = -T link.ld
 
-QEMU=qemu-system-rv64im
+QEMU=qemu-system-rv64imv
 QFLAGS = -nographic
 
 PREPROCESSED=$(TESTS:tests/%.S=$(OUT_DIR)/%.preprocessed.S)

--- a/vadl/test/vadl/iss/IssInstrTest.java
+++ b/vadl/test/vadl/iss/IssInstrTest.java
@@ -18,23 +18,44 @@ package vadl.iss;
 
 import static vadl.iss.IssTestUtils.writeTestSuiteConfigYaml;
 import static vadl.iss.IssTestUtils.yamlToTestResult;
+import static vadl.iss.IssTestUtils.yamlToTestResultHeader;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DynamicContainer;
+import org.junit.jupiter.api.DynamicNode;
 import org.junit.jupiter.api.DynamicTest;
-import org.testcontainers.shaded.com.google.common.collect.Streams;
 import org.testcontainers.utility.MountableFile;
 import vadl.DockerImage;
 
+@SuppressWarnings("OverloadMethodsDeclarationOrder")
 public abstract class IssInstrTest extends QemuIssTest {
+  public record InstructionTestGroup(
+      String name,
+      List<IssTestUtils.TestCase> testCases
+  ) {
+  }
+
+  private static final Map<Class<? extends IssInstrTest>, InstructionBatchState>
+      INSTRUCTION_BATCHES =
+      new ConcurrentHashMap<>();
+
+  private static final class InstructionBatchState {
+    private List<InstructionTestGroup> instructionGroups;
+    private Map<String, String> failures;
+  }
 
   public record Tool(
       String path,
@@ -68,10 +89,123 @@ public abstract class IssInstrTest extends QemuIssTest {
     return runTestsWith(1, (i) -> test);
   }
 
+  /**
+   * Initializes a cached batched ISS run for the current test class.
+   *
+   * <p>Use this when the suite already has an explicit grouping structure. The batch is executed
+   * at most once per concrete subclass; repeated calls are cheap and simply reuse the cached
+   * results.</p>
+   */
+  protected final void initializeInstructionBatch(
+      List<InstructionTestGroup> instructionGroups)
+      throws IOException {
+    initializeInstructionBatch(() -> instructionGroups);
+  }
+
+  /**
+   * Lazy variant of {@link #initializeInstructionBatch(List)}.
+   *
+   * <p>The supplier is only evaluated if the current subclass has not initialized its cached batch
+   * yet. This is useful when both a setup test and a {@code @TestFactory} call into the same
+   * initialization path.</p>
+   */
+  protected final void initializeInstructionBatch(
+      Supplier<List<InstructionTestGroup>> instructionGroupsSupplier)
+      throws IOException {
+    var state =
+        INSTRUCTION_BATCHES.computeIfAbsent(getClass(), ignored -> new InstructionBatchState());
+    synchronized (state) {
+      if (state.instructionGroups != null && state.failures != null) {
+        return;
+      }
+      state.instructionGroups = List.copyOf(instructionGroupsSupplier.get());
+      var testCases = state.instructionGroups.stream()
+          .flatMap(group -> group.testCases().stream())
+          .toList();
+      state.failures =
+          runQemuInstrTestsAndCollectFailures(generateIssSimulator(getVadlSpec()), testCases);
+    }
+  }
+
+  /**
+   * Initializes a cached batched ISS run from a flat testcase list and a grouping function.
+   *
+   * <p>This is the most common entry point for instruction suites: subclasses build all testcases
+   * once, then provide a function that maps each testcase to the container name that should be
+   * shown in JUnit.</p>
+   */
+  protected final void initializeInstructionBatchFromTestCases(
+      List<IssTestUtils.TestCase> testCases,
+      Function<IssTestUtils.TestCase, String> groupName)
+      throws IOException {
+    initializeInstructionBatchFromTestCases(() -> testCases, groupName);
+  }
+
+  protected final void initializeInstructionBatchFromTestCases(
+      Supplier<List<IssTestUtils.TestCase>> testCasesSupplier,
+      Function<IssTestUtils.TestCase, String> groupName)
+      throws IOException {
+    initializeInstructionBatch(() -> {
+      var groups = new LinkedHashMap<String, List<IssTestUtils.TestCase>>();
+      for (var testCase : testCasesSupplier.get()) {
+        groups.computeIfAbsent(groupName.apply(testCase), ignored -> new ArrayList<>())
+            .add(testCase);
+      }
+      return groups.entrySet().stream()
+          .map(entry -> new InstructionTestGroup(entry.getKey(), List.copyOf(entry.getValue())))
+          .toList();
+    });
+  }
+
+  /**
+   * Builds one {@link DynamicContainer} per previously initialized instruction group.
+   *
+   * <p>Call one of the {@code initializeInstructionBatch*} methods first. Each container contains
+   * one dynamic test per testcase, and each dynamic test simply replays the cached pass/fail result
+   * of the batched ISS run.</p>
+   */
+  protected final Stream<DynamicNode> buildInstructionTestContainers() {
+    var state = requireInstructionBatchState();
+    return state.instructionGroups.stream()
+        .map(group -> DynamicContainer.dynamicContainer(
+            group.name(),
+            buildDynamicTests(group.testCases(), state.failures)));
+  }
+
+  protected final Map<String, String> getInstructionBatchFailures() {
+    return requireInstructionBatchState().failures;
+  }
+
+  protected final List<InstructionTestGroup> getInstructionBatchGroups() {
+    return requireInstructionBatchState().instructionGroups;
+  }
+
+  private InstructionBatchState requireInstructionBatchState() {
+    var state = INSTRUCTION_BATCHES.get(getClass());
+    if (state == null || state.instructionGroups == null || state.failures == null) {
+      throw new IllegalStateException(
+          "Instruction batch not initialized for " + getClass().getSimpleName());
+    }
+    return state;
+  }
+
   @SafeVarargs
   protected final Stream<DynamicTest> runTestsWith(
       Function<Integer, IssTestUtils.TestCase>... generators) throws IOException {
     return runTestsWith(getTestPerInstruction(), List.of(generators));
+  }
+
+  /**
+   * Builds testcase specifications without executing them.
+   *
+   * <p>Prefer this over {@code runTestsWith(...)} when a suite wants to batch all testcases into a
+   * single ISS run and report the results later via {@code DynamicContainer}s or cached dynamic
+   * tests.</p>
+   */
+  @SafeVarargs
+  protected final List<IssTestUtils.TestCase> buildTestsWith(
+      Function<Integer, IssTestUtils.TestCase>... generators) {
+    return buildTestsWith(getTestPerInstruction(), List.of(generators));
   }
 
   @SafeVarargs
@@ -81,25 +215,48 @@ public abstract class IssInstrTest extends QemuIssTest {
     return runTestsWith(runs, List.of(generators));
   }
 
+  @SafeVarargs
+  protected final List<IssTestUtils.TestCase> buildTestsWith(int runs,
+                                                             Function<Integer, IssTestUtils.TestCase>... generators) {
+    return buildTestsWith(runs, List.of(generators));
+  }
+
   protected final Stream<DynamicTest> runTestsWith(
       List<Function<Integer, IssTestUtils.TestCase>> generators)
       throws IOException {
     return runTestsWith(getTestPerInstruction(), generators);
   }
 
+  protected final List<IssTestUtils.TestCase> buildTestsWith(
+      List<Function<Integer, IssTestUtils.TestCase>> generators) {
+    return buildTestsWith(getTestPerInstruction(), generators);
+  }
+
   protected final Stream<DynamicTest> runTestsWith(
       int runs,
       List<Function<Integer, IssTestUtils.TestCase>> generators) throws IOException {
+    var image = generateIssSimulator(getVadlSpec());
+    var testCases = buildTestsWith(runs, generators);
+    return runQemuInstrTests(image, testCases);
+  }
+
+  /**
+   * Materializes testcase specifications by invoking each generator {@code runs} times.
+   *
+   * <p>This method is pure with respect to ISS execution: it only creates
+   * {@link IssTestUtils.TestCase} objects and does not run QEMU or containers.</p>
+   */
+  protected final List<IssTestUtils.TestCase> buildTestsWith(
+      int runs,
+      List<Function<Integer, IssTestUtils.TestCase>> generators) {
     if (generators.isEmpty()) {
       throw new IllegalArgumentException("No generators specified");
     }
-    var image = generateIssSimulator(getVadlSpec());
-    var testCases = generators.stream()
+    return generators.stream()
         .flatMap(genFunc -> IntStream.range(0, runs)
             .mapToObj(genFunc::apply)
         )
         .toList();
-    return runQemuInstrTests(image, testCases);
   }
 
   /**
@@ -112,7 +269,34 @@ public abstract class IssInstrTest extends QemuIssTest {
   protected Stream<DynamicTest> runQemuInstrTests(DockerImage image,
                                                   Collection<IssTestUtils.TestCase> testCases)
       throws IOException {
+    var failures = runQemuInstrTestsAndCollectFailures(image, testCases);
+    return buildDynamicTests(testCases, failures);
+  }
 
+  protected Stream<DynamicTest> buildDynamicTests(
+      Collection<IssTestUtils.TestCase> testCases,
+      Map<String, String> failures) {
+    return testCases.stream()
+        .sorted(Comparator.comparing(IssTestUtils.TestCase::id))
+        .map(testCase -> DynamicTest.dynamicTest(testCase.id(), () -> {
+          var failure = failures.get(testCase.id());
+          if (failure != null) {
+            Assertions.fail(failure);
+          }
+        }));
+  }
+
+  /**
+   * Executes the given testcase collection once and returns only the failing results.
+   *
+   * <p>The returned map is keyed by testcase id. Passing tests are intentionally omitted so
+   * subclasses can cheaply render either flat dynamic tests or grouped containers from the cached
+   * failure set.</p>
+   */
+  protected Map<String, String> runQemuInstrTestsAndCollectFailures(
+      DockerImage image,
+      Collection<IssTestUtils.TestCase> testCases)
+      throws IOException {
     var statePlugin = "/qemu/build/tests/tcg/plugins/libendstate.so";
 
     var testConfig = new IssTestUtils.TestConfig(
@@ -131,63 +315,79 @@ public abstract class IssInstrTest extends QemuIssTest {
     var resultDirectory = testDirectory.resolve("results").toAbsolutePath();
     // write the test cases to this yaml file
     writeTestSuiteConfigYaml(testConfig, testSuiteYaml);
+    var configuredJobs = System.getProperty("vadl.iss.jobs");
     // run the container and copy the test cases into the container
     // and after execution, copy the results from the container
     runContainer(image, container -> container
             .withCreateContainerCmdModifier(
                 createContainerCmd -> createContainerCmd.withTty(true).withStdinOpen(true))
             .withCopyToContainer(MountableFile.forHostPath(testSuiteYaml.getPath()),
-                "/work/test-suite.yaml"),
+                "/work/test-suite.yaml")
+            .withEnv(configuredJobs == null ? Map.of() : Map.of("VADL_ISS_JOBS", configuredJobs)),
         container -> copyPathFromContainer(container, "/work/results/", resultDirectory)
     );
 
-
-    List<IssTestUtils.TestResult> testResults = List.of();
+    var expectedTests = testCases.stream()
+        .collect(Collectors.toMap(
+            IssTestUtils.TestCase::id,
+            Function.identity(),
+            (left, right) -> left,
+            LinkedHashMap::new));
+    Map<String, String> failures = new LinkedHashMap<>();
 
     try (var walkStream = java.nio.file.Files.walk(resultDirectory)) {
-      // parse the result yaml files into a list of TestResults
-      testResults = walkStream
+      walkStream
           .filter(file -> file.toString().endsWith(".yaml"))
-          .map(file -> yamlToTestResult(file.toFile()))
-          .toList();
+          .forEach(file -> {
+            var resultFile = file.toFile();
+            var header = yamlToTestResultHeader(resultFile);
+            var testCase = expectedTests.remove(header.id());
+            if (testCase == null) {
+              return;
+            }
+            if (header.status() == IssTestUtils.TestResult.Status.PASS) {
+              return;
+            }
+            var result = yamlToTestResult(resultFile);
+            failures.put(testCase.id(), buildFailureMessage(testCase, result));
+          });
     } catch (Exception e) {
       Assertions.fail("Failed to load test results.", e);
     }
 
-    // just for fast access later
-    var specIds = testResults.stream()
-        .map(IssTestUtils.TestResult::id)
-        .collect(Collectors.toSet());
-    var testCaseMap = testCases.stream()
-        .collect(Collectors.toMap(IssTestUtils.TestCase::id, s -> s));
+    return testCases.stream()
+        .sorted(Comparator.comparing(IssTestUtils.TestCase::id))
+        .<Map.Entry<String, String>>mapMulti((testCase, consumer) -> {
+          var failure = validateResult(testCase, failures, expectedTests);
+          if (failure != null) {
+            consumer.accept(Map.entry(testCase.id(), failure));
+          }
+        })
+        .collect(Collectors.toMap(
+            Map.Entry::getKey,
+            Map.Entry::getValue,
+            (left, right) -> left,
+            LinkedHashMap::new));
+  }
 
-    // produce DynamicTests for all parsed test results.
-    // these will be listed in the JUnit test report
-    var normalTestResultDynamicTests = testResults.stream()
-        .map(e -> DynamicTest.dynamicTest(e.id(),
-            () -> {
-              var testSpec = testCaseMap.get(e.id());
-              var success = IssTestUtils.TestResult.Status.PASS == e.status();
-              if (!success) {
-                var sb = new StringBuilder();
-                appendFailureDetails(sb, testSpec, e);
-                Assertions.fail(sb.toString());
-              }
-            }
-        ));
+  private String validateResult(IssTestUtils.TestCase testCase,
+                                Map<String, String> failures,
+                                Map<String, IssTestUtils.TestCase> missingTests) {
+    var failure = failures.get(testCase.id());
+    if (failure != null) {
+      return failure;
+    }
+    if (missingTests.containsKey(testCase.id())) {
+      return "No result found for test " + testCase.id();
+    }
+    return null;
+  }
 
-    // produces dynamic tests for all cases where no result was found
-    var notFoundResultDynamicTests = testCases.stream()
-        .filter(c -> !specIds.contains(c.id()))
-        .map(c -> DynamicTest.dynamicTest("Find result of " + c.id(),
-            () -> Assertions.fail("No result found for test " + c.id())
-        ));
-
-    // return stream of all dynamic test cases
-    return Streams.concat(
-        normalTestResultDynamicTests,
-        notFoundResultDynamicTests
-    );
+  private String buildFailureMessage(IssTestUtils.TestCase testCase,
+                                     IssTestUtils.TestResult result) {
+    var sb = new StringBuilder();
+    appendFailureDetails(sb, testCase, result);
+    return sb.toString();
   }
 
   private void appendFailureDetails(StringBuilder sb,

--- a/vadl/test/vadl/iss/IssTestUtils.java
+++ b/vadl/test/vadl/iss/IssTestUtils.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -84,6 +84,12 @@ public class IssTestUtils {
     }
   }
 
+  public record TestResultHeader(
+      String id,
+      TestResult.Status status
+  ) {
+  }
+
   /**
    * Writes the test suite configuration YAML file.
    */
@@ -120,42 +126,57 @@ public class IssTestUtils {
    * @throws IOException if an I/O error occurs.
    */
   public static TestResult yamlToTestResult(File yamlFile) {
+    var result = loadYamlResult(yamlFile);
+
+    try {
+      String id = result.get("id").toString();
+      TestResult.Status status =
+          TestResult.Status.valueOf((String) result.get("status"));
+      List<TestResult.Stage> completedStages =
+          ((List<String>) result.get("completedStages")).stream()
+              .map(TestResult.Stage::valueOf)
+              .toList();
+      List<String> errors = (List<String>) result.get("errors");
+      String duration = (String) result.get("duration");
+      List<TestResult.RegTestResult> regTests =
+          ((Map<String, Object>) result.get("regTests")).entrySet()
+              .stream().map(e -> {
+                var val = (Map<String, String>) e.getValue();
+                return new TestResult.RegTestResult(e.getKey(),
+                    Objects.toString(val.get("exp")),
+                    Objects.toString(val.get("act")));
+              }).toList();
+
+      Map<String, List<String>> simLogs = (Map<String, List<String>>) result.get("simLogs");
+      Map<String, List<String>> refLogs = (Map<String, List<String>>) result.get("refLogs");
+
+      return new TestResult(id, status, completedStages, regTests, simLogs, refLogs, errors,
+          duration);
+
+    } catch (Exception e) {
+      log.error("Failed to parse file, result was\n {}", result);
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static TestResultHeader yamlToTestResultHeader(File yamlFile) {
+    var result = loadYamlResult(yamlFile);
+
+    try {
+      return new TestResultHeader(
+          result.get("id").toString(),
+          TestResult.Status.valueOf((String) result.get("status"))
+      );
+    } catch (Exception e) {
+      log.error("Failed to parse result header, result was\n {}", result);
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static Map<String, Object> loadYamlResult(File yamlFile) {
     try (var reader = new FileInputStream(yamlFile)) {
       Yaml yaml = new Yaml();
-
-      // load all results
-      Map<String, Object> result = yaml.load(reader);
-
-      try {
-        String id = result.get("id").toString();
-        // Assuming the YAML structure matches the fields in TestResult
-        TestResult.Status status =
-            TestResult.Status.valueOf((String) result.get("status"));
-        List<TestResult.Stage> completedStages =
-            ((List<String>) result.get("completedStages")).stream()
-                .map(e -> TestResult.Stage.valueOf(e))
-                .toList();
-        List<String> errors = (List<String>) result.get("errors");
-        String duration = (String) result.get("duration");
-        List<TestResult.RegTestResult> regTests =
-            ((Map<String, Object>) result.get("regTests")).entrySet()
-                .stream().map(e -> {
-                  var val = (Map<String, String>) e.getValue();
-                  return new TestResult.RegTestResult(e.getKey(),
-                      Objects.toString(val.get("exp")),
-                      Objects.toString(val.get("act")));
-                }).toList();
-
-        Map<String, List<String>> simLogs = (Map<String, List<String>>) result.get("simLogs");
-        Map<String, List<String>> refLogs = (Map<String, List<String>>) result.get("refLogs");
-
-        return new TestResult(id, status, completedStages, regTests, simLogs, refLogs, errors,
-            duration);
-
-      } catch (Exception e) {
-        log.error("Failed to parse file, result was\n {}", result);
-        throw new RuntimeException(e);
-      }
+      return yaml.load(reader);
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/vadl/test/vadl/iss/aarch64/IssA64InstrTest.java
+++ b/vadl/test/vadl/iss/aarch64/IssA64InstrTest.java
@@ -24,9 +24,12 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.DynamicNode;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
+import org.junit.jupiter.api.TestMethodOrder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.shaded.com.google.errorprone.annotations.concurrent.LazyInit;
@@ -43,6 +46,7 @@ import vadl.viam.Definition;
 import vadl.viam.Instruction;
 import vadl.viam.InstructionSetArchitecture;
 
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class IssA64InstrTest extends AbstractIssAarch64InstrTest {
 
   private static final Logger log = LoggerFactory.getLogger(IssA64InstrTest.class);
@@ -99,171 +103,57 @@ public class IssA64InstrTest extends AbstractIssAarch64InstrTest {
   }
 
 
-  @TestFactory
-  Stream<DynamicTest> testADC() throws IOException {
-    return runTestsWith(makeTestCases("ADCW", "ADCX"));
+  @Test
+  @Order(1)
+  void setupInstructionTests() throws IOException {
+    initializeInstructionBatch(this::buildInstructionTestGroups);
   }
 
   @TestFactory
-  Stream<DynamicTest> testADCS() throws IOException {
-    return runTestsWith(makeTestCasesFromPrefixes("ADCS"));
+  @Order(2)
+  Stream<DynamicNode> buildInstructionTests() throws IOException {
+    initializeInstructionBatch(this::buildInstructionTestGroups);
+    return buildInstructionTestContainers();
   }
 
-  @TestFactory
-  Stream<DynamicTest> testADDExt() throws IOException {
-    // ADD (extended register): Add extended and scaled register.
-    return runTestsWith(makeTestCasesFromPrefixes("ADDWUX", "ADDWSX", "ADDXUX", "ADDXSX"));
+  private List<InstructionTestGroup> buildInstructionTestGroups() {
+    return List.of(
+        instructionGroup("ADC", makeTestCases("ADCW", "ADCX")),
+        instructionGroup("ADCS", makeTestCasesFromPrefixes("ADCS")),
+        instructionGroup("ADD_EXT", makeTestCasesFromPrefixes("ADDWUX", "ADDWSX", "ADDXUX", "ADDXSX")),
+        instructionGroup("ADD_IMM", makeTestCasesFromPrefixes("ADDXI", "ADDWI")),
+        instructionGroup("ADD_SHIFTED_REG", makeTestCases(
+            "ADDW", "ADDWLSL", "ADDWLSR", "ADDWASR", "ADDX", "ADDXLSL", "ADDXLSR", "ADDXASR")),
+        instructionGroup("ADDS_EXT", makeTestCasesFromPrefixes("ADDWSUX", "ADDWSSX", "ADDXSUX", "ADDXSSX")),
+        instructionGroup("ADDS_IMM", makeTestCasesFromPrefixes("ADDXSI", "ADDWSI")),
+        instructionGroup("ADDS_SHIFTED_REG", makeTestCases(
+            "ADDWS", "ADDWSLSL", "ADDWSLSR", "ADDWSASR", "ADDXS", "ADDXSLSL", "ADDXSLSR", "ADDXSASR")),
+        instructionGroup("ANDS_SHIFTED", makeTestCasesFromPrefixes("ANDSW", "ANDSX")),
+        instructionGroup("ASR", makeTestCasesFromPrefixes("ASRW", "ASRX")),
+        instructionGroup("BICS", makeTestCasesFromPrefixes("BICS")),
+        instructionGroup("CCMP", makeTestCasesFromPrefixes("CCMPI")),
+        instructionGroup("CSINC", makeTestCasesFromPrefixes("CSINC")),
+        instructionGroup("CSINV", makeTestCasesFromPrefixes("CSINV")),
+        instructionGroup("CSNEG", makeTestCasesFromPrefixes("CSNEG")),
+        instructionGroup("EXTR", makeTestCases("EXTRX", "EXTRW")),
+        instructionGroup("MOVK", makeTestCasesFromPrefixes("MOVK")),
+        instructionGroup("SBC", makeTestCases("SBCW", "SBCX")),
+        instructionGroup("SBCS", makeTestCasesFromPrefixes("SBCS")),
+        instructionGroup("SDIV", makeTestCasesFromPrefixes("SDIV")),
+        instructionGroup("SUB_EXT", makeTestCasesFromPrefixes("SUBWUX", "SUBWSX", "SUBXUX", "SUBXSX")),
+        instructionGroup("SUB_IMM", makeTestCasesFromPrefixes("SUBXI", "SUBWI")),
+        instructionGroup("SUB_SHIFTED_REG", makeTestCases(
+            "SUBW", "SUBWLSL", "SUBWLSR", "SUBWASR", "SUBX", "SUBXLSL", "SUBXLSR", "SUBXASR")),
+        instructionGroup("SUBS_EXT", makeTestCasesFromPrefixes("SUBWSUX", "SUBWSSX", "SUBXSUX", "SUBXSSX")),
+        instructionGroup("SUBS_IMM", makeTestCasesFromPrefixes("SUBXSI", "SUBWSI")),
+        instructionGroup("SUBS_SHIFTED_REG", makeTestCases(
+            "SUBWS", "SUBWSLSL", "SUBWSLSR", "SUBWSASR", "SUBXS", "SUBXSLSL", "SUBXSLSR", "SUBXSASR")),
+        instructionGroup("UDIV", makeTestCasesFromPrefixes("UDIV")));
   }
 
-  @TestFactory
-  Stream<DynamicTest> testADDImm() throws IOException {
-    // ADD (immediate): Add immediate value.
-    return runTestsWith(makeTestCasesFromPrefixes("ADDXI", "ADDWI"));
-  }
-
-  @TestFactory
-  Stream<DynamicTest> testADDShiftedReg() throws IOException {
-    // ADD (shifted register): Add optionally-shifted register.
-    return runTestsWith(makeTestCases(
-        "ADDW", "ADDWLSL", "ADDWLSR", "ADDWASR", "ADDX", "ADDXLSL", "ADDXLSR", "ADDXASR"
-    ));
-  }
-
-  @TestFactory
-  Stream<DynamicTest> testADDSExt() throws IOException {
-    // ADDS (extended register): Add extended and scaled register.
-    return runTestsWith(makeTestCasesFromPrefixes("ADDWSUX", "ADDWSSX", "ADDXSUX", "ADDXSSX"));
-  }
-
-  @TestFactory
-  Stream<DynamicTest> testADDSImm() throws IOException {
-    // ADDS (immediate): Add immediate value.
-    return runTestsWith(makeTestCasesFromPrefixes("ADDXSI", "ADDWSI"));
-  }
-
-  @TestFactory
-  Stream<DynamicTest> testADDSShiftedReg() throws IOException {
-    // ADDS (shifted register): Add optionally-shifted register.
-    return runTestsWith(makeTestCases(
-        "ADDWS", "ADDWSLSL", "ADDWSLSR", "ADDWSASR", "ADDXS", "ADDXSLSL", "ADDXSLSR", "ADDXSASR"
-    ));
-  }
-
-  // TODO: Test ANDSImm (decoding to complicated to find correct constraint)
-
-  @TestFactory
-  Stream<DynamicTest> testANDSShifted() throws IOException {
-    // ANDS (shifted register): Bitwise AND (shifted register), setting flags
-    return runTestsWith(makeTestCasesFromPrefixes("ANDSW", "ANDSX"));
-  }
-
-  @TestFactory
-  Stream<DynamicTest> testASR() throws IOException {
-    return runTestsWith(makeTestCasesFromPrefixes("ASRW", "ASRX"));
-  }
-
-  @TestFactory
-  Stream<DynamicTest> testBICS() throws IOException {
-    // Bitwise bit clear (shifted register), setting flags
-    return runTestsWith(makeTestCasesFromPrefixes("BICS"));
-  }
-
-  @TestFactory
-  Stream<DynamicTest> testCCMP() throws IOException {
-    // CCMP (immediate): Conditional compare (immediate)
-    return runTestsWith(makeTestCasesFromPrefixes("CCMPI"));
-  }
-
-
-  @TestFactory
-  Stream<DynamicTest> testCSINC() throws IOException {
-    // CSINC: Conditional select increment.
-    return runTestsWith(makeTestCasesFromPrefixes("CSINC"));
-  }
-
-  @TestFactory
-  Stream<DynamicTest> testCSINV() throws IOException {
-    // CSINV: Conditional select invert.
-    return runTestsWith(makeTestCasesFromPrefixes("CSINV"));
-  }
-
-  @TestFactory
-  Stream<DynamicTest> testCSNEG() throws IOException {
-    // CSNEG: Conditional select negation.
-    return runTestsWith(makeTestCasesFromPrefixes("CSNEG"));
-  }
-
-  @TestFactory
-  Stream<DynamicTest> testEXTR() throws IOException {
-    // EXTR: Extract register.
-    return runTestsWith(makeTestCases("EXTRX", "EXTRW"));
-  }
-
-  @TestFactory
-  Stream<DynamicTest> testMOVK() throws IOException {
-    return runTestsWith(makeTestCasesFromPrefixes("MOVK"));
-  }
-
-
-  @TestFactory
-  Stream<DynamicTest> testSBC() throws IOException {
-    return runTestsWith(makeTestCases("SBCW", "SBCX"));
-  }
-
-  @TestFactory
-  Stream<DynamicTest> testSBCS() throws IOException {
-    return runTestsWith(makeTestCasesFromPrefixes("SBCS"));
-  }
-
-  @TestFactory
-  Stream<DynamicTest> testSDIV() throws IOException {
-    return runTestsWith(makeTestCasesFromPrefixes("SDIV"));
-  }
-
-  @TestFactory
-  Stream<DynamicTest> testSUBExt() throws IOException {
-    // SUB (extended register): Subtract extended and scaled register.
-    return runTestsWith(makeTestCasesFromPrefixes("SUBWUX", "SUBWSX", "SUBXUX", "SUBXSX"));
-  }
-
-  @TestFactory
-  Stream<DynamicTest> testSUBImm() throws IOException {
-    // SUB (immediate): Subtract immediate value.
-    return runTestsWith(makeTestCasesFromPrefixes("SUBXI", "SUBWI"));
-  }
-
-  @TestFactory
-  Stream<DynamicTest> testSUBShiftedReg() throws IOException {
-    // SUB (shifted register): Subtract optionally-shifted register.
-    return runTestsWith(makeTestCases(
-        "SUBW", "SUBWLSL", "SUBWLSR", "SUBWASR", "SUBX", "SUBXLSL", "SUBXLSR", "SUBXASR"
-    ));
-  }
-
-
-  @TestFactory
-  Stream<DynamicTest> testSUBSExt() throws IOException {
-    // SUBS (extended register): Subtract extended and scaled register.
-    return runTestsWith(makeTestCasesFromPrefixes("SUBWSUX", "SUBWSSX", "SUBXSUX", "SUBXSSX"));
-  }
-
-  @TestFactory
-  Stream<DynamicTest> testSUBSImm() throws IOException {
-    // SUB (immediate): Subtract immediate value.
-    return runTestsWith(makeTestCasesFromPrefixes("SUBXSI", "SUBWSI"));
-  }
-
-  @TestFactory
-  Stream<DynamicTest> testSUBSShiftedReg() throws IOException {
-    // SUB (shifted register): Subtract optionally-shifted register.
-    return runTestsWith(makeTestCases(
-        "SUBWS", "SUBWSLSL", "SUBWSLSR", "SUBWSASR", "SUBXS", "SUBXSLSL", "SUBXSLSR", "SUBXSASR"
-    ));
-  }
-
-  @TestFactory
-  Stream<DynamicTest> testUDIV() throws IOException {
-    return runTestsWith(makeTestCasesFromPrefixes("UDIV"));
+  private InstructionTestGroup instructionGroup(String name,
+                                                List<Function<Integer, IssTestUtils.TestCase>> generators) {
+    return new InstructionTestGroup(name, buildTestsWith(generators));
   }
 
   private List<Function<Integer, IssTestUtils.TestCase>> makeTestCasesFromPrefixes(

--- a/vadl/test/vadl/iss/aarch64/IssA64InstrTest.java
+++ b/vadl/test/vadl/iss/aarch64/IssA64InstrTest.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -60,7 +60,7 @@ public class IssA64InstrTest extends AbstractIssAarch64InstrTest {
 
   @Override
   public String getVadlSpec() {
-    return "sys/aarch64/virt.vadl";
+    return "sys/aarch64/vprocessor.vadl";
   }
 
   @Override
@@ -87,9 +87,13 @@ public class IssA64InstrTest extends AbstractIssAarch64InstrTest {
   }
 
   @Test
-  void testAutoAssembler() {
-    // just test that all instructions can be assembled
-    for (var instr : isa.ownInstructions()) {
+  void testAutoAssembler() throws IOException, DuplicatedPassKeyException {
+    var a64Isa = setupPassManagerAndRunSpec("sys/aarch64/virt.vadl",
+        PassOrders.iss(getConfiguration(false))
+    ).specification().isa().get();
+    
+    // just test that all aarch64 base instructions can be assembled
+    for (var instr : a64Isa.ownInstructions()) {
       System.out.println(autoAssembler.produce(instr).assembly());
     }
   }

--- a/vadl/test/vadl/iss/aarch64/IssA64SVEInstrTest.java
+++ b/vadl/test/vadl/iss/aarch64/IssA64SVEInstrTest.java
@@ -25,8 +25,12 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.DynamicNode;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
+import org.junit.jupiter.api.TestMethodOrder;
 import vadl.iss.IssTestUtils;
 import vadl.pass.PassOrders;
 import vadl.pass.exception.DuplicatedPassKeyException;
@@ -37,6 +41,7 @@ import vadl.viam.RegisterTensor;
 /**
  * Tests a core subset of AArch64 SVE instructions.
  */
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class IssA64SVEInstrTest extends AbstractIssAarch64InstrTest {
 
   private static final String VADL_SPEC = "sys/aarch64/vprocessor.vadl";
@@ -252,100 +257,72 @@ public class IssA64SVEInstrTest extends AbstractIssAarch64InstrTest {
     return new RandomRegs(zd, zn, zm, pg);
   }
 
-  private Stream<DynamicTest> runPredicatedBinaryInstrTests(String instruction,
-                                                            String... elemSuffixes)
-      throws IOException {
+  @Test
+  @Order(1)
+  void setupInstructionTests() throws IOException {
+    initializeInstructionBatch(this::buildInstructionTestGroups);
+  }
+
+  @TestFactory
+  @Order(2)
+  Stream<DynamicNode> buildInstructionTests() throws IOException {
+    initializeInstructionBatch(this::buildInstructionTestGroups);
+    return buildInstructionTestContainers();
+  }
+
+  private List<InstructionTestGroup> buildInstructionTestGroups() {
+    return List.of(
+        instructionGroup("svePredAdd", predicatedBinaryInstrTests("add", "b", "h", "s", "d")),
+        instructionGroup("svePredSub", predicatedBinaryInstrTests("sub", "b", "h", "s", "d")),
+        instructionGroup("svePredMul", predicatedBinaryInstrTests("mul", "b", "h", "s", "d")),
+        instructionGroup("sveUnpredAdd", unpredicatedBinaryInstrTests("add", "b", "h", "s", "d")),
+        instructionGroup("sveUnpredSub", unpredicatedBinaryInstrTests("sub", "b", "h", "s", "d")),
+        instructionGroup("sveUnpredMul", unpredicatedBinaryInstrTests("mul", "b", "h", "s", "d")),
+        instructionGroup("sveFoldSaddv", reductionInstrTests("saddv", true, "b", "h", "s")),
+        instructionGroup("sveFoldUaddv", reductionInstrTests("uaddv", true, "b", "h", "s")),
+        instructionGroup("sveFoldAndv", reductionInstrTests("andv", false, "b", "h", "s", "d")),
+        instructionGroup("sveFoldOrv", reductionInstrTests("orv", false, "b", "h", "s", "d")),
+        instructionGroup("sveFoldEorv", reductionInstrTests("eorv", false, "b", "h", "s", "d")),
+        instructionGroup("sveUmov",
+            buildTestsWith((id) -> createUmovInstrTest(getBuilder("SVE.UMOV", id), id))));
+  }
+
+  private InstructionTestGroup instructionGroup(String name,
+                                                List<IssTestUtils.TestCase> testCases) {
+    return new InstructionTestGroup(name, testCases);
+  }
+
+  private List<IssTestUtils.TestCase> predicatedBinaryInstrTests(String instruction,
+                                                                 String... elemSuffixes) {
     var generators = Arrays.stream(elemSuffixes)
         .map(elem -> (Function<Integer, IssTestUtils.TestCase>) (id -> {
           var builder = getBuilder("SVE.PRED." + instruction.toUpperCase() + "." + elem, id);
           return createPredicatedBinaryInstrTest(builder, instruction, elem, id);
         }))
         .toList();
-    return runTestsWith(generators);
+    return buildTestsWith(generators);
   }
 
-  private Stream<DynamicTest> runUnpredicatedBinaryInstrTests(String instruction,
-                                                              String... elemSuffixes)
-      throws IOException {
+  private List<IssTestUtils.TestCase> unpredicatedBinaryInstrTests(String instruction,
+                                                                   String... elemSuffixes) {
     var generators = Arrays.stream(elemSuffixes)
         .map(elem -> (Function<Integer, IssTestUtils.TestCase>) (id -> {
           var builder = getBuilder("SVE.UNPRED." + instruction.toUpperCase() + "." + elem, id);
           return createUnpredicatedBinaryInstrTest(builder, instruction, elem, id);
         }))
         .toList();
-    return runTestsWith(generators);
+    return buildTestsWith(generators);
   }
 
-  private Stream<DynamicTest> runReductionInstrTests(String instruction,
-                                                     boolean extendedAddReduction,
-                                                     String... elemSuffixes)
-      throws IOException {
+  private List<IssTestUtils.TestCase> reductionInstrTests(String instruction,
+                                                          boolean extendedAddReduction,
+                                                          String... elemSuffixes) {
     List<Function<Integer, IssTestUtils.TestCase>> generators = Arrays.stream(elemSuffixes)
         .map(elem -> (Function<Integer, IssTestUtils.TestCase>) (id -> {
           var builder = getBuilder("SVE.RED." + instruction.toUpperCase() + "." + elem, id);
           return createReductionInstrTest(builder, instruction, elem, extendedAddReduction, id);
         }))
         .toList();
-    return runTestsWith(generators);
-  }
-
-  @TestFactory
-  Stream<DynamicTest> svePredAdd() throws IOException {
-    return runPredicatedBinaryInstrTests("add", "b", "h", "s", "d");
-  }
-
-  @TestFactory
-  Stream<DynamicTest> svePredSub() throws IOException {
-    return runPredicatedBinaryInstrTests("sub", "b", "h", "s", "d");
-  }
-
-  @TestFactory
-  Stream<DynamicTest> svePredMul() throws IOException {
-    return runPredicatedBinaryInstrTests("mul", "b", "h", "s", "d");
-  }
-
-  @TestFactory
-  Stream<DynamicTest> sveUnpredAdd() throws IOException {
-    return runUnpredicatedBinaryInstrTests("add", "b", "h", "s", "d");
-  }
-
-  @TestFactory
-  Stream<DynamicTest> sveUnpredSub() throws IOException {
-    return runUnpredicatedBinaryInstrTests("sub", "b", "h", "s", "d");
-  }
-
-  @TestFactory
-  Stream<DynamicTest> sveUnpredMul() throws IOException {
-    return runUnpredicatedBinaryInstrTests("mul", "b", "h", "s", "d");
-  }
-
-  @TestFactory
-  Stream<DynamicTest> sveFoldSaddv() throws IOException {
-    return runReductionInstrTests("saddv", true, "b", "h", "s");
-  }
-
-  @TestFactory
-  Stream<DynamicTest> sveFoldUaddv() throws IOException {
-    return runReductionInstrTests("uaddv", true, "b", "h", "s");
-  }
-
-  @TestFactory
-  Stream<DynamicTest> sveFoldAndv() throws IOException {
-    return runReductionInstrTests("andv", false, "b", "h", "s", "d");
-  }
-
-  @TestFactory
-  Stream<DynamicTest> sveFoldOrv() throws IOException {
-    return runReductionInstrTests("orv", false, "b", "h", "s", "d");
-  }
-
-  @TestFactory
-  Stream<DynamicTest> sveFoldEorv() throws IOException {
-    return runReductionInstrTests("eorv", false, "b", "h", "s", "d");
-  }
-
-  @TestFactory
-  Stream<DynamicTest> sveUmov() throws IOException {
-    return runTestsWith((id) -> createUmovInstrTest(getBuilder("SVE.UMOV", id), id));
+    return buildTestsWith(generators);
   }
 }

--- a/vadl/test/vadl/iss/aarch64/IssAarch64EmbenchTest.java
+++ b/vadl/test/vadl/iss/aarch64/IssAarch64EmbenchTest.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -31,7 +31,7 @@ public class IssAarch64EmbenchTest extends QemuIssTest {
 
   @Test
   void a64EmbenchTest() throws IOException {
-    runEmbenchTest("sys/aarch64/virt.vadl", "build_virt-iss-a64.sh", "qemu-system-a64");
+    runEmbenchTest("sys/aarch64/vprocessor.vadl", "build_virt-iss-a64.sh", "qemu-system-a64");
   }
 
   private void runEmbenchTest(String vadlPath, String buildScript, String qemuSystem)

--- a/vadl/test/vadl/iss/ppc64/CosimPpc64InstrTest.java
+++ b/vadl/test/vadl/iss/ppc64/CosimPpc64InstrTest.java
@@ -44,6 +44,7 @@ import vadl.iss.CosimTestUtils;
 public class CosimPpc64InstrTest extends AbstractCosimPpc64InstrTest {
 
   private static final long BASE_ADDRESS_LOAD_STORE = 0x1000L;
+  private static final Object INIT_LOCK = new Object();
 
   private static List<CosimTestUtils.TestCase> testCases;
   private static Map<String, TestResult> failures;
@@ -53,13 +54,13 @@ public class CosimPpc64InstrTest extends AbstractCosimPpc64InstrTest {
   @Test
   @Order(1)
   void setupInstructionTests() throws IOException {
-    testCases = buildInstructionTestCases();
-    failures = runQemuInstrTestsAndCollectFailures(generateIssSimulator(getVadlSpec()), testCases);
+    ensureInstructionTestsInitialized();
   }
 
   @TestFactory
   @Order(2)
-  Stream<DynamicTest> buildInstructionTests() {
+  Stream<DynamicTest> buildInstructionTests() throws IOException {
+    ensureInstructionTestsInitialized();
     return testCases.stream()
         .map(testCase -> DynamicTest.dynamicTest(
             testCase.id(),
@@ -69,6 +70,16 @@ public class CosimPpc64InstrTest extends AbstractCosimPpc64InstrTest {
                 fail(failure.failureMessage());
               }
             }));
+  }
+
+  private void ensureInstructionTestsInitialized() throws IOException {
+    synchronized (INIT_LOCK) {
+      if (testCases != null && failures != null) {
+        return;
+      }
+      testCases = buildInstructionTestCases();
+      failures = runQemuInstrTestsAndCollectFailures(generateIssSimulator(getVadlSpec()), testCases);
+    }
   }
 
   private List<CosimTestUtils.TestCase> buildInstructionTestCases() throws IOException {

--- a/vadl/test/vadl/iss/riscv/AbstractIssRiscv64InstrTest.java
+++ b/vadl/test/vadl/iss/riscv/AbstractIssRiscv64InstrTest.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -39,7 +39,7 @@ public abstract class AbstractIssRiscv64InstrTest extends IssInstrTest {
 
   @Override
   public Tool simulator() {
-    return new Tool("/qemu/build/qemu-system-rv64im", "-bios");
+    return new Tool("/qemu/build/qemu-system-rv64imv", "-bios");
   }
 
   @Override

--- a/vadl/test/vadl/iss/riscv/IssCustomTests.java
+++ b/vadl/test/vadl/iss/riscv/IssCustomTests.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -41,7 +41,7 @@ public class IssCustomTests extends QemuIssTest {
 
   @TestFactory
   Stream<DynamicTest> customTests() {
-    var qemuImage = generateIssSimulator("sys/risc-v/rv64im.vadl");
+    var qemuImage = generateIssSimulator("sys/risc-v/rv64v.vadl");
 
     // Find test source directory and results directory
     var testSources = getTestSourcePath("iss/riscv/custom");

--- a/vadl/test/vadl/iss/riscv/IssRV64IInstrTest.java
+++ b/vadl/test/vadl/iss/riscv/IssRV64IInstrTest.java
@@ -21,15 +21,22 @@ import static vadl.TestUtils.arbitraryUnsignedInt;
 
 import java.io.IOException;
 import java.math.BigInteger;
+import java.util.List;
 import java.util.stream.Stream;
 import net.jqwik.api.Arbitraries;
-import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.DynamicNode;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
+import org.junit.jupiter.api.TestMethodOrder;
 import vadl.iss.AsmTestBuilder;
+import vadl.iss.IssTestUtils;
 
 /**
  * Tests the RV64I instructions set.
  */
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class IssRV64IInstrTest extends AbstractIssRiscv64InstrTest {
 
   private static final String VADL_SPEC = "sys/risc-v/rv64v.vadl";
@@ -49,10 +56,84 @@ public class IssRV64IInstrTest extends AbstractIssRiscv64InstrTest {
     return new RV64IMVTestBuilder(testNamePrefix + "_" + id);
   }
 
+  // We cannot use @BeforeAll here because it runs before AbstractTest.beforeEach initializes
+  // the frontend required by generateIssSimulator().
+  @Test
+  @Order(1)
+  void setupInstructionTests() throws IOException {
+    initializeInstructionBatchFromTestCases(this::buildInstructionTestCases, this::getInstructionName);
+  }
+
+  @TestFactory
+  @Order(2)
+  Stream<DynamicNode> buildInstructionTests() throws IOException {
+    initializeInstructionBatchFromTestCases(this::buildInstructionTestCases, this::getInstructionName);
+    return buildInstructionTestContainers();
+  }
+
+  private List<IssTestUtils.TestCase> buildInstructionTestCases() {
+    var tests = new java.util.ArrayList<IssTestUtils.TestCase>();
+    tests.addAll(testBinaryRegRegInstruction("add", "ADD"));
+    tests.addAll(testBinaryRegRegInstruction("sub", "SUB"));
+    tests.addAll(testBinaryRegRegInstruction("and", "AND"));
+    tests.addAll(testBinaryRegRegInstruction("or", "OR"));
+    tests.addAll(testBinaryRegRegInstruction("xor", "XOR"));
+    tests.addAll(testBinaryRegRegInstruction("slt", "SLT"));
+    tests.addAll(testBinaryRegRegInstruction("sltu", "SLTU"));
+    tests.addAll(testBinaryRegImmInstruction("addi", "ADDI"));
+    tests.addAll(testBinaryRegImmInstruction("andi", "ANDI"));
+    tests.addAll(testBinaryRegImmInstruction("ori", "ORI"));
+    tests.addAll(testBinaryRegImmInstruction("xori", "XORI"));
+    tests.addAll(testBinaryRegImmInstruction("slti", "SLTI"));
+    tests.addAll(testBinaryRegImmInstruction("sltiu", "SLTIU"));
+    tests.addAll(testShiftImmInstruction("slli", "SLLI"));
+    tests.addAll(testShiftImmInstruction("srli", "SRLI"));
+    tests.addAll(testShiftImmInstruction("srai", "SRAI"));
+    tests.addAll(testLoadInstruction("lb", "LB", "sb", 8));
+    tests.addAll(testLoadInstruction("lh", "LH", "sh", 16));
+    tests.addAll(testLoadInstruction("lw", "LW", "sw", 32));
+    tests.addAll(testLoadInstruction("ld", "LD", "sd", 64));
+    tests.addAll(testLoadInstruction("lbu", "LBU", "sb", 8));
+    tests.addAll(testLoadInstruction("lhu", "LHU", "sh", 16));
+    tests.addAll(testLoadInstruction("lwu", "LWU", "sw", 32));
+    tests.addAll(testStoreInstruction("sb", "SB", "lb", 8));
+    tests.addAll(testStoreInstruction("sh", "SH", "lh", 16));
+    tests.addAll(testStoreInstruction("sw", "SW", "lw", 32));
+    tests.addAll(testStoreInstruction("sd", "SD", "ld", 64));
+    tests.addAll(testEqualityBranchInstruction("beq", "BEQ", true));
+    tests.addAll(testEqualityBranchInstruction("bne", "BNE", false));
+    tests.addAll(testRelationalBranchInstruction("blt", "BLT", true, false));
+    tests.addAll(testRelationalBranchInstruction("bge", "BGE", false, false));
+    tests.addAll(testRelationalBranchInstruction("bltu", "BLTU", true, true));
+    tests.addAll(testRelationalBranchInstruction("bgeu", "BGEU", false, true));
+    tests.addAll(testBinaryRegRegInstruction("addw", "ADDW"));
+    tests.addAll(testBinaryRegRegInstruction("subw", "SUBW"));
+    tests.addAll(testBinaryRegImmInstruction("addiw", "ADDIW"));
+    tests.addAll(sllwCases());
+    tests.addAll(srlwCases());
+    tests.addAll(srawCases());
+    tests.addAll(slliwCases());
+    tests.addAll(srliwCases());
+    tests.addAll(sraiwCases());
+    tests.addAll(luiCases());
+    tests.addAll(auipcCases());
+    tests.addAll(jalCases());
+    tests.addAll(jalrCases());
+    return tests;
+  }
+
+  private String getInstructionName(IssTestUtils.TestCase testCase) {
+    var separator = testCase.id().lastIndexOf('_');
+    if (separator <= 0) {
+      return testCase.id();
+    }
+    return testCase.id().substring(0, separator).toLowerCase();
+  }
+
   // Helper methods
-  private Stream<DynamicTest> testBinaryRegRegInstruction(String instruction, String testNamePrefix)
-      throws IOException {
-    return runTestsWith(id -> {
+  private List<IssTestUtils.TestCase> testBinaryRegRegInstruction(String instruction,
+                                                                  String testNamePrefix) {
+    return buildTestsWith(id -> {
       var b = getBuilder(testNamePrefix, id);
       var regSrc1 = b.anyTempReg().sample();
       var regSrc2 = b.anyTempReg().sample();
@@ -64,9 +145,9 @@ public class IssRV64IInstrTest extends AbstractIssRiscv64InstrTest {
     });
   }
 
-  private Stream<DynamicTest> testBinaryRegImmInstruction(String instruction, String testNamePrefix)
-      throws IOException {
-    return runTestsWith(id -> {
+  private List<IssTestUtils.TestCase> testBinaryRegImmInstruction(String instruction,
+                                                                  String testNamePrefix) {
+    return buildTestsWith(id -> {
       var b = getBuilder(testNamePrefix, id);
       var regSrc = b.anyTempReg().sample();
       b.fillRegSigned(regSrc, 64);
@@ -77,9 +158,9 @@ public class IssRV64IInstrTest extends AbstractIssRiscv64InstrTest {
     });
   }
 
-  private Stream<DynamicTest> testShiftImmInstruction(String instruction, String testNamePrefix)
-      throws IOException {
-    return runTestsWith(id -> {
+  private List<IssTestUtils.TestCase> testShiftImmInstruction(String instruction,
+                                                              String testNamePrefix) {
+    return buildTestsWith(id -> {
       var b = getBuilder(testNamePrefix, id);
       var regSrc = b.anyTempReg().sample();
       b.fillRegSigned(regSrc, 64);
@@ -99,10 +180,11 @@ public class IssRV64IInstrTest extends AbstractIssRiscv64InstrTest {
     return Integer.highestOneBit(dataSizeInBytes);
   }
 
-  private Stream<DynamicTest> testLoadInstruction(String instruction, String testNamePrefix,
-                                                  String storeInstruction, int dataSize)
-      throws IOException {
-    return runTestsWith(id -> {
+  private List<IssTestUtils.TestCase> testLoadInstruction(String instruction,
+                                                          String testNamePrefix,
+                                                          String storeInstruction,
+                                                          int dataSize) {
+    return buildTestsWith(id -> {
       var b = getBuilder(testNamePrefix, id);
       var storeReg = b.anyTempReg().sample();
       b.fillRegSigned(storeReg, dataSize);
@@ -116,10 +198,11 @@ public class IssRV64IInstrTest extends AbstractIssRiscv64InstrTest {
     });
   }
 
-  private Stream<DynamicTest> testStoreInstruction(String instruction, String testNamePrefix,
-                                                   String loadInstruction, int dataSize)
-      throws IOException {
-    return runTestsWith(id -> {
+  private List<IssTestUtils.TestCase> testStoreInstruction(String instruction,
+                                                           String testNamePrefix,
+                                                           String loadInstruction,
+                                                           int dataSize) {
+    return buildTestsWith(id -> {
       var b = getBuilder(testNamePrefix, id);
       var storeReg = b.anyTempReg().sample();
       b.fillRegSigned(storeReg, dataSize);
@@ -134,11 +217,10 @@ public class IssRV64IInstrTest extends AbstractIssRiscv64InstrTest {
     });
   }
 
-  private Stream<DynamicTest> testEqualityBranchInstruction(String instruction,
-                                                            String testNamePrefix,
-                                                            boolean branchWhenEqual)
-      throws IOException {
-    return runTestsWith(id -> {
+  private List<IssTestUtils.TestCase> testEqualityBranchInstruction(String instruction,
+                                                                    String testNamePrefix,
+                                                                    boolean branchWhenEqual) {
+    return buildTestsWith(id -> {
       var b = new RV64IMVTestBuilder(testNamePrefix + "_" + id);
       var rs1 = b.anyTempReg().sample();
       var rs2 = b.anyTempReg().sample();
@@ -163,12 +245,11 @@ public class IssRV64IInstrTest extends AbstractIssRiscv64InstrTest {
     });
   }
 
-  private Stream<DynamicTest> testRelationalBranchInstruction(String instruction,
-                                                              String testNamePrefix,
-                                                              boolean branchWhenLessThan,
-                                                              boolean unsignedComparison)
-      throws IOException {
-    return runTestsWith(id -> {
+  private List<IssTestUtils.TestCase> testRelationalBranchInstruction(String instruction,
+                                                                      String testNamePrefix,
+                                                                      boolean branchWhenLessThan,
+                                                                      boolean unsignedComparison) {
+    return buildTestsWith(id -> {
       var b = new RV64IMVTestBuilder(testNamePrefix + "_" + id);
       var rs1 = b.anyTempReg().sample();
       var rs2 = b.anyTempReg().sample();
@@ -251,191 +332,8 @@ public class IssRV64IInstrTest extends AbstractIssRiscv64InstrTest {
     });
   }
 
-// Test methods using helper functions
-
-  @TestFactory
-  Stream<DynamicTest> add() throws IOException {
-    return testBinaryRegRegInstruction("add", "ADD");
-  }
-
-  @TestFactory
-  Stream<DynamicTest> sub() throws IOException {
-    return testBinaryRegRegInstruction("sub", "SUB");
-  }
-
-  @TestFactory
-  Stream<DynamicTest> and() throws IOException {
-    return testBinaryRegRegInstruction("and", "AND");
-  }
-
-  @TestFactory
-  Stream<DynamicTest> or() throws IOException {
-    return testBinaryRegRegInstruction("or", "OR");
-  }
-
-  @TestFactory
-  Stream<DynamicTest> xor() throws IOException {
-    return testBinaryRegRegInstruction("xor", "XOR");
-  }
-
-  @TestFactory
-  Stream<DynamicTest> slt() throws IOException {
-    return testBinaryRegRegInstruction("slt", "SLT");
-  }
-
-  @TestFactory
-  Stream<DynamicTest> sltu() throws IOException {
-    return testBinaryRegRegInstruction("sltu", "SLTU");
-  }
-
-  @TestFactory
-  Stream<DynamicTest> addi() throws IOException {
-    return testBinaryRegImmInstruction("addi", "ADDI");
-  }
-
-  @TestFactory
-  Stream<DynamicTest> andi() throws IOException {
-    return testBinaryRegImmInstruction("andi", "ANDI");
-  }
-
-  @TestFactory
-  Stream<DynamicTest> ori() throws IOException {
-    return testBinaryRegImmInstruction("ori", "ORI");
-  }
-
-  @TestFactory
-  Stream<DynamicTest> xori() throws IOException {
-    return testBinaryRegImmInstruction("xori", "XORI");
-  }
-
-  @TestFactory
-  Stream<DynamicTest> slti() throws IOException {
-    return testBinaryRegImmInstruction("slti", "SLTI");
-  }
-
-  @TestFactory
-  Stream<DynamicTest> sltiu() throws IOException {
-    return testBinaryRegImmInstruction("sltiu", "SLTIU");
-  }
-
-  @TestFactory
-  Stream<DynamicTest> slli() throws IOException {
-    return testShiftImmInstruction("slli", "SLLI");
-  }
-
-  @TestFactory
-  Stream<DynamicTest> srli() throws IOException {
-    return testShiftImmInstruction("srli", "SRLI");
-  }
-
-  @TestFactory
-  Stream<DynamicTest> srai() throws IOException {
-    return testShiftImmInstruction("srai", "SRAI");
-  }
-
-  @TestFactory
-  Stream<DynamicTest> lb() throws IOException {
-    return testLoadInstruction("lb", "LB", "sb", 8);
-  }
-
-  @TestFactory
-  Stream<DynamicTest> lh() throws IOException {
-    return testLoadInstruction("lh", "LH", "sh", 16);
-  }
-
-  @TestFactory
-  Stream<DynamicTest> lw() throws IOException {
-    return testLoadInstruction("lw", "LW", "sw", 32);
-  }
-
-  @TestFactory
-  Stream<DynamicTest> ld() throws IOException {
-    return testLoadInstruction("ld", "LD", "sd", 64);
-  }
-
-  @TestFactory
-  Stream<DynamicTest> lbu() throws IOException {
-    return testLoadInstruction("lbu", "LBU", "sb", 8);
-  }
-
-  @TestFactory
-  Stream<DynamicTest> lhu() throws IOException {
-    return testLoadInstruction("lhu", "LHU", "sh", 16);
-  }
-
-  @TestFactory
-  Stream<DynamicTest> lwu() throws IOException {
-    return testLoadInstruction("lwu", "LWU", "sw", 32);
-  }
-
-  @TestFactory
-  Stream<DynamicTest> sb() throws IOException {
-    return testStoreInstruction("sb", "SB", "lb", 8);
-  }
-
-  @TestFactory
-  Stream<DynamicTest> sh() throws IOException {
-    return testStoreInstruction("sh", "SH", "lh", 16);
-  }
-
-  @TestFactory
-  Stream<DynamicTest> sw() throws IOException {
-    return testStoreInstruction("sw", "SW", "lw", 32);
-  }
-
-  @TestFactory
-  Stream<DynamicTest> sd() throws IOException {
-    return testStoreInstruction("sd", "SD", "ld", 64);
-  }
-
-  @TestFactory
-  Stream<DynamicTest> beq() throws IOException {
-    return testEqualityBranchInstruction("beq", "BEQ", true);
-  }
-
-  @TestFactory
-  Stream<DynamicTest> bne() throws IOException {
-    return testEqualityBranchInstruction("bne", "BNE", false);
-  }
-
-  @TestFactory
-  Stream<DynamicTest> blt() throws IOException {
-    return testRelationalBranchInstruction("blt", "BLT", true, false);
-  }
-
-  @TestFactory
-  Stream<DynamicTest> bge() throws IOException {
-    return testRelationalBranchInstruction("bge", "BGE", false, false);
-  }
-
-  @TestFactory
-  Stream<DynamicTest> bltu() throws IOException {
-    return testRelationalBranchInstruction("bltu", "BLTU", true, true);
-  }
-
-  @TestFactory
-  Stream<DynamicTest> bgeu() throws IOException {
-    return testRelationalBranchInstruction("bgeu", "BGEU", false, true);
-  }
-
-  @TestFactory
-  Stream<DynamicTest> addw() throws IOException {
-    return testBinaryRegRegInstruction("addw", "ADDW");
-  }
-
-  @TestFactory
-  Stream<DynamicTest> subw() throws IOException {
-    return testBinaryRegRegInstruction("subw", "SUBW");
-  }
-
-  @TestFactory
-  Stream<DynamicTest> addiw() throws IOException {
-    return testBinaryRegImmInstruction("addiw", "ADDIW");
-  }
-
-  @TestFactory
-  Stream<DynamicTest> sllw() throws IOException {
-    return runTestsWith(id -> {
+  private List<IssTestUtils.TestCase> sllwCases() {
+    return buildTestsWith(id -> {
       var b = new RV64IMVTestBuilder("SLLW_" + id);
       var regSrc1 = b.anyTempReg().sample();
       var regSrc2 = b.anyTempReg().sample();
@@ -447,9 +345,8 @@ public class IssRV64IInstrTest extends AbstractIssRiscv64InstrTest {
     });
   }
 
-  @TestFactory
-  Stream<DynamicTest> srlw() throws IOException {
-    return runTestsWith(id -> {
+  private List<IssTestUtils.TestCase> srlwCases() {
+    return buildTestsWith(id -> {
       var b = new RV64IMVTestBuilder("SRLW_" + id);
       var regSrc1 = b.anyTempReg().sample();
       var regSrc2 = b.anyTempReg().sample();
@@ -461,9 +358,8 @@ public class IssRV64IInstrTest extends AbstractIssRiscv64InstrTest {
     });
   }
 
-  @TestFactory
-  Stream<DynamicTest> sraw() throws IOException {
-    return runTestsWith(id -> {
+  private List<IssTestUtils.TestCase> srawCases() {
+    return buildTestsWith(id -> {
       var b = new RV64IMVTestBuilder("SRAW_" + id);
       var regSrc1 = b.anyTempReg().sample();
       var regSrc2 = b.anyTempReg().sample();
@@ -475,9 +371,8 @@ public class IssRV64IInstrTest extends AbstractIssRiscv64InstrTest {
     });
   }
 
-  @TestFactory
-  Stream<DynamicTest> slliw() throws IOException {
-    return runTestsWith(id -> {
+  private List<IssTestUtils.TestCase> slliwCases() {
+    return buildTestsWith(id -> {
       var b = new RV64IMVTestBuilder("SLLIW_" + id);
       var regSrc = b.anyTempReg().sample();
       b.fillRegSigned(regSrc, 64);
@@ -488,9 +383,8 @@ public class IssRV64IInstrTest extends AbstractIssRiscv64InstrTest {
     });
   }
 
-  @TestFactory
-  Stream<DynamicTest> srliw() throws IOException {
-    return runTestsWith(id -> {
+  private List<IssTestUtils.TestCase> srliwCases() {
+    return buildTestsWith(id -> {
       var b = new RV64IMVTestBuilder("SRLIW_" + id);
       var regSrc = b.anyTempReg().sample();
       b.fillRegSigned(regSrc, 64);
@@ -501,9 +395,8 @@ public class IssRV64IInstrTest extends AbstractIssRiscv64InstrTest {
     });
   }
 
-  @TestFactory
-  Stream<DynamicTest> sraiw() throws IOException {
-    return runTestsWith(id -> {
+  private List<IssTestUtils.TestCase> sraiwCases() {
+    return buildTestsWith(id -> {
       var b = new RV64IMVTestBuilder("SRAIW_" + id);
       var regSrc = b.anyTempReg().sample();
       b.fillRegSigned(regSrc, 64);
@@ -514,12 +407,8 @@ public class IssRV64IInstrTest extends AbstractIssRiscv64InstrTest {
     });
   }
 
-
-// The following instructions are unique and might not fit into the above helpers, so we'll keep them as is.
-
-  @TestFactory
-  Stream<DynamicTest> lui() throws IOException {
-    return runTestsWith((id) -> {
+  private List<IssTestUtils.TestCase> luiCases() {
+    return buildTestsWith(id -> {
       var b = new RV64IMVTestBuilder("LUI_" + id);
       var destReg = b.anyTempReg().sample();
       var value = arbitraryUnsignedInt(20).sample();
@@ -528,9 +417,8 @@ public class IssRV64IInstrTest extends AbstractIssRiscv64InstrTest {
     });
   }
 
-  @TestFactory
-  Stream<DynamicTest> auipc() throws IOException {
-    return runTestsWith(id -> {
+  private List<IssTestUtils.TestCase> auipcCases() {
+    return buildTestsWith(id -> {
       var b = new RV64IMVTestBuilder("AUIPC_" + id);
       var rd = b.anyTempReg().sample();
       var imm = arbitraryUnsignedInt(20).sample();
@@ -539,9 +427,8 @@ public class IssRV64IInstrTest extends AbstractIssRiscv64InstrTest {
     });
   }
 
-  @TestFactory
-  Stream<DynamicTest> jal() throws IOException {
-    return runTestsWith(id -> {
+  private List<IssTestUtils.TestCase> jalCases() {
+    return buildTestsWith(id -> {
       var b = new RV64IMVTestBuilder("JAL_" + id);
       var rd = b.anyTempReg().sample();
       String targetLabel = "target_" + id;
@@ -556,9 +443,8 @@ public class IssRV64IInstrTest extends AbstractIssRiscv64InstrTest {
     });
   }
 
-  @TestFactory
-  Stream<DynamicTest> jalr() throws IOException {
-    return runTestsWith(id -> {
+  private List<IssTestUtils.TestCase> jalrCases() {
+    return buildTestsWith(id -> {
       var b = new RV64IMVTestBuilder("JALR_" + id);
       var rd = b.anyTempReg().sample();
       var rs1 = b.anyTempReg().sample();

--- a/vadl/test/vadl/iss/riscv/IssRV64IInstrTest.java
+++ b/vadl/test/vadl/iss/riscv/IssRV64IInstrTest.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -32,7 +32,7 @@ import vadl.iss.AsmTestBuilder;
  */
 public class IssRV64IInstrTest extends AbstractIssRiscv64InstrTest {
 
-  private static final String VADL_SPEC = "sys/risc-v/rv64im.vadl";
+  private static final String VADL_SPEC = "sys/risc-v/rv64v.vadl";
   private static final int TESTS_PER_INSTRUCTION = 50;
 
   @Override

--- a/vadl/test/vadl/iss/riscv/IssRV64MInstrTest.java
+++ b/vadl/test/vadl/iss/riscv/IssRV64MInstrTest.java
@@ -18,15 +18,22 @@ package vadl.iss.riscv;
 
 import java.io.IOException;
 import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.DynamicNode;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
+import org.junit.jupiter.api.TestMethodOrder;
 import vadl.iss.AsmTestBuilder;
 import vadl.iss.IssTestUtils;
 
 /**
  * Tests the RV64I instructions set.
  */
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class IssRV64MInstrTest extends AbstractIssRiscv64InstrTest {
 
 
@@ -44,115 +51,57 @@ public class IssRV64MInstrTest extends AbstractIssRiscv64InstrTest {
     return new RV64IMVTestBuilder(testNamePrefix + "_" + id);
   }
 
-  @TestFactory
-  Stream<DynamicTest> mul() throws IOException {
-    return testBinaryRegRegInstruction("mul", "MUL");
+  @Test
+  @Order(1)
+  void setupInstructionTests() throws IOException {
+    initializeInstructionBatchFromTestCases(this::buildInstructionTestCases, this::getInstructionName);
   }
 
   @TestFactory
-  Stream<DynamicTest> mulh() throws IOException {
-    return testBinaryRegRegInstruction("mulh", "MULH");
-  }
-
-  @TestFactory
-  Stream<DynamicTest> mulhu() throws IOException {
-    return testBinaryRegRegInstruction("mulhu", "MULHU");
-  }
-
-  @TestFactory
-  Stream<DynamicTest> mulhsu() throws IOException {
-    return testBinaryRegRegInstruction("mulhsu", "MULHSU");
-  }
-
-  @TestFactory
-  Stream<DynamicTest> div() throws IOException {
-    return testBinaryRegRegInstruction("div", "DIV");
-  }
-
-  @TestFactory
-  Stream<DynamicTest> divByZero() throws IOException {
-    return testDivRemByCustom(10, "div", BigInteger.ZERO, "DIV_BY_ZERO");
-  }
-
-  @TestFactory
-  Stream<DynamicTest> divByMinusOne() throws IOException {
-    return testDivRemByCustom(10, "div", BigInteger.ONE.negate(), "DIV_BY_MINUS_ONE");
-  }
-
-  @TestFactory
-  Stream<DynamicTest> divu() throws IOException {
-    return testBinaryRegRegInstruction("divu", "DIVU");
-  }
-
-  @TestFactory
-  Stream<DynamicTest> divuByZero() throws IOException {
-    return testDivRemByCustom(10, "divu", BigInteger.ZERO, "DIVU_BY_ZERO");
-  }
-
-  @TestFactory
-  Stream<DynamicTest> divuByMinusOne() throws IOException {
-    return testDivRemByCustom(10, "divu", BigInteger.ONE.negate(), "DIVU_BY_MINUS_ONE");
-  }
-
-  @TestFactory
-  Stream<DynamicTest> rem() throws IOException {
-    return testBinaryRegRegInstruction("rem", "REM");
-  }
-
-  @TestFactory
-  Stream<DynamicTest> remByZero() throws IOException {
-    return testDivRemByCustom(10, "rem", BigInteger.ZERO, "REM_BY_ZERO");
-  }
-
-  @TestFactory
-  Stream<DynamicTest> remByMinusOne() throws IOException {
-    return testDivRemByCustom(10, "rem", BigInteger.ONE.negate(), "REM_BY_MINUS_ONE");
-  }
-
-  @TestFactory
-  Stream<DynamicTest> remu() throws IOException {
-    return testBinaryRegRegInstruction("remu", "REMU");
-  }
-
-  @TestFactory
-  Stream<DynamicTest> remuByZero() throws IOException {
-    return testDivRemByCustom(10, "remu", BigInteger.ZERO, "REMU_BY_ZERO");
-  }
-
-  @TestFactory
-  Stream<DynamicTest> remuByMinusOne() throws IOException {
-    return testDivRemByCustom(10, "remu", BigInteger.ONE.negate(), "REMU_BY_MINUS_ONE");
-  }
-
-  @TestFactory
-  Stream<DynamicTest> mulw() throws IOException {
-    return testBinaryRegRegInstructionW("mulw", "MULW");
-  }
-
-  @TestFactory
-  Stream<DynamicTest> divw() throws IOException {
-    return testBinaryRegRegInstructionW("divw", "DIVW");
-  }
-
-  @TestFactory
-  Stream<DynamicTest> divuw() throws IOException {
-    return testBinaryRegRegInstructionW("divuw", "DIVUW");
-  }
-
-  @TestFactory
-  Stream<DynamicTest> remw() throws IOException {
-    return testBinaryRegRegInstructionW("remw", "REMW");
-  }
-
-  @TestFactory
-  Stream<DynamicTest> remuw() throws IOException {
-    return testBinaryRegRegInstructionW("remuw", "REMUW");
+  @Order(2)
+  Stream<DynamicNode> buildInstructionTests() throws IOException {
+    initializeInstructionBatchFromTestCases(this::buildInstructionTestCases, this::getInstructionName);
+    return buildInstructionTestContainers();
   }
 
   // Helper methods
-  private Stream<DynamicTest> testBinaryRegRegInstruction(String instruction, String testNamePrefix)
-      throws IOException {
-    return runTestsWith(id -> {
+  private List<IssTestUtils.TestCase> buildInstructionTestCases() {
+    var tests = new ArrayList<IssTestUtils.TestCase>();
+    tests.addAll(testBinaryRegRegInstruction("mul", "MUL"));
+    tests.addAll(testBinaryRegRegInstruction("mulh", "MULH"));
+    tests.addAll(testBinaryRegRegInstruction("mulhu", "MULHU"));
+    tests.addAll(testBinaryRegRegInstruction("mulhsu", "MULHSU"));
+    tests.addAll(testBinaryRegRegInstruction("div", "DIV"));
+    tests.addAll(testDivRemByCustom(10, "div", BigInteger.ZERO, "DIV_BY_ZERO"));
+    tests.addAll(testDivRemByCustom(10, "div", BigInteger.ONE.negate(), "DIV_BY_MINUS_ONE"));
+    tests.addAll(testBinaryRegRegInstruction("divu", "DIVU"));
+    tests.addAll(testDivRemByCustom(10, "divu", BigInteger.ZERO, "DIVU_BY_ZERO"));
+    tests.addAll(testDivRemByCustom(10, "divu", BigInteger.ONE.negate(), "DIVU_BY_MINUS_ONE"));
+    tests.addAll(testBinaryRegRegInstruction("rem", "REM"));
+    tests.addAll(testDivRemByCustom(10, "rem", BigInteger.ZERO, "REM_BY_ZERO"));
+    tests.addAll(testDivRemByCustom(10, "rem", BigInteger.ONE.negate(), "REM_BY_MINUS_ONE"));
+    tests.addAll(testBinaryRegRegInstruction("remu", "REMU"));
+    tests.addAll(testDivRemByCustom(10, "remu", BigInteger.ZERO, "REMU_BY_ZERO"));
+    tests.addAll(testDivRemByCustom(10, "remu", BigInteger.ONE.negate(), "REMU_BY_MINUS_ONE"));
+    tests.addAll(testBinaryRegRegInstructionW("mulw", "MULW"));
+    tests.addAll(testBinaryRegRegInstructionW("divw", "DIVW"));
+    tests.addAll(testBinaryRegRegInstructionW("divuw", "DIVUW"));
+    tests.addAll(testBinaryRegRegInstructionW("remw", "REMW"));
+    tests.addAll(testBinaryRegRegInstructionW("remuw", "REMUW"));
+    return tests;
+  }
+
+  private String getInstructionName(IssTestUtils.TestCase testCase) {
+    var separator = testCase.id().lastIndexOf('_');
+    if (separator <= 0) {
+      return testCase.id();
+    }
+    return testCase.id().substring(0, separator).toLowerCase();
+  }
+
+  private List<IssTestUtils.TestCase> testBinaryRegRegInstruction(String instruction,
+                                                                  String testNamePrefix) {
+    return buildTestsWith(id -> {
       var b = getBuilder(testNamePrefix, id);
       var regSrc1 = b.anyTempReg().sample();
       var regSrc2 = b.anyTempReg().sample();
@@ -176,10 +125,9 @@ public class IssRV64MInstrTest extends AbstractIssRiscv64InstrTest {
     return b.toTestCase(regSrc1, regSrc2, regDest);
   }
 
-  private Stream<DynamicTest> testDivRemByCustom(int runs, String instr, BigInteger divisor,
-                                                 String testPrefix)
-      throws IOException {
-    return runTestsWith(runs, (i) -> {
+  private List<IssTestUtils.TestCase> testDivRemByCustom(int runs, String instr, BigInteger divisor,
+                                                         String testPrefix) {
+    return buildTestsWith(runs, (i) -> {
       var b = getBuilder(testPrefix, i);
       var regSrc1 = b.anyTempReg().sample();
       var regSrc2 = b.anyTempReg().sample();
@@ -192,10 +140,9 @@ public class IssRV64MInstrTest extends AbstractIssRiscv64InstrTest {
   }
 
   // Helper for 32-bit wide instructions (sign-extended)
-  private Stream<DynamicTest> testBinaryRegRegInstructionW(String instruction,
-                                                           String testNamePrefix)
-      throws IOException {
-    return runTestsWith(id -> {
+  private List<IssTestUtils.TestCase> testBinaryRegRegInstructionW(String instruction,
+                                                                   String testNamePrefix) {
+    return buildTestsWith(id -> {
       var b = getBuilder(testNamePrefix, id);
       var regSrc1 = b.anyTempReg().sample();
       var regSrc2 = b.anyTempReg().sample();

--- a/vadl/test/vadl/iss/riscv/IssRV64MInstrTest.java
+++ b/vadl/test/vadl/iss/riscv/IssRV64MInstrTest.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -37,7 +37,7 @@ public class IssRV64MInstrTest extends AbstractIssRiscv64InstrTest {
 
   @Override
   public String getVadlSpec() {
-    return "sys/risc-v/rv64im.vadl";
+    return "sys/risc-v/rv64v.vadl";
   }
 
   public AsmTestBuilder getBuilder(String testNamePrefix, int id) {

--- a/vadl/test/vadl/iss/riscv/IssRV64VInstrTest.java
+++ b/vadl/test/vadl/iss/riscv/IssRV64VInstrTest.java
@@ -25,13 +25,18 @@ import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.DynamicNode;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
+import org.junit.jupiter.api.TestMethodOrder;
 import vadl.iss.IssTestUtils;
 
 /**
  * Tests the RV64V instructions set.
  */
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class IssRV64VInstrTest extends AbstractIssRiscv64InstrTest {
 
   private static final String VADL_SPEC = "sys/risc-v/rv64v.vadl";
@@ -69,6 +74,19 @@ public class IssRV64VInstrTest extends AbstractIssRiscv64InstrTest {
 
   public RV64IMVTestBuilder getBuilder(String testNamePrefix, int id) {
     return new RV64IMVTestBuilder(testNamePrefix + "_" + id);
+  }
+
+  @Test
+  @Order(1)
+  void setupInstructionTests() throws IOException {
+    initializeInstructionBatchFromTestCases(this::buildInstructionTestCases, this::getInstructionName);
+  }
+
+  @TestFactory
+  @Order(2)
+  Stream<DynamicNode> buildInstructionTests() throws IOException {
+    initializeInstructionBatchFromTestCases(this::buildInstructionTestCases, this::getInstructionName);
+    return buildInstructionTestContainers();
   }
 
   private IssTestUtils.TestCase createBinaryVecInstrTest(RV64IMVTestBuilder b, String instruction,
@@ -153,9 +171,46 @@ public class IssRV64VInstrTest extends AbstractIssRiscv64InstrTest {
     return b.toTestCase();
   }
 
-  private Stream<DynamicTest> testBinaryVecInstr(String instruction,
-                                                 boolean v, boolean x, boolean i)
-      throws IOException {
+  private List<IssTestUtils.TestCase> buildInstructionTestCases() {
+    var tests = new ArrayList<IssTestUtils.TestCase>();
+    tests.addAll(testBinaryVecInstr("vadd", true, true, true));
+    tests.addAll(testBinaryVecInstr("vsub", true, true, false));
+    tests.addAll(testBinaryVecInstr("vmul", true, true, false));
+    tests.addAll(testBinaryVecInstr("vmulh", true, true, false));
+    tests.addAll(testBinaryVecInstr("vmulhu", true, true, false));
+    tests.addAll(testBinaryVecInstr("vmulhsu", true, true, false));
+    tests.addAll(testBinaryVecInstr("vdiv", true, true, false));
+    tests.addAll(testBinaryVecInstr("vdivu", true, true, false));
+    tests.addAll(testBinaryVecInstr("vrem", true, true, false));
+    tests.addAll(testBinaryVecInstr("vremu", true, true, false));
+    tests.addAll(testBinaryVecInstr("vminu", true, true, false));
+    tests.addAll(testBinaryVecInstr("vmin", true, true, false));
+    tests.addAll(testBinaryVecInstr("vmaxu", true, true, false));
+    tests.addAll(testBinaryVecInstr("vmax", true, true, false));
+    tests.addAll(testBinaryVecInstr("vand", true, true, true));
+    tests.addAll(testBinaryVecInstr("vor", true, true, true));
+    tests.addAll(testBinaryVecInstr("vmseq", true, true, true));
+    tests.addAll(testBinaryVecInstr("vxor", true, true, true));
+    tests.addAll(testBinaryVecInstr("vmadd", true, true, true, true, false));
+    tests.addAll(testBinaryVecInstr("vnmsub", true, true, true, true, false));
+    tests.addAll(testBinaryVecInstr("vmacc", true, true, true, true, false));
+    tests.addAll(testBinaryVecInstr("vnmsac", true, true, true, true, false));
+    tests.addAll(buildTestsWith((id) -> createReductionVecInstrTest(getBuilder("VREDSUM.VS", id), "vredsum")));
+    tests.addAll(buildTestsWith((id) -> createReductionVecInstrTest(getBuilder("VREDAND.VS", id), "vredand")));
+    tests.addAll(buildTestsWith((id) -> createReductionVecInstrTest(getBuilder("VREDOR.VS", id), "vredor")));
+    tests.addAll(buildTestsWith((id) -> createReductionVecInstrTest(getBuilder("VREDXOR.VS", id), "vredxor")));
+    return tests;
+  }
+
+  private String getInstructionName(IssTestUtils.TestCase testCase) {
+    var separator = testCase.id().lastIndexOf('_');
+    var instructionId = separator <= 0 ? testCase.id() : testCase.id().substring(0, separator);
+    var dot = instructionId.indexOf('.');
+    return (dot >= 0 ? instructionId.substring(0, dot) : instructionId).toLowerCase();
+  }
+
+  private List<IssTestUtils.TestCase> testBinaryVecInstr(String instruction,
+                                                         boolean v, boolean x, boolean i) {
     return testBinaryVecInstr(instruction, false, false, v, x, i);
   }
 
@@ -176,10 +231,9 @@ public class IssRV64VInstrTest extends AbstractIssRiscv64InstrTest {
    * @return a stream of dynamic tests for the specified combinations of binary vector instructions.
    * @throws IOException if an error occurs during test case generation or execution.
    */
-  private Stream<DynamicTest> testBinaryVecInstr(String instruction,
-                                                 boolean fillDest, boolean flipArgs,
-                                                 boolean v, boolean x, boolean i)
-      throws IOException {
+  private List<IssTestUtils.TestCase> testBinaryVecInstr(String instruction,
+                                                         boolean fillDest, boolean flipArgs,
+                                                         boolean v, boolean x, boolean i) {
     var testNamePrefix = instruction.toUpperCase();
     List<Function<Integer, IssTestUtils.TestCase>> generators = new ArrayList<>();
     if (v) {
@@ -200,140 +254,7 @@ public class IssRV64VInstrTest extends AbstractIssRiscv64InstrTest {
         return createBinaryVecImmInstrTest(builder, instruction + ".vi", fillDest);
       });
     }
-    return runTestsWith(generators);
-  }
-
-
-// Test methods using helper functions
-
-  @TestFactory
-  Stream<DynamicTest> vadd() throws IOException {
-    return testBinaryVecInstr("vadd", true, true, true);
-  }
-
-  @TestFactory
-  Stream<DynamicTest> vsub() throws IOException {
-    return testBinaryVecInstr("vsub", true, true, false);
-  }
-
-  @TestFactory
-  Stream<DynamicTest> vmul() throws IOException {
-    return testBinaryVecInstr("vmul", true, true, false);
-  }
-
-  @TestFactory
-  Stream<DynamicTest> vmulh() throws IOException {
-    return testBinaryVecInstr("vmulh", true, true, false);
-  }
-
-  @TestFactory
-  Stream<DynamicTest> vmulhu() throws IOException {
-    return testBinaryVecInstr("vmulhu", true, true, false);
-  }
-
-  @TestFactory
-  Stream<DynamicTest> vmulhsu() throws IOException {
-    return testBinaryVecInstr("vmulhsu", true, true, false);
-  }
-
-  @TestFactory
-  Stream<DynamicTest> vdiv() throws IOException {
-    return testBinaryVecInstr("vdiv", true, true, false);
-  }
-
-  @TestFactory
-  Stream<DynamicTest> vdivu() throws IOException {
-    return testBinaryVecInstr("vdivu", true, true, false);
-  }
-
-  @TestFactory
-  Stream<DynamicTest> vrem() throws IOException {
-    return testBinaryVecInstr("vrem", true, true, false);
-  }
-
-  @TestFactory
-  Stream<DynamicTest> vremu() throws IOException {
-    return testBinaryVecInstr("vremu", true, true, false);
-  }
-
-  @TestFactory
-  Stream<DynamicTest> vminu() throws IOException {
-    return testBinaryVecInstr("vminu", true, true, false);
-  }
-
-  @TestFactory
-  Stream<DynamicTest> vmin() throws IOException {
-    return testBinaryVecInstr("vmin", true, true, false);
-  }
-
-  @TestFactory
-  Stream<DynamicTest> vmaxu() throws IOException {
-    return testBinaryVecInstr("vmaxu", true, true, false);
-  }
-
-  @TestFactory
-  Stream<DynamicTest> vmax() throws IOException {
-    return testBinaryVecInstr("vmax", true, true, false);
-  }
-
-  @TestFactory
-  Stream<DynamicTest> vand() throws IOException {
-    return testBinaryVecInstr("vand", true, true, true);
-  }
-
-  @TestFactory
-  Stream<DynamicTest> vor() throws IOException {
-    return testBinaryVecInstr("vor", true, true, true);
-  }
-
-  @TestFactory
-  Stream<DynamicTest> vm() throws IOException {
-    return testBinaryVecInstr("vmseq", true, true, true);
-  }
-
-  @TestFactory
-  Stream<DynamicTest> vxor() throws IOException {
-    return testBinaryVecInstr("vxor", true, true, true);
-  }
-
-  @TestFactory
-  Stream<DynamicTest> vmadd() throws IOException {
-    return testBinaryVecInstr("vmadd", true, true, true, true, false);
-  }
-
-  @TestFactory
-  Stream<DynamicTest> vnmsub() throws IOException {
-    return testBinaryVecInstr("vnmsub", true, true, true, true, false);
-  }
-
-  @TestFactory
-  Stream<DynamicTest> vmacc() throws IOException {
-    return testBinaryVecInstr("vmacc", true, true, true, true, false);
-  }
-
-  @TestFactory
-  Stream<DynamicTest> vnmsac() throws IOException {
-    return testBinaryVecInstr("vnmsac", true, true, true, true, false);
-  }
-
-  @TestFactory
-  Stream<DynamicTest> vredsum() throws IOException {
-    return runTestsWith((id) -> createReductionVecInstrTest(getBuilder("VREDSUM.VS", id), "vredsum"));
-  }
-
-  @TestFactory
-  Stream<DynamicTest> vredand() throws IOException {
-    return runTestsWith((id) -> createReductionVecInstrTest(getBuilder("VREDAND.VS", id), "vredand"));
-  }
-
-  @TestFactory
-  Stream<DynamicTest> vredor() throws IOException {
-    return runTestsWith((id) -> createReductionVecInstrTest(getBuilder("VREDOR.VS", id), "vredor"));
-  }
-
-  @TestFactory
-  Stream<DynamicTest> vredxor() throws IOException {
-    return runTestsWith((id) -> createReductionVecInstrTest(getBuilder("VREDXOR.VS", id), "vredxor"));
+    return buildTestsWith(generators);
   }
 
 }

--- a/vadl/test/vadl/iss/riscv/IssRiscvEmbenchTest.java
+++ b/vadl/test/vadl/iss/riscv/IssRiscvEmbenchTest.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -36,7 +36,7 @@ public class IssRiscvEmbenchTest extends QemuIssTest {
 
   @Test
   void rv64imEmbenchTest() throws IOException {
-    runEmbenchTest("sys/risc-v/rv64im.vadl", "build_spike-rv64im.sh", "qemu-system-rv64im");
+    runEmbenchTest("sys/risc-v/rv64v.vadl", "build_spike-rv64im.sh", "qemu-system-rv64imv");
   }
 
   @Test
@@ -75,4 +75,3 @@ public class IssRiscvEmbenchTest extends QemuIssTest {
   }
 
 }
-


### PR DESCRIPTION
This PR replaces VADL test specs by the vector equivalents. While the specs are still tested, it reduces the number of built images during the CI run.

The PR also collapses all instruction tests per architecture into as single container execution which should further reduce the execution time.