### PR TITLE
iss: Move bi-endian condition evaluation to DisasContext creation

### DIFF
--- a/vadl/main/resources/templates/iss/target/gen-arch/translate.c
+++ b/vadl/main/resources/templates/iss/target/gen-arch/translate.c
@@ -47,15 +47,17 @@ typedef struct DisasContext {
     [/][/]
   } tb_state;
 
+  [# th:if="${mem_bi_endian}"]bool endian_cond;[/]
+
 } DisasContext;
 
 static bool swap_insn(const DisasContext *ctx) {
   // default byte order is LE, but VDT assumes BE
 [# th:if="${mem_bi_endian}"]
 #if TARGET_BIG_ENDIAN
-  return [# th:unless="${mem_big_endian}"]![/]([(${bi_endian_condition})]);
+  return [# th:unless="${mem_big_endian}"]![/]ctx->endian_cond;
 #else
-  return [# th:if="${mem_big_endian}"]![/]([(${bi_endian_condition})]);
+  return [# th:if="${mem_big_endian}"]![/]ctx->endian_cond;
 #endif
 [/][# th:unless="${mem_bi_endian}"]
   return true;
@@ -233,6 +235,8 @@ static void [(${gen_arch_lower})]_tr_init_disas_context(DisasContextBase *db, CP
     ctx->tb_state.[(${reg.name_lower})] |= ((flags >> off) & [(${part.mask})]) << [(${part.lsb})];
     off += [(${part.width})];
     [/][/][/]
+
+    [# th:if="${mem_bi_endian}"]ctx->endian_cond = [(${bi_endian_condition})];[/]
 }
 
 static void [(${gen_arch_lower})]_tr_tb_start(DisasContextBase *db, CPUState *cpu)

--- a/vadl/main/vadl/iss/codegen/IssCMixins.java
+++ b/vadl/main/vadl/iss/codegen/IssCMixins.java
@@ -24,6 +24,7 @@ import vadl.iss.passes.nodes.IssConstExtractNode;
 import vadl.iss.passes.nodes.IssGhostCastNode;
 import vadl.iss.passes.nodes.IssMoveNode;
 import vadl.iss.passes.nodes.IssSelectNode;
+import vadl.iss.passes.nodes.IssStaticEndianConditionNode;
 import vadl.iss.passes.nodes.IssStaticPcRegNode;
 import vadl.iss.passes.nodes.IssStaticReadRegNode;
 import vadl.iss.passes.nodes.IssTempExprNode;
@@ -355,6 +356,11 @@ public interface IssCMixins {
     @Handler
     default void handler(CGenContext<Node> ctx, IssStaticPcRegNode node) {
       ctx.wr("(ctx->pc_curr)");
+    }
+
+    @Handler
+    default void handler(CGenContext<Node> ctx, IssStaticEndianConditionNode node) {
+      ctx.wr("(ctx->endian_cond)");
     }
 
     @Handler

--- a/vadl/main/vadl/iss/codegen/IssInstrHelperGenerator.java
+++ b/vadl/main/vadl/iss/codegen/IssInstrHelperGenerator.java
@@ -26,6 +26,7 @@ import vadl.cppCodeGen.context.CNodeContext;
 import vadl.iss.passes.extensions.InstrInfo;
 import vadl.iss.passes.extensions.IssAccessorRegistry;
 import vadl.iss.passes.nodes.IssRegBitfieldWriteNode;
+import vadl.iss.passes.nodes.IssStaticEndianConditionNode;
 import vadl.iss.passes.nodes.IssStaticPcRegNode;
 import vadl.iss.passes.nodes.IssStaticReadRegNode;
 import vadl.iss.passes.tcgLowering.Tcg_32_64;
@@ -182,6 +183,12 @@ public class IssInstrHelperGenerator extends IssProcGen
   @Handler
   void handle(CGenContext<Node> ctx, IssStaticPcRegNode toHandle) {
     throw new UnsupportedOperationException("Type IssStaticPcRegNode not yet implemented");
+  }
+
+  @Handler
+  void handle(CGenContext<Node> ctx, IssStaticEndianConditionNode toHandle) {
+    throw new UnsupportedOperationException(
+        "Type IssStaticEndianConditionNode not yet implemented");
   }
 
   @Handler

--- a/vadl/main/vadl/iss/passes/IssApplyMemoryEndiannessPass.java
+++ b/vadl/main/vadl/iss/passes/IssApplyMemoryEndiannessPass.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-package vadl.viam.passes;
+package vadl.iss.passes;
 
 import static java.util.Objects.requireNonNull;
 import static vadl.error.Diagnostic.error;
@@ -28,6 +28,7 @@ import javax.annotation.Nullable;
 import vadl.configuration.GeneralConfiguration;
 import vadl.error.Diagnostic;
 import vadl.error.DiagnosticList;
+import vadl.iss.passes.nodes.IssStaticEndianConditionNode;
 import vadl.pass.Pass;
 import vadl.pass.PassName;
 import vadl.pass.PassResults;
@@ -42,7 +43,6 @@ import vadl.viam.annotations.TbStateRegisterAnnotation;
 import vadl.viam.graph.Graph;
 import vadl.viam.graph.control.AbstractEndNode;
 import vadl.viam.graph.control.ProcEndNode;
-import vadl.viam.graph.control.ReturnNode;
 import vadl.viam.graph.dependency.ExpressionNode;
 import vadl.viam.graph.dependency.ReadMemNode;
 import vadl.viam.graph.dependency.ReadRegTensorNode;
@@ -65,9 +65,11 @@ import vadl.viam.graph.dependency.WriteRegTensorNode;
  * condition must be statically evaluated since register reads are not possible at that point.
  * Therefore, register values are taken from the default branch of the processor reset procedure and
  * must be constant.
+ *
+ * <p><b>Note: this adds ISS-specific nodes</b>
  */
-public class ApplyMemoryEndiannessPass extends Pass {
-  public ApplyMemoryEndiannessPass(GeneralConfiguration configuration) {
+public class IssApplyMemoryEndiannessPass extends Pass {
+  public IssApplyMemoryEndiannessPass(GeneralConfiguration configuration) {
     super(configuration);
   }
 
@@ -143,6 +145,7 @@ class ApplyMemoryEndiannessInMemoryRegionInit {
             WriteRegTensorNode::value
         ));
 
+    // FIXME: this does not account for changes to the register values during the procedure
     processor.memoryRegions().forEach(mr ->
         mr.behavior().getNodes(ReadRegTensorNode.class).forEach(read ->
           handleRead(read, resetVector, reset, mr.memoryRef())
@@ -199,7 +202,7 @@ class ApplyMemoryEndianness {
     var mem = read.memory();
     if (mem.isBiEndian()) {
       read.replace(new SelectNode(
-          getConditionCopy(mem),
+          new IssStaticEndianConditionNode(),
           read.overwriteEndianness(mem.endianness()),
           read.overwriteEndianness(mem.endianness().other())
       ));
@@ -215,7 +218,8 @@ class ApplyMemoryEndianness {
       var prev = requireNonNull(next.predecessor());
       prev.unlinkNext();
       prev.setNext(GraphUtils.ifElseSideEffect(
-          behaviour, getConditionCopy(mem),
+          behaviour,
+          new IssStaticEndianConditionNode(),
           List.of(write.overwriteEndianness(mem.endianness())),
           List.of(write.overwriteEndianness(mem.endianness().other())),
           next,
@@ -223,11 +227,5 @@ class ApplyMemoryEndianness {
       ));
       write.safeDelete();
     }
-  }
-
-  private ExpressionNode getConditionCopy(Memory mem) {
-    return requireNonNull(mem.biEndianCondition())
-        .getNodes(ReturnNode.class).findFirst().get()
-        .value().copy();
   }
 }

--- a/vadl/main/vadl/iss/passes/IssNormalizationPass.java
+++ b/vadl/main/vadl/iss/passes/IssNormalizationPass.java
@@ -36,6 +36,7 @@ import vadl.configuration.IssConfiguration;
 import vadl.iss.passes.nodes.IssConstExtractNode;
 import vadl.iss.passes.nodes.IssGhostCastNode;
 import vadl.iss.passes.nodes.IssSelectNode;
+import vadl.iss.passes.nodes.IssStaticEndianConditionNode;
 import vadl.iss.passes.nodes.IssStaticPcRegNode;
 import vadl.iss.passes.nodes.IssStaticReadRegNode;
 import vadl.iss.passes.nodes.IssTempExprNode;
@@ -252,6 +253,11 @@ class IssNormalizer implements VadlBuiltInNoStatusDispatcher<BuiltInCall> {
 
   @Handler
   void handle(IssStaticPcRegNode toHandle) {
+    // do nothing
+  }
+
+  @Handler
+  void handle(IssStaticEndianConditionNode toHandle) {
     // do nothing
   }
 

--- a/vadl/main/vadl/iss/passes/nodes/IssStaticEndianConditionNode.java
+++ b/vadl/main/vadl/iss/passes/nodes/IssStaticEndianConditionNode.java
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText : © 2026 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.iss.passes.nodes;
+
+import vadl.types.Type;
+import vadl.viam.Memory;
+import vadl.viam.graph.Node;
+import vadl.viam.graph.dependency.ExpressionNode;
+
+/**
+ * Represents a static read of the bi-endianness condition value from
+ * the {@code DisasContext} like this: {@code ctx->endian_cond}. The
+ * condition determines whether memory ops are big- or little-endian.
+ * The actual condition (from {@link Memory#biEndianCondition()}) is
+ * evaluated once per TB during the creation of the {@code DisasContext}.
+ */
+public class IssStaticEndianConditionNode extends ExpressionNode {
+
+  public IssStaticEndianConditionNode() {
+    super(Type.bool());
+  }
+
+  @Override
+  public ExpressionNode copy() {
+    return new IssStaticEndianConditionNode();
+  }
+
+  @Override
+  public Node shallowCopy() {
+    return new IssStaticEndianConditionNode();
+  }
+}

--- a/vadl/main/vadl/iss/passes/tcgLowering/TcgOpLoweringPass.java
+++ b/vadl/main/vadl/iss/passes/tcgLowering/TcgOpLoweringPass.java
@@ -39,6 +39,7 @@ import vadl.iss.passes.nodes.IssMoveNode;
 import vadl.iss.passes.nodes.IssReadRegNode;
 import vadl.iss.passes.nodes.IssRegBitfieldWriteNode;
 import vadl.iss.passes.nodes.IssSelectNode;
+import vadl.iss.passes.nodes.IssStaticEndianConditionNode;
 import vadl.iss.passes.nodes.IssStaticPcRegNode;
 import vadl.iss.passes.nodes.IssStaticReadRegNode;
 import vadl.iss.passes.nodes.IssStoreNode;
@@ -725,6 +726,11 @@ class TcgOpLoweringExecutor implements CfgTraverser {
 
   @Handler
   void handle(IssStaticPcRegNode node) {
+    // nothing to do
+  }
+
+  @Handler
+  void handle(IssStaticEndianConditionNode node) {
     // nothing to do
   }
 

--- a/vadl/main/vadl/pass/PassOrders.java
+++ b/vadl/main/vadl/pass/PassOrders.java
@@ -51,6 +51,7 @@ import vadl.gcb.passes.SetMissingConfigurationValuesPass;
 import vadl.gcb.passes.assembly.AssemblyConcatBuiltinMergingPass;
 import vadl.gcb.passes.encodingGeneration.GenerateFieldAccessEncodingAndPredicateFunctionsPass;
 import vadl.gcb.passes.operands.GenerateInstructionOperandsPass;
+import vadl.iss.passes.IssApplyMemoryEndiannessPass;
 import vadl.iss.passes.IssBitfieldWriteLoweringPass;
 import vadl.iss.passes.IssBuiltInArgTruncOptPass;
 import vadl.iss.passes.IssCFunctionExtractionPass;
@@ -160,7 +161,6 @@ import vadl.vdt.passes.VdtInputPreparationPass;
 import vadl.vdt.passes.VdtLoweringPass;
 import vadl.vdt.passes.VdtVerificationPass;
 import vadl.viam.Specification;
-import vadl.viam.passes.ApplyMemoryEndiannessPass;
 import vadl.viam.passes.ControlFlowOptimizationPass;
 import vadl.viam.passes.DetectRegisterIndicesPass;
 import vadl.viam.passes.DuplicateWriteDetectionPass;
@@ -226,7 +226,6 @@ public class PassOrders {
     order.add(new NormalizeFieldsToFieldAccessFunctionsPass(configuration));
     order.add(new RenamingConflictingRegistersPass(configuration));
     order.add(new SnapshotInstructionBehaviorPass(configuration));
-    order.add(new ApplyMemoryEndiannessPass(configuration));
 
     order.add(new RemoveUnusedStatusFlagsFromBuiltinsPass(configuration));
     order.add(new StatusBuiltInInlinePass(configuration));
@@ -523,6 +522,7 @@ public class PassOrders {
     order
         .add(new IssInfoRetrievalPass(config))
         .add(new IssConfigurationPass(config))
+        .add(new IssApplyMemoryEndiannessPass(config))
         .add(new IssMemoryDetectionPass(config))
         .add(new IssRegisterAccessLoweringPass(config))
         .add(new IssExecStrategyPass(config))


### PR DESCRIPTION
- If the memory definition is bi-endian, the DisasContext gets a new field `endian_cond`, which stores the value of the bi-endian condition
  - The condition is evaluated once per TB instead of per instruction (fetch and memory op)
  - Added IssStaticEndianConditionNode, which is translated to `ctx->endian_cond`