### PR TITLE
setup: Enable GC for native builds

### DIFF
--- a/vadl-cli/build.gradle.kts
+++ b/vadl-cli/build.gradle.kts
@@ -34,7 +34,14 @@ graalvmNative {
             }
             imageName.set("openvadl")
             mainClass.set(application.mainClass)
-            buildArgs.addAll("-O2", "--gc=epsilon")
+            buildArgs.addAll(
+                "-O2",
+                // This is different from the GC as for graalvm builds, which is mainly because this is the only one that
+                // also works outside Linux.
+                "--gc=serial",
+                "-R:MinHeapSize=4g",
+                "-R:MaxNewSize=2g",
+            )
             buildArgs.add("--enable-url-protocols=https")
             buildArgs.add("--enable-native-access=ALL-UNNAMED")
         }
@@ -45,6 +52,9 @@ tasks.startScripts {
     defaultJvmOpts = listOf(
         "-XX:TieredStopAtLevel=1",
         "--enable-native-access=ALL-UNNAMED",
+        "-Xms4g",
+        "-Xmn2g",
+        "-XX:+UseParallelGC"
     )
 }
 


### PR DESCRIPTION
Closes: #927

The GC is now (as good as possible) the same between native and normal graalvm.


I've decided to set the limits in a way that is quite liberal with memory, and focuses on throughput rather than latency which does make sense for compilations. 

For the LSP this might be different, as it is right now for most specs not a single GC cycle is run, for aarch32 one is. However even then almost 40% is spent in the GC.