### PR TITLE
aarch32: Prepare for ISS

### DIFF
--- a/docs/refman/refmanual.md
+++ b/docs/refman/refmanual.md
@@ -384,7 +384,7 @@ zeros for logical shifts (`UInt`).
 `M` has to be smaller or equal to `N`.
 
 For instructions which set the status register (`*s`, `*c`, `rrx`) the carry flag is set to the last bit shifted out.
-The carry flag is unchanged if the shift/rotate amount is `0`.
+The carry flag is set to `0` if `b` is `0`.
 
 Rotate left (right) provides the operand `a` rotated by a variable number of bits.
 The bits that are rotated off the left (right) end are inserted into the vacated bit positions on the right (left).

--- a/sys/aarch32/aarch32.vadl
+++ b/sys/aarch32/aarch32.vadl
@@ -913,7 +913,6 @@ instruction set architecture AArch32v6 = {
   $CondInstr          (HalfMemStoreImmInstr ; (STRHI ; "strh"  ; None  ; 0b10'1011  ))
   $CondInstr          (HalfMemStoreRegInstr ; (STRH  ; "strh"  ; None  ; 0b00'1011  ))
 
-  // NOTE: IssTcgVAllocationPass takes very long for these instructions, use --skip=opt-var-alloc
   $CondInstr          (LoadMultipleInstr    ; (LDM   ; "ldm"   ; None  ; 0b100'01   ))
   $CondInstr          (StoreMultipleInstr   ; (STM   ; "stm"   ; None  ; 0b100'00   ))
 

--- a/sys/aarch32/aarch32.vadl
+++ b/sys/aarch32/aarch32.vadl
@@ -217,8 +217,11 @@ instruction set architecture AArch32v6 = {
   model XOrS()   : Ex = {VADL::xors (R(rn),  operand2)}
   model AndNot() : Ex = {VADL::ands (R(rn), ~operand2)}
   model OrNot()  : Ex = {VADL::ors  (R(rn), ~operand2)}
-  model MovSft() : Ex = {VADL::lsls (operand2, 0)}
-  model MovImm() : Ex = {VADL::rors (imm12(7..0) as Word, imm12(11..8) as Bits5 << 1)}
+
+  // TODO: re-enable once inlining for lsls/rors works
+  //       see RemoveUnusedStatusFlagsFromBuiltinsPass
+  //model MovSft() : Ex = {VADL::lsls (operand2, 0)}
+  //model MovImm() : Ex = {VADL::rors (imm12(7..0) as Word, imm12(11..8) as Bits5 << 1)}
 
   model ArithmeticImmBehavior (c : CondRec, i : InstrRec, f : FlagRec) : IsaDefs = {
     instruction AsId ($i.id, $f.flagExt, $c.condStr) : ArithmeticImmFormat =
@@ -320,13 +323,19 @@ instruction set architecture AArch32v6 = {
     , rn       [3..0]                 // 1st source register
     }
 
-  model Mul()    : Ex = {VADL::muls  (R(rn), R(rm))}
+  // TODO: re-enable once inlining for muls works
+  //       see StatusBuiltInInlinePass
+  //model Mul()    : Ex = {VADL::muls  (R(rn), R(rm))}
   model MulAcc() : Ex = {VADL::adds  (R(rn) * R(rm), R(ra))}
   model MulSub() : Ex = {VADL::subsc (R(rn) * R(rm), R(ra))}
-  model SMull()  : Ex = {VADL::smulls(R(rn), R(rm))}
-  model UMull()  : Ex = {VADL::umulls(R(rn), R(rm))}
-  model SMlAl()  : Ex = {VADL::adds((R(rd),R(ra)), VADL::smull(R(rn), R(rm)))}
-  model UMlAl()  : Ex = {VADL::adds((R(rd),R(ra)), VADL::umull(R(rn), R(rm)))}
+  // TODO: re-enable once inlining for smulls works
+  //model SMull()  : Ex = {VADL::smulls(R(rn), R(rm))}
+  // TODO: re-enable once inlining for umulls works
+  //model UMull()  : Ex = {VADL::umulls(R(rn), R(rm))}
+  // TODO: re-enable once ISS supports smull/umull result size > 32 bits
+  //       see IssOpDecompositionPass::checkUserSliceOrTruncate
+  //model SMlAl()  : Ex = {VADL::adds((R(rd),R(ra)), VADL::smull(R(rn), R(rm)))}
+  //model UMlAl()  : Ex = {VADL::adds((R(rd),R(ra)), VADL::umull(R(rn), R(rm)))}
 
   model MultiplyInstr (c : CondRec, i : InstrRec, f : FlagRec) : IsaDefs = {
     instruction AsId ($i.id, $f.flagExt, $c.condStr) : MultiplyDivideFormat =
@@ -859,7 +868,8 @@ instruction set architecture AArch32v6 = {
   $CondInstr3Flags    (ArithmeticSftInstr   ; (ORR   ; "orr"   ; OrS   ; 0b000'1100 )) // TODO set correct carry
   $CondInstr3Flags    (ArithmeticSftInstr   ; (EOR   ; "eor"   ; XOrS  ; 0b000'0001 )) // TODO set correct carry
   $CondInstr3Flags    (ArithmeticSftInstr   ; (BIC   ; "bic"   ; AndNot; 0b000'1110 )) // TODO set correct carry
-  $CondInstr3Flags    (ArithMovSftInstr     ; (MOV   ; "mov"   ; MovSft; 0b000'1101 )) // TODO set correct carry
+  // TODO: re-enable once inlining for lsls/rors works
+  //$CondInstr3Flags    (ArithMovSftInstr     ; (MOV   ; "mov"   ; MovSft; 0b000'1101 )) // TODO set correct carry
 
   $CondInstr4Flags    (ArithmeticImmInstr   ; (ADDI  ; "add"   ; AddS  ; 0b001'0100 ))
   $CondInstr4Flags    (ArithmeticImmInstr   ; (ADCI  ; "adc"   ; AddC  ; 0b001'0101 ))
@@ -870,15 +880,20 @@ instruction set architecture AArch32v6 = {
   $CondInstr3Flags    (ArithmeticImmInstr   ; (ORRI  ; "orr"   ; OrS   ; 0b001'1100 )) // TODO set correct carry
   $CondInstr3Flags    (ArithmeticImmInstr   ; (EORI  ; "eor"   ; XOrS  ; 0b001'0001 )) // TODO set correct carry
   $CondInstr3Flags    (ArithmeticImmInstr   ; (BICI  ; "bic"   ; AndNot; 0b001'1110 )) // TODO set correct carry
-  $CondInstr3Flags    (ArithMovImmInstr     ; (MOVI  ; "mov"   ; MovImm; 0b001'1101 ))
+  // TODO: re-enable once inlining for lsls/rors works
+  //$CondInstr3Flags    (ArithMovImmInstr     ; (MOVI  ; "mov"   ; MovImm; 0b001'1101 ))
 
-  $CondInstr2Flags    (MultiplyInstr        ; (MUL   ; "mul"   ; Mul   ; 0b000'0000 ))
+  // TODO: re-enable once inlining for muls works
+  //$CondInstr2Flags    (MultiplyInstr        ; (MUL   ; "mul"   ; Mul   ; 0b000'0000 ))
   $CondInstr2Flags    (MultiplyAccInstr     ; (MLA   ; "mla"   ; MulAcc; 0b000'0001 ))
   $CondInstr          (MultiplySubInstr     ; (MLS   ; "mls"   ; MulSub; 0b000'0011 ))
-  $CondInstr2Flags    (MultiplyLongInstr    ; (UMULL ; "umull" ; UMull ; 0b000'0100 ))
-  $CondInstr2Flags    (MultiplyLongInstr    ; (SMULL ; "smull" ; SMull ; 0b000'0110 ))
-  $CondInstr2Flags    (MultiplyLongInstr    ; (UMLAL ; "umlal" ; UMlAl ; 0b000'0101 ))
-  $CondInstr2Flags    (MultiplyLongInstr    ; (SMLAL ; "smlal" ; SMlAl ; 0b000'0111 ))
+  // TODO: re-enable once inlining for umulls works
+  //$CondInstr2Flags    (MultiplyLongInstr    ; (UMULL ; "umull" ; UMull ; 0b000'0100 ))
+  // TODO: re-enable once inlining for smulls works
+  //$CondInstr2Flags    (MultiplyLongInstr    ; (SMULL ; "smull" ; SMull ; 0b000'0110 ))
+  // TODO: re-enable once ISS supports smull/umull result size > 32 bits
+  //$CondInstr2Flags    (MultiplyLongInstr    ; (UMLAL ; "umlal" ; UMlAl ; 0b000'0101 ))
+  //$CondInstr2Flags    (MultiplyLongInstr    ; (SMLAL ; "smlal" ; SMlAl ; 0b000'0111 ))
 
   $CondInstr          (DivideInstr          ; (SDIV  ; "sdiv"  ; SDiv  ; 0b011'1000 ))
   $CondInstr          (DivideInstr          ; (UDIV  ; "udiv"  ; UDiv  ; 0b011'1001 ))
@@ -904,6 +919,7 @@ instruction set architecture AArch32v6 = {
   $CondInstr          (HalfMemStoreImmInstr ; (STRHI ; "strh"  ; None  ; 0b10'1011  ))
   $CondInstr          (HalfMemStoreRegInstr ; (STRH  ; "strh"  ; None  ; 0b00'1011  ))
 
+  // NOTE: IssTcgVAllocationPass takes very long for these instructions, use --skip=opt-var-alloc
   $CondInstr          (LoadMultipleInstr    ; (LDM   ; "ldm"   ; None  ; 0b100'01   ))
   $CondInstr          (StoreMultipleInstr   ; (STM   ; "stm"   ; None  ; 0b100'00   ))
 

--- a/sys/aarch32/aarch32.vadl
+++ b/sys/aarch32/aarch32.vadl
@@ -217,10 +217,8 @@ instruction set architecture AArch32v6 = {
   model AndNot() : Ex = {VADL::ands (R(rn), ~operand2)}
   model OrNot()  : Ex = {VADL::ors  (R(rn), ~operand2)}
 
-  // TODO: re-enable once inlining for lsls/rors works
-  //       see RemoveUnusedStatusFlagsFromBuiltinsPass
-  //model MovSft() : Ex = {VADL::lsls (operand2, 0)}
-  //model MovImm() : Ex = {VADL::rors (imm12(7..0) as Word, imm12(11..8) as Bits5 << 1)}
+  model MovSft() : Ex = {VADL::lsls (operand2, 0)}
+  model MovImm() : Ex = {VADL::rors (imm12(7..0) as Word, imm12(11..8) as Bits5 << 1)}
 
   model ArithmeticImmBehavior (c : CondRec, i : InstrRec, f : FlagRec) : IsaDefs = {
     instruction AsId ($i.id, $f.flagExt, $c.condStr) : ArithmeticImmFormat =
@@ -867,8 +865,7 @@ instruction set architecture AArch32v6 = {
   $CondInstr3Flags    (ArithmeticSftInstr   ; (ORR   ; "orr"   ; OrS   ; 0b000'1100 )) // TODO set correct carry
   $CondInstr3Flags    (ArithmeticSftInstr   ; (EOR   ; "eor"   ; XOrS  ; 0b000'0001 )) // TODO set correct carry
   $CondInstr3Flags    (ArithmeticSftInstr   ; (BIC   ; "bic"   ; AndNot; 0b000'1110 )) // TODO set correct carry
-  // TODO: re-enable once inlining for lsls/rors works
-  //$CondInstr3Flags    (ArithMovSftInstr     ; (MOV   ; "mov"   ; MovSft; 0b000'1101 )) // TODO set correct carry
+  $CondInstr3Flags    (ArithMovSftInstr     ; (MOV   ; "mov"   ; MovSft; 0b000'1101 )) // TODO set correct carry
 
   $CondInstr4Flags    (ArithmeticImmInstr   ; (ADDI  ; "add"   ; AddS  ; 0b001'0100 ))
   $CondInstr4Flags    (ArithmeticImmInstr   ; (ADCI  ; "adc"   ; AddC  ; 0b001'0101 ))
@@ -879,8 +876,7 @@ instruction set architecture AArch32v6 = {
   $CondInstr3Flags    (ArithmeticImmInstr   ; (ORRI  ; "orr"   ; OrS   ; 0b001'1100 )) // TODO set correct carry
   $CondInstr3Flags    (ArithmeticImmInstr   ; (EORI  ; "eor"   ; XOrS  ; 0b001'0001 )) // TODO set correct carry
   $CondInstr3Flags    (ArithmeticImmInstr   ; (BICI  ; "bic"   ; AndNot; 0b001'1110 )) // TODO set correct carry
-  // TODO: re-enable once inlining for lsls/rors works
-  //$CondInstr3Flags    (ArithMovImmInstr     ; (MOVI  ; "mov"   ; MovImm; 0b001'1101 ))
+  $CondInstr3Flags    (ArithMovImmInstr     ; (MOVI  ; "mov"   ; MovImm; 0b001'1101 ))
 
   // TODO: re-enable once inlining for muls works
   //$CondInstr2Flags    (MultiplyInstr        ; (MUL   ; "mul"   ; Mul   ; 0b000'0000 ))

--- a/sys/aarch32/aarch32.vadl
+++ b/sys/aarch32/aarch32.vadl
@@ -31,8 +31,7 @@ instruction set architecture AArch32v6 = {
   register R : Index -> Word          // general purpose register file
 
   [next next]                         // PC points to the end of the following instruction
-  program counter PC : Addr           // program counter TODO alias R(15)
-//alias program counter PC : Addr = R(15)  // program counter
+  alias program counter PC : Addr = R(15)  // program counter
   alias register LR : Addr = R(14)    // link register
   alias register SP : Addr = R(13)    // stack pointer
 

--- a/sys/aarch32/aarch32.vadl
+++ b/sys/aarch32/aarch32.vadl
@@ -216,7 +216,6 @@ instruction set architecture AArch32v6 = {
   model XOrS()   : Ex = {VADL::xors (R(rn),  operand2)}
   model AndNot() : Ex = {VADL::ands (R(rn), ~operand2)}
   model OrNot()  : Ex = {VADL::ors  (R(rn), ~operand2)}
-
   model MovSft() : Ex = {VADL::lsls (operand2, 0)}
   model MovImm() : Ex = {VADL::rors (imm12(7..0) as Word, imm12(11..8) as Bits5 << 1)}
 

--- a/sys/aarch32/aarch32.vadl
+++ b/sys/aarch32/aarch32.vadl
@@ -319,19 +319,13 @@ instruction set architecture AArch32v6 = {
     , rn       [3..0]                 // 1st source register
     }
 
-  // TODO: re-enable once inlining for muls works
-  //       see StatusBuiltInInlinePass
-  //model Mul()    : Ex = {VADL::muls  (R(rn), R(rm))}
+  model Mul()    : Ex = {VADL::muls  (R(rn), R(rm))}
   model MulAcc() : Ex = {VADL::adds  (R(rn) * R(rm), R(ra))}
   model MulSub() : Ex = {VADL::subsc (R(rn) * R(rm), R(ra))}
-  // TODO: re-enable once inlining for smulls works
-  //model SMull()  : Ex = {VADL::smulls(R(rn), R(rm))}
-  // TODO: re-enable once inlining for umulls works
-  //model UMull()  : Ex = {VADL::umulls(R(rn), R(rm))}
-  // TODO: re-enable once ISS supports smull/umull result size > 32 bits
-  //       see IssOpDecompositionPass::checkUserSliceOrTruncate
-  //model SMlAl()  : Ex = {VADL::adds((R(rd),R(ra)), VADL::smull(R(rn), R(rm)))}
-  //model UMlAl()  : Ex = {VADL::adds((R(rd),R(ra)), VADL::umull(R(rn), R(rm)))}
+  model SMull()  : Ex = {VADL::smulls(R(rn), R(rm))}
+  model UMull()  : Ex = {VADL::umulls(R(rn), R(rm))}
+  model SMlAl()  : Ex = {VADL::adds((R(rd),R(ra)), VADL::smull(R(rn), R(rm)))}
+  model UMlAl()  : Ex = {VADL::adds((R(rd),R(ra)), VADL::umull(R(rn), R(rm)))}
 
   model MultiplyInstr (c : CondRec, i : InstrRec, f : FlagRec) : IsaDefs = {
     instruction AsId ($i.id, $f.flagExt, $c.condStr) : MultiplyDivideFormat =
@@ -877,17 +871,13 @@ instruction set architecture AArch32v6 = {
   $CondInstr3Flags    (ArithmeticImmInstr   ; (BICI  ; "bic"   ; AndNot; 0b001'1110 )) // TODO set correct carry
   $CondInstr3Flags    (ArithMovImmInstr     ; (MOVI  ; "mov"   ; MovImm; 0b001'1101 ))
 
-  // TODO: re-enable once inlining for muls works
-  //$CondInstr2Flags    (MultiplyInstr        ; (MUL   ; "mul"   ; Mul   ; 0b000'0000 ))
+  $CondInstr2Flags    (MultiplyInstr        ; (MUL   ; "mul"   ; Mul   ; 0b000'0000 ))
   $CondInstr2Flags    (MultiplyAccInstr     ; (MLA   ; "mla"   ; MulAcc; 0b000'0001 ))
   $CondInstr          (MultiplySubInstr     ; (MLS   ; "mls"   ; MulSub; 0b000'0011 ))
-  // TODO: re-enable once inlining for umulls works
-  //$CondInstr2Flags    (MultiplyLongInstr    ; (UMULL ; "umull" ; UMull ; 0b000'0100 ))
-  // TODO: re-enable once inlining for smulls works
-  //$CondInstr2Flags    (MultiplyLongInstr    ; (SMULL ; "smull" ; SMull ; 0b000'0110 ))
-  // TODO: re-enable once ISS supports smull/umull result size > 32 bits
-  //$CondInstr2Flags    (MultiplyLongInstr    ; (UMLAL ; "umlal" ; UMlAl ; 0b000'0101 ))
-  //$CondInstr2Flags    (MultiplyLongInstr    ; (SMLAL ; "smlal" ; SMlAl ; 0b000'0111 ))
+  $CondInstr2Flags    (MultiplyLongInstr    ; (UMULL ; "umull" ; UMull ; 0b000'0100 ))
+  $CondInstr2Flags    (MultiplyLongInstr    ; (SMULL ; "smull" ; SMull ; 0b000'0110 ))
+  $CondInstr2Flags    (MultiplyLongInstr    ; (UMLAL ; "umlal" ; UMlAl ; 0b000'0101 ))
+  $CondInstr2Flags    (MultiplyLongInstr    ; (SMLAL ; "smlal" ; SMlAl ; 0b000'0111 ))
 
   $CondInstr          (DivideInstr          ; (SDIV  ; "sdiv"  ; SDiv  ; 0b011'1000 ))
   $CondInstr          (DivideInstr          ; (UDIV  ; "udiv"  ; UDiv  ; 0b011'1001 ))

--- a/sys/aarch32/virt.vadl
+++ b/sys/aarch32/virt.vadl
@@ -1,0 +1,25 @@
+
+import aarch32::AArch32v6
+
+instruction set architecture A32 extending AArch32v6 = { }
+
+[ htif ]
+processor Virt implements A32 = {
+
+  reset = {
+    PC := 0x0
+    // upstream QEMU sets everything to zero
+  }
+
+  [ firmware ]
+  [ base : 0x0 ]
+  [ size : 0x08000000 ]
+  memory region [ROM] FLASH in MEM = {
+    MEM<4>(0x0) := 0x0101a0e3  // mov  r0, 0x40000000
+    MEM<4>(0x4) := 0x10ff2fe1  // bx   r0
+  }
+
+  [ base : 0x40000000 ]
+  memory region [RAM] MAIN_RAM in MEM
+
+}

--- a/sys/aarch32/virt.vadl
+++ b/sys/aarch32/virt.vadl
@@ -15,12 +15,7 @@ processor Virt implements A32 = {
   [ base : 0x0 ]
   [ size : 0x08000000 ]
   memory region [ROM] FLASH in MEM = {
-    // TODO: use this instead once mov instructions work
-    //MEM<4>(0x0) := 0xe3a0f101  // mov  pc, #0x40000000
-
-    MEM<4>(0x0) := 0xe0200000  // eor r0, r0, r0
-    MEM<4>(0x4) := 0xe590f00c  // ldr pc, [r0, #12]
-    MEM<4>(0xc) := 0x40000000  // target address
+    MEM<4>(0x0) := 0xe3a0f101  // mov  pc, #0x40000000
   }
 
   [ base : 0x40000000 ]

--- a/sys/aarch32/virt.vadl
+++ b/sys/aarch32/virt.vadl
@@ -16,13 +16,10 @@ processor Virt implements A32 = {
   [ size : 0x08000000 ]
   memory region [ROM] FLASH in MEM = {
     // TODO: use this instead once mov instructions work
-    //MEM<4>(0x0) := 0xe3a00101  // mov  r0, 0x40000000
-    //MEM<4>(0x4) := 0xe12fff10  // bx   r0
+    //MEM<4>(0x0) := 0xe3a0f101  // mov  pc, #0x40000000
 
-    // branch currently only works with b and bx, not writes to r15
     MEM<4>(0x0) := 0xe0200000  // eor r0, r0, r0
-    MEM<4>(0x4) := 0xe590000c  // ldr r0, [r0, #12]
-    MEM<4>(0x8) := 0xe12fff10  // bx r0
+    MEM<4>(0x4) := 0xe590f00c  // ldr pc, [r0, #12]
     MEM<4>(0xc) := 0x40000000  // target address
   }
 

--- a/sys/aarch32/virt.vadl
+++ b/sys/aarch32/virt.vadl
@@ -15,8 +15,15 @@ processor Virt implements A32 = {
   [ base : 0x0 ]
   [ size : 0x08000000 ]
   memory region [ROM] FLASH in MEM = {
-    MEM<4>(0x0) := 0x0101a0e3  // mov  r0, 0x40000000
-    MEM<4>(0x4) := 0x10ff2fe1  // bx   r0
+    // TODO: use this instead once mov instructions work
+    //MEM<4>(0x0) := 0xe3a00101  // mov  r0, 0x40000000
+    //MEM<4>(0x4) := 0xe12fff10  // bx   r0
+
+    // branch currently only works with b and bx, not writes to r15
+    MEM<4>(0x0) := 0xe0200000  // eor r0, r0, r0
+    MEM<4>(0x4) := 0xe590000c  // ldr r0, [r0, #12]
+    MEM<4>(0x8) := 0xe12fff10  // bx r0
+    MEM<4>(0xc) := 0x40000000  // target address
   }
 
   [ base : 0x40000000 ]

--- a/vadl-test/resources/cosim_configs/aarch32_config.toml
+++ b/vadl-test/resources/cosim_configs/aarch32_config.toml
@@ -1,0 +1,184 @@
+# SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+# General settings for the QEMU plugin system which set up the co-simulation
+[qemu]
+
+# The path to the compiled cosimulation qemu-plugin
+plugin="/opt/qemu/lib/qemu/libcosimulation.so"
+
+# Whether to ignore registers that are not defined by a [qemu.gdb_reg_map] mapping
+# This option is useful to test the current implementation of a simulator which might not yet have all registers implemented against another (complete) implementation
+# Filters in conjunction with `ignore_registers`
+ignore_unset_registers = true
+
+# Ignore specific registers
+# Filters in conjunction with `ignore_unset_registers`
+ignore_registers = []
+
+
+# Defines a list of clients to test against
+# A single client is also possible, e.g. to check if a crash or similar occurs
+# In most use-cases, 2 clients (one test-simulator and one reference-simulator) are used
+[[qemu.clients]]
+
+# Optional: A custom name for a client
+# Will default to the index of the client in this list
+name = "VADL"
+
+# The executable of the ISS
+exec = "/opt/qemu/bin/qemu-system-a32"
+
+# The path to the compiled file to use for testing
+test_exec="./test-execs/test_vadl"
+
+# "bios" | "kernel": Defines where the test-executable is passed to when starting the QEMU-client
+pass_test_exec_to = "bios"
+
+# Applies additional arguments to the ISS-executable, e.g. `qemu-system-riscv64 -nographic -d plugin`
+additional_args = [
+    "-plugin",
+    "/opt/qemu/lib/qemu/libstoptrigger.so,addr=0x40000004",
+    "-nographic",
+    "-d", "plugin"
+]
+
+# A hint for the cosimulator whether the client uses little or big endian
+# This setting does not change the execution in any way and is only used in case clients have differing endianess
+# but should still be compared "correctly"
+# This field is optional, not setting it means the register-data is being compared left-to-right (i.e. big-endian by default)
+# This setting also *does not* have an effect on tracing, data will still be stored in the original endianess
+
+# This setting must match the `TARGET_BIG_ENDIAN` definition in `gen-arch-softmmu.mak`
+# If the vadl memory definition is annotated with `[ big endian : Condition ]`, this setting should be set to
+# "big" or be ommitted. If it is annotated with `[ little endian : Condition ]` or not annotated with any
+# of the two, this setting should be explicitly set to "little".
+endian = "little"
+
+# The following three options configure which instructions from the `test_exec` executable should actually be tested.
+# NOTE: Only applies to `layer = "insn" | "tb-strict"`
+# NOTE: This option is must be set per client to be able to account for different setup-codes per ISS
+# Skips the first n instructions
+
+# UPSTREAM starts execution at 0x40000000. VADL uses a firmware instruction at 0x0 to jump to
+# 0x40000000. Hence, we skip our first instruction.
+skip_n_instructions = 1
+
+# Settings for running the qemu-clients with gdb-debugging enabled.
+# Use these settings when possible instead of configuring the flags in the additional_args array since otherwise the runner will mark the client as finished because it did not respond in time.
+[qemu.clients.gdb]
+enable = false
+# The target_type can be optionally set ("chardev" | "port"), default is "chardev"
+# For reference see the QEMU GDB usage documentation: https://qemu-project.gitlab.io/qemu/system/gdb.html
+# For more info regarding chardev/unix sockets see: https://qemu-project.gitlab.io/qemu/system/gdb.html#using-unix-sockets
+# Using a chardev is preferred to ensure that the target is always available for cosimulation
+# NOTE: It is not necessary (and will lead to errors if done anyway) to manually create the char-device, simply use a path that is available and
+#		QEMU will automatically handle creating the device-file.
+# If target_type is "port" then simply enter the port (e.g. "tcp:1234") into the remote_target field, QEMU will try to listen on the port automatically
+target_type = "chardev"
+remote_target = "/tmp/gdb-cosim-VADL"
+
+[[qemu.clients]]
+name = "UPSTREAM"
+
+exec = "/opt/qemu/bin/qemu-system-aarch64"
+
+test_exec="./test-execs/test_upstream"
+
+# UPSTREAM virt seems to not support .elf files with the -bios option. Furthermore, we cannot load
+# testcode into the firmware region with VADL, because the aarch32.vadl processor spec already defines
+# firmare code.
+pass_test_exec_to = "kernel"
+
+additional_args = [
+    "-plugin",
+    "/opt/qemu/lib/qemu/libstoptrigger.so,addr=0x40000004",
+    "-nographic",
+    "-cpu", "cortex-a15",
+    "-M", "virt",
+    "-d", "plugin"
+]
+
+skip_n_instructions = 0
+
+[qemu.clients.gdb]
+enable = false
+target_type = "chardev"
+remote_target = "/tmp/gdb-cosim-VADL"
+
+
+# Defines a custom map where the key (e.g. x0) is mapped to another value (e.g. zero)
+[qemu.gdb_reg_map] # TODO
+
+# Defines the test-source and how to test
+[testing]
+
+# The testing-protocol defines how the clients are run and tested against eachother
+[testing.protocol]
+# Defines an *execution-step* of a test-run.
+# "insn": The execution-step is the *execution of a single instruction*, e.g. `addi t4,zero,2`.
+#		  This layer is independent of how an ISS generates translation-blocks for qemu.
+#		  This is the most thorough but also slowest option.
+#
+# NOTE: the following is not yet implemented.
+# "tb":   The execution-step is the *execution of a single or multiple translation-blocks*.
+#		  Multiple translation-blocks might be executed in a single step if another client executed a larger.
+#		  (but potentially equivalent to multiple smaller TBs) translation-block.
+#		  This allows instruction-equivalent clients to "synchronize" even if the generated translation-blocks differ.
+#		  This option is faster than "insn" but less thorough.
+#
+# "tb-strict": The execution-step is the *execution of a single translation-blocks*.
+#			   The same as "tb" but without the synchronization logic. Meaning that equal translation-blocks are assumed.
+#			   This option is useful if the instructions of the ISS are already correct and the TB-Block generator needs to be tested.
+layer = "insn"
+
+# Whether reads/writes from/to memory should also be compared
+with_memory_checks = true
+
+# "lockstep": All clients are run and compared one *execution-step* at a time.
+# 			  This means that the test will exit on the first divergence (or at the end if no diffs where found)
+# Currently, this is the only implemented mode.
+mode = "lockstep"
+
+
+# Execute all remaining instructions (overrides `stop_after_n_instructions` if set to true)
+execute_all_remaining_instructions = false
+
+# Execute the next (after skipped) n instructions
+stop_after_n_instructions = 100
+
+# Where the test result should be saved and in which format
+[testing.protocol.out]
+# file = "./cosim-run/result/result.json"
+
+# "short" | "full"
+verbosity = "full"
+
+[logging]
+enable = false
+# tracing log-levels as defined here: https://docs.rs/tracing/latest/tracing/struct.Level.html#implementations
+level = "info"
+
+# The directory will also contain files for the stdout and stderr of each client
+dir = "."
+file = "cosim.log"
+
+# Clears the logfile every time the program is run
+clear_on_rerun = true
+
+[dev]
+# Prints the loaded configuration if set to true and exits
+dry_run = false

--- a/vadl-test/resources/cosim_scripts/aarch32/compiler.py
+++ b/vadl-test/resources/cosim_scripts/aarch32/compiler.py
@@ -1,0 +1,102 @@
+import os
+import subprocess
+from pathlib import Path
+
+AS = "arm-linux-gnueabihf-as"
+LD = "arm-linux-gnueabihf-ld"
+OBJDUMP = "arm-linux-gnueabihf-objdump"
+
+def compile(id: str, asm: str, debug: bool = True) -> dict:
+    asm_path = build_assembly(id, asm)
+    linker_path = build_linker_script(id)
+
+    obj = _tmp_file(id, f"obj-{id}.o")
+    elf = _tmp_file(id, f"elf-{id}")
+    assemble(AS, asm_path, obj)
+    link(LD, linker_path, obj, elf)
+
+    result = {
+        "asm": asm_path,
+        "lnscript": linker_path,
+        "obj": obj,
+        "elf": elf
+    }
+
+    if debug:
+        objdump_file = _tmp_file(id, f"elf-{id}.dump")
+        objdump(OBJDUMP, elf, objdump_file)
+        result.update({
+            "objdump": objdump_file
+        })
+
+    return result
+
+
+def assemble(as_cmd: str, asm_path: Path, obj_out: Path) -> None:
+    proc = subprocess.run([
+        as_cmd, "-o", str(obj_out), str(asm_path)],
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"Assembly failed ({as_cmd}): {proc.stderr.decode()}")
+
+def link(ld_cmd: str, linker_script: Path, obj_in: Path, elf_out: Path) -> None:
+    proc = subprocess.run([
+        ld_cmd, "-T", str(linker_script), "-o", str(elf_out), str(obj_in)],
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"Linking failed ({ld_cmd}): {proc.stderr.decode()}")
+
+def build_assembly(id: str, core: str) -> Path:
+    asm_out = _tmp_file(id, f"asm-{id}.s")
+
+    # We load the tests into the RAM region at 0x40000000, because loading into the
+    # firmware region does not work, because aarch32/virt.vadl already has firmware.
+
+    content = f"""
+    .globl _start
+    .section .text
+    _start:
+    ldr pc, =0x40000008
+    nop
+    {core}
+    ldr pc, =0x40000004
+    """
+    with open(asm_out, "w") as f:
+        f.write(content)
+    return asm_out
+
+
+def build_linker_script(id: str) -> Path:
+    linker_out = _tmp_file(id, f"linker-{id}.ld")
+
+    content = """
+    ENTRY(_start)
+
+    PHDRS
+    {
+      text_seg  PT_LOAD FLAGS(5);   /* R + X = 4 + 1 */
+    }
+
+    SECTIONS
+    {
+        . = 0x40000000;
+        .text : { *(.text) }  :text_seg
+    }
+    """
+    with open(linker_out, "w") as f:
+        f.write(content)
+    return linker_out
+
+def objdump(objdump_bin: str, obj_file: Path, out_file: Path):
+    with out_file.open("wb") as f:
+      proc = subprocess.run(
+          [objdump_bin, "-D", str(obj_file)],
+          stdout=f,
+      )
+    if proc.returncode != 0:
+        raise RuntimeError(proc.stderr.decode())
+
+def _tmp_file(id: str, name: str) -> Path:
+    build_dir = f"/tmp/build-{id}/"
+    os.makedirs(build_dir, exist_ok=True)
+    return Path(f"{build_dir}/{name}")

--- a/vadl-test/resources/cosim_scripts/aarch32/compiler.py
+++ b/vadl-test/resources/cosim_scripts/aarch32/compiler.py
@@ -59,6 +59,7 @@ def build_assembly(id: str, core: str) -> Path:
     ldr pc, =0x40000008
     nop
     {core}
+    @ Jump triggers simulation termination (stoptrigger plugin)
     ldr pc, =0x40000004
     """
     with open(asm_out, "w") as f:

--- a/vadl-test/resources/cosim_scripts/aarch32/main.py
+++ b/vadl-test/resources/cosim_scripts/aarch32/main.py
@@ -1,0 +1,91 @@
+import argparse
+from pathlib import Path
+import subprocess
+from concurrent.futures import ProcessPoolExecutor, as_completed
+import yaml
+import os
+import compiler
+import shutil
+import sys
+import threading
+
+def dump_debug_info(tid: str, results: Path, comp: dict):
+    debug_dir = results / f"{tid}_debug"
+    os.makedirs(debug_dir, exist_ok=True)
+    shutil.copy(comp["asm"], debug_dir)
+    shutil.copy(comp["lnscript"], debug_dir)
+    shutil.copy(comp["elf"], debug_dir)
+    shutil.copy(comp["objdump"], debug_dir)
+
+def run_cosim(elf: str, out: Path, cosim_config: Path):
+    e = os.environ.copy()
+    e["RUST_BACKTRACE"] = "1"
+    subprocess.run([
+        "vadl-cosim-broker",
+        "--config", cosim_config,
+        "--test-exec", elf,
+        "--output-file", str(out)
+        ],
+        env=e,
+    )
+
+def compile_test(t: dict, results: Path) -> dict:
+    tid = str(t["id"])
+    debug = t["debug"]
+    comp = compiler.compile(tid, str(t["asm_core"]), debug)
+    if debug:
+        dump_debug_info(tid, results, comp)
+    return comp
+
+def run_test(t: dict, results: Path, cosim_config: Path):
+    tid = t["id"]
+    comp = compile_test(t, results)
+    try:
+        run_cosim(str(comp["elf"]), results / f"result-{tid}", cosim_config)
+    except Exception as e:
+        print(f"error for test=\"{tid}\": ", e)
+
+def report_progress(completed: int, total: int):
+    width = 30
+    filled = width if total == 0 else int(width * completed / total)
+    bar = "#" * filled + "-" * (width - filled)
+    print(f"[{bar}] {completed}/{total}", file=sys.stderr, flush=True)
+
+def main(testsuite_path: Path):
+    config = yaml.safe_load(testsuite_path.read_text())
+    results = Path(config.get("result_dir", "/work/results"))
+    results.mkdir(parents=True, exist_ok=True)
+
+    num_cores = os.cpu_count()
+    if num_cores is None:
+        num_cores = 1 # safe fallback
+
+    cosim_config = config.get("cosim_config", "/cosim_config/aarch32_config.toml")
+    tests = config.get("tests", [])
+    total_tests = len(tests)
+
+    if total_tests == 0:
+        report_progress(0, 0)
+        return
+
+    with ProcessPoolExecutor(num_cores) as executor:
+        futures = [
+            executor.submit(run_test, t, results, cosim_config)
+            for t in tests
+        ]
+
+        report_progress(0, total_tests)
+        completed = 0
+        lock = threading.Lock()
+        for future in as_completed(futures):
+            future.result()
+            with lock:
+              completed += 1
+              if completed % 100 == 0:
+                report_progress(completed, total_tests)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("config")
+    args = parser.parse_args()
+    main(Path(args.config))

--- a/vadl/main/vadl/iss/passes/common/opDecomposition/Decomposer.java
+++ b/vadl/main/vadl/iss/passes/common/opDecomposition/Decomposer.java
@@ -463,6 +463,21 @@ class Decomposer
   }
 
   @Override
+  public void handleUMULL(Request rq) {
+    rq.result = mullDecompose(currCall, rq.slice.hi(), rq.slice.lo());
+  }
+
+  @Override
+  public void handleSMULL(Request rq) {
+    rq.result = mullDecompose(currCall, rq.slice.hi(), rq.slice.lo());
+  }
+
+  @Override
+  public void handleSUMULL(Request rq) {
+    rq.result = mullDecompose(currCall, rq.slice.hi(), rq.slice.lo());
+  }
+
+  @Override
   public void handleUDIV(Request rq) {
     rq.result = udivDecompose(currCall, rq.slice.hi(), rq.slice.lo());
   }

--- a/vadl/main/vadl/iss/passes/common/opDecomposition/IssOpDecompositionPass.java
+++ b/vadl/main/vadl/iss/passes/common/opDecomposition/IssOpDecompositionPass.java
@@ -489,8 +489,9 @@ class OpDecomposer {
     if (!(user instanceof SliceNode || user instanceof TruncateNode)) {
       throw Diagnostic.error("Slice or cast required", userLoc)
           .description(
-              "The ISS currently requires that a smull result greater than %s bit is "
+              "The ISS currently requires that a %s result greater than %s bit is "
                   + "directly cast or sliced to a value <= %s bit before further usage.",
+              call.builtIn().name(),
               targetSize.width, targetSize.width)
           .locationNote(callLoc, "The result of this is %s bits wide.",
               call.type().asDataType().bitWidth())

--- a/vadl/main/vadl/iss/passes/common/opDecomposition/IssOpDecompositionPass.java
+++ b/vadl/main/vadl/iss/passes/common/opDecomposition/IssOpDecompositionPass.java
@@ -16,13 +16,6 @@
 
 package vadl.iss.passes.common.opDecomposition;
 
-import static vadl.types.BuiltInTable.LSL;
-import static vadl.types.BuiltInTable.MUL;
-import static vadl.types.BuiltInTable.OR;
-import static vadl.types.BuiltInTable.SMULL;
-import static vadl.types.BuiltInTable.SUMULL;
-import static vadl.types.BuiltInTable.UMULL;
-
 import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -39,8 +32,6 @@ import vadl.configuration.IssConfiguration;
 import vadl.error.Diagnostic;
 import vadl.error.DiagnosticList;
 import vadl.iss.passes.AbstractIssPass;
-import vadl.iss.passes.common.opDecomposition.nodes.IssMul2Node;
-import vadl.iss.passes.common.opDecomposition.nodes.IssMulKind;
 import vadl.iss.passes.common.opDecomposition.nodes.IssMulhNode;
 import vadl.iss.passes.nodes.IssReadRegNode;
 import vadl.iss.passes.nodes.IssWriteRegNode;
@@ -48,25 +39,17 @@ import vadl.iss.passes.tcg.lowering.Tcg_32_64;
 import vadl.pass.PassName;
 import vadl.pass.PassResults;
 import vadl.types.DataType;
-import vadl.types.Type;
 import vadl.utils.ViamUtils;
-import vadl.viam.Constant;
 import vadl.viam.Instruction;
 import vadl.viam.Procedure;
 import vadl.viam.Specification;
 import vadl.viam.graph.Graph;
 import vadl.viam.graph.Node;
-import vadl.viam.graph.NodeList;
 import vadl.viam.graph.dependency.BuiltInCall;
-import vadl.viam.graph.dependency.ConstantNode;
 import vadl.viam.graph.dependency.ExpressionNode;
 import vadl.viam.graph.dependency.SideEffectNode;
-import vadl.viam.graph.dependency.SliceNode;
-import vadl.viam.graph.dependency.StructGetFieldNode;
-import vadl.viam.graph.dependency.TruncateNode;
 import vadl.viam.graph.dependency.WriteMemNode;
 import vadl.viam.graph.dependency.WriteRegTensorNode;
-import vadl.viam.graph.dependency.ZeroExtendNode;
 
 /**
  * This pass splits certain operations in the behavior into multiple nodes, depending on the
@@ -197,10 +180,6 @@ class OpDecomposer {
   }
 
   void decompose() {
-    behavior.getNodes(BuiltInCall.class).forEach(this::handle);
-    // delete all dependency nodes that are not used anymore
-    behavior.deleteUnusedDependencies();
-
     // decompose nodes until there any more nodes to decompose.
     var foundOne = true;
     var processed = new HashSet<Node>();
@@ -209,7 +188,7 @@ class OpDecomposer {
       // first decompose side effects, then expressions.
       iteration++;
       var oversizedBefore = oversizedSideEffectCount();
-      var sideEffectHit = decomposeSideeffects();
+      var sideEffectHit = decomposeSideEffects();
       if (sideEffectHit) {
         var oversizedAfter = oversizedSideEffectCount();
         behavior.ensure(oversizedAfter < oversizedBefore,
@@ -236,7 +215,7 @@ class OpDecomposer {
     behavior.deleteUnusedDependencies();
   }
 
-  private boolean decomposeSideeffects() {
+  private boolean decomposeSideEffects() {
     var hit = Stream.concat(
             behavior.getNodes(WriteMemNode.class).map(SideEffectNode.class::cast),
             behavior.getNodes(IssWriteRegNode.class).map(SideEffectNode.class::cast)
@@ -316,195 +295,5 @@ class OpDecomposer {
         && node.inputs().map(ExpressionNode.class::cast)
         .anyMatch(i -> i.type().asDataType().bitWidth() > targetSize.width);
   }
-
-  private void handle(BuiltInCall call) {
-    var b = call.builtIn();
-    if (b == UMULL || b == SMULL || b == SUMULL) {
-      replaceLongMul(call);
-    }
-  }
-
-  // Handle decomposition of umull and smull call.
-  // This will replace it by a call to mul2 which returns two values (upper and lower bits).
-  private void replaceLongMul(BuiltInCall call) {
-    if (call.type().asDataType().bitWidth() <= targetSize.width) {
-      return;
-    }
-
-    var kind = call.builtIn() == SUMULL
-        ? IssMulKind.SIGNED_UNSIGNED
-        : call.builtIn() == SMULL
-          ? IssMulKind.SIGNED_SIGNED
-          : IssMulKind.UNSIGNED_UNSIGNED;
-
-    for (var user : call.usages().toList()) {
-      replaceLongMulForUser(call, user, kind);
-    }
-  }
-
-  private void replaceLongMulForUser(BuiltInCall longMul, Node user, IssMulKind kind) {
-    // check that user is slice or truncate.
-    // otherwise, we currently cannot handle this built-in call, as
-    // the value is too big to hold it in a QEMU TCGv.
-    checkUserSliceOrTruncate(longMul, user);
-
-    var arg1 = longMul.arguments().get(0);
-    var argWidth = arg1.type().asDataType().bitWidth();
-    var singleLengthType = Type.bits(argWidth);
-
-    if (user instanceof TruncateNode) {
-      // if the user is just a truncate node, we can also use the normal MUL built-in instead.
-      user.replaceInput(longMul,
-          new BuiltInCall(MUL, longMul.arguments(), singleLengthType)
-      );
-      return;
-    }
-
-    if (user instanceof SliceNode sliceNode) {
-      // currently we only handle continuous slices
-      sliceNode.ensure(sliceNode.bitSlice().isContinuous(),
-          "Non continuous slices are currently not supported");
-      var slice = sliceNode.bitSlice();
-
-      var targetWith = targetSize.width;
-
-      if (slice.msb() < targetWith || slice.lsb() >= targetWith) {
-        // the slice does not use parts from both, the upper half and lower half.
-        handleSliceWithinUpperOrLowerBoundary(longMul, sliceNode, kind);
-      } else {
-        // the slice crosses the middle point, so we have to compute upper and lower halves.
-        handleSliceAcrossUpperLowerBoundary(longMul, sliceNode, kind);
-      }
-    }
-  }
-
-  private void handleSliceWithinUpperOrLowerBoundary(BuiltInCall longMul, SliceNode sliceNode,
-                                                     IssMulKind kind) {
-    var arg1 = longMul.arguments().get(0);
-    var arg2 = longMul.arguments().get(1);
-    var argWidth = arg1.type().asDataType().bitWidth();
-    var singleLengthType = Type.bits(argWidth);
-
-    var slice = sliceNode.bitSlice();
-    var targetWith = targetSize.width;
-    var upperHalf = slice.msb() >= targetWith;
-
-    ExpressionNode longMulReplacement;
-    if (upperHalf) {
-      // if upper half, we use the mulh operation.
-      longMulReplacement = behavior.add(new IssMulhNode(arg1, arg2, kind, singleLengthType));
-
-      // adjust the slice by targetWidth bit, as we are now handling the upper half only.
-      sliceNode.setSlice(
-          new Constant.BitSlice(
-              new Constant.BitSlice.Part(slice.msb() - targetWith, slice.lsb() - targetWith))
-      );
-    } else {
-      // if lower half, we just use the normal mul built-in.
-      longMulReplacement =
-          behavior.add(new BuiltInCall(MUL, longMul.arguments(), singleLengthType));
-    }
-
-    sliceNode.replaceInput(longMul, longMulReplacement);
-
-    // TODO: Refactor this in `TransformerNode` or something similar
-    var bitSlice = sliceNode.bitSlice();
-    if (bitSlice.lsb() == 0 && bitSlice.bitSize() == argWidth) {
-      // the slice is not necessary, we can just remove it
-      for (var u : sliceNode.usages().toList()) {
-        u.replaceInput(sliceNode, longMulReplacement);
-      }
-    }
-  }
-
-  private void handleSliceAcrossUpperLowerBoundary(BuiltInCall longMul, SliceNode sliceNode,
-                                                   IssMulKind kind) {
-    var arg1 = longMul.arguments().get(0);
-    var arg2 = longMul.arguments().get(1);
-    var argWidth = arg1.type().asDataType().bitWidth();
-
-    var targetType = Type.bits(argWidth);
-    var structType = Type.struct(
-        "low", targetType,
-        "high", targetType
-    );
-
-    var slice = sliceNode.bitSlice();
-
-    var mul2 = behavior.add(new IssMul2Node(arg1, arg2, kind, structType));
-    // lower and upper half in target type size (not final expected size yet)
-    var lowerHalf = behavior.add(new StructGetFieldNode("low", mul2, targetType));
-    var upperHalf = behavior.add(new StructGetFieldNode("high", mul2, targetType));
-
-    // lower half sub slice [targetSize - 1 ... lsb]
-    var lhMsb = targetSize.width - 1;
-    var lhLsb = slice.lsb();
-    // +1 because msb and lsb are inclusive
-    var lhSize = lhMsb - lhLsb + 1;
-
-    // upper half sub slice [msb - targetSize ... 0]
-    var uhMsb = slice.msb() - targetSize.width;
-    var uhLsb = 0;
-    var uhSize = uhMsb - uhLsb + 1;
-
-    // final size is uhSize + lhSize
-    var finalSize = uhSize + lhSize;
-    var finalType = Type.bits(finalSize);
-
-    var lowerHalfSlice = behavior.addWithInputs(new ZeroExtendNode(
-        new SliceNode(
-            lowerHalf,
-            new Constant.BitSlice(new Constant.BitSlice.Part(lhMsb, lhLsb)),
-            Type.bits(lhSize)
-        ), finalType));
-
-    var upperHalfSlice = behavior.addWithInputs(
-        new ZeroExtendNode(
-            new SliceNode(
-                upperHalf,
-                new Constant.BitSlice(new Constant.BitSlice.Part(uhMsb, uhLsb)),
-                Type.bits(uhSize)
-            ), finalType));
-
-    // now we shift the upper half to the correct position upperHalfSlice << lhSize.
-    var shiftAmount = new ConstantNode(Constant.Value.of(lhSize, Type.bits(16)));
-    var upperHalfShifted = behavior.addWithInputs(new BuiltInCall(
-        LSL, new NodeList<>(upperHalfSlice, shiftAmount), finalType
-    ));
-
-    // now we merge both halves into a single value
-    var combined = behavior.add(new BuiltInCall(
-        OR, new NodeList<>(upperHalfShifted, lowerHalfSlice),
-        finalType
-    ));
-
-    // replace the slice by the new decomposed value.
-    sliceNode.replace(combined);
-  }
-
-
-  private void checkUserSliceOrTruncate(BuiltInCall call, Node user) {
-    var callLoc = call.location();
-    var userLoc = user.location().orDefault(behavior.sourceLocation());
-    if (!(user instanceof SliceNode || user instanceof TruncateNode)) {
-      throw Diagnostic.error("Slice or cast required", userLoc)
-          .description(
-              "The ISS currently requires that a %s result greater than %s bit is "
-                  + "directly cast or sliced to a value <= %s bit before further usage.",
-              call.builtIn().name(),
-              targetSize.width, targetSize.width)
-          .locationNote(callLoc, "The result of this is %s bits wide.",
-              call.type().asDataType().bitWidth())
-          .help("Cast the result to something <= %s bit.", targetSize.width)
-          .build();
-    }
-
-    if (user instanceof TruncateNode truncNode && truncNode.type().bitWidth() > targetSize.width) {
-      throw Diagnostic.error("Type to big", userLoc)
-          .description("The ISS currently requires a type <= %s bit.", targetSize.width)
-          .build();
-    }
-  }
-
 
 }

--- a/vadl/main/vadl/iss/passes/common/opDecomposition/decomposer/ArithmeticDecomposer.java
+++ b/vadl/main/vadl/iss/passes/common/opDecomposition/decomposer/ArithmeticDecomposer.java
@@ -16,7 +16,16 @@
 
 package vadl.iss.passes.common.opDecomposition.decomposer;
 
+import static vadl.types.BuiltInTable.LSL;
+import static vadl.types.BuiltInTable.MUL;
+import static vadl.types.BuiltInTable.SMULL;
+import static vadl.types.BuiltInTable.SUMULL;
+
 import java.math.BigInteger;
+import java.util.List;
+import vadl.iss.passes.common.opDecomposition.nodes.IssMul2Node;
+import vadl.iss.passes.common.opDecomposition.nodes.IssMulKind;
+import vadl.iss.passes.common.opDecomposition.nodes.IssMulhNode;
 import vadl.types.BuiltInTable;
 import vadl.types.DataType;
 import vadl.types.Type;
@@ -25,6 +34,7 @@ import vadl.viam.Constant;
 import vadl.viam.graph.dependency.BuiltInCall;
 import vadl.viam.graph.dependency.ConstantNode;
 import vadl.viam.graph.dependency.ExpressionNode;
+import vadl.viam.graph.dependency.StructGetFieldNode;
 
 /**
  * Decomposes arithmetic operations (SUB) that require carry/borrow handling.
@@ -225,6 +235,126 @@ public interface ArithmeticDecomposer extends IDecomposer {
 
     src.ensure(result != null, "No result generated for SUB decomposition");
     return result;
+  }
+
+  /**
+   * Decomposes a long multiplication call to extract only the bit-range [hi:lo] of the result.
+   *
+   * <p>The original result bit width of the operation may not be twice as large as the target
+   * size, as that would imply that the input operands are larger than the target size, which
+   * cannot be decomposed. Also, the bit width of the requested slice may not exceed the target
+   * size.
+   *
+   * <p>If the slice covers both the high and low part of the result, the long multiplication is
+   * decomposed into a {@link IssMul2Node}. Otherwise, it is either replaced by a
+   * {@link IssMulhNode} or a call to {@link BuiltInTable#MUL}.
+   *
+   * @param src built-in UMULL, SMULL or SUMULL call
+   * @param hi  most-significant bit of the slice (inclusive, 0 = LSB)
+   * @param lo  least-significant bit of the slice
+   * @return graph expression that equals {@code (a * b)[hi:lo]}
+   */
+  default ExpressionNode mullDecompose(BuiltInCall src, int hi, int lo) {
+    src.ensure(
+        List.of(BuiltInTable.SMULL, BuiltInTable.UMULL, BuiltInTable.SUMULL)
+            .contains(src.builtIn()),
+        "Not a UMULL, SMULL or SUMULL built-in call"
+    );
+    src.ensure(hi >= lo, "Expected hi >= lo");
+    checkMullSlice(src, hi, lo);
+
+    var kind = src.builtIn() == SUMULL
+        ? IssMulKind.SIGNED_UNSIGNED
+        : src.builtIn() == SMULL
+          ? IssMulKind.SIGNED_SIGNED
+          : IssMulKind.UNSIGNED_UNSIGNED;
+
+    if (hi < targetSize() || lo >= targetSize()) {
+      // the slice does not use parts from both, the upper half and lower half.
+      return handleSliceWithinUpperOrLowerBoundary(src, kind, hi, lo);
+    } else {
+      // the slice crosses the middle point, so we have to compute upper and lower halves.
+      return handleSliceAcrossUpperLowerBoundary(src, kind, hi, lo);
+    }
+  }
+
+  private ExpressionNode handleSliceWithinUpperOrLowerBoundary(BuiltInCall src, IssMulKind kind,
+                                                               int hi, int lo) {
+    var a = src.arg(0);
+    var b = src.arg(1);
+    var targetType = a.type();
+
+    ExpressionNode result;
+    if (hi >= targetSize()) {
+      // if upper half, we use the mulh operation.
+      result = new IssMulhNode(a, b, kind, targetType);
+
+      // adjust the slice by targetSize bit, as we are now handling the upper half only.
+      hi -= targetSize();
+      lo -= targetSize();
+    } else {
+      // if lower half, we just use the normal mul built-in.
+      result = new BuiltInCall(MUL, src.arguments(), targetType);
+    }
+    if (lo == 0 && hi == targetSize() - 1) {
+      return result;
+    }
+    return GraphUtils.slice(result, hi, lo);
+  }
+
+  private ExpressionNode handleSliceAcrossUpperLowerBoundary(BuiltInCall src, IssMulKind kind,
+                                                             int hi, int lo) {
+    var a = src.arg(0);
+    var b = src.arg(1);
+
+    var targetType = a.type();
+    var structType = Type.struct(
+        "low", targetType,
+        "high", targetType
+    );
+
+    var mul2 = new IssMul2Node(a, b, kind, structType);
+    // lower and upper half in target type size (not final expected size yet)
+    var lowerHalf = new StructGetFieldNode("low", mul2, targetType);
+    var upperHalf = new StructGetFieldNode("high", mul2, targetType);
+
+    // lower half sub slice [targetSize - 1 ... lsb]
+    var lhMsb = targetSize() - 1;
+    var lhLsb = lo;
+    // +1 because msb and lsb are inclusive
+    var lhSize = lhMsb - lhLsb + 1;
+
+    // upper half sub slice [msb - targetSize ... 0]
+    var uhMsb = hi - targetSize();
+    var uhLsb = 0;
+    var uhSize = uhMsb - uhLsb + 1;
+
+    var finalType = Type.bits(uhSize + lhSize);
+
+    var lhSlice = GraphUtils.zeroExtend(GraphUtils.slice(lowerHalf, lhMsb, lhLsb), finalType);
+    var uhSlice = GraphUtils.zeroExtend(GraphUtils.slice(upperHalf, uhMsb, uhLsb), finalType);
+
+    // now we shift the upper half to the correct position uhSlice << lhSize.
+    var shiftAmount = new ConstantNode(Constant.Value.of(lhSize, Type.bits(16)));
+    var upperHalfShifted = LSL.call(uhSlice, shiftAmount);
+
+    // now we merge both halves into a single value
+    return GraphUtils.or(upperHalfShifted, lhSlice);
+  }
+
+  private void checkMullSlice(BuiltInCall src, int hi, int lo) {
+    var mullSize = src.type().asDataType().bitWidth();
+    var sliceSize = hi - lo + 1;
+    src.ensure(
+        mullSize <= targetSize() * 2,
+        "Long multiplication result size (%s) cannot be larger than twice the target size (2 * %s)",
+        mullSize, targetSize()
+    );
+    src.ensure(
+        sliceSize <= targetSize(),
+        "Long multiplication result size (%s) must be sliced to less than the target size (%s)",
+        sliceSize, targetSize()
+    );
   }
 
   private static ExpressionNode boolToWord(ExpressionNode bit, DataType chunkType) {

--- a/vadl/main/vadl/types/BuiltInTable.java
+++ b/vadl/main/vadl/types/BuiltInTable.java
@@ -856,6 +856,7 @@ public class BuiltInTable {
    */
   public static final BuiltIn ROL =
       func("VADL::rol", "<<>", Type.relation(BitsType.class, UIntType.class, BitsType.class))
+          .compute(Constant.Value::rol)
           .takesDefault()
           .returnsFirstBitWidth(BitsType.class)
           .build();

--- a/vadl/main/vadl/viam/Constant.java
+++ b/vadl/main/vadl/viam/Constant.java
@@ -692,7 +692,7 @@ public abstract class Constant {
     }
 
     /**
-     * Performs a logical shift left of this constant value by the specified amount
+     * Performs a logical shift right of this constant value by the specified amount
      * of the other value (which must be an unsigned integer).
      * The resulting type is the same as this type, the result is truncated on overflow.
      */
@@ -700,12 +700,34 @@ public abstract class Constant {
       var shift = other;
       var valWidth = BigInteger.valueOf(type().bitWidth());
       if (shift.value.compareTo(valWidth) >= 0) {
-        // if shift value is greather equal the value width, we must take the modulo
+        // if shift value is greater equal the value width, we must take the modulo
         shift = other.modulo(of(type().bitWidth(), other.type()), false);
       }
       var newValue = value
           .shiftRight(shift.intValue());
       return fromTwosComplement(newValue, type());
+    }
+
+    /**
+     * Performs a rotation left of this constant value by the specified amount
+     * of the other value (which must be an unsigned integer).
+     * The resulting type is the same as this type, the result is truncated on overflow.
+     */
+    public Constant.Value rol(Constant.Value other) {
+      int width = type().bitWidth();
+      int amt = other.intValue() % width;
+      if (amt == 0) {
+        return this;                  // nothing to do
+      }
+
+      BigInteger mask = BigInteger.ONE.shiftLeft(width).subtract(BigInteger.ONE); // width-bit mask
+
+      BigInteger rotated =
+          value.shiftLeft(amt)                     // upper part
+              .or(value.shiftRight(width - amt))   // wrapped-around part
+              .and(mask);                          // truncate to <width> bits
+
+      return fromTwosComplement(rotated, type());
     }
 
     /**

--- a/vadl/main/vadl/viam/passes/functionInliner/FunctionInlinerPass.java
+++ b/vadl/main/vadl/viam/passes/functionInliner/FunctionInlinerPass.java
@@ -18,19 +18,31 @@ package vadl.viam.passes.functionInliner;
 
 import java.io.IOException;
 import java.util.IdentityHashMap;
+import java.util.Objects;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
 import javax.annotation.Nullable;
+import org.apache.commons.lang3.stream.Streams;
 import vadl.configuration.GeneralConfiguration;
 import vadl.pass.Pass;
 import vadl.pass.PassName;
 import vadl.pass.PassResults;
 import vadl.utils.ViamUtils;
+import vadl.viam.ArtificialResource;
 import vadl.viam.DefProp;
+import vadl.viam.Format;
+import vadl.viam.Function;
 import vadl.viam.Instruction;
 import vadl.viam.Specification;
+import vadl.viam.graph.Graph;
 
 /**
- * A pass which inlines all the function with the given function.
- * Note that the function must be {@code pure} to be inlined.
+ * A pass which inlines all the function calls with the given function in certain behaviors.
+ * Calls inside functions are only inlined when the function itself is inlined into another
+ * behavior or when the function is used later by something that requires it to have no
+ * function calls.
+ *
+ * <p>Note that the function must be {@code pure} to be inlined.
  * Also, the given {@link Specification} will be mutated in-place. However, the pass
  * saves the original uninlined instruction's behaviors as pass result.
  */
@@ -54,32 +66,44 @@ public class FunctionInlinerPass extends Pass {
   @Nullable
   @Override
   public Object execute(PassResults passResults, Specification viam) throws IOException {
-    IdentityHashMap<Instruction, UninlinedGraph> behaviors = new IdentityHashMap<>();
+    IdentityHashMap<Instruction, UninlinedGraph> uninlined = new IdentityHashMap<>();
 
-    allWithBehavior(viam, behaviors);
+    // functions calls in function are not inlined by default, but in some places it is
+    // still required
+    getFunctionsToInline(viam).map(Function::behavior).forEach(Inliner::inlineFuncs);
 
-    return new Output(behaviors);
+    // we inline into every behavior except functions
+    getDefs(viam, DefProp.WithOptionalBehaviour.class)
+        .filter(Predicate.not(Function.class::isInstance))
+        .forEach(def -> handleDefinition(def, uninlined));
+
+    return new Output(uninlined);
   }
 
-  private void allWithBehavior(Specification viam,
-                               IdentityHashMap<Instruction, UninlinedGraph> behaviors) {
-
-    ViamUtils.findDefinitionsByFilter(viam, d -> d instanceof DefProp.WithBehavior)
-        .stream()
-        .map(DefProp.WithBehavior.class::cast)
-        .forEach(withBehavior -> {
-          var uninlinedGraph = handleMainBehavior(withBehavior);
-          var def = withBehavior.asDefinition();
-          if (def instanceof Instruction instr) {
-            behaviors.put(instr, uninlinedGraph);
-          }
-        });
+  private Stream<Function> getFunctionsToInline(Specification viam) {
+    // TODO: check if other functions need to be inlined
+    return Stream.concat(
+        getDefs(viam, Format.class)
+            .flatMap(f -> f.fieldAccesses().stream())
+            .flatMap(fa -> Streams.of(fa.accessFunction(), fa.predicate()))
+            .filter(Objects::nonNull),
+        getDefs(viam, ArtificialResource.class)
+            .map(ArtificialResource::readFunction)
+    );
   }
 
-  private UninlinedGraph handleMainBehavior(DefProp.WithBehavior def) {
-    var behavior = def.behaviors().getFirst();
-    var copy = behavior.copy();
-    Inliner.inlineFuncs(behavior);
-    return new UninlinedGraph(copy, def.asDefinition());
+  private void handleDefinition(DefProp.WithOptionalBehaviour def,
+                                IdentityHashMap<Instruction, UninlinedGraph> uninlined) {
+    def.behaviors().forEach(behavior -> {
+      if (def instanceof Instruction instr) {
+        // we save the uninlined version of the instruction behavior
+        uninlined.put(instr, new UninlinedGraph(behavior.copy(), def.asDefinition()));
+      }
+      Inliner.inlineFuncs(behavior);
+    });
+  }
+
+  private <T> Stream<T> getDefs(Specification viam, Class<T> type) {
+    return ViamUtils.findDefinitionsByFilter(viam, type::isInstance).stream().map(type::cast);
   }
 }

--- a/vadl/main/vadl/viam/passes/statusBuiltInInlinePass/ArithmeticInliner.java
+++ b/vadl/main/vadl/viam/passes/statusBuiltInInlinePass/ArithmeticInliner.java
@@ -27,6 +27,7 @@ import static vadl.utils.GraphUtils.zeroExtend;
 
 import com.google.errorprone.annotations.concurrent.LazyInit;
 import java.math.BigInteger;
+import vadl.error.Diagnostic;
 import vadl.types.BuiltInTable;
 import vadl.types.Type;
 import vadl.viam.Constant;
@@ -593,6 +594,117 @@ abstract class ArithmeticInliner {
     ExpressionNode checkCarry() {
       return Constant.Value.of(false).toNode();
     }
+  }
+
+  static class MulS extends Inliner {
+
+    MulS(BuiltInCall builtInCall) {
+      super(builtInCall);
+    }
+
+    @Override
+    ExpressionNode createResult() {
+      var a = arg0();
+      var b = arg1();
+      return BuiltInTable.MUL.call(a, b);
+    }
+
+    @Override
+    ExpressionNode checkOverflow() {
+      // TODO: how is ov defined? If the high bits are non-zero?
+      throw throwNotImplemented(builtInCall, "overflow");
+    }
+
+    @Override
+    ExpressionNode checkCarry() {
+      // TODO: how is carry defined? Undefined? Equal to ov?
+      throw throwNotImplemented(builtInCall, "carry");
+    }
+  }
+
+  static class SMullS extends Inliner {
+
+    SMullS(BuiltInCall builtInCall) {
+      super(builtInCall);
+    }
+
+    @Override
+    ExpressionNode createResult() {
+      var a = arg0();
+      var b = arg1();
+      return BuiltInTable.SMULL.call(a, b);
+    }
+
+    @Override
+    ExpressionNode checkOverflow() {
+      // TODO: how is ov defined? If the high bits are non-zero?
+      throw throwNotImplemented(builtInCall, "overflow");
+    }
+
+    @Override
+    ExpressionNode checkCarry() {
+      // TODO: how is carry defined? Undefined? Equal to ov?
+      throw throwNotImplemented(builtInCall, "carry");
+    }
+  }
+
+  static class UMullS extends Inliner {
+
+    UMullS(BuiltInCall builtInCall) {
+      super(builtInCall);
+    }
+
+    @Override
+    ExpressionNode createResult() {
+      var a = arg0();
+      var b = arg1();
+      return BuiltInTable.UMULL.call(a, b);
+    }
+
+    @Override
+    ExpressionNode checkOverflow() {
+      // TODO: how is ov defined? If the high bits are non-zero?
+      throw throwNotImplemented(builtInCall, "overflow");
+    }
+
+    @Override
+    ExpressionNode checkCarry() {
+      // TODO: how is carry defined? Undefined? Equal to ov?
+      throw throwNotImplemented(builtInCall, "carry");
+    }
+  }
+
+  static class SUMullS extends Inliner {
+
+    SUMullS(BuiltInCall builtInCall) {
+      super(builtInCall);
+    }
+
+    @Override
+    ExpressionNode createResult() {
+      var a = arg0();
+      var b = arg1();
+      return BuiltInTable.SUMULL.call(a, b);
+    }
+
+    @Override
+    ExpressionNode checkOverflow() {
+      // TODO: how is ov defined? If the high bits are non-zero?
+      throw throwNotImplemented(builtInCall, "overflow");
+    }
+
+    @Override
+    ExpressionNode checkCarry() {
+      // TODO: how is carry defined? Undefined? Equal to ov?
+      throw throwNotImplemented(builtInCall, "carry");
+    }
+  }
+
+  private static Diagnostic throwNotImplemented(BuiltInCall input, String flag) {
+    return Diagnostic.error("Built-In Status-Flag Not Implemented", input)
+        .description("OpenVADL does not yet implement the %s flag of the %s built-in.",
+            flag, input.builtIn().name())
+        .build();
   }
 
 }

--- a/vadl/main/vadl/viam/passes/statusBuiltInInlinePass/RemoveUnusedStatusFlagsFromBuiltinsPass.java
+++ b/vadl/main/vadl/viam/passes/statusBuiltInInlinePass/RemoveUnusedStatusFlagsFromBuiltinsPass.java
@@ -270,7 +270,7 @@ class ResultInliner implements VadlBuiltInStatusOnlyDispatcher<BuiltInCall> {
 
   @Override
   public void handleLSLS(BuiltInCall input) {
-    throwNotImplemented(input);
+    inlineDefault(input, BuiltInTable.LSL);
   }
 
   @Override
@@ -280,12 +280,12 @@ class ResultInliner implements VadlBuiltInStatusOnlyDispatcher<BuiltInCall> {
 
   @Override
   public void handleASRS(BuiltInCall input) {
-    throwNotImplemented(input);
+    inlineDefault(input, BuiltInTable.ASR);
   }
 
   @Override
   public void handleLSRS(BuiltInCall input) {
-    throwNotImplemented(input);
+    inlineDefault(input, BuiltInTable.LSR);
   }
 
   @Override

--- a/vadl/main/vadl/viam/passes/statusBuiltInInlinePass/ShiftRotateInliner.java
+++ b/vadl/main/vadl/viam/passes/statusBuiltInInlinePass/ShiftRotateInliner.java
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText : © 2026 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.viam.passes.statusBuiltInInlinePass;
+
+import static vadl.utils.GraphUtils.binaryOp;
+import static vadl.utils.GraphUtils.bitsNode;
+import static vadl.utils.GraphUtils.testSignBit;
+import static vadl.utils.GraphUtils.truncate;
+
+import vadl.types.BuiltInTable;
+import vadl.types.Type;
+import vadl.viam.Constant;
+import vadl.viam.graph.dependency.BuiltInCall;
+import vadl.viam.graph.dependency.ExpressionNode;
+
+/**
+ * Contains the status built-in {@link Inliner}s for all shift/rotate operations.
+ */
+public abstract class ShiftRotateInliner {
+
+  /**
+   * Implements {@link #checkOverflow()}. Shift/rotate operations do not set
+   * the overflow flag, so {@code false} is returned by default.
+   */
+  abstract static class ShiftRotate extends Inliner {
+
+    ShiftRotate(BuiltInCall builtInCall) {
+      super(builtInCall);
+    }
+
+    @Override
+    ExpressionNode checkOverflow() {
+      return Constant.Value.fromBoolean(false).toNode();
+    }
+
+  }
+
+  static class LSLS extends ShiftRotate {
+
+    LSLS(BuiltInCall builtInCall) {
+      super(builtInCall);
+    }
+
+    @Override
+    ExpressionNode createResult() {
+      return binaryOf(BuiltInTable.LSL);
+    }
+
+    @Override
+    ExpressionNode checkCarry() {
+      var a = arg0();
+      var b = arg1();
+
+      // if b is 0, carry is 0
+
+      // check: (a <<> b) & (b != 0)
+      return binaryOp(BuiltInTable.AND,
+          truncate(binaryOp(BuiltInTable.ROL, a, b), Type.bits(1)),
+          binaryOp(BuiltInTable.NEQ, b, bitsNode(0, b.type().asDataType().bitWidth()))
+      );
+    }
+  }
+
+  static class RORS extends ShiftRotate {
+
+    RORS(BuiltInCall builtInCall) {
+      super(builtInCall);
+    }
+
+    @Override
+    ExpressionNode createResult() {
+      return binaryOf(BuiltInTable.ROR);
+    }
+
+    @Override
+    ExpressionNode checkCarry() {
+      var result = getResult();
+      var b = arg1();
+
+      // the last bit rotated off the right side is the
+      // msb of the result
+      // if b is 0, carry is 0
+
+      // check: msb(result) & (b != 0)
+      return binaryOp(BuiltInTable.AND,
+          testSignBit(result),
+          binaryOp(BuiltInTable.NEQ, b, bitsNode(0, b.type().asDataType().bitWidth()))
+      );
+    }
+  }
+
+}

--- a/vadl/main/vadl/viam/passes/statusBuiltInInlinePass/StatusBuiltInInlinePass.java
+++ b/vadl/main/vadl/viam/passes/statusBuiltInInlinePass/StatusBuiltInInlinePass.java
@@ -166,6 +166,7 @@ class StatusBuiltInInliner implements VadlBuiltInStatusOnlyDispatcher<BuiltInCal
 
   @Override
   public void handleMULS(BuiltInCall input) {
+    // TODO: required for aarch32.vadl
     throwNotImplemented(input);
   }
 
@@ -202,7 +203,6 @@ class StatusBuiltInInliner implements VadlBuiltInStatusOnlyDispatcher<BuiltInCal
   @Override
   public void handleUDIVS(BuiltInCall input) {
     new ArithmeticInliner.UDivS(input).inline();
-
   }
 
   @Override
@@ -218,61 +218,51 @@ class StatusBuiltInInliner implements VadlBuiltInStatusOnlyDispatcher<BuiltInCal
   @Override
   public void handleORS(BuiltInCall input) {
     new LogicInliner.OrS(input).inline();
-
   }
 
   @Override
   public void handleLSLS(BuiltInCall input) {
-    throwNotImplemented(input);
-
+    new ShiftRotateInliner.LSLS(input).inline();
   }
 
   @Override
   public void handleLSLC(BuiltInCall input) {
     throwNotImplemented(input);
-
   }
 
   @Override
   public void handleASRS(BuiltInCall input) {
     throwNotImplemented(input);
-
   }
 
   @Override
   public void handleLSRS(BuiltInCall input) {
     throwNotImplemented(input);
-
   }
 
   @Override
   public void handleASRC(BuiltInCall input) {
     throwNotImplemented(input);
-
   }
 
   @Override
   public void handleLSRC(BuiltInCall input) {
     throwNotImplemented(input);
-
   }
 
   @Override
   public void handleROLS(BuiltInCall input) {
     throwNotImplemented(input);
-
   }
 
   @Override
   public void handleROLC(BuiltInCall input) {
     throwNotImplemented(input);
-
   }
 
   @Override
   public void handleRORS(BuiltInCall input) {
-    throwNotImplemented(input);
-
+    new ShiftRotateInliner.RORS(input).inline();
   }
 
   @Override

--- a/vadl/main/vadl/viam/passes/statusBuiltInInlinePass/StatusBuiltInInlinePass.java
+++ b/vadl/main/vadl/viam/passes/statusBuiltInInlinePass/StatusBuiltInInlinePass.java
@@ -166,23 +166,22 @@ class StatusBuiltInInliner implements VadlBuiltInStatusOnlyDispatcher<BuiltInCal
 
   @Override
   public void handleMULS(BuiltInCall input) {
-    // TODO: required for aarch32.vadl
-    throwNotImplemented(input);
+    new ArithmeticInliner.MulS(input).inline();
   }
 
   @Override
   public void handleSMULLS(BuiltInCall input) {
-    throwNotImplemented(input);
+    new ArithmeticInliner.SMullS(input).inline();
   }
 
   @Override
   public void handleUMULLS(BuiltInCall input) {
-    throwNotImplemented(input);
+    new ArithmeticInliner.UMullS(input).inline();
   }
 
   @Override
   public void handleSUMULLS(BuiltInCall input) {
-    throwNotImplemented(input);
+    new ArithmeticInliner.SUMullS(input).inline();
   }
 
   @Override

--- a/vadl/test/resources/scripts/iss_qemu/compilers/aarch32_compiler.py
+++ b/vadl/test/resources/scripts/iss_qemu/compilers/aarch32_compiler.py
@@ -57,17 +57,14 @@ async def build_assembly(id: str, core: str) -> Path:
   
   exit:
       @ exit VADL virt (HTIF)
-      eor     r0, r0, r0       @ cmd: exit 0
-      add     r0, r0, #1
+      mov     r0, #1           @ cmd: exit 0
       ldr     r1, =tohost      @ load addr of 'tohost' into r1
       str     r0, [r1]         @ store r0 to 'tohost'
       
       @ exit upstream (semihosting)
-      ldr r1, =args
-      eor r0, r0, r0           @ SYS_EXIT_EXTENDED operation
-      add r0, r0, #0x20
-      @ mov r0, #0x20  @ mov is not yet supported by aarch32.vadl
-      svc #0x123456            @ Trigger semihosting call
+      ldr     r1, =args
+      mov     r0, #0x20        @ SYS_EXIT_EXTENDED operation
+      svc     #0x123456        @ Trigger semihosting call
 
   1:  b       1b               @ Infinite loop
   

--- a/vadl/test/resources/scripts/iss_qemu/compilers/aarch32_compiler.py
+++ b/vadl/test/resources/scripts/iss_qemu/compilers/aarch32_compiler.py
@@ -54,11 +54,40 @@ async def build_assembly(id: str, core: str) -> Path:
   
   _start:
       {core}
-
-  @ TODO: exit VADL virt (HTIF)
-  @ TODO: exit upstream virt (semihosting)
+  
+  exit:
+      @ exit VADL virt (HTIF)
+      eor     r0, r0, r0       @ cmd: exit 0
+      add     r0, r0, #1
+      ldr     r1, =tohost      @ load addr of 'tohost' into r1
+      str     r0, [r1]         @ store r0 to 'tohost'
+      
+      @ exit upstream (semihosting)
+      ldr r1, =args
+      eor r0, r0, r0           @ SYS_EXIT_EXTENDED operation
+      add r0, r0, #0x20
+      @ mov r0, #0x20  @ mov is not yet supported by aarch32.vadl
+      svc #0x123456            @ Trigger semihosting call
 
   1:  b       1b               @ Infinite loop
+  
+  .section .data
+  .align 3
+  
+  args:
+  .word 0x20026                @ ADP_Stopped_ApplicationExit command
+  .word 0x0                    @ Exit Code (0)
+  
+  .section .tohost, "aw", %progbits
+  .align 6
+  .global tohost
+  tohost: .quad 0
+  .size tohost, 8
+
+  .align 6
+  .global fromhost
+  fromhost: .quad 0
+  .size fromhost, 8
   """
   with open(asm_out, "w") as f:
     f.write(content)

--- a/vadl/test/resources/scripts/iss_qemu/compilers/aarch32_compiler.py
+++ b/vadl/test/resources/scripts/iss_qemu/compilers/aarch32_compiler.py
@@ -1,0 +1,97 @@
+import asyncio
+import os
+from pathlib import Path
+
+CC="arm-linux-gnueabihf-gcc"
+NM="arm-linux-gnueabihf-nm"
+
+async def compile(id: str, asm: str, compargs: str) -> dict:
+  asm_path = await build_assembly(id, asm)
+  linker_path = await build_linker_script(id)
+
+  elf_out = _tmp_file(id, f"elf-{id}")
+
+  # Find tohost symbol address.
+  proc = await asyncio.create_subprocess_exec(
+    CC, *compargs.split(), "-T", linker_path, "-nostartfiles", "-o", elf_out, asm_path,
+    stdout=asyncio.subprocess.PIPE,
+    stderr=asyncio.subprocess.PIPE
+  )
+  stdout, stderr = await proc.communicate()
+  if proc.returncode != 0:
+    raise RuntimeError(f"Compilation failed: {stderr.decode()}")
+
+  # Find the address of 'tohost' symbol
+  proc = await asyncio.create_subprocess_exec(
+    NM, elf_out,
+    stdout=asyncio.subprocess.PIPE,
+    stderr=asyncio.subprocess.PIPE
+  )
+  stdout, _ = await proc.communicate()
+  tohost_addr = None
+  for line in stdout.decode().splitlines():
+    if " tohost" in line:
+      tohost_addr = int(line.split()[0], 16)
+      break
+
+  return {
+    "elf": elf_out,
+    "asm": asm_path,
+    "lnscript": linker_path,
+    "tohost_addr": tohost_addr,
+  }
+
+
+async def build_assembly(id: str, core: str) -> Path:
+  asm_out = _tmp_file(id, f"asm-{id}.s")
+
+  content = f"""
+  .section .text.init
+  .global _start
+  
+  .arm                         @ only A32, no T32
+  .syntax unified
+  
+  _start:
+      {core}
+
+  @ TODO: exit VADL virt (HTIF)
+  @ TODO: exit upstream virt (semihosting)
+
+  1:  b       1b               @ Infinite loop
+  """
+  with open(asm_out, "w") as f:
+    f.write(content)
+  return asm_out
+
+
+async def build_linker_script(id: str) -> Path:
+  linker_out = _tmp_file(id, f"linker-{id}.ld")
+
+  content = """
+  OUTPUT_ARCH("arm")
+  ENTRY(_start)
+
+  SECTIONS
+  {
+    . = 0x40000000;
+    .text.init : { *(.text.init) }
+    . = ALIGN(0x1000);
+    .tohost : { *(.tohost) }
+    . = ALIGN(0x1000);
+    .text : { *(.text) }
+    . = ALIGN(0x1000);
+    .data : { *(.data) }
+    .bss : { *(.bss) }
+    _end = .;
+  }
+  """
+  with open(linker_out, "w") as f:
+    f.write(content)
+  return linker_out
+
+def _tmp_file(id: str, name: str) -> Path:
+  build_dir = f"/tmp/build-{id}/"
+  os.makedirs(build_dir, exist_ok=True)
+  return Path(f"{build_dir}/{name}")
+

--- a/vadl/test/resources/scripts/iss_qemu/compilers/aarch64_compiler.py
+++ b/vadl/test/resources/scripts/iss_qemu/compilers/aarch64_compiler.py
@@ -59,7 +59,7 @@ async def build_assembly(id: str, core: str) -> Path:
 
       # exit upstream virt (semihosting)
       ldr     x1, =args
-      mov     w0, #0x20        // SYS_EXIT operation
+      mov     w0, #0x20        // SYS_EXIT_EXTENDED operation
       hlt     #0xF000          // Trigger semihosting call
 
   1:  b       1b               // Infinite loop

--- a/vadl/test/vadl/viam/passes/statusBuiltInInlinePass/ShiftRotateInlineTest.java
+++ b/vadl/test/vadl/viam/passes/statusBuiltInInlinePass/ShiftRotateInlineTest.java
@@ -1,0 +1,136 @@
+// SPDX-FileCopyrightText : © 2026 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.viam.passes.statusBuiltInInlinePass;
+
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+import vadl.types.BuiltInTable;
+import vadl.types.Type;
+import vadl.viam.Constant;
+
+public class ShiftRotateInlineTest extends StatusBuiltinInlineTest {
+
+  @TestFactory
+  public Stream<DynamicTest> lslsTests() {
+    return runTests(
+        // single bit
+        lsls(0b0, 1, 0, 1, 0b0, false, true, false),
+        lsls(0b1, 1, 0, 1, 0b1, true, false, false),
+        lsls(0b0, 1, 1, 1, 0b0, false, true, false),
+        lsls(0b1, 1, 1, 1, 0b0, false, true, true),
+
+        // shifting zero bits
+        lsls(0b0000, 4, 0, 1, 0b0000, false, true, false),
+        lsls(0b1000, 4, 0, 1, 0b1000, true, false, false),
+
+        // shifting one bit
+        lsls(0b0000, 4, 1, 1, 0b0000, false, true, false),
+        lsls(0b1000, 4, 1, 1, 0b0000, false, true, true),
+        lsls(0b0111, 4, 1, 1, 0b1110, true, false, false),
+        lsls(0b1111, 4, 1, 1, 0b1110, true, false, true),
+        lsls(0b0000, 4, 1, 1, 0b0000, false, true, false),
+        lsls(0b0001, 4, 1, 1, 0b0010, false, false, false),
+        lsls(0b1110, 4, 1, 1, 0b1100, true, false, true),
+        lsls(0b1111, 4, 1, 1, 0b1110, true, false, true),
+
+        // shifting multiple bits
+        lsls(0b01001011, 8, 2, 2, 0b00101100, false, false, true),
+        lsls(0b11001011, 8, 3, 2, 0b01011000, false, false, false),
+        lsls(0b01001011, 8, 4, 3, 0b10110000, true, false, false),
+        lsls(0b11001011, 8, 5, 3, 0b01100000, false, false, true),
+
+        // shift amount around bit width
+        lsls(0xFFFFFFFFL, 32, 31, 6, 0x80000000L, true, false, true),
+        lsls(0xFFFFFFFFL, 32, 32, 6, 0x00000000, false, true, true),
+        lsls(0xFFFFFFFFL, 32, 33, 6, 0x00000000, false, true, true),
+        lsls(0x0, 32, 31, 6, 0x0, false, true, false),
+        lsls(0x0, 32, 32, 6, 0x0, false, true, false),
+        lsls(0x0, 32, 33, 6, 0x0, false, true, false),
+
+        // shift large amount
+        lsls(0xFFFFFFFFL, 32, 0xFFFF, 32, 0x0, false, true, true),
+        lsls(0x0,         32, 0xFFFF, 32, 0x0, false, true, false)
+    );
+  }
+
+  @TestFactory
+  public Stream<DynamicTest> rorsTests() {
+    return runTests(
+        // single bit
+        rors(0b0, 1, 0, 1, 0b0, false, true, false),
+        rors(0b1, 1, 0, 1, 0b1, true, false, false),
+        rors(0b0, 1, 1, 1, 0b0, false, true, false),
+        rors(0b1, 1, 1, 1, 0b1, true, false, true),
+
+        // rotating zero bits
+        rors(0b0000, 4, 0, 1, 0b0000, false, true, false),
+        rors(0b1000, 4, 0, 1, 0b1000, true, false, false),
+
+        // rotating one bit
+        rors(0b0000, 4, 1, 1, 0b0000, false, true, false),
+        rors(0b1000, 4, 1, 1, 0b0100, false, false, false),
+        rors(0b0111, 4, 1, 1, 0b1011, true, false, true),
+        rors(0b1111, 4, 1, 1, 0b1111, true, false, true),
+        rors(0b0000, 4, 1, 1, 0b0000, false, true, false),
+        rors(0b0001, 4, 1, 1, 0b1000, true, false, true),
+        rors(0b1110, 4, 1, 1, 0b0111, false, false, false),
+        rors(0b1111, 4, 1, 1, 0b1111, true, false, true),
+
+        // rotating multiple bits
+        rors(0b01001011, 8, 2, 2, 0b11010010, true, false, true),
+        rors(0b11001011, 8, 3, 2, 0b01111001, false, false, false),
+        rors(0b01001011, 8, 4, 3, 0b10110100, true, false, true),
+        rors(0b11001011, 8, 5, 3, 0b01011110, false, false, false),
+
+        // rotate amount around bit width
+        rors(0xFFFFFFFFL, 32, 31, 6, 0xFFFFFFFFL, true, false, true),
+        rors(0xFFFFFFFFL, 32, 32, 6, 0xFFFFFFFFL, true, false, true),
+        rors(0xFFFFFFFFL, 32, 33, 6, 0xFFFFFFFFL, true, false, true),
+        rors(0x0, 32, 31, 6, 0x0, false, true, false),
+        rors(0x0, 32, 32, 6, 0x0, false, true, false),
+        rors(0x0, 32, 33, 6, 0x0, false, true, false),
+
+        // rotate large amount
+        rors(0xFFFFFFFFL, 32, 0xFFFF, 32, 0xFFFFFFFFL, true, false, true),
+        rors(0x0,         32, 0xFFFF, 32, 0x0,         false, true, false)
+    );
+  }
+
+  private Stream<Test> lsls(long a, int sizeA, long b, int sizeB,
+                            long result, boolean negative, boolean zero, boolean carry) {
+    return binary(BuiltInTable.LSLS, a, sizeA, b, sizeB, result, negative, zero, carry);
+  }
+
+  private Stream<Test> rors(long a, int sizeA, long b, int sizeB,
+                            long result, boolean negative, boolean zero, boolean carry) {
+    return binary(BuiltInTable.RORS, a, sizeA, b, sizeB, result, negative, zero, carry);
+  }
+
+  private Stream<Test> binary(BuiltInTable.BuiltIn op, long a, int sizeA, long b, int sizeB,
+                              long result, boolean negative, boolean zero, boolean carry) {
+    return operation(op,
+        List.of(
+            Constant.Value.of(a, Type.bits(sizeA)),
+            Constant.Value.of(b, Type.bits(sizeB))
+        ),
+        Constant.Value.of(result, Type.bits(sizeA)),
+        negative, zero, carry, false
+    );
+  }
+}


### PR DESCRIPTION
- Add `aarch32/virt.vadl`
- Add `aarch32_compiler.py`
  - Includes HTIF and semihosting calls in the assembly template
- Add `cosim_scripts/aarch32/compiler.py`, `cosim_scripts/aarch32/main.py` and `cosim_configs/aarch32_config.toml`
  - Uses cosim to compare to upstream's `cortex-a15` cpu and `virt` machine
  - Tests are loaded into `MAIN_RAM` at `0x40000000`
  - UPSTREAM sets `pc` to `0x40000000` loads the elf using `-kernel`
  - VADL jumps to `0x40000000` with firmware instruction and loads the elf using `-bios`
- Implement all built-ins required for aarch32 for ISS