### PR TITLE
iss: Implement CPU-vector storage metadata foundation

### DIFF
--- a/vadl/main/resources/templates/iss/target/gen-arch/cpu.h
+++ b/vadl/main/resources/templates/iss/target/gen-arch/cpu.h
@@ -25,7 +25,7 @@ extern const char * const [(${gen_arch_lower})]_cpu_[(${reg.name_lower})]_names[
 typedef struct CPUArchState {
   // CPU registers
   [# th:each="reg, iterState : ${register_tensors}"]
-  uint[(${reg.cpu_state_type_width})]_t [(${reg.name_lower})][(${reg.c_array_def})];
+  uint[(${reg.cpu_state_type_width})]_t [(${reg.name_lower})][(${reg.c_array_def})][(${reg.cpu_state_alignment})];
   [/]
 
   // Exception arguments (intermediate store during exception handling)

--- a/vadl/main/resources/templates/iss/target/gen-arch/translate.c
+++ b/vadl/main/resources/templates/iss/target/gen-arch/translate.c
@@ -84,6 +84,15 @@ static target_ulong next_insn(DisasContext *ctx)
     return translator_ld[(${insn_width.short})]_swap(ctx->env, &ctx->base, pc_next, swap_insn(ctx));
 }
 
+[# th:each="reg : ${register_tensors}" th:if="${reg.is_gvec_capable}"]
+static inline uint32_t [(${reg.gvec_offset_helper_name})](DisasContext *ctx[(${reg.gvec_offset_params})])
+{   [# th:each="dim : ${reg.gvec_offset_dims}"]
+    assert( [(${dim.arg_name})] < [(${dim["size"]})]); [/]
+    (void) ctx;
+    return [(${reg.gvec_offset_expr})];
+}
+[/]
+
 [# th:each="reg : ${register_tensors}" th:if="${reg.is_tcg}"]
 static TCGv get_[(${reg.name_lower})](DisasContext *ctx [(${reg.getter_params})])
 {   [# th:each="dim : ${reg.index_dims}"]

--- a/vadl/main/vadl/iss/codegen/IssInstrHelperGenerator.java
+++ b/vadl/main/vadl/iss/codegen/IssInstrHelperGenerator.java
@@ -48,7 +48,7 @@ import vadl.viam.passes.sideEffectScheduling.nodes.InstrExitNode;
 /**
  * Generates helper function implementations for instructions in {@code target/gen-arch/helper.c}.
  * These helper functions are called by the translate functions for instructions that are too
- * complex to be directly translated into TCG operations (e.g., instructions using generic vector
+ * complex to be directly translated into TCG operations (e.g., instructions using CPU-vector
  * registers).
  *
  * <p>The generated helper functions have the signature:

--- a/vadl/main/vadl/iss/codegen/RegisterAccessEmitters.java
+++ b/vadl/main/vadl/iss/codegen/RegisterAccessEmitters.java
@@ -129,7 +129,7 @@ public final class RegisterAccessEmitters {
   private static RegisterAccessEmitter emitterFor(RegInfo regInfo) {
     return regInfo.execClass() == RegInfo.ExecClass.TCG_SCALAR
         ? TcgScalarRegisterAccessEmitter.INSTANCE
-        : HelperOnlyRegisterAccessEmitter.INSTANCE;
+        : CpuVectorRegisterAccessEmitter.INSTANCE;
   }
 
   private interface RegisterAccessEmitter {
@@ -160,10 +160,10 @@ public final class RegisterAccessEmitters {
   }
 
   /**
-   * Emitter for helper-only register accesses.
+   * Emitter for CPU-vector register accesses.
    */
-  private static final class HelperOnlyRegisterAccessEmitter implements RegisterAccessEmitter {
-    static final HelperOnlyRegisterAccessEmitter INSTANCE = new HelperOnlyRegisterAccessEmitter();
+  private static final class CpuVectorRegisterAccessEmitter implements RegisterAccessEmitter {
+    static final CpuVectorRegisterAccessEmitter INSTANCE = new CpuVectorRegisterAccessEmitter();
 
     @Override
     public void emitRead(CGenContext<Node> ctx, ReadRegTensorNode node,

--- a/vadl/main/vadl/iss/passes/common/IssCommonExprSavePass.java
+++ b/vadl/main/vadl/iss/passes/common/IssCommonExprSavePass.java
@@ -158,7 +158,7 @@ public class IssCommonExprSavePass extends AbstractIssPass {
   }
 
   private boolean containsDisallowedSubtree(Node node, Set<Node> visited) {
-    // Keep the pass conservative: helper-only repeated scalar arithmetic is fine to save,
+    // Keep the pass conservative: CPU-vector repeated scalar arithmetic is fine to save,
     // but memory reads and function calls may imply extra evaluation constraints or side effects.
     if (!visited.add(node)) {
       return false;

--- a/vadl/main/vadl/iss/passes/common/IssExecStrategyPass.java
+++ b/vadl/main/vadl/iss/passes/common/IssExecStrategyPass.java
@@ -59,17 +59,17 @@ public class IssExecStrategyPass extends AbstractIssPass {
 
     var isa = viam.isa().get();
     isa.ownInstructions().forEach(instr -> {
-      var hasHelperOnlyReads = instr.behavior().getNodes(IssReadRegNode.class)
-          .anyMatch(n -> regInfo(n.regTensor()).execClass() == RegInfo.ExecClass.HELPER_ONLY);
-      var hasHelperOnlyWrites = instr.behavior().getNodes(IssWriteRegNode.class)
-          .anyMatch(n -> regInfo(n.regTensor()).execClass() == RegInfo.ExecClass.HELPER_ONLY);
+      var hasCpuVectorReads = instr.behavior().getNodes(IssReadRegNode.class)
+          .anyMatch(n -> regInfo(n.regTensor()).execClass() == RegInfo.ExecClass.CPU_VECTOR);
+      var hasCpuVectorWrites = instr.behavior().getNodes(IssWriteRegNode.class)
+          .anyMatch(n -> regInfo(n.regTensor()).execClass() == RegInfo.ExecClass.CPU_VECTOR);
 
       // TODO: Eventually this must be supported by TCG as well
       var anyTensorExpr = instr.behavior().getNodes(ForallNode.class).findAny().isPresent()
           || instr.behavior().getNodes(TensorNode.class).findAny().isPresent()
           || instr.behavior().getNodes(FoldNode.class).findAny().isPresent();
 
-      var strategy = hasHelperOnlyReads || hasHelperOnlyWrites || anyTensorExpr
+      var strategy = hasCpuVectorReads || hasCpuVectorWrites || anyTensorExpr
           ? InstrInfo.ExecStrategy.HELPER_CALL
           : InstrInfo.ExecStrategy.DIRECT_TCG;
 

--- a/vadl/main/vadl/iss/passes/common/IssRegisterAccessInfoRetrievalPass.java
+++ b/vadl/main/vadl/iss/passes/common/IssRegisterAccessInfoRetrievalPass.java
@@ -174,8 +174,8 @@ public class IssRegisterAccessInfoRetrievalPass extends AbstractIssPass {
     if (descriptor.elementWidth() <= configuration().targetSize().width) {
       return true;
     }
-    if (regInfo(node.regTensor()).execClass() == RegInfo.ExecClass.HELPER_ONLY) {
-      // Helper-only wide accesses are emitted via helper/cpu paths and do not require
+    if (regInfo(node.regTensor()).execClass() == RegInfo.ExecClass.CPU_VECTOR) {
+      // CPU-vector wide accesses are emitted via helper/cpu paths and do not require
       // scalar base-accessor signatures.
       return false;
     }
@@ -194,8 +194,8 @@ public class IssRegisterAccessInfoRetrievalPass extends AbstractIssPass {
     if (descriptor.elementWidth() <= configuration().targetSize().width) {
       return true;
     }
-    if (regInfo(node.regTensor()).execClass() == RegInfo.ExecClass.HELPER_ONLY) {
-      // Helper-only wide accesses are emitted via helper/cpu paths and do not require
+    if (regInfo(node.regTensor()).execClass() == RegInfo.ExecClass.CPU_VECTOR) {
+      // CPU-vector wide accesses are emitted via helper/cpu paths and do not require
       // scalar base-accessor signatures.
       return false;
     }

--- a/vadl/main/vadl/iss/passes/common/IssRegisterAccessLoweringPass.java
+++ b/vadl/main/vadl/iss/passes/common/IssRegisterAccessLoweringPass.java
@@ -240,7 +240,7 @@ class IssRegisterAccessLowering {
     var simpleAliasAccessor = semantics.aliasSlice() == null
         && aliasIndices.size() == baseDims;
     var helperExpansionAccessor = regInfo(semantics.baseTensor()).execClass()
-        == RegInfo.ExecClass.HELPER_ONLY
+        == RegInfo.ExecClass.CPU_VECTOR
         && semantics.aliasSlice() == null
         && aliasIndices.size() > baseDims
         && read.type().asDataType().bitWidth() <= 64;

--- a/vadl/main/vadl/iss/passes/extensions/InstrInfo.java
+++ b/vadl/main/vadl/iss/passes/extensions/InstrInfo.java
@@ -85,11 +85,11 @@ public class InstrInfo extends DefinitionExtension<Instruction> {
   }
 
   private ExecStrategy computeFallbackExecStrategy() {
-    var hasHelperOnlyReads = instr().behavior().getNodes(IssReadRegNode.class)
-        .anyMatch(n -> regInfo(n.regTensor()).execClass() == RegInfo.ExecClass.HELPER_ONLY);
-    var hasHelperOnlyWrites = instr().behavior().getNodes(IssWriteRegNode.class)
-        .anyMatch(n -> regInfo(n.regTensor()).execClass() == RegInfo.ExecClass.HELPER_ONLY);
-    return hasHelperOnlyReads || hasHelperOnlyWrites
+    var hasCpuVectorReads = instr().behavior().getNodes(IssReadRegNode.class)
+        .anyMatch(n -> regInfo(n.regTensor()).execClass() == RegInfo.ExecClass.CPU_VECTOR);
+    var hasCpuVectorWrites = instr().behavior().getNodes(IssWriteRegNode.class)
+        .anyMatch(n -> regInfo(n.regTensor()).execClass() == RegInfo.ExecClass.CPU_VECTOR);
+    return hasCpuVectorReads || hasCpuVectorWrites
         ? ExecStrategy.HELPER_CALL
         : ExecStrategy.DIRECT_TCG;
   }

--- a/vadl/main/vadl/iss/passes/extensions/RegInfo.java
+++ b/vadl/main/vadl/iss/passes/extensions/RegInfo.java
@@ -24,7 +24,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import javax.annotation.Nullable;
 import vadl.configuration.IssConfiguration;
@@ -85,9 +84,9 @@ public class RegInfo extends DefinitionExtension<RegisterTensor> implements Rend
      */
     TCG_SCALAR,
     /**
-     * Register must be accessed through helper/cpu-state code.
+     * Register is stored as a CPU-state byte array for helper access and future gvec offsets.
      */
-    HELPER_ONLY
+    CPU_VECTOR
   }
 
   /**
@@ -137,14 +136,17 @@ public class RegInfo extends DefinitionExtension<RegisterTensor> implements Rend
   }
 
   /**
-   * Checks if this register is handled as a generic vector.
-   * A register will be handled as generic vector if its inner type
-   * does not fit into the target size (max 64 bit), or if it has vector-style accesses.
-   *
-   * @return true if register is a generic vector
+   * Returns whether this register is stored as a CPU-state byte array for helper and vector paths.
    */
-  public boolean isGVec() {
-    return execClass == ExecClass.HELPER_ONLY;
+  public boolean isCpuVector() {
+    return execClass == ExecClass.CPU_VECTOR;
+  }
+
+  /**
+   * Returns whether this register has the minimum storage metadata needed for future gvec offsets.
+   */
+  public boolean isGvecCapable() {
+    return isCpuVector() && reg().totalWidth() % 8 == 0 && cpuVectorAlignmentBytes() >= 16;
   }
 
   /**
@@ -195,7 +197,7 @@ public class RegInfo extends DefinitionExtension<RegisterTensor> implements Rend
    * Returns whether this register is stored as an array in the CPU state.
    */
   public boolean hasCpuStateArrayStorage() {
-    return isGVec() || reg().maxNumberOfAccessIndices() > 0;
+    return isCpuVector() || reg().maxNumberOfAccessIndices() > 0;
   }
 
   /**
@@ -224,17 +226,38 @@ public class RegInfo extends DefinitionExtension<RegisterTensor> implements Rend
    * TCG variable, otherwise there would be an overflow when QEMU synchronizes the
    * TCG variables with the CPU state object.
    *
-   * <p>However, if the register is a generic vector, there is no corresponding TCG variable
+   * <p>However, if the register is a CPU vector, there is no corresponding TCG variable
    * and so is not synchronization involved, which means the above constraint does not apply
    * to them.
    *
-   * <p>Furthermore, generic vector registers are always rendered as byte arrays (uint8_t)
+   * <p>Furthermore, CPU vector registers are always rendered as byte arrays (uint8_t)
    * in the CPU state object.
    *
    * @return the CPU state type width in bits
    */
   public int cpuStateTypeWidth() {
-    return isGVec() ? 8 : config.targetSize().width;
+    return isCpuVector() ? 8 : config.targetSize().width;
+  }
+
+  /**
+   * Returns the CPU-state field alignment in bytes for CPU-vector storage.
+   */
+  public int cpuVectorAlignmentBytes() {
+    return 16;
+  }
+
+  /**
+   * Returns the C field attribute used for CPU-vector storage alignment.
+   */
+  public String cpuStateAlignment() {
+    return isCpuVector() ? " QEMU_ALIGNED(" + cpuVectorAlignmentBytes() + ")" : "";
+  }
+
+  /**
+   * Returns the name of the future gvec offset helper for this register.
+   */
+  public String gvecOffsetHelperName() {
+    return "ofs_" + nameLower();
   }
 
   protected String cpuStateName() {
@@ -261,9 +284,11 @@ public class RegInfo extends DefinitionExtension<RegisterTensor> implements Rend
       renderObj.put("index_dims", dims);
       renderObj.put("value_width", resultType.bitWidth());
       renderObj.put("cpu_state_type_width", cpuStateTypeWidth());
+      renderObj.put("cpu_state_alignment", cpuStateAlignment());
       renderObj.put("names", names());
       renderObj.put("is_tcg", isTcgScalar());
-      renderObj.put("is_gvec", isGVec());
+      renderObj.put("is_cpu_vector", isCpuVector());
+      renderObj.put("is_gvec_capable", isGvecCapable());
       renderObj.put("is_tb_state", isTbState());
       renderObj.put("tb_state_parts", tbStateParts());
       renderObj.put("exec_class", execClass().name());
@@ -277,6 +302,11 @@ public class RegInfo extends DefinitionExtension<RegisterTensor> implements Rend
       renderObj.put("c_array_def", renderCArrayDef());
       renderObj.put("c_array_index", cArrayIndex("d"));
       renderObj.put("c_reg_name_array_def", renderCRegNameArrayDef());
+      renderObj.put("gvec_offset_helper_name", gvecOffsetHelperName());
+      renderObj.put("gvec_offset_dims", renderGvecOffsetDims());
+      renderObj.put("gvec_offset_params", renderGvecOffsetParams());
+      renderObj.put("gvec_offset_args", renderGvecOffsetArgs());
+      renderObj.put("gvec_offset_expr", renderGvecOffsetExpr());
     }
     return renderObj;
   }
@@ -314,10 +344,9 @@ public class RegInfo extends DefinitionExtension<RegisterTensor> implements Rend
   private String renderCArrayDef() {
     var sb = new StringBuilder();
 
-    if (isGVec()) {
-      // if the register is a gvec, we will use a single-dimensional array
-      // for simplicity when accessing it. The array is a byte array (uint8_t),
-      // so we must adjust the element number accordingly.
+    if (isCpuVector()) {
+      // CPU-vector registers use one flattened byte array in CPU state. Helper accessors and
+      // future gvec offset helpers use explicit byte offsets into this storage.
       var elementSize = 8;
       var numElements = reg().totalWidth() / elementSize;
       sb.append("[").append(numElements).append("]");
@@ -361,6 +390,44 @@ public class RegInfo extends DefinitionExtension<RegisterTensor> implements Rend
         })
         .collect(joining(", "));
     return args;
+  }
+
+  private List<Map<String, Object>> renderGvecOffsetDims() {
+    return reg().indexDimensions().stream()
+        .limit(1)
+        .map(d -> Map.of(
+            "size", (Object) d.size(),
+            "index_ctype", CppTypeMap.getCppTypeNameByVadlType(
+                Objects.requireNonNull(d.indexType().fittingCppType())),
+            "arg_name", "d" + d.index()
+        ))
+        .toList();
+  }
+
+  private String renderGvecOffsetParams() {
+    var args = renderGvecOffsetDims().stream()
+        .map(d -> d.get("index_ctype") + " " + d.get("arg_name"))
+        .collect(joining(", "));
+    return args.isEmpty() ? "" : ", " + args;
+  }
+
+  private String renderGvecOffsetArgs() {
+    var args = renderGvecOffsetDims().stream()
+        .map(d -> Objects.requireNonNull(d.get("arg_name")).toString())
+        .collect(joining(", "));
+    return args.isEmpty() ? "" : ", " + args;
+  }
+
+  private String renderGvecOffsetExpr() {
+    var targetUpper = config.targetName().toUpperCase();
+    var base = "offsetof(CPU" + targetUpper + "State, " + nameLower() + ")";
+    var dims = renderGvecOffsetDims();
+    if (dims.isEmpty()) {
+      return base;
+    }
+    var strideBytes = reg().resultType(1).bitWidth() / 8;
+    return base + " + ((uint32_t) " + dims.getFirst().get("arg_name") + ") * "
+        + strideBytes + "u";
   }
 
   /**
@@ -415,7 +482,7 @@ public class RegInfo extends DefinitionExtension<RegisterTensor> implements Rend
 
   /// Determines backend execution class for a register tensor.
   ///
-  /// A register is considered a gvec if:
+  /// A register uses CPU-vector storage if:
   /// - Any single element exceeds 64 bits (can't fit in TCG scalar types)
   /// - It has vector-style accesses (accessing multiple elements at once)
   /// - The total register width exceeds 64 bits AND it's not a register file with
@@ -444,7 +511,7 @@ public class RegInfo extends DefinitionExtension<RegisterTensor> implements Rend
     //    If so, even scalar accesses can't use TCG variables
     int fullyIndexedWidth = reg.resultType(reg.maxNumberOfAccessIndices()).bitWidth();
     if (fullyIndexedWidth > 64) {
-      return ExecClass.HELPER_ONLY;
+      return ExecClass.CPU_VECTOR;
     }
 
     // TODO: We should propably do proper analysis if the register is used
@@ -452,10 +519,10 @@ public class RegInfo extends DefinitionExtension<RegisterTensor> implements Rend
     // 2. Check if it is more than 2 dimensions.
     //    If so, it is typically used as vector registers within loops.
     if (reg.dimensions().size() > 2) {
-      return ExecClass.HELPER_ONLY;
+      return ExecClass.CPU_VECTOR;
     }
 
-    // 3. If we have vector-style accesses, use gvec
+    // 3. If we have vector-style accesses, use CPU-vector storage.
     //    Otherwise, all accesses are fully indexed (scalar accesses)
     //    Even if total width > 64 bits, we can use separate TCG variables
     //    for each element (like GPR[32] where each register is separate)
@@ -463,7 +530,7 @@ public class RegInfo extends DefinitionExtension<RegisterTensor> implements Rend
         .anyMatch(read -> isVectorAccess(reg, read.indices().size()))
         || writes.stream()
         .anyMatch(write -> isVectorAccess(reg, write.indices().size()));
-    return hasVectorStyleAccess ? ExecClass.HELPER_ONLY : ExecClass.TCG_SCALAR;
+    return hasVectorStyleAccess ? ExecClass.CPU_VECTOR : ExecClass.TCG_SCALAR;
   }
 
   /**
@@ -508,7 +575,7 @@ public class RegInfo extends DefinitionExtension<RegisterTensor> implements Rend
    *   from the effective base-register call.</li>
    *   <li>Dynamic chunk helpers such as
    *   {@code uint64_t cpu_get_z_chunk(CPUState *env, uint32_t i0, uint32_t bit_offset,
-   *   uint32_t bit_width)} are emitted by dedicated helper-only chunk generation and are not
+   *   uint32_t bit_width)} are emitted by dedicated CPU-vector chunk generation and are not
    *   represented by these descriptors.</li>
    *   <li>TCG chunk accesses are also not represented as standalone descriptors: they are emitted
    *   inline in {@code trans_*} through explicit extract/deposit operations using the
@@ -809,15 +876,15 @@ public class RegInfo extends DefinitionExtension<RegisterTensor> implements Rend
      * Generates the C function body for this descriptor.
      */
     private String body() {
-      if (owner.isGVec()) {
-        return gVecBody();
+      if (owner.isCpuVector()) {
+        return cpuVectorBody();
       } else {
         return normalBody();
       }
     }
 
     /**
-     * Generates function body for normal (non-gvec) register access.
+     * Generates function body for scalar CPU-state register access.
      *
      * @return the function body code
      */
@@ -860,12 +927,12 @@ public class RegInfo extends DefinitionExtension<RegisterTensor> implements Rend
     }
 
     /**
-     * Generates function body for generic vector register access.
+     * Generates function body for CPU-vector byte-array register access.
      *
      * @return the function body code
      */
     @SuppressWarnings("MethodName")
-    private String gVecBody() {
+    private String cpuVectorBody() {
 
       // precompute strides (row-major)
       int ndims = dims.size();

--- a/vadl/main/vadl/iss/template/target/BaseChunkCpuAccessors.java
+++ b/vadl/main/vadl/iss/template/target/BaseChunkCpuAccessors.java
@@ -25,7 +25,7 @@ import vadl.viam.RegisterTensor;
 import vadl.viam.Specification;
 
 /**
- * Renders dynamic chunk read accessors for helper-only base register accesses.
+ * Renders dynamic chunk read accessors for CPU-vector base register accesses.
  *
  * <p>These accessors are consumed by helper/procedure/exception emitters for unified
  * {@code IssReadRegNode(BASE, CHUNK)} reads with translation-time or runtime bit windows.
@@ -40,7 +40,7 @@ final class BaseChunkCpuAccessors {
     var out = new ArrayList<Map<String, Object>>();
     specification.isa().get().registerTensors().forEach(reg -> {
       var info = reg.expectExtension(RegInfo.class);
-      if (info.execClass() == RegInfo.ExecClass.HELPER_ONLY) {
+      if (info.execClass() == RegInfo.ExecClass.CPU_VECTOR) {
         out.add(renderReadAccessor(reg, config));
       }
     });
@@ -52,7 +52,7 @@ final class BaseChunkCpuAccessors {
     var out = new ArrayList<Map<String, Object>>();
     specification.isa().get().registerTensors().forEach(reg -> {
       var info = reg.expectExtension(RegInfo.class);
-      if (info.execClass() == RegInfo.ExecClass.HELPER_ONLY) {
+      if (info.execClass() == RegInfo.ExecClass.CPU_VECTOR) {
         out.add(renderWriteAccessor(reg, config));
       }
     });

--- a/vadl/main/vadl/iss/template/target/EmitIssCpuSourcePass.java
+++ b/vadl/main/vadl/iss/template/target/EmitIssCpuSourcePass.java
@@ -90,8 +90,8 @@ public class EmitIssCpuSourcePass extends IssTemplateRenderingPass {
     var dims = reg.indexDimensions();
     var regInfo = reg.expectExtension(RegInfo.class);
 
-    if (regInfo.execClass() == RegInfo.ExecClass.HELPER_ONLY) {
-      dumpHelperOnlyRegCode(sb, reg, regLower, names, dims.size());
+    if (regInfo.execClass() == RegInfo.ExecClass.CPU_VECTOR) {
+      dumpCpuVectorRegCode(sb, reg, regLower, names, dims.size());
     } else if (dims.isEmpty()) {
       sb.callStmt("qemu_fprintf", "f",
           "\" " + reg.simpleName() + ":    \" TARGET_FMT_lx \"\\n\"",
@@ -133,8 +133,8 @@ public class EmitIssCpuSourcePass extends IssTemplateRenderingPass {
     }
   }
 
-  private void dumpHelperOnlyRegCode(CCodeBuilder sb, RegisterTensor reg, String regLower,
-                                     String names, int indexDimCount) {
+  private void dumpCpuVectorRegCode(CCodeBuilder sb, RegisterTensor reg, String regLower,
+                                    String names, int indexDimCount) {
     var bytesPerReg = reg.resultType(indexDimCount).bitWidth() / 8;
     if (indexDimCount == 0) {
       sb.callStmt("qemu_fprintf", "f", "\" " + reg.simpleName() + ":    \"");

--- a/vadl/main/vadl/viam/passes/DuplicateWriteDetectionPass.java
+++ b/vadl/main/vadl/viam/passes/DuplicateWriteDetectionPass.java
@@ -156,16 +156,16 @@ class DuplicateWriteDetector {
   }
 
   private boolean skipCheck() {
-    var hasHelperOnlyRegAccess = behavior.getNodes(ReadResourceNode.class).anyMatch(n ->
+    var hasCpuVectorRegAccess = behavior.getNodes(ReadResourceNode.class).anyMatch(n ->
         n.resourceDefinition() instanceof RegisterTensor reg
             && reg.hasExtension(RegInfo.class)
-            && reg.expectExtension(RegInfo.class).execClass() == RegInfo.ExecClass.HELPER_ONLY
+            && reg.expectExtension(RegInfo.class).execClass() == RegInfo.ExecClass.CPU_VECTOR
     ) || behavior.getNodes(WriteRegTensorNode.class).anyMatch(n ->
         n.regTensor().hasExtension(RegInfo.class)
             && n.regTensor().expectExtension(RegInfo.class).execClass()
-            == RegInfo.ExecClass.HELPER_ONLY
+            == RegInfo.ExecClass.CPU_VECTOR
     );
-    if (hasHelperOnlyRegAccess) {
+    if (hasCpuVectorRegAccess) {
       return true;
     }
 


### PR DESCRIPTION
This PR is vector metadata and renaming only.

- Rename helper-only register execution class to CPU_VECTOR
- Add CPU-vector and gvec-capable register metadata
- Align CPU-vector state arrays and emit future offset helpers
- Add RV64V metadata/template regression coverage
- Preserve existing helper-call vector execution behavior