### PR TITLE
vadl: Convert all pass timinigs to nanoseconds

### DIFF
--- a/vadl-cli/main/vadl/cli/BaseCommand.java
+++ b/vadl-cli/main/vadl/cli/BaseCommand.java
@@ -135,7 +135,7 @@ public abstract class BaseCommand implements Callable<Integer> {
    */
   private final List<Timing> timings = new ArrayList<>();
 
-  private record Timing(String name, long durationMs) {
+  private record Timing(String name, long durationNS) {
   }
 
   /**
@@ -150,9 +150,9 @@ public abstract class BaseCommand implements Callable<Integer> {
   }
 
   private void withTimings(String title, Runnable runnable) {
-    var startTime = System.currentTimeMillis();
+    var startTime = System.nanoTime();
     runnable.run();
-    timings.add(new Timing(title, System.currentTimeMillis() - startTime));
+    timings.add(new Timing(title, System.nanoTime() - startTime));
   }
 
   /**
@@ -267,20 +267,20 @@ public abstract class BaseCommand implements Callable<Integer> {
     printSpecStats(ast, new DiskVirtualFileSystem());
     printSpecStatsCsv(ast, new DiskVirtualFileSystem());
     ast.timingRecorder.passTimings.forEach(
-        t -> timings.add(new Timing(t.description(), t.durationNS() / 1000_000)));
+        t -> timings.add(new Timing(t.description(), t.durationNS())));
     ast.timingRecorder.passTimings.clear();
     dumpExpaned(ast);
     dumpUntyped(ast);
 
     TypeChecker.verify(ast);
     ast.timingRecorder.passTimings.forEach(
-        t -> timings.add(new Timing(t.description(), t.durationNS() / 1000_000)));
+        t -> timings.add(new Timing(t.description(), t.durationNS())));
     ast.timingRecorder.passTimings.clear();
     dumpTyped(ast);
 
     var spec = ViamLowering.generate(ast);
     ast.timingRecorder.passTimings.forEach(
-        t -> timings.add(new Timing(t.description(), t.durationNS() / 1000_000)));
+        t -> timings.add(new Timing(t.description(), t.durationNS())));
 
     return spec;
   }
@@ -349,7 +349,10 @@ public abstract class BaseCommand implements Callable<Integer> {
 
     System.out.println("\nTimings:");
     timings.forEach(t -> {
-      System.out.printf("\t- %-40s %5dms\n", t.name + ":", t.durationMs);
+      var microSeconds = t.durationNS / 1000;
+      var beforePoint = microSeconds / 1000;
+      var afterPoint = microSeconds % 1000;
+      System.out.printf("\t- %-40s %5d.%03dms\n", t.name + ":", beforePoint, afterPoint);
     });
   }
 
@@ -358,7 +361,15 @@ public abstract class BaseCommand implements Callable<Integer> {
       return;
     }
     var sb = new StringBuilder("pass,duration_ms\n");
-    timings.forEach(t -> sb.append(t.name()).append(',').append(t.durationMs()).append('\n'));
+
+    timings.forEach(
+        t -> {
+          var microSeconds = t.durationNS / 1000;
+          var beforePoint = microSeconds / 1000;
+          var afterPoint = microSeconds % 1000;
+          sb.append(t.name()).append(',').append("%d.03%d".formatted(beforePoint, afterPoint))
+              .append('\n');
+        });
     var csvPath = output.resolve("timings.csv");
     try {
       Files.writeString(csvPath, sb, StandardCharsets.UTF_8);
@@ -409,8 +420,8 @@ public abstract class BaseCommand implements Callable<Integer> {
       passManager.run(viam);
       var result = passManager.getPassResults();
       result.executedPasses()
-          .forEach(p -> timings.add(new Timing(p.pass().getName().value(), p.durationMs())));
-      timings.add(new Timing("Total", (System.nanoTime() - totalStartTime) / 1_000_000));
+          .forEach(p -> timings.add(new Timing(p.pass().getName().value(), p.durationNs())));
+      timings.add(new Timing("Total", System.nanoTime() - totalStartTime));
 
 
     } catch (TypeConversionException | MaxValuesExceededException e) {

--- a/vadl/main/vadl/dump/CollectBehaviorDotGraphPass.java
+++ b/vadl/main/vadl/dump/CollectBehaviorDotGraphPass.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -72,7 +72,7 @@ public class CollectBehaviorDotGraphPass extends Pass {
               .map(behaviorDotGraph -> new PassResults.DotGraphResult(
                   prevPass.passKey(),
                   prevPass().pass(),
-                  prevPass().durationMs(),
+                  prevPass().durationNs(),
                   behaviorDotGraph,
                   prevPass().skipped(),
                   x.getKey())))

--- a/vadl/main/vadl/dump/HtmlDumpPass.java
+++ b/vadl/main/vadl/dump/HtmlDumpPass.java
@@ -290,7 +290,7 @@ public class HtmlDumpPass extends AbstractTemplateRenderingPass {
         "nr", nr,
         "passKey", singleResult.passKey().value(),
         "pass", mapPass(singleResult.pass()),
-        "duration", singleResult.durationMs(),
+        "duration", singleResult.durationNs(),
         "hasLink", hasLink,
         "skipped", singleResult.skipped()
     );

--- a/vadl/main/vadl/pass/PassManager.java
+++ b/vadl/main/vadl/pass/PassManager.java
@@ -140,7 +140,7 @@ public class PassManager {
     for (int passIdx = 0; passIdx < affectedSteps.size(); passIdx++) {
       var step = affectedSteps.get(passIdx);
       @SuppressWarnings("VariableDeclarationUsageDistance")
-      var startTime = System.currentTimeMillis();
+      var startTime = System.nanoTime();
       // Wrapping the passResults into an unmodifiable map so a pass cannot modify
       // the results.
       var pass = step.pass();
@@ -162,7 +162,7 @@ public class PassManager {
       pass.verification(viam, passResult);
 
       // we always store the pass result, even if the result is `null`
-      var duration = System.currentTimeMillis() - startTime;
+      var duration = System.nanoTime() - startTime;
       passResults.add(step.key(), pass, duration, passResult);
 
       logger.debug(">>> [{}/{}] Pass done: key='{}' ({} ms)",

--- a/vadl/main/vadl/pass/PassResults.java
+++ b/vadl/main/vadl/pass/PassResults.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -198,7 +198,7 @@ public final class PassResults {
   public static class SingleResult {
     protected final PassKey passKey;
     protected final Pass pass;
-    private final long durationMs;
+    private final long durationNs;
     @Nullable
     protected final Object result;
     private final boolean skipped;
@@ -206,17 +206,17 @@ public final class PassResults {
     /**
      * Constructor.
      */
-    public SingleResult(PassKey passKey, Pass pass, long durationMs, @Nullable Object result,
+    public SingleResult(PassKey passKey, Pass pass, long durationNs, @Nullable Object result,
                         boolean skipped) {
       this.passKey = passKey;
       this.pass = pass;
-      this.durationMs = durationMs;
+      this.durationNs = durationNs;
       this.result = result;
       this.skipped = skipped;
     }
 
-    public long durationMs() {
-      return durationMs;
+    public long durationNs() {
+      return durationNs;
     }
 
     public Pass pass() {
@@ -250,11 +250,11 @@ public final class PassResults {
      */
     public DotGraphResult(PassKey passKey,
                           Pass pass,
-                          long durationMs,
+                          long durationNs,
                           String result,
                           boolean skipped,
                           Definition definition) {
-      super(passKey, pass, durationMs, result, skipped);
+      super(passKey, pass, durationNs, result, skipped);
       this.definition = definition;
     }
 


### PR DESCRIPTION
During some performance evaluation we discovered that the previous tracking in milliseconds wasn't granular enough as the native build on small specs is simply to fast.