### PR TITLE
frontend: Further performance improvements

### DIFF
--- a/vadl/main/vadl/ast/AstUtils.java
+++ b/vadl/main/vadl/ast/AstUtils.java
@@ -18,7 +18,6 @@ package vadl.ast;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import vadl.types.BuiltInTable;
@@ -28,16 +27,30 @@ import vadl.types.UIntType;
 
 class AstUtils {
 
+  // FIXME: We decided that in the future this behaivor will be removed and only the
+  //  signed/unsigned versions are available.
+  // Discussion: https://ea.complang.tuwien.ac.at/vadl/open-vadl/issues/287#issuecomment-23771
+  // There are some pseudo functions that will get resolved to either the signed or unsinged one.
+  private static Map<String, List<String>> pseudoRewrites =
+      Map.of("VADL::div", List.of("VADL::sdiv", "VADL::udiv"), "VADL::mod",
+          List.of("VADL::smod", "VADL::umod"));
+
+  private static Map<String, BuiltInTable.BuiltIn> nameLookupTable =
+      BuiltInTable.builtIns().collect(Collectors.toMap(BuiltInTable.BuiltIn::name, b -> b));
+
+  private static Map<String, String> operatorRewrites = Map.of(
+      "&&", "&",
+      "||", "|"
+  );
+
+  private static Map<String, List<BuiltInTable.BuiltIn>> operatorLookupTable =
+      BuiltInTable.builtIns()
+          .filter(b -> b.operator() != null)
+          .collect(Collectors.groupingBy(BuiltInTable.BuiltIn::operator));
+
+
   @Nullable
   static BuiltInTable.BuiltIn getBuiltIn(String name, List<Type> argTypes) {
-
-    // FIXME: We decided that in the future this behaivor will be removed and only the
-    //  signed/unsigned versions are available.
-    // Discussion: https://ea.complang.tuwien.ac.at/vadl/open-vadl/issues/287#issuecomment-23771
-
-    // There are some pseudo functions that will get resolved to either the signed or unsinged one.
-    var pseudoRewrites = Map.of("VADL::div", List.of("VADL::sdiv", "VADL::udiv"), "VADL::mod",
-        List.of("VADL::smod", "VADL::umod"));
     if (pseudoRewrites.containsKey(name)) {
       var singed = argTypes.stream().anyMatch(t -> t instanceof SIntType);
       name = pseudoRewrites.get(name).get(singed ? 0 : 1);
@@ -48,27 +61,13 @@ class AstUtils {
     }
 
     String finalBuiltinName = name;
-    var matchingBuiltin = BuiltInTable.builtIns()
-        .filter(b -> b.name().equals(finalBuiltinName)).toList();
-
-    if (matchingBuiltin.size() > 1) {
-      throw new IllegalStateException("Multiple builtin match '$s': " + finalBuiltinName);
-    }
-
-    if (matchingBuiltin.isEmpty()) {
-      return null;
-    }
-
-    return matchingBuiltin.get(0);
+    var matchingBuiltin = nameLookupTable.get(finalBuiltinName);
+    return matchingBuiltin;
   }
 
   static BuiltInTable.BuiltIn getOperatorBuiltIn(Operator operator, List<Type> argTypes) {
 
     var symbol = operator.symbol;
-    var operatorRewrites = Map.of(
-        "&&", "&",
-        "||", "|"
-    );
     if (operatorRewrites.containsKey(symbol)) {
       symbol = operatorRewrites.get(symbol);
     }
@@ -78,9 +77,8 @@ class AstUtils {
     }
 
     String finalOperatorSymbol = symbol;
-    var builtIns = BuiltInTable.builtIns()
+    var builtIns = operatorLookupTable.getOrDefault(finalOperatorSymbol, List.of()).stream()
         .filter(b -> b.signature().argTypeClasses().size() == argTypes.size())
-        .filter(b -> Objects.equals(b.operator(), finalOperatorSymbol))
         .toList();
 
     // Sometimes there are a singed and unsigned version of builtin operation

--- a/vadl/main/vadl/ast/AstVisitor.java
+++ b/vadl/main/vadl/ast/AstVisitor.java
@@ -63,13 +63,17 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
     }
 
     // If it's just a intermediate node, just visit it's children
-    node.children().forEach(this::travel);
+    for (var child : node.children()) {
+      travel(child);
+    }
   }
 
   @Override
   public Void visit(AbiSequenceDefinition definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -77,7 +81,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(AliasDefinition definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -85,7 +91,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(AnnotationDefinition definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -93,7 +101,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(ApplicationBinaryInterfaceDefinition definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -101,7 +111,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(AsmDescriptionDefinition definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -109,7 +121,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(AsmDirectiveDefinition definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -117,7 +131,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(AsmGrammarAlternativesDefinition definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -125,7 +141,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(AsmGrammarElementDefinition definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -133,7 +151,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(AsmGrammarLiteralDefinition definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -141,7 +161,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(AsmGrammarLocalVarDefinition definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -149,7 +171,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(AsmGrammarRuleDefinition definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -157,7 +181,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(AsmGrammarTypeDefinition definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -165,7 +191,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(AsmModifierDefinition definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -173,7 +201,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(AssemblyDefinition definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -181,7 +211,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(CacheDefinition definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -189,7 +221,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(ConstantDefinition definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -197,7 +231,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(CounterDefinition definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -205,7 +241,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(CpuFunctionDefinition definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -213,7 +251,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(CpuMemoryRegionDefinition definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -221,7 +261,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(CpuProcessDefinition definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -229,7 +271,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(DefinitionList definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -237,7 +281,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(EncodingDefinition definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -245,7 +291,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(EnumerationDefinition definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -253,7 +301,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(ExceptionDefinition definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -261,7 +311,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(FormatDefinition definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -269,7 +321,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(DerivedFormatField definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -277,7 +331,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(RangeFormatField definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -285,7 +341,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(TypedFormatField definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -293,7 +351,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(EncodingFormatField definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -301,7 +361,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(PredicateFormatField definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -309,7 +371,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(FunctionDefinition definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -317,7 +381,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(GroupDefinition definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -325,7 +391,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(ImportDefinition definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -333,7 +401,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(InstructionDefinition definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -341,7 +411,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(InstructionSetDefinition definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -349,7 +421,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(LogicDefinition definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -357,7 +431,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(MacroInstanceDefinition definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -365,7 +441,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(MacroInstructionDefinition definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -373,7 +451,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(MacroMatchDefinition definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -381,7 +461,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(MemoryDefinition definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -389,7 +471,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(MicroArchitectureDefinition definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -397,7 +481,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(ProcessorDefinition definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -405,7 +491,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(ModelDefinition definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -413,7 +501,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(ModelTypeDefinition definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -421,7 +511,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(OperationDefinition definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -429,7 +521,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(Parameter definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -437,7 +531,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(PatchDefinition definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -445,7 +541,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(PipelineDefinition definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -453,7 +551,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(PlaceholderDefinition definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -461,7 +561,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(PortBehaviorDefinition definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -469,7 +571,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(ProcessDefinition definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -477,7 +581,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(PseudoInstructionDefinition definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -485,7 +591,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(RecordTypeDefinition definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -493,7 +601,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(RegisterDefinition definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -501,7 +611,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(RelocationDefinition definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -509,7 +621,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(SignalDefinition definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -517,7 +631,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(SourceDefinition definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -525,7 +641,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(SpecialPurposeRegisterDefinition definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -533,7 +651,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(StageDefinition definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -541,7 +661,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(UsingDefinition definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -549,7 +671,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(AbiClangTypeDefinition definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -557,7 +681,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(AbiClangNumericTypeDefinition definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -565,7 +691,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(StageOutputDefinition definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -573,7 +701,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(AbiSpecialPurposeInstructionDefinition definition) {
     beforeTravel(definition);
-    definition.children().forEach(this::travel);
+    for (var child : definition.children()) {
+      travel(child);
+    }
     afterTravel(definition);
     return null;
   }
@@ -581,7 +711,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(Identifier expr) {
     beforeTravel(expr);
-    expr.children().forEach(this::travel);
+    for (var child : expr.children()) {
+      travel(child);
+    }
     afterTravel(expr);
     return null;
   }
@@ -589,7 +721,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(BinaryExpr expr) {
     beforeTravel(expr);
-    expr.children().forEach(this::travel);
+    for (var child : expr.children()) {
+      travel(child);
+    }
     afterTravel(expr);
     return null;
   }
@@ -597,7 +731,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(GroupedExpr expr) {
     beforeTravel(expr);
-    expr.children().forEach(this::travel);
+    for (var child : expr.children()) {
+      travel(child);
+    }
     afterTravel(expr);
     return null;
   }
@@ -605,7 +741,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(IntegerLiteral expr) {
     beforeTravel(expr);
-    expr.children().forEach(this::travel);
+    for (var child : expr.children()) {
+      travel(child);
+    }
     afterTravel(expr);
     return null;
   }
@@ -613,7 +751,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(WildcardLiteral expr) {
     beforeTravel(expr);
-    expr.children().forEach(this::travel);
+    for (var child : expr.children()) {
+      travel(child);
+    }
     afterTravel(expr);
     return null;
   }
@@ -621,7 +761,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(BinaryLiteral expr) {
     beforeTravel(expr);
-    expr.children().forEach(this::travel);
+    for (var child : expr.children()) {
+      travel(child);
+    }
     afterTravel(expr);
     return null;
   }
@@ -629,7 +771,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(BoolLiteral expr) {
     beforeTravel(expr);
-    expr.children().forEach(this::travel);
+    for (var child : expr.children()) {
+      travel(child);
+    }
     afterTravel(expr);
     return null;
   }
@@ -637,7 +781,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(StringLiteral expr) {
     beforeTravel(expr);
-    expr.children().forEach(this::travel);
+    for (var child : expr.children()) {
+      travel(child);
+    }
     afterTravel(expr);
     return null;
   }
@@ -645,7 +791,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(PlaceholderExpr expr) {
     beforeTravel(expr);
-    expr.children().forEach(this::travel);
+    for (var child : expr.children()) {
+      travel(child);
+    }
     afterTravel(expr);
     return null;
   }
@@ -653,7 +801,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(MacroInstanceExpr expr) {
     beforeTravel(expr);
-    expr.children().forEach(this::travel);
+    for (var child : expr.children()) {
+      travel(child);
+    }
     afterTravel(expr);
     return null;
   }
@@ -661,7 +811,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(RangeExpr expr) {
     beforeTravel(expr);
-    expr.children().forEach(this::travel);
+    for (var child : expr.children()) {
+      travel(child);
+    }
     afterTravel(expr);
     return null;
   }
@@ -669,7 +821,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(TypeLiteral expr) {
     beforeTravel(expr);
-    expr.children().forEach(this::travel);
+    for (var child : expr.children()) {
+      travel(child);
+    }
     afterTravel(expr);
     return null;
   }
@@ -677,7 +831,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(IdentifierPath expr) {
     beforeTravel(expr);
-    expr.children().forEach(this::travel);
+    for (var child : expr.children()) {
+      travel(child);
+    }
     afterTravel(expr);
     return null;
   }
@@ -685,7 +841,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(UnaryExpr expr) {
     beforeTravel(expr);
-    expr.children().forEach(this::travel);
+    for (var child : expr.children()) {
+      travel(child);
+    }
     afterTravel(expr);
     return null;
   }
@@ -693,7 +851,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(CallIndexExpr expr) {
     beforeTravel(expr);
-    expr.children().forEach(this::travel);
+    for (var child : expr.children()) {
+      travel(child);
+    }
     afterTravel(expr);
     return null;
   }
@@ -701,7 +861,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(IfExpr expr) {
     beforeTravel(expr);
-    expr.children().forEach(this::travel);
+    for (var child : expr.children()) {
+      travel(child);
+    }
     afterTravel(expr);
     return null;
   }
@@ -709,7 +871,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(LetExpr expr) {
     beforeTravel(expr);
-    expr.children().forEach(this::travel);
+    for (var child : expr.children()) {
+      travel(child);
+    }
     afterTravel(expr);
     return null;
   }
@@ -717,7 +881,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(CastExpr expr) {
     beforeTravel(expr);
-    expr.children().forEach(this::travel);
+    for (var child : expr.children()) {
+      travel(child);
+    }
     afterTravel(expr);
     return null;
   }
@@ -725,7 +891,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(SymbolExpr expr) {
     beforeTravel(expr);
-    expr.children().forEach(this::travel);
+    for (var child : expr.children()) {
+      travel(child);
+    }
     afterTravel(expr);
     return null;
   }
@@ -733,7 +901,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(MacroMatchExpr expr) {
     beforeTravel(expr);
-    expr.children().forEach(this::travel);
+    for (var child : expr.children()) {
+      travel(child);
+    }
     afterTravel(expr);
     return null;
   }
@@ -741,7 +911,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(MatchExpr expr) {
     beforeTravel(expr);
-    expr.children().forEach(this::travel);
+    for (var child : expr.children()) {
+      travel(child);
+    }
     afterTravel(expr);
     return null;
   }
@@ -749,7 +921,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(AsIdExpr expr) {
     beforeTravel(expr);
-    expr.children().forEach(this::travel);
+    for (var child : expr.children()) {
+      travel(child);
+    }
     afterTravel(expr);
     return null;
   }
@@ -757,7 +931,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(AsStrExpr expr) {
     beforeTravel(expr);
-    expr.children().forEach(this::travel);
+    for (var child : expr.children()) {
+      travel(child);
+    }
     afterTravel(expr);
     return null;
   }
@@ -765,7 +941,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(ExistsInExpr expr) {
     beforeTravel(expr);
-    expr.children().forEach(this::travel);
+    for (var child : expr.children()) {
+      travel(child);
+    }
     afterTravel(expr);
     return null;
   }
@@ -773,7 +951,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(ExistsInThenExpr expr) {
     beforeTravel(expr);
-    expr.children().forEach(this::travel);
+    for (var child : expr.children()) {
+      travel(child);
+    }
     afterTravel(expr);
     return null;
   }
@@ -781,7 +961,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(ForallExpr expr) {
     beforeTravel(expr);
-    expr.children().forEach(this::travel);
+    for (var child : expr.children()) {
+      travel(child);
+    }
     afterTravel(expr);
     return null;
   }
@@ -789,7 +971,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(SequenceCallExpr expr) {
     beforeTravel(expr);
-    expr.children().forEach(this::travel);
+    for (var child : expr.children()) {
+      travel(child);
+    }
     afterTravel(expr);
     return null;
   }
@@ -797,7 +981,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(ExpandedSequenceCallExpr expr) {
     beforeTravel(expr);
-    expr.children().forEach(this::travel);
+    for (var child : expr.children()) {
+      travel(child);
+    }
     afterTravel(expr);
     return null;
   }
@@ -805,7 +991,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(ExpandedAliasDefSequenceCallExpr expr) {
     beforeTravel(expr);
-    expr.children().forEach(this::travel);
+    for (var child : expr.children()) {
+      travel(child);
+    }
     afterTravel(expr);
     return null;
   }
@@ -813,7 +1001,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(ResourceReferenceExression expr) {
     beforeTravel(expr);
-    expr.children().forEach(this::travel);
+    for (var child : expr.children()) {
+      travel(child);
+    }
     afterTravel(expr);
     return null;
   }
@@ -821,7 +1011,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(AssignmentStatement statement) {
     beforeTravel(statement);
-    statement.children().forEach(this::travel);
+    for (var child : statement.children()) {
+      travel(child);
+    }
     afterTravel(statement);
     return null;
   }
@@ -829,7 +1021,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(BlockStatement statement) {
     beforeTravel(statement);
-    statement.children().forEach(this::travel);
+    for (var child : statement.children()) {
+      travel(child);
+    }
     afterTravel(statement);
     return null;
   }
@@ -837,7 +1031,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(CallStatement statement) {
     beforeTravel(statement);
-    statement.children().forEach(this::travel);
+    for (var child : statement.children()) {
+      travel(child);
+    }
     afterTravel(statement);
     return null;
   }
@@ -845,7 +1041,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(ForallStatement statement) {
     beforeTravel(statement);
-    statement.children().forEach(this::travel);
+    for (var child : statement.children()) {
+      travel(child);
+    }
     afterTravel(statement);
     return null;
   }
@@ -853,7 +1051,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(IfStatement statement) {
     beforeTravel(statement);
-    statement.children().forEach(this::travel);
+    for (var child : statement.children()) {
+      travel(child);
+    }
     afterTravel(statement);
     return null;
   }
@@ -861,7 +1061,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(InstructionCallStatement statement) {
     beforeTravel(statement);
-    statement.children().forEach(this::travel);
+    for (var child : statement.children()) {
+      travel(child);
+    }
     afterTravel(statement);
     return null;
   }
@@ -869,7 +1071,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(LetStatement statement) {
     beforeTravel(statement);
-    statement.children().forEach(this::travel);
+    for (var child : statement.children()) {
+      travel(child);
+    }
     afterTravel(statement);
     return null;
   }
@@ -877,7 +1081,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(LockStatement statement) {
     beforeTravel(statement);
-    statement.children().forEach(this::travel);
+    for (var child : statement.children()) {
+      travel(child);
+    }
     afterTravel(statement);
     return null;
   }
@@ -885,7 +1091,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(MacroInstanceStatement statement) {
     beforeTravel(statement);
-    statement.children().forEach(this::travel);
+    for (var child : statement.children()) {
+      travel(child);
+    }
     afterTravel(statement);
     return null;
   }
@@ -893,7 +1101,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(MacroMatchStatement statement) {
     beforeTravel(statement);
-    statement.children().forEach(this::travel);
+    for (var child : statement.children()) {
+      travel(child);
+    }
     afterTravel(statement);
     return null;
   }
@@ -901,7 +1111,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(MatchStatement statement) {
     beforeTravel(statement);
-    statement.children().forEach(this::travel);
+    for (var child : statement.children()) {
+      travel(child);
+    }
     afterTravel(statement);
     return null;
   }
@@ -909,7 +1121,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(PlaceholderStatement statement) {
     beforeTravel(statement);
-    statement.children().forEach(this::travel);
+    for (var child : statement.children()) {
+      travel(child);
+    }
     afterTravel(statement);
     return null;
   }
@@ -917,7 +1131,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(RaiseStatement statement) {
     beforeTravel(statement);
-    statement.children().forEach(this::travel);
+    for (var child : statement.children()) {
+      travel(child);
+    }
     afterTravel(statement);
     return null;
   }
@@ -925,7 +1141,9 @@ class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(StatementList statement) {
     beforeTravel(statement);
-    statement.children().forEach(this::travel);
+    for (var child : statement.children()) {
+      travel(child);
+    }
     afterTravel(statement);
     return null;
   }

--- a/vadl/main/vadl/ast/Definition.java
+++ b/vadl/main/vadl/ast/Definition.java
@@ -796,20 +796,19 @@ class FormatDefinition extends Definition implements IdentifiableNode, TypedNode
     this.loc = location;
   }
 
-  List<FormatField> fieldsWithoutEncodingPredicate() {
+  Stream<FormatField> fieldsWithoutEncodingPredicate() {
     return fields.stream()
         .filter(f -> !(f instanceof PredicateFormatField))
-        .filter(f -> !(f instanceof EncodingFormatField))
-        .toList();
+        .filter(f -> !(f instanceof EncodingFormatField));
   }
 
   boolean hasField(String name) {
-    return fieldsWithoutEncodingPredicate().stream()
+    return fieldsWithoutEncodingPredicate()
         .anyMatch(f -> f.identifier().name.equals(name));
   }
 
   FormatField getField(String name) {
-    return fieldsWithoutEncodingPredicate().stream()
+    return fieldsWithoutEncodingPredicate()
         .filter(f -> f.identifier().name.equals(name)).findFirst()
         .orElseThrow();
   }

--- a/vadl/main/vadl/ast/Definition.java
+++ b/vadl/main/vadl/ast/Definition.java
@@ -54,9 +54,9 @@ abstract class Definition extends Node {
 
   Definition withAnnotations(List<AnnotationDefinition> annotations) {
     this.annotations = annotations;
-    annotations.forEach(a -> {
-      a.target = this;
-    });
+    for (var annotation : annotations) {
+      annotation.target = this;
+    }
     return this;
   }
 
@@ -803,14 +803,27 @@ class FormatDefinition extends Definition implements IdentifiableNode, TypedNode
   }
 
   boolean hasField(String name) {
-    return fieldsWithoutEncodingPredicate()
-        .anyMatch(f -> f.identifier().name.equals(name));
+    for (var field : fields) {
+      if (field instanceof PredicateFormatField || field instanceof EncodingFormatField) {
+        continue;
+      }
+      if (field.identifier().name.equals(name)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   FormatField getField(String name) {
-    return fieldsWithoutEncodingPredicate()
-        .filter(f -> f.identifier().name.equals(name)).findFirst()
-        .orElseThrow();
+    for (var field : fields) {
+      if (field instanceof PredicateFormatField || field instanceof EncodingFormatField) {
+        continue;
+      }
+      if (field.identifier().name.equals(name)) {
+        return field;
+      }
+    }
+    throw new IllegalArgumentException("Field with name '" + name + "' not found");
   }
 
   @Nullable

--- a/vadl/main/vadl/ast/MacroExpander.java
+++ b/vadl/main/vadl/ast/MacroExpander.java
@@ -48,13 +48,15 @@ class MacroExpander
   final Map<String, Identifier> macroOverrides;
   final List<Diagnostic> errors = new ArrayList<>();
   @Nullable
-  final List<SourceLocation.DirectLocation> expandingFrom;
+  final RopeList<SourceLocation.DirectLocation> expandingFrom;
 
   MacroExpander(Map<String, Node> args, Map<String, Identifier> macroOverrides,
                 @Nullable List<SourceLocation.DirectLocation> expandingFrom) {
     this.args = args;
     this.macroOverrides = macroOverrides;
-    this.expandingFrom = expandingFrom;
+    this.expandingFrom = expandingFrom == null || expandingFrom.isEmpty()
+        ? null
+        : RopeList.of(expandingFrom);
   }
 
   /**

--- a/vadl/main/vadl/ast/MacroExpander.java
+++ b/vadl/main/vadl/ast/MacroExpander.java
@@ -1157,7 +1157,8 @@ class MacroExpander
 
   @Override
   public Definition visit(AsmGrammarAlternativesDefinition definition) {
-    var alternatives = new ArrayList<List<AsmGrammarElementDefinition>>(definition.alternatives.size());
+    var alternatives =
+        new ArrayList<List<AsmGrammarElementDefinition>>(definition.alternatives.size());
     for (var alternative : definition.alternatives) {
       alternatives.add(expandDefinitions(alternative));
     }

--- a/vadl/main/vadl/ast/MacroExpander.java
+++ b/vadl/main/vadl/ast/MacroExpander.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import vadl.error.Diagnostic;
 import vadl.error.DiagnosticList;
+import vadl.utils.RopeList;
 import vadl.utils.SourceLocation;
 
 /**
@@ -1565,7 +1566,7 @@ class MacroExpander
   private SourceLocation copyLoc(SourceLocation loc) {
     // FIXME: At the time of writing we sometimes issued the pass twice resulting in double
     // reporting of expandedFrom
-    if (expandingFrom == null || expandingFrom.isEmpty()) {
+    if (expandingFrom == null) {
       return loc;
     }
 

--- a/vadl/main/vadl/ast/MacroExpander.java
+++ b/vadl/main/vadl/ast/MacroExpander.java
@@ -1565,7 +1565,7 @@ class MacroExpander
   private SourceLocation copyLoc(SourceLocation loc) {
     // FIXME: At the time of writing we sometimes issued the pass twice resulting in double
     // reporting of expandedFrom
-    if (expandingFrom == null) {
+    if (expandingFrom == null || expandingFrom.isEmpty()) {
       return loc;
     }
 

--- a/vadl/main/vadl/ast/MacroExpander.java
+++ b/vadl/main/vadl/ast/MacroExpander.java
@@ -23,7 +23,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import vadl.error.Diagnostic;
 import vadl.error.DiagnosticList;
@@ -87,9 +86,11 @@ class MacroExpander
   }
 
   private <T> List<T> expandExprs(List<T> expressions) {
-    return expressions.stream()
-        .map(this::expandExpr)
-        .collect(Collectors.toCollection(ArrayList::new));
+    var result = new ArrayList<T>(expressions.size());
+    for (var expr : expressions) {
+      result.add(expandExpr(expr));
+    }
+    return result;
   }
 
   @SuppressWarnings("unchecked")
@@ -154,17 +155,19 @@ class MacroExpander
   }
 
   private CallIndexExpr.Arguments expandArgs(CallIndexExpr.Arguments args) {
-    return new CallIndexExpr.Arguments(
-        args.values.stream()
-            .map(this::expandExpr)
-            .collect(Collectors.toCollection(ArrayList::new)),
-        copyLoc(args.location));
+    var values = new ArrayList<Expr>(args.values.size());
+    for (var value : args.values) {
+      values.add(expandExpr(value));
+    }
+    return new CallIndexExpr.Arguments(values, copyLoc(args.location));
   }
 
   private List<AnnotationDefinition> expandAnnotations(List<AnnotationDefinition> annotations) {
-    return annotations.stream()
-        .map(a -> (AnnotationDefinition) a.accept(this))
-        .collect(Collectors.toCollection(ArrayList::new));
+    var result = new ArrayList<AnnotationDefinition>(annotations.size());
+    for (var a : annotations) {
+      result.add((AnnotationDefinition) a.accept(this));
+    }
+    return result;
   }
 
   public <T extends Node> T expandNode(T node, Ast ast) {
@@ -178,9 +181,10 @@ class MacroExpander
       case Definition definition -> expandDefinition(definition);
       case Statement statement -> expandStatement(statement);
       case RecordInstance recordInstance -> {
-        var entries = recordInstance.entries.stream()
-            .map(this::expandNode)
-            .collect(Collectors.toCollection(ArrayList::new));
+        var entries = new ArrayList<Node>(recordInstance.entries.size());
+        for (var entry : recordInstance.entries) {
+          entries.add(expandNode(entry));
+        }
         yield new RecordInstance(recordInstance.type, entries, recordInstance.sourceLocation);
       }
       case EncodingDefinition.EncsNode encs -> resolveEncs(encs);
@@ -206,12 +210,15 @@ class MacroExpander
    * @return a list of the expanded definitions.
    */
   public List<AssemblyDefinition> expandAssemblies(AssemblyDefinition definition) {
-    return definition.identifiers.stream().map(identifier -> new AssemblyDefinition(
-            new ArrayList<>(List.of(identifier)),
-            expandExpr(definition.expr),
-            copyLoc(definition.loc)
-        ))
-        .collect(Collectors.toCollection(ArrayList::new));
+    var result = new ArrayList<AssemblyDefinition>(definition.identifiers.size());
+    for (var identifier : definition.identifiers) {
+      result.add(new AssemblyDefinition(
+          new ArrayList<>(List.of(identifier)),
+          expandExpr(definition.expr),
+          copyLoc(definition.loc)
+      ));
+    }
+    return result;
   }
 
   @Override
@@ -336,17 +343,18 @@ class MacroExpander
 
   @Override
   public Expr visit(CallIndexExpr expr) {
-    var argsIndices = expr.argsIndices.stream()
-        .map(this::expandArgs)
-        .collect(Collectors.toCollection(ArrayList::new));
-    var subCalls = expr.subCalls.stream()
-        .map(subCall -> {
-          var subCallArgsIndices = subCall.argsIndices.stream()
-              .map(this::expandArgs)
-              .collect(Collectors.toCollection(ArrayList::new));
-          return new CallIndexExpr.SubCall(expandExpr(subCall.id), subCallArgsIndices);
-        })
-        .collect(Collectors.toCollection(ArrayList::new));
+    var argsIndices = new ArrayList<CallIndexExpr.Arguments>(expr.argsIndices.size());
+    for (var argsIndex : expr.argsIndices) {
+      argsIndices.add(expandArgs(argsIndex));
+    }
+    var subCalls = new ArrayList<CallIndexExpr.SubCall>(expr.subCalls.size());
+    for (var subCall : expr.subCalls) {
+      var subCallArgsIndices = new ArrayList<CallIndexExpr.Arguments>(subCall.argsIndices.size());
+      for (var argsIndex : subCall.argsIndices) {
+        subCallArgsIndices.add(expandArgs(argsIndex));
+      }
+      subCalls.add(new CallIndexExpr.SubCall(expandExpr(subCall.id), subCallArgsIndices));
+    }
 
     return new CallIndexExpr(
         expandExpr(expr.target),
@@ -398,10 +406,10 @@ class MacroExpander
 
   @Override
   public Expr visit(MatchExpr expr) {
-    var cases = expr.cases.stream()
-        .map(matchCase ->
-            new MatchExpr.Case(expandExprs(matchCase.patterns), expandExpr(matchCase.result)))
-        .collect(Collectors.toCollection(ArrayList::new));
+    var cases = new ArrayList<MatchExpr.Case>(expr.cases.size());
+    for (var matchCase : expr.cases) {
+      cases.add(new MatchExpr.Case(expandExprs(matchCase.patterns), expandExpr(matchCase.result)));
+    }
     return new MatchExpr(
         expandExpr(expr.candidate),
         cases,
@@ -476,24 +484,25 @@ class MacroExpander
 
   @Override
   public Expr visit(ExistsInThenExpr expr) {
-    var conditions = expr.conditions.stream()
-        .map(condition ->
-            new ExistsInThenExpr.Condition(
-                expandExpr(expandExpr(condition.id())),
-                expandExprs(condition.operations())))
-        .collect(Collectors.toCollection(ArrayList::new));
+    var conditions = new ArrayList<ExistsInThenExpr.Condition>(expr.conditions.size());
+    for (var condition : expr.conditions) {
+      conditions.add(new ExistsInThenExpr.Condition(
+          expandExpr(expandExpr(condition.id())),
+          expandExprs(condition.operations())));
+    }
     return new ExistsInThenExpr(conditions, expandExpr(expr.thenExpr), copyLoc(expr.loc));
   }
 
 
   @Override
   public Expr visit(ForallExpr expr) {
-    var indices = expr.indices.stream()
-        .map(index -> new ForallIndex(
-            expandExpr(index.name),
-            index.typeLiteral == null ? null : expandExpr(index.typeLiteral),
-            expandExpr(index.domain)))
-        .collect(Collectors.toCollection(ArrayList::new));
+    var indices = new ArrayList<ForallIndex>(expr.indices.size());
+    for (var index : expr.indices) {
+      indices.add(new ForallIndex(
+          expandExpr(index.name),
+          index.typeLiteral == null ? null : expandExpr(index.typeLiteral),
+          expandExpr(index.domain)));
+    }
 
     return new ForallExpr(
         indices,
@@ -548,9 +557,10 @@ class MacroExpander
 
   @Override
   public Definition visit(FormatDefinition definition) {
-    var fields = definition.fields.stream()
-        .map(this::expandDefinition)
-        .collect(Collectors.toCollection(ArrayList::new));
+    var fields = new ArrayList<FormatField>(definition.fields.size());
+    for (var field : definition.fields) {
+      fields.add(expandDefinition(field));
+    }
 
     return new FormatDefinition(
         expandExpr(definition.identifier),
@@ -570,9 +580,13 @@ class MacroExpander
 
   @Override
   public Definition visit(RangeFormatField definition) {
+    var ranges = new ArrayList<Expr>(definition.ranges.size());
+    for (var range : definition.ranges) {
+      ranges.add(expandExpr(range));
+    }
     return new RangeFormatField(
         expandExpr(definition.identifier),
-        definition.ranges.stream().map(this::expandExpr).toList(),
+        ranges,
         definition.typeLiteral == null ? null : expandExpr(definition.typeLiteral)
     );
   }
@@ -759,23 +773,25 @@ class MacroExpander
 
   @Override
   public Definition visit(AnnotationDefinition definition) {
-    return new AnnotationDefinition(
-        definition.keywords.stream()
-            .map(this::expandExpr)
-            .toList(),
-        definition.values.stream()
-            .map(this::expandExpr)
-            .collect(Collectors.toCollection(ArrayList::new)),
-        copyLoc(definition.loc));
+    var keywords = new ArrayList<IdentifierOrPlaceholder>(definition.keywords.size());
+    for (var keyword : definition.keywords) {
+      keywords.add(expandExpr(keyword));
+    }
+    var values = new ArrayList<Expr>(definition.values.size());
+    for (var value : definition.values) {
+      values.add(expandExpr(value));
+    }
+    return new AnnotationDefinition(keywords, values, copyLoc(definition.loc));
   }
 
   @Override
   public Definition visit(EnumerationDefinition definition) {
-    var entries = definition.entries.stream()
-        .map(entry -> new EnumerationDefinition.Entry(
-            expandExpr(entry.name),
-            entry.value == null ? null : expandExpr(entry.value)))
-        .collect(Collectors.toCollection(ArrayList::new));
+    var entries = new ArrayList<EnumerationDefinition.Entry>(definition.entries.size());
+    for (var entry : definition.entries) {
+      entries.add(new EnumerationDefinition.Entry(
+          expandExpr(entry.name),
+          entry.value == null ? null : expandExpr(entry.value)));
+    }
 
     return new EnumerationDefinition(
         expandExpr(definition.id),
@@ -882,11 +898,12 @@ class MacroExpander
 
   @Override
   public Definition visit(ProcessDefinition processDefinition) {
-    var templateParams = processDefinition.templateParams.stream()
-        .map(templateParam -> new TemplateParam(templateParam.identifier(),
-            templateParam.type,
-            templateParam.value == null ? null : expandExpr(templateParam.value)))
-        .collect(Collectors.toCollection(ArrayList::new));
+    var templateParams = new ArrayList<TemplateParam>(processDefinition.templateParams.size());
+    for (var templateParam : processDefinition.templateParams) {
+      templateParams.add(new TemplateParam(templateParam.identifier(),
+          templateParam.type,
+          templateParam.value == null ? null : expandExpr(templateParam.value)));
+    }
 
     return new ProcessDefinition(
         expandExpr(processDefinition.name),
@@ -1140,12 +1157,11 @@ class MacroExpander
 
   @Override
   public Definition visit(AsmGrammarAlternativesDefinition definition) {
-    return new AsmGrammarAlternativesDefinition(
-        definition.alternatives.stream()
-            .map(this::expandDefinitions)
-            .collect(Collectors.toCollection(ArrayList::new)),
-        copyLoc(definition.loc)
-    );
+    var alternatives = new ArrayList<List<AsmGrammarElementDefinition>>(definition.alternatives.size());
+    for (var alternative : definition.alternatives) {
+      alternatives.add(expandDefinitions(alternative));
+    }
+    return new AsmGrammarAlternativesDefinition(alternatives, copyLoc(definition.loc));
   }
 
   @Override
@@ -1296,11 +1312,12 @@ class MacroExpander
 
   @Override
   public Statement visit(MatchStatement matchStatement) {
-    var cases = matchStatement.cases.stream()
-        .map(matchCase -> new MatchStatement.Case(
-            expandExprs(matchCase.patterns),
-            expandStatement(matchCase.result)))
-        .collect(Collectors.toCollection(ArrayList::new));
+    var cases = new ArrayList<MatchStatement.Case>(matchStatement.cases.size());
+    for (var matchCase : matchStatement.cases) {
+      cases.add(new MatchStatement.Case(
+          expandExprs(matchCase.patterns),
+          expandStatement(matchCase.result)));
+    }
 
     return new MatchStatement(
         expandExpr(matchStatement.candidate),
@@ -1320,11 +1337,14 @@ class MacroExpander
 
   @Override
   public InstructionCallStatement visit(InstructionCallStatement instructionCallStatement) {
-    var namedArguments = instructionCallStatement.namedArguments.stream()
-        .map(namedArgument -> new InstructionCallStatement.NamedArgument(
-            expandExpr(namedArgument.name),
-            expandExpr(namedArgument.value)))
-        .collect(Collectors.toCollection(ArrayList::new));
+    var namedArguments =
+        new ArrayList<InstructionCallStatement.NamedArgument>(
+            instructionCallStatement.namedArguments.size());
+    for (var namedArgument : instructionCallStatement.namedArguments) {
+      namedArguments.add(new InstructionCallStatement.NamedArgument(
+          expandExpr(namedArgument.name),
+          expandExpr(namedArgument.value)));
+    }
 
     return new InstructionCallStatement(
         expandExpr(instructionCallStatement.id),
@@ -1344,12 +1364,13 @@ class MacroExpander
 
   @Override
   public Statement visit(ForallStatement forallStatement) {
-    var indices = forallStatement.indices.stream()
-        .map(index -> new ForallIndex(
-            expandExpr(index.name),
-            index.typeLiteral != null ? expandExpr(index.typeLiteral) : null,
-            expandExpr(index.domain)))
-        .collect(Collectors.toCollection(ArrayList::new));
+    var indices = new ArrayList<ForallIndex>(forallStatement.indices.size());
+    for (var index : forallStatement.indices) {
+      indices.add(new ForallIndex(
+          expandExpr(index.name),
+          index.typeLiteral != null ? expandExpr(index.typeLiteral) : null,
+          expandExpr(index.domain)));
+    }
 
     return new ForallStatement(
         indices,

--- a/vadl/main/vadl/ast/SymbolTable.java
+++ b/vadl/main/vadl/ast/SymbolTable.java
@@ -1186,16 +1186,10 @@ class SymbolTable {
       if (format != null) {
         statement.instrDef = instr;
         for (var namedArgument : statement.namedArguments) {
-          FormatField foundField = null;
-          for (var field : format.fieldsWithoutEncodingPredicate()) {
-            if (field.identifier().name.equals(namedArgument.identifier().name)) {
-              foundField = field;
-              break;
-            }
-          }
+          FormatField foundField = format.getField(namedArgument.identifier().name);
           if (foundField == null) {
             var suggestions = Levenshtein.suggestions(namedArgument.identifier().name,
-                format.fieldsWithoutEncodingPredicate().stream()
+                format.fieldsWithoutEncodingPredicate()
                     .map(f -> f.identifier().name).toList());
 
             statement.symbolTable().reportUnkownError(

--- a/vadl/main/vadl/ast/SymbolTable.java
+++ b/vadl/main/vadl/ast/SymbolTable.java
@@ -552,13 +552,7 @@ class SymbolTable {
   static List<Diagnostic> collectAndResolveSymbols(Ast ast) {
     return ast.timingRecorder.withPassTiming("Symbol Resolution", () -> {
       SymbolCollector.collectSymbols(ast);
-      var errs =  SymbolResolver.resolveSymbols(ast);
-      try {
-        Thread.sleep(1000 * 60 * 60);
-      } catch (InterruptedException e) {
-        throw new RuntimeException(e);
-      }
-      return errs;
+      return SymbolResolver.resolveSymbols(ast);
     });
   }
 

--- a/vadl/main/vadl/ast/SymbolTable.java
+++ b/vadl/main/vadl/ast/SymbolTable.java
@@ -552,7 +552,13 @@ class SymbolTable {
   static List<Diagnostic> collectAndResolveSymbols(Ast ast) {
     return ast.timingRecorder.withPassTiming("Symbol Resolution", () -> {
       SymbolCollector.collectSymbols(ast);
-      return SymbolResolver.resolveSymbols(ast);
+      var errs =  SymbolResolver.resolveSymbols(ast);
+      try {
+        Thread.sleep(1000 * 60 * 60);
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+      return errs;
     });
   }
 

--- a/vadl/main/vadl/ast/TypeChecker.java
+++ b/vadl/main/vadl/ast/TypeChecker.java
@@ -3736,7 +3736,7 @@ public class TypeChecker
           var formatName = formatType.format.identifier().name;
           var suggestions = Levenshtein.suggestions(
               fieldName,
-              formatType.format.fieldsWithoutEncodingPredicate().stream()
+              formatType.format.fieldsWithoutEncodingPredicate()
                   .map(f -> f.identifier().name).toList());
 
           addErrorAndStopChecking(error("Unknown format field `%s`".formatted(fieldName), expr)

--- a/vadl/main/vadl/ast/Ungrouper.java
+++ b/vadl/main/vadl/ast/Ungrouper.java
@@ -39,7 +39,9 @@ public class Ungrouper
   public static void ungroup(Ast ast) {
     ast.withPassTiming("Ungrouping", () -> {
       var ungrouper = new Ungrouper();
-      ast.definitions.forEach(def -> def.accept(ungrouper));
+      for (var def : ast.definitions) {
+        def.accept(ungrouper);
+      }
     });
   }
 
@@ -177,10 +179,10 @@ public class Ungrouper
   public Expr visit(MatchExpr expr) {
     expr.candidate = expr.candidate.accept(this);
     expr.defaultResult = expr.defaultResult.accept(this);
-    expr.cases.forEach(matchCase -> {
+    for (var matchCase : expr.cases) {
       matchCase.patterns.replaceAll(pattern -> pattern.accept(this));
       matchCase.result = matchCase.result.accept(this);
-    });
+    }
     return expr;
   }
 
@@ -207,8 +209,9 @@ public class Ungrouper
 
   @Override
   public Expr visit(ForallExpr expr) {
-    expr.indices.forEach(
-        index -> index.domain = index.domain.accept(this));
+    for (var index : expr.indices) {
+      index.domain = index.domain.accept(this);
+    }
     expr.body = expr.body.accept(this);
     return expr;
   }
@@ -243,7 +246,9 @@ public class Ungrouper
   @Override
   public Void visit(FormatDefinition definition) {
     ungroupAnnotations(definition);
-    definition.fields.forEach(f -> f.accept(this));
+    for (var f : definition.fields) {
+      f.accept(this);
+    }
     return null;
   }
 
@@ -286,7 +291,9 @@ public class Ungrouper
   @Override
   public Void visit(InstructionSetDefinition definition) {
     ungroupAnnotations(definition);
-    definition.definitions.forEach(d -> d.accept(this));
+    for (var d : definition.definitions) {
+      d.accept(this);
+    }
     return null;
   }
 
@@ -318,7 +325,9 @@ public class Ungrouper
   @Override
   public Void visit(PseudoInstructionDefinition definition) {
     ungroupAnnotations(definition);
-    definition.statements.forEach(this::visit);
+    for (var stmt : definition.statements) {
+      stmt.accept(this);
+    }
     return null;
   }
 
@@ -331,10 +340,10 @@ public class Ungrouper
   @Override
   public Void visit(EncodingDefinition definition) {
     ungroupAnnotations(definition);
-    definition.encodings.items.forEach(encoding -> {
+    for (var encoding : definition.encodings.items) {
       var enc = (EncodingDefinition.EncodingField) encoding;
       enc.value = enc.value.accept(this);
-    });
+    }
     return null;
   }
 
@@ -456,12 +465,10 @@ public class Ungrouper
   @Override
   public Void visit(ProcessDefinition processDefinition) {
     ungroupAnnotations(processDefinition);
-    processDefinition.templateParams.forEach(
-        templateParam ->
-            templateParam.value =
-                templateParam.value == null
-                    ? null
-                    : templateParam.value.accept(this));
+    for (var templateParam : processDefinition.templateParams) {
+      templateParam.value =
+          templateParam.value == null ? null : templateParam.value.accept(this);
+    }
     processDefinition.statement.accept(this);
     return null;
   }
@@ -497,7 +504,9 @@ public class Ungrouper
   @Override
   public Void visit(AbiSequenceDefinition definition) {
     ungroupAnnotations(definition);
-    definition.statements.forEach(stmt -> stmt.accept(this));
+    for (var stmt : definition.statements) {
+      stmt.accept(this);
+    }
     return null;
   }
 
@@ -510,7 +519,9 @@ public class Ungrouper
   @Override
   public Void visit(ProcessorDefinition definition) {
     ungroupAnnotations(definition);
-    definition.definitions.forEach(def -> def.accept(this));
+    for (var def : definition.definitions) {
+      def.accept(this);
+    }
     return null;
   }
 
@@ -552,7 +563,9 @@ public class Ungrouper
   @Override
   public Void visit(MicroArchitectureDefinition definition) {
     ungroupAnnotations(definition);
-    definition.definitions.forEach(def -> def.accept(this));
+    for (var def : definition.definitions) {
+      def.accept(this);
+    }
     return null;
   }
 
@@ -650,7 +663,9 @@ public class Ungrouper
 
   @Override
   public Void visit(BlockStatement blockStatement) {
-    blockStatement.statements.forEach(statement -> statement.accept(this));
+    for (var statement : blockStatement.statements) {
+      statement.accept(this);
+    }
     return null;
   }
 
@@ -711,24 +726,26 @@ public class Ungrouper
     if (matchStatement.defaultResult != null) {
       matchStatement.defaultResult.accept(this);
     }
-    matchStatement.cases.forEach(matchCase -> {
+    for (var matchCase : matchStatement.cases) {
       matchCase.patterns.replaceAll(pattern -> pattern.accept(this));
       matchCase.result.accept(this);
-    });
+    }
     return null;
   }
 
   @Override
   public Void visit(StatementList statementList) {
-    statementList.items.forEach(stmt -> stmt.accept(this));
+    for (var stmt : statementList.items) {
+      stmt.accept(this);
+    }
     return null;
   }
 
   @Override
   public Void visit(InstructionCallStatement instructionCallStatement) {
-    instructionCallStatement.namedArguments.forEach(namedArgument ->
-        namedArgument.value = namedArgument.value.accept(this)
-    );
+    for (var namedArgument : instructionCallStatement.namedArguments) {
+      namedArgument.value = namedArgument.value.accept(this);
+    }
     instructionCallStatement.unnamedArguments.replaceAll(expr -> expr.accept(this));
     return null;
   }
@@ -742,12 +759,16 @@ public class Ungrouper
 
   @Override
   public Void visit(ForallStatement forallStatement) {
-    forallStatement.indices.forEach(index -> index.domain = index.domain.accept(this));
+    for (var index : forallStatement.indices) {
+      index.domain = index.domain.accept(this);
+    }
     forallStatement.body.accept(this);
     return null;
   }
 
   private void ungroupAnnotations(Definition definition) {
-    definition.annotations.forEach(this::visit);
+    for (var annotation : definition.annotations) {
+      visit(annotation);
+    }
   }
 }

--- a/vadl/main/vadl/ast/ViamLowering.java
+++ b/vadl/main/vadl/ast/ViamLowering.java
@@ -1165,7 +1165,7 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
 
     // first lower all format fields (that are not derived format fields).
     // this is because derived format fields may reference fields, which already must be lowered.
-    var fields = definition.fieldsWithoutEncodingPredicate().stream()
+    var fields = definition.fieldsWithoutEncodingPredicate()
         .filter(f -> !(f instanceof DerivedFormatField))
         .map(fieldDefinition -> {
           var fieldIdent =

--- a/vadl/main/vadl/utils/RopeList.java
+++ b/vadl/main/vadl/utils/RopeList.java
@@ -71,7 +71,7 @@ public sealed interface RopeList<T> permits RopeList.ItemLeaf, RopeList.ListLeaf
    * @return a new rope list containing the elements.
    */
   static <T> RopeList<T> of(T... elements) {
-    if (elements.length ==1) {
+    if (elements.length == 1) {
       return new ItemLeaf<>(elements[0]);
     }
     return new ListLeaf<>(List.of(elements));

--- a/vadl/main/vadl/utils/RopeList.java
+++ b/vadl/main/vadl/utils/RopeList.java
@@ -71,6 +71,9 @@ public sealed interface RopeList<T> permits RopeList.ItemLeaf, RopeList.ListLeaf
    * @return a new rope list containing the elements.
    */
   static <T> RopeList<T> of(T... elements) {
+    if (elements.length ==1) {
+      return new ItemLeaf<>(elements[0]);
+    }
     return new ListLeaf<>(List.of(elements));
   }
 
@@ -82,6 +85,9 @@ public sealed interface RopeList<T> permits RopeList.ItemLeaf, RopeList.ListLeaf
    * @return a new rope list containing the elements.
    */
   static <T> RopeList<T> of(List<T> elements) {
+    if (elements.size() == 1) {
+      return new ItemLeaf<>(elements.get(0));
+    }
     return new ListLeaf<>(elements);
   }
 

--- a/vadl/main/vadl/utils/SourceLocation.java
+++ b/vadl/main/vadl/utils/SourceLocation.java
@@ -208,11 +208,11 @@ public sealed interface SourceLocation extends WithLocation, Comparable<SourceLo
    * @param newExpandedFrom to be appended.
    * @return the new location.
    */
-  default SourceLocation copyWithAppendedExpandedFrom(List<DirectLocation> newExpandedFrom) {
+  default SourceLocation copyWithAppendedExpandedFrom(RopeList<DirectLocation> newExpandedFrom) {
     return switch (this) {
-      case DirectLocation direct -> new ExpandedLocation(direct, RopeList.of(newExpandedFrom));
+      case DirectLocation direct -> new ExpandedLocation(direct, newExpandedFrom);
       case ExpandedLocation original -> new ExpandedLocation(original.primaryLocation,
-          original.expandedFrom.concat(RopeList.of(newExpandedFrom)));
+          original.expandedFrom.concat(newExpandedFrom));
     };
   }
 

--- a/vadl/main/vadl/utils/SourceLocation.java
+++ b/vadl/main/vadl/utils/SourceLocation.java
@@ -152,9 +152,13 @@ public sealed interface SourceLocation extends WithLocation, Comparable<SourceLo
     }
 
     // Shortcut if both have the same expansion stack
-    if (this.expandedFromStack().equals(other.expandedFromStack())) {
-      return new ExpandedLocation(new DirectLocation(this.path(), this.begin(), other.end()),
-          RopeList.of(this.expandedFromStack()));
+    if (this instanceof ExpandedLocation thisExpandedLoc
+        && other instanceof ExpandedLocation otherExpandedLoc
+        && thisExpandedLoc.expandedFrom.equals(otherExpandedLoc.expandedFrom)) {
+      var begin = this.begin().compareTo(other.begin()) < 0 ? this.begin() : other.begin();
+      var end = this.end().compareTo(other.end()) > 0 ? this.end() : other.end();
+      return new ExpandedLocation(new DirectLocation(this.path(), begin, end),
+          thisExpandedLoc.expandedFrom);
     }
 
     // The expansion stacks differ, let's find a shared substack or use the innermost invocation.


### PR DESCRIPTION
This is some continuation of my work with #933 

These optimizations come from a mixture of educated guesses and spending too much time in the profiler, investigating memory allocations and time spent.

### Results
Here are some benchmark results from my M3 Max with the miniARMv7 spec on native.

- **master:**  507ms
- **Avoiding empty entries in RopeList** 483ms
- **Reusing rope in macro expander:** 479ms
- **Rewriting macro expander in imperative style and preallocate lists:** 372ms
- **Refactor location joining:** 369ms (not noteworthy but cleaner, and faster in lowering)
- **Better builtin lookups:** 321ms
- **Avoiding unecessary lists in format field access:** 297ms
- **Replacing many forEach with loops:** 290ms

