### PR TITLE
viam: Optimize Graph API to reduce memory consumption

### DIFF
--- a/java-annotations/main/vadl/javaannotations/viam/ApplyOnInputsChecker.java
+++ b/java-annotations/main/vadl/javaannotations/viam/ApplyOnInputsChecker.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -105,11 +105,8 @@ public class ApplyOnInputsChecker extends AbstractAnnotationChecker {
 
       String stmt;
       if (fieldType.toString().startsWith(NODELIST)) {
-        // if the field is a nodelist, we implement it as stream
-        stmt =
-            ("%s = %s.stream().map((e) -> %s.apply(this, e%s))"
-                + ".collect(Collectors.toCollection(NodeList::new));")
-                .formatted(fieldName, fieldName, paramNames.get(0), typeOverload);
+        stmt = "%s = rewriteNodeList(%s, %s%s);".formatted(
+            fieldName, fieldName, paramNames.get(0), typeOverload);
       } else {
         var applyMethod = fieldIsNullable ? "applyNullable" : "apply";
 

--- a/java-annotations/main/vadl/javaannotations/viam/ApplyOnSuccessorsChecker.java
+++ b/java-annotations/main/vadl/javaannotations/viam/ApplyOnSuccessorsChecker.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -105,11 +105,8 @@ public class ApplyOnSuccessorsChecker extends AbstractAnnotationChecker {
 
       String stmt;
       if (fieldType.toString().startsWith(NODELIST)) {
-        // if the field is a nodelist, we implement it as stream
-        stmt =
-            ("%s = %s.stream().map((e) -> %s.apply(this, e%s))"
-                + ".collect(Collectors.toCollection(NodeList::new));")
-                .formatted(fieldName, fieldName, paramNames.get(0), typeOverload);
+        stmt = "%s = rewriteNodeList(%s, %s%s);".formatted(
+            fieldName, fieldName, paramNames.get(0), typeOverload);
       } else {
         var applyMethod = fieldIsNullable ? "applyNullable" : "apply";
 

--- a/vadl/main/vadl/gcb/passes/DetermineBuiltinAttributesPass.java
+++ b/vadl/main/vadl/gcb/passes/DetermineBuiltinAttributesPass.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -104,8 +104,8 @@ public class DetermineBuiltinAttributesPass extends Pass {
   }
 
   private boolean isMem(Graph snapshot) {
-    return !snapshot.getNodes(WriteMemNode.class).toList().isEmpty()
-        || !snapshot.getNodes(ReadMemNode.class).toList().isEmpty();
+    return snapshot.getNodes(WriteMemNode.class).findAny().isPresent()
+        || snapshot.getNodes(ReadMemNode.class).findAny().isPresent();
   }
 
   private boolean isNoMem(Graph snapshot) {
@@ -113,7 +113,7 @@ public class DetermineBuiltinAttributesPass extends Pass {
   }
 
   private boolean willReturn(Graph snapshot) {
-    return !snapshot.getNodes(WritesRegisterTensor.class).toList().isEmpty();
+    return snapshot.getNodes(WritesRegisterTensor.class).findAny().isPresent();
   }
 
   /**
@@ -127,6 +127,6 @@ public class DetermineBuiltinAttributesPass extends Pass {
    * x) No division-by-zero traps
    */
   private boolean speculatable(Graph snapshot) {
-    return isNoMem(snapshot) && snapshot.getNodes(ProcCallNode.class).toList().isEmpty();
+    return isNoMem(snapshot) && snapshot.getNodes(ProcCallNode.class).findAny().isEmpty();
   }
 }

--- a/vadl/main/vadl/gcb/passes/GenerateGcbIntrinsicsPass.java
+++ b/vadl/main/vadl/gcb/passes/GenerateGcbIntrinsicsPass.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -105,8 +105,8 @@ public class GenerateGcbIntrinsicsPass extends Pass {
 
       var isNoMem = isNoMem(snapshot);
       var speculatable = speculatable(snapshot);
-      var readsMem = !snapshot.getNodes(ReadMemNode.class).toList().isEmpty();
-      var writesMem = !snapshot.getNodes(WriteMemNode.class).toList().isEmpty();
+      var readsMem = snapshot.getNodes(ReadMemNode.class).findAny().isPresent();
+      var writesMem = snapshot.getNodes(WriteMemNode.class).findAny().isPresent();
 
       var attributes = new ArrayList<InstructionIntrinsicAttributesCtx.Attribute>();
       if (isNoMem) {
@@ -152,8 +152,8 @@ public class GenerateGcbIntrinsicsPass extends Pass {
   }
 
   private boolean isMem(Graph snapshot) {
-    return !snapshot.getNodes(WriteMemNode.class).toList().isEmpty()
-        || !snapshot.getNodes(ReadMemNode.class).toList().isEmpty();
+    return snapshot.getNodes(WriteMemNode.class).findAny().isPresent()
+        || snapshot.getNodes(ReadMemNode.class).findAny().isPresent();
   }
 
   private boolean isNoMem(Graph snapshot) {
@@ -171,7 +171,7 @@ public class GenerateGcbIntrinsicsPass extends Pass {
    * x) No division-by-zero traps
    */
   private boolean speculatable(Graph snapshot) {
-    return isNoMem(snapshot) && snapshot.getNodes(ProcCallNode.class).toList().isEmpty();
+    return isNoMem(snapshot) && snapshot.getNodes(ProcCallNode.class).findAny().isEmpty();
   }
 
   private boolean hasValidInputOperands(List<GcbInstructionOperand> operands) {

--- a/vadl/main/vadl/gcb/passes/IsaMatchingUtils.java
+++ b/vadl/main/vadl/gcb/passes/IsaMatchingUtils.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import vadl.gcb.annotations.StatusRegisterAnnotation;
 import vadl.lcb.passes.isaMatching.IsaMachineInstructionMatchingPass;
 import vadl.lcb.passes.isaMatching.IsaPseudoInstructionMatchingPass;
@@ -194,8 +193,8 @@ public interface IsaMatchingUtils {
 
     return !matched.isEmpty()
         && ((TupleType) ((BuiltInCall) matched.getFirst()).type()).first().equals(ty)
-        && behavior.getNodes(Set.of(IfNode.class, SliceNode.class)).toList().isEmpty()
-        && behavior.getNodes(BuiltInCall.class).toList().size() == 1
+        && behavior.getNodes(Set.of(IfNode.class, SliceNode.class)).findAny().isEmpty()
+        && behavior.getNodes(BuiltInCall.class).limit(2).count() == 1
         && noPcAccess(behavior)
         && hasNegative
         && hasOverflow

--- a/vadl/main/vadl/iss/passes/nodes/IssReadRegNode.java
+++ b/vadl/main/vadl/iss/passes/nodes/IssReadRegNode.java
@@ -17,7 +17,6 @@
 package vadl.iss.passes.nodes;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import vadl.javaannotations.viam.DataValue;
 import vadl.javaannotations.viam.Input;
@@ -253,9 +252,7 @@ public class IssReadRegNode extends ReadRegTensorNode {
   public void applyOnInputsUnsafe(
       vadl.viam.graph.GraphVisitor.Applier<vadl.viam.graph.Node> visitor) {
     super.applyOnInputsUnsafe(visitor);
-    accessorIndices = accessorIndices.stream()
-        .map(e -> visitor.apply(this, e, ExpressionNode.class))
-        .collect(Collectors.toCollection(NodeList::new));
+    accessorIndices = rewriteNodeList(accessorIndices, visitor, ExpressionNode.class);
     bitOffset = visitor.apply(this, bitOffset, ExpressionNode.class);
     bitWidth = visitor.apply(this, bitWidth, ExpressionNode.class);
   }

--- a/vadl/main/vadl/iss/passes/nodes/IssRegBitfieldWriteNode.java
+++ b/vadl/main/vadl/iss/passes/nodes/IssRegBitfieldWriteNode.java
@@ -17,7 +17,6 @@
 package vadl.iss.passes.nodes;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import vadl.javaannotations.viam.DataValue;
 import vadl.javaannotations.viam.Input;
@@ -130,9 +129,7 @@ public class IssRegBitfieldWriteNode extends SideEffectNode {
   @Override
   protected void applyOnInputsUnsafe(GraphVisitor.Applier<Node> visitor) {
     super.applyOnInputsUnsafe(visitor);
-    indices = indices.stream()
-        .map(e -> visitor.apply(this, e, ExpressionNode.class))
-        .collect(Collectors.toCollection(NodeList::new));
+    indices = rewriteNodeList(indices, visitor, ExpressionNode.class);
     value = visitor.apply(this, value, ExpressionNode.class);
     bitOffset = visitor.apply(this, bitOffset, ExpressionNode.class);
     bitWidth = visitor.apply(this, bitWidth, ExpressionNode.class);

--- a/vadl/main/vadl/iss/passes/nodes/IssWriteRegNode.java
+++ b/vadl/main/vadl/iss/passes/nodes/IssWriteRegNode.java
@@ -17,7 +17,6 @@
 package vadl.iss.passes.nodes;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import vadl.javaannotations.viam.DataValue;
 import vadl.javaannotations.viam.Input;
@@ -256,9 +255,7 @@ public class IssWriteRegNode extends WriteRegTensorNode {
   @Override
   public void applyOnInputsUnsafe(vadl.viam.graph.GraphVisitor.Applier<Node> visitor) {
     super.applyOnInputsUnsafe(visitor);
-    accessorIndices = accessorIndices.stream()
-        .map(e -> visitor.apply(this, e, ExpressionNode.class))
-        .collect(Collectors.toCollection(NodeList::new));
+    accessorIndices = rewriteNodeList(accessorIndices, visitor, ExpressionNode.class);
     bitOffset = visitor.apply(this, bitOffset, ExpressionNode.class);
     bitWidth = visitor.apply(this, bitWidth, ExpressionNode.class);
   }

--- a/vadl/main/vadl/iss/passes/nodes/TcgVRefNode.java
+++ b/vadl/main/vadl/iss/passes/nodes/TcgVRefNode.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -17,7 +17,6 @@
 package vadl.iss.passes.nodes;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import vadl.iss.passes.tcgLowering.TcgV;
 import vadl.iss.passes.tcgLowering.Tcg_32_64;
 import vadl.javaannotations.viam.DataValue;
@@ -101,7 +100,6 @@ public class TcgVRefNode extends DependencyNode {
   @Override
   protected void applyOnInputsUnsafe(GraphVisitor.Applier<Node> visitor) {
     super.applyOnInputsUnsafe(visitor);
-    indices = indices.stream().map((e) -> visitor.apply(this, e, ExpressionNode.class))
-        .collect(Collectors.toCollection(NodeList::new));
+    indices = rewriteNodeList(indices, visitor, ExpressionNode.class);
   }
 }

--- a/vadl/main/vadl/iss/passes/scalar/tcgLowering/nodes/TcgGenException.java
+++ b/vadl/main/vadl/iss/passes/scalar/tcgLowering/nodes/TcgGenException.java
@@ -92,8 +92,6 @@ public class TcgGenException extends TcgNode {
   @Override
   protected void applyOnInputsUnsafe(GraphVisitor.Applier<Node> visitor) {
     super.applyOnInputsUnsafe(visitor);
-    args = args.stream().map(e ->
-            visitor.apply(this, e, TcgVRefNode.class))
-        .collect(Collectors.toCollection(NodeList::new));
+    args = rewriteNodeList(args, visitor, TcgVRefNode.class);
   }
 }

--- a/vadl/main/vadl/iss/passes/scalar/tcgLowering/nodes/TcgGetVar.java
+++ b/vadl/main/vadl/iss/passes/scalar/tcgLowering/nodes/TcgGetVar.java
@@ -249,8 +249,7 @@ public abstract sealed class TcgGetVar extends TcgOpNode {
     protected void applyOnInputsUnsafe(
         vadl.viam.graph.GraphVisitor.Applier<vadl.viam.graph.Node> visitor) {
       super.applyOnInputsUnsafe(visitor);
-      indices = indices.stream().map((e) -> visitor.apply(this, e, ExpressionNode.class))
-          .collect(Collectors.toCollection(NodeList::new));
+      indices = rewriteNodeList(indices, visitor, ExpressionNode.class);
     }
   }
 }

--- a/vadl/main/vadl/iss/passes/scalar/tcgLowering/nodes/TcgHelperCall.java
+++ b/vadl/main/vadl/iss/passes/scalar/tcgLowering/nodes/TcgHelperCall.java
@@ -132,7 +132,6 @@ public class TcgHelperCall extends TcgNode {
   protected void applyOnInputsUnsafe(GraphVisitor.Applier<Node> visitor) {
     super.applyOnInputsUnsafe(visitor);
     result = visitor.applyNullable(this, result, TcgVRefNode.class);
-    args = args.stream().map((e) -> visitor.apply(this, e, DependencyNode.class))
-        .collect(Collectors.toCollection(NodeList::new));
+    args = rewriteNodeList(args, visitor, DependencyNode.class);
   }
 }

--- a/vadl/main/vadl/iss/passes/scalar/tcgLowering/nodes/TcgOpNode.java
+++ b/vadl/main/vadl/iss/passes/scalar/tcgLowering/nodes/TcgOpNode.java
@@ -19,7 +19,6 @@ package vadl.iss.passes.tcgLowering.nodes;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 import vadl.iss.passes.nodes.TcgVRefNode;
 import vadl.iss.passes.tcgLowering.Tcg_32_64;
 import vadl.javaannotations.viam.DataValue;
@@ -100,8 +99,7 @@ public abstract class TcgOpNode extends TcgNode {
   @Override
   protected void applyOnInputsUnsafe(GraphVisitor.Applier<Node> visitor) {
     super.applyOnInputsUnsafe(visitor);
-    destinations = destinations.stream().map((e) -> visitor.apply(this, e, TcgVRefNode.class))
-        .collect(Collectors.toCollection(NodeList::new));
+    destinations = rewriteNodeList(destinations, visitor, TcgVRefNode.class);
   }
 
   @Override

--- a/vadl/main/vadl/lcb/passes/isaMatching/IsaMachineInstructionMatchingPass.java
+++ b/vadl/main/vadl/lcb/passes/isaMatching/IsaMachineInstructionMatchingPass.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -425,7 +425,7 @@ public class IsaMachineInstructionMatchingPass extends Pass implements IsaMatchi
         if (originalGraph.getNodes(ReadsRegisterTensor.class).anyMatch(x -> x.registerTensor()
             .hasAnnotation(StatusRegisterAnnotation.ZeroStatusRegisterAnnotation.class))) {
 
-          return originalGraph.getNodes(TruncateNode.class).toList().isEmpty();
+          return originalGraph.getNodes(TruncateNode.class).findAny().isEmpty();
         }
       }
     }
@@ -583,7 +583,7 @@ public class IsaMachineInstructionMatchingPass extends Pass implements IsaMatchi
   }
 
   private boolean findWriteMem(UninlinedGraph graph) {
-    if (graph.getNodes(WriteMemNode.class).toList().size() != 1) {
+    if (graph.getNodes(WriteMemNode.class).limit(2).count() != 1) {
       return false;
     }
 
@@ -655,7 +655,7 @@ public class IsaMachineInstructionMatchingPass extends Pass implements IsaMatchi
 
     return matched.isPresent()
         && writesExactlyOneRegisterClassWithType(behavior, Type.bits(bitWidth))
-        && behavior.getNodes(SliceNode.class).toList().isEmpty() // no slices to exclude `ADDXUXTB`
+        && behavior.getNodes(SliceNode.class).findAny().isEmpty() // no slices to exclude `ADDXUXTB`
         && behavior.getNodes(BuiltInCall.class).count() == 1;
   }
 
@@ -682,11 +682,12 @@ public class IsaMachineInstructionMatchingPass extends Pass implements IsaMatchi
             .findFirst();
 
     // only one read is allowed
-    var registerReads =
-        behavior.getNodes(ReadsRegisterTensor.class).filter(HasRegisterTensor::hasRegisterFile)
-            .toList();
+    var registerReads = behavior.getNodes(ReadsRegisterTensor.class)
+        .filter(HasRegisterTensor::hasRegisterFile)
+        .limit(2)
+        .count();
 
-    return registerReads.size() == 1 && matched.isPresent()
+    return registerReads == 1 && matched.isPresent()
         && writesExactlyOneRegisterClassWithType(behavior, Type.bits(bitWidth));
   }
 
@@ -702,12 +703,12 @@ public class IsaMachineInstructionMatchingPass extends Pass implements IsaMatchi
   private boolean findBranchWithConditionalWithoutStatusRegisters(UninlinedGraph behavior,
                                                                   BuiltInTable.BuiltIn builtin) {
     var base = findBranchWithConditional(behavior, builtin);
-    var statusRegisters = behavior.getNodes(ReadsRegisterTensor.class)
-        .filter(x -> x.registerTensor().hasAnnotation(StatusRegisterAnnotation.class)).toList();
-
     return base
-        && statusRegisters.isEmpty()
-        && behavior.getNodes(ProcCallNode.class).toList().isEmpty();
+        && behavior.getNodes(ReadsRegisterTensor.class)
+        .filter(x -> x.registerTensor().hasAnnotation(StatusRegisterAnnotation.class))
+        .findAny()
+        .isEmpty()
+        && behavior.getNodes(ProcCallNode.class).findAny().isEmpty();
   }
 
   private boolean findBranchWithConditionalWithStatusRegisters(UninlinedGraph behavior,

--- a/vadl/main/vadl/lcb/passes/llvmLowering/RemoveTruncationAndAnyExtPass.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/RemoveTruncationAndAnyExtPass.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -58,8 +58,8 @@ public class RemoveTruncationAndAnyExtPass extends Pass {
             .filter(x -> !x.builtIn().hasSameBitWidth())
             .toList();
 
-        if (!behavior.getNodes(SignExtendNode.class).toList().isEmpty()
-            || !behavior.getNodes(ZeroExtendNode.class).toList().isEmpty()) {
+        if (behavior.getNodes(SignExtendNode.class).findAny().isPresent()
+            || behavior.getNodes(ZeroExtendNode.class).findAny().isPresent()) {
           continue;
         }
 

--- a/vadl/main/vadl/lcb/passes/llvmLowering/strategies/LlvmCompilerInstructionLowerStrategy.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/strategies/LlvmCompilerInstructionLowerStrategy.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -61,7 +61,7 @@ public abstract class LlvmCompilerInstructionLowerStrategy {
     var mayStore = false;
     var isBranch = false;
 
-    if (compilerInstruction.behavior().getNodes(InstrCallNode.class).toList().size() > 1) {
+    if (compilerInstruction.behavior().getNodes(InstrCallNode.class).limit(2).count() > 1) {
       DeferredDiagnosticStore.add(
           Diagnostic.warning(
               "Cannot generate instruction selectors for pseudo instruction with multiple "

--- a/vadl/main/vadl/lcb/passes/llvmLowering/strategies/LlvmInstructionLoweringStrategy.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/strategies/LlvmInstructionLoweringStrategy.java
@@ -494,8 +494,8 @@ public abstract class LlvmInstructionLoweringStrategy {
       We don't want that!
      */
 
-    return graph.getNodes(WriteResourceNode.class).toList().size() == 1
-        && graph.getNodes(ReadResourceNode.class).toList().size() == 1
+    return graph.getNodes(WriteResourceNode.class).limit(2).count() == 1
+        && graph.getNodes(ReadResourceNode.class).limit(2).count() == 1
         && graph.getNodes(WriteResourceNode.class)
         .anyMatch(writeResourceNode -> writeResourceNode.value() instanceof ReadResourceNode);
   }
@@ -538,7 +538,7 @@ public abstract class LlvmInstructionLoweringStrategy {
    * If there are any {@link SelectNode} in the graph.
    */
   private boolean hasSelectNodes(Graph graph) {
-    return graph.getNodes(SelectNode.class).toList().size() == 1;
+    return graph.getNodes(SelectNode.class).limit(2).count() == 1;
   }
 
   /**
@@ -572,21 +572,21 @@ public abstract class LlvmInstructionLoweringStrategy {
    * If the {@link Graph} it has nodes which writes to memory then we cannot lower it.
    */
   protected boolean rejectWhenWritingToMemory(Graph graph) {
-    return !graph.getNodes(WriteMemNode.class).toList().isEmpty();
+    return graph.getNodes(WriteMemNode.class).findAny().isPresent();
   }
 
   /**
    * If the {@link Graph} it has nodes which read from memory then we cannot lower it.
    */
   protected boolean rejectWhenReadingFromMemory(Graph graph) {
-    return !graph.getNodes(ReadMemNode.class).toList().isEmpty();
+    return graph.getNodes(ReadMemNode.class).findAny().isPresent();
   }
 
   /**
    * If the {@link Graph} it has multiple writes then we cannot lower it.
    */
   protected boolean hasMultipleOutputs(Graph graph) {
-    return graph.getNodes(WriteResourceNode.class).toList().size() > 1;
+    return graph.getNodes(WriteResourceNode.class).limit(2).count() > 1;
   }
 
   /**
@@ -599,7 +599,7 @@ public abstract class LlvmInstructionLoweringStrategy {
   }
 
   protected boolean hasUnlowerableSDNode(Graph graph) {
-    return !graph.getNodes(LlvmUnlowerableSD.class).toList().isEmpty();
+    return graph.getNodes(LlvmUnlowerableSD.class).findAny().isPresent();
   }
 
   /**

--- a/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/conditionals/LlvmInstructionLoweringLessThanImmediateUnsignedConditionalsStrategyImpl.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/conditionals/LlvmInstructionLoweringLessThanImmediateUnsignedConditionalsStrategyImpl.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -19,7 +19,6 @@ package vadl.lcb.passes.llvmLowering.strategies.instruction.conditionals;
 import static vadl.viam.ViamError.ensurePresent;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -37,7 +36,6 @@ import vadl.lcb.passes.llvmLowering.strategies.LlvmInstructionLoweringStrategy;
 import vadl.lcb.passes.llvmLowering.tablegen.model.TableGenPattern;
 import vadl.lcb.passes.llvmLowering.tablegen.model.TableGenSelectionWithOutputPattern;
 import vadl.types.BuiltInTable;
-import vadl.types.DataType;
 import vadl.viam.Abi;
 import vadl.viam.Constant;
 import vadl.viam.Instruction;
@@ -123,8 +121,7 @@ public class LlvmInstructionLoweringLessThanImmediateUnsignedConditionalsStrateg
       if (copy instanceof TableGenSelectionWithOutputPattern outputPattern) {
         // Change condition code
         var setcc = ensurePresent(
-            outputPattern.selector().getNodes(LlvmSetccSD.class).toList().stream()
-                .findFirst(),
+            outputPattern.selector().getNodes(LlvmSetccSD.class).findFirst(),
             () -> Diagnostic.error("No setcc node was found", pattern.selector()
                 .sourceLocation()));
         // Only RR and not RI should be replaced here.

--- a/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/conditionals/LlvmInstructionLoweringLessThanSignedConditionalsStrategyImpl.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/conditionals/LlvmInstructionLoweringLessThanSignedConditionalsStrategyImpl.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -36,7 +36,6 @@ import vadl.lcb.passes.llvmLowering.strategies.LlvmInstructionLoweringStrategy;
 import vadl.lcb.passes.llvmLowering.tablegen.model.TableGenPattern;
 import vadl.lcb.passes.llvmLowering.tablegen.model.TableGenSelectionWithOutputPattern;
 import vadl.types.BuiltInTable;
-import vadl.types.DataType;
 import vadl.viam.Abi;
 import vadl.viam.Constant;
 import vadl.viam.Instruction;
@@ -111,8 +110,7 @@ public class LlvmInstructionLoweringLessThanSignedConditionalsStrategyImpl
       if (copy instanceof TableGenSelectionWithOutputPattern outputPattern) {
         // Change condition code
         var setcc = ensurePresent(
-            outputPattern.selector().getNodes(LlvmSetccSD.class).toList().stream()
-                .findFirst(),
+            outputPattern.selector().getNodes(LlvmSetccSD.class).findFirst(),
             () -> Diagnostic.error("No setcc node was found", pattern.selector()
                 .sourceLocation()));
         // Only RR and not RI should be replaced here.
@@ -175,8 +173,7 @@ public class LlvmInstructionLoweringLessThanSignedConditionalsStrategyImpl
       if (copy instanceof TableGenSelectionWithOutputPattern outputPattern) {
         // Change condition code
         var setcc = ensurePresent(
-            outputPattern.selector().getNodes(LlvmSetccSD.class).toList().stream()
-                .findFirst(),
+            outputPattern.selector().getNodes(LlvmSetccSD.class).findFirst(),
             () -> Diagnostic.error("No setcc node was found", pattern.selector()
                 .sourceLocation()));
         // Only RR and not RI should be replaced here.
@@ -229,8 +226,7 @@ public class LlvmInstructionLoweringLessThanSignedConditionalsStrategyImpl
       if (copy instanceof TableGenSelectionWithOutputPattern outputPattern) {
         // Change condition code
         var setcc = ensurePresent(
-            outputPattern.selector().getNodes(LlvmSetccSD.class).toList().stream()
-                .findFirst(),
+            outputPattern.selector().getNodes(LlvmSetccSD.class).findFirst(),
             () -> Diagnostic.error("No setcc node was found", pattern.selector()
                 .sourceLocation()));
         // Only RR and not RI should be replaced here.
@@ -279,8 +275,7 @@ public class LlvmInstructionLoweringLessThanSignedConditionalsStrategyImpl
       if (copy instanceof TableGenSelectionWithOutputPattern outputPattern) {
         // Change condition code
         var setcc = ensurePresent(
-            outputPattern.selector().getNodes(LlvmSetccSD.class).toList().stream()
-                .findFirst(),
+            outputPattern.selector().getNodes(LlvmSetccSD.class).findFirst(),
             () -> Diagnostic.error("No setcc node was found", pattern.selector()
                 .sourceLocation()));
         // Only RR and not RI should be replaced here.

--- a/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/conditionals/LlvmInstructionLoweringLessThanUnsignedConditionalsStrategyImpl.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/conditionals/LlvmInstructionLoweringLessThanUnsignedConditionalsStrategyImpl.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -36,7 +36,6 @@ import vadl.lcb.passes.llvmLowering.strategies.LlvmInstructionLoweringStrategy;
 import vadl.lcb.passes.llvmLowering.tablegen.model.TableGenPattern;
 import vadl.lcb.passes.llvmLowering.tablegen.model.TableGenSelectionWithOutputPattern;
 import vadl.types.BuiltInTable;
-import vadl.types.DataType;
 import vadl.viam.Abi;
 import vadl.viam.Constant;
 import vadl.viam.Instruction;
@@ -109,8 +108,7 @@ public class LlvmInstructionLoweringLessThanUnsignedConditionalsStrategyImpl
       if (copy instanceof TableGenSelectionWithOutputPattern outputPattern) {
         // Change condition code
         var setcc = ensurePresent(
-            outputPattern.selector().getNodes(LlvmSetccSD.class).toList().stream()
-                .findFirst(),
+            outputPattern.selector().getNodes(LlvmSetccSD.class).findFirst(),
             () -> Diagnostic.error("No setcc node was found", pattern.selector()
                 .sourceLocation()));
         // Only RR and not RI should be replaced here.
@@ -169,8 +167,7 @@ public class LlvmInstructionLoweringLessThanUnsignedConditionalsStrategyImpl
       if (copy instanceof TableGenSelectionWithOutputPattern outputPattern) {
         // Change condition code
         var setcc = ensurePresent(
-            outputPattern.selector().getNodes(LlvmSetccSD.class).toList().stream()
-                .findFirst(),
+            outputPattern.selector().getNodes(LlvmSetccSD.class).findFirst(),
             () -> Diagnostic.error("No setcc node was found", pattern.selector()
                 .sourceLocation()));
         // Only RR and not RI should be replaced here.
@@ -219,8 +216,7 @@ public class LlvmInstructionLoweringLessThanUnsignedConditionalsStrategyImpl
       if (copy instanceof TableGenSelectionWithOutputPattern outputPattern) {
         // Change condition code
         var setcc = ensurePresent(
-            outputPattern.selector().getNodes(LlvmSetccSD.class).toList().stream()
-                .findFirst(),
+            outputPattern.selector().getNodes(LlvmSetccSD.class).findFirst(),
             () -> Diagnostic.error("No setcc node was found", pattern.selector()
                 .sourceLocation()));
         // Only RR and not RI should be replaced here.
@@ -270,8 +266,7 @@ public class LlvmInstructionLoweringLessThanUnsignedConditionalsStrategyImpl
       if (copy instanceof TableGenSelectionWithOutputPattern outputPattern) {
         // Change condition code
         var setcc = ensurePresent(
-            outputPattern.selector().getNodes(LlvmSetccSD.class).toList().stream()
-                .findFirst(),
+            outputPattern.selector().getNodes(LlvmSetccSD.class).findFirst(),
             () -> Diagnostic.error("No setcc node was found", pattern.selector()
                 .sourceLocation()));
         // Only RR and not RI should be replaced here.

--- a/vadl/main/vadl/lcb/passes/llvmLowering/tablegen/lowering/TableGenInstAliasRenderer.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/tablegen/lowering/TableGenInstAliasRenderer.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -64,8 +64,7 @@ public class TableGenInstAliasRenderer {
 
   private static String generateAssembly(PseudoInstruction pseudoInstruction, Assembly assembly) {
     var entryPoint =
-        ensurePresent(
-            assembly.function().behavior().getNodes(ReturnNode.class).toList().stream().findFirst(),
+        ensurePresent(assembly.function().behavior().getNodes(ReturnNode.class).findFirst(),
             "must exist");
 
     StringWriter result = new StringWriter();

--- a/vadl/main/vadl/rtl/ipg/nodes/RtlDebugPrintNode.java
+++ b/vadl/main/vadl/rtl/ipg/nodes/RtlDebugPrintNode.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -18,9 +18,7 @@ package vadl.rtl.ipg.nodes;
 
 import java.util.List;
 import java.util.function.BiFunction;
-import java.util.function.Function;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import vadl.javaannotations.viam.DataValue;
 import vadl.javaannotations.viam.Input;
@@ -47,9 +45,9 @@ public class RtlDebugPrintNode extends SideEffectNode implements RtlConditionalN
   /**
    * Create new debug print node.
    *
-   * @param condition print only when this is true
+   * @param condition    print only when this is true
    * @param formatString string with <code>%[a-z]</code> as placeholders
-   * @param values values to replace the placeholders with
+   * @param values       values to replace the placeholders with
    */
   public RtlDebugPrintNode(@Nullable ExpressionNode condition, String formatString,
                            NodeList<ExpressionNode> values) {
@@ -73,9 +71,7 @@ public class RtlDebugPrintNode extends SideEffectNode implements RtlConditionalN
   @Override
   protected void applyOnInputsUnsafe(GraphVisitor.Applier<Node> visitor) {
     super.applyOnInputsUnsafe(visitor);
-    values = values.stream()
-        .map((e) -> visitor.apply(this, e, ExpressionNode.class))
-        .collect(Collectors.toCollection(NodeList::new));
+    values = rewriteNodeList(values, visitor, ExpressionNode.class);
   }
 
   @Override

--- a/vadl/main/vadl/rtl/ipg/nodes/RtlSelectByInstructionNode.java
+++ b/vadl/main/vadl/rtl/ipg/nodes/RtlSelectByInstructionNode.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -23,7 +23,6 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import vadl.javaannotations.viam.DataValue;
 import vadl.javaannotations.viam.Input;
@@ -66,9 +65,9 @@ public class RtlSelectByInstructionNode extends ExpressionNode {
    * a list of values, which the output of this node is selected from.
    * The instructions and values lists need to have the same length.
    *
-   * @param type result type
+   * @param type         result type
    * @param instructions list of sets of instructions
-   * @param values list of values for the result
+   * @param values       list of values for the result
    */
   public RtlSelectByInstructionNode(Type type, List<Set<Instruction>> instructions,
                                     NodeList<ExpressionNode> values) {
@@ -79,10 +78,10 @@ public class RtlSelectByInstructionNode extends ExpressionNode {
    * See {@link RtlSelectByInstructionNode#RtlSelectByInstructionNode(Type, List, NodeList)}.
    * The selection input supplies an integer that addresses the value to choose.
    *
-   * @param type result type
+   * @param type         result type
    * @param instructions list of sets of instructions
-   * @param values list of values for the result
-   * @param selection selection input
+   * @param values       list of values for the result
+   * @param selection    selection input
    */
   public RtlSelectByInstructionNode(Type type, List<Set<Instruction>> instructions,
                                     NodeList<ExpressionNode> values,
@@ -144,7 +143,7 @@ public class RtlSelectByInstructionNode extends ExpressionNode {
    * the given value, if the instruction matches.
    *
    * @param instruction instruction
-   * @param value value
+   * @param value       value
    */
   public void add(Instruction instruction, ExpressionNode value) {
     for (int i = 0; i < instructions.size(); i++) {
@@ -262,9 +261,7 @@ public class RtlSelectByInstructionNode extends ExpressionNode {
   protected void applyOnInputsUnsafe(GraphVisitor.Applier<Node> visitor) {
     super.applyOnInputsUnsafe(visitor);
     selection = visitor.applyNullable(this, selection, ExpressionNode.class);
-    values = values.stream()
-        .map((e) -> visitor.apply(this, e, ExpressionNode.class))
-        .collect(Collectors.toCollection(NodeList::new));
+    values = rewriteNodeList(values, visitor, ExpressionNode.class);
   }
 
   @Override

--- a/vadl/main/vadl/viam/graph/Graph.java
+++ b/vadl/main/vadl/viam/graph/Graph.java
@@ -28,7 +28,6 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
@@ -121,7 +120,7 @@ public class Graph {
    * @return iterable of all nodes of type clazz
    */
   public final <T> Stream<T> getNodes(Class<T> clazz) {
-    return getNodes().filter(clazz::isInstance).map(clazz::cast);
+    return Streams.stream(new NodeIter.TypedSnapshotIter<>(this, clazz));
   }
 
   /**
@@ -132,8 +131,7 @@ public class Graph {
    * @return iterable of all nodes with one of the given types.
    */
   public final Stream<Node> getNodes(Set<Class<?>> clazz) {
-    return getNodes().filter(Objects::nonNull)
-        .filter(x -> clazz.stream().anyMatch(y -> y.isInstance(x)));
+    return Streams.stream(new NodeIter.MultiTypeSnapshotIter(this, clazz));
   }
 
   /**

--- a/vadl/main/vadl/viam/graph/Node.java
+++ b/vadl/main/vadl/viam/graph/Node.java
@@ -372,6 +372,44 @@ public abstract class Node implements WithLocation {
   }
 
   /**
+   * Rewrites a node list with copy-on-write semantics.
+   *
+   * <p>The original list instance is returned unchanged if all rewritten nodes are identical to
+   * their previous values and this node is already initialized. Uninitialized nodes must detach
+   * shared {@link NodeList} instances because shallow copies commonly reuse the original list
+   * object.</p>
+   */
+  protected final <T extends Node> NodeList<T> rewriteNodeList(
+      NodeList<T> nodes,
+      GraphVisitor.Applier<Node> visitor,
+      Class<T> clazz) {
+    NodeList<T> rewritten = null;
+
+    for (int i = 0; i < nodes.size(); i++) {
+      var oldNode = nodes.get(i);
+      var newNode = visitor.apply(this, oldNode, clazz);
+
+      if (rewritten == null) {
+        if (newNode == oldNode) {
+          continue;
+        }
+
+        rewritten = new NodeList<>(nodes.size());
+        for (int j = 0; j < i; j++) {
+          rewritten.add(nodes.get(j));
+        }
+      }
+
+      rewritten.add(newNode);
+    }
+
+    if (rewritten == null) {
+      return isUninitialized() ? new NodeList<>(nodes) : nodes;
+    }
+    return rewritten;
+  }
+
+  /**
    * Applies the visitor's output on each successor of this node.
    * If the new successor node differs from the old one, this method will automatically handle
    * the usage transfer.
@@ -837,9 +875,15 @@ public abstract class Node implements WithLocation {
   }
 
   private void verifyAllEdges() {
-    inputs().forEach(this::verifyInput);
-    usages().forEach(this::verifyUsage);
-    successors().forEach(this::verifySuccessor);
+    for (var input : inputList()) {
+      verifyInput(input);
+    }
+    for (var usage : usages) {
+      verifyUsage(usage);
+    }
+    for (var successor : successorList()) {
+      verifySuccessor(successor);
+    }
     verifyPredecessor();
   }
 

--- a/vadl/main/vadl/viam/graph/NodeIter.java
+++ b/vadl/main/vadl/viam/graph/NodeIter.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -16,13 +16,73 @@
 
 package vadl.viam.graph;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.Set;
+import javax.annotation.Nullable;
 
 /**
  * A iterator that is used to iterate over nodes in a graph.
  */
 public interface NodeIter<T> extends Iterator<T> {
+
+  /**
+   * Base implementation for iterating over a graph snapshot while optionally filtering nodes.
+   */
+  abstract class AbstractSnapshotIter<T> implements NodeIter<T> {
+
+    private final int sizeAtCreation;
+    protected int currentIndex;
+    protected final Graph graph;
+    private @Nullable T nextNode;
+    private boolean nextNodeReady;
+
+    protected AbstractSnapshotIter(Graph graph) {
+      this.graph = graph;
+      this.sizeAtCreation = graph.nodes.size();
+    }
+
+    protected abstract @Nullable T tryConvert(Node node);
+
+    @Override
+    public boolean hasNext() {
+      if (nextNodeReady) {
+        return true;
+      }
+
+      while (currentIndex < sizeAtCreation) {
+        Node node = graph.nodes.get(currentIndex);
+        currentIndex++;
+
+        if (node == null) {
+          continue;
+        }
+
+        var converted = tryConvert(node);
+        if (converted != null) {
+          nextNode = converted;
+          nextNodeReady = true;
+          return true;
+        }
+      }
+
+      return false;
+    }
+
+    @Override
+    public T next() {
+      if (!hasNext()) {
+        throw new NoSuchElementException("No more nodes available");
+      }
+
+      nextNodeReady = false;
+      var result = nextNode;
+      nextNode = null;
+      return requireNonNull(result);
+    }
+  }
 
   /**
    * This iterator iterates over a snapshot of the graph.
@@ -32,33 +92,56 @@ public interface NodeIter<T> extends Iterator<T> {
    * However, if nodes are getting deleted during the iteration and were not yet iterated,
    * they will never be iterated.
    */
-  class SnapshotIter implements NodeIter<Node> {
-
-    private final int sizeAtCreation;
-    protected int currentIndex;
-    protected final Graph graph;
+  class SnapshotIter extends AbstractSnapshotIter<Node> {
 
     public SnapshotIter(Graph graph) {
-      this.graph = graph;
-      sizeAtCreation = graph.nodes.size();
+      super(graph);
     }
 
     @Override
-    public boolean hasNext() {
-      while (currentIndex < sizeAtCreation && graph.nodes.get(currentIndex) == null) {
-        currentIndex++;  // Skip null entries
-      }
-      return currentIndex < sizeAtCreation;
-    }
-
-    @Override
-    public Node next() {
-      if (currentIndex >= sizeAtCreation) {
-        throw new NoSuchElementException("No more nodes available");
-      }
-      Node node = graph.nodes.get(currentIndex);
-      currentIndex++;  // Move to the next index for future calls
+    protected Node tryConvert(Node node) {
       return node;
+    }
+  }
+
+  /**
+   * This iterator iterates over nodes of a specific type in a graph snapshot.
+   */
+  class TypedSnapshotIter<T> extends AbstractSnapshotIter<T> {
+
+    private final Class<T> clazz;
+
+    public TypedSnapshotIter(Graph graph, Class<T> clazz) {
+      super(graph);
+      this.clazz = clazz;
+    }
+
+    @Override
+    protected @Nullable T tryConvert(Node node) {
+      return clazz.isInstance(node) ? clazz.cast(node) : null;
+    }
+  }
+
+  /**
+   * This iterator iterates over nodes matching any of the provided types in a graph snapshot.
+   */
+  class MultiTypeSnapshotIter extends AbstractSnapshotIter<Node> {
+
+    private final Set<Class<?>> classes;
+
+    public MultiTypeSnapshotIter(Graph graph, Set<Class<?>> classes) {
+      super(graph);
+      this.classes = classes;
+    }
+
+    @Override
+    protected @Nullable Node tryConvert(Node node) {
+      for (var clazz : classes) {
+        if (clazz.isInstance(node)) {
+          return node;
+        }
+      }
+      return null;
     }
   }
 }

--- a/vadl/main/vadl/viam/graph/NodeList.java
+++ b/vadl/main/vadl/viam/graph/NodeList.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -31,6 +31,10 @@ import vadl.viam.graph.dependency.ExpressionNode;
 public class NodeList<T extends Node> extends ArrayList<T> {
 
   public NodeList() {
+  }
+
+  public NodeList(int initialCapacity) {
+    super(initialCapacity);
   }
 
   public NodeList(@Nonnull Collection<? extends T> c) {

--- a/vadl/main/vadl/viam/graph/control/AbstractEndNode.java
+++ b/vadl/main/vadl/viam/graph/control/AbstractEndNode.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -17,7 +17,6 @@
 package vadl.viam.graph.control;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import vadl.javaannotations.viam.Input;
 import vadl.viam.graph.GraphVisitor;
@@ -71,9 +70,7 @@ public abstract class AbstractEndNode extends ControlNode {
   @Override
   protected void applyOnInputsUnsafe(GraphVisitor.Applier<Node> visitor) {
     super.applyOnInputsUnsafe(visitor);
-    sideEffects = sideEffects.stream()
-        .map(e -> visitor.apply(this, e, SideEffectNode.class))
-        .collect(Collectors.toCollection(NodeList::new));
+    sideEffects = rewriteNodeList(sideEffects, visitor, SideEffectNode.class);
   }
 
   /**

--- a/vadl/main/vadl/viam/graph/control/ControlSplitNode.java
+++ b/vadl/main/vadl/viam/graph/control/ControlSplitNode.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -18,7 +18,6 @@ package vadl.viam.graph.control;
 
 import com.google.errorprone.annotations.concurrent.LazyInit;
 import java.util.List;
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import vadl.javaannotations.viam.Successor;
 import vadl.viam.graph.GraphVisitor;
@@ -78,9 +77,7 @@ public abstract class ControlSplitNode extends ControlNode {
   @Override
   protected void applyOnSuccessorsUnsafe(GraphVisitor.Applier<Node> visitor) {
     super.applyOnSuccessorsUnsafe(visitor);
-    branches = branches.stream().map(e ->
-            visitor.apply(this, e, BranchBeginNode.class))
-        .collect(Collectors.toCollection(NodeList::new));
+    branches = rewriteNodeList(branches, visitor, BranchBeginNode.class);
   }
 
   public void clearPredecessor() {

--- a/vadl/main/vadl/viam/graph/control/InstrCallNode.java
+++ b/vadl/main/vadl/viam/graph/control/InstrCallNode.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -18,7 +18,6 @@ package vadl.viam.graph.control;
 
 import com.google.common.collect.Streams;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import vadl.javaannotations.viam.DataValue;
@@ -201,8 +200,7 @@ public class InstrCallNode extends DirectionalNode {
   @Override
   protected void applyOnInputsUnsafe(GraphVisitor.Applier<Node> visitor) {
     super.applyOnInputsUnsafe(visitor);
-    arguments = arguments.stream().map(e -> visitor.apply(this, e, ExpressionNode.class))
-        .collect(Collectors.toCollection(NodeList::new));
+    arguments = rewriteNodeList(arguments, visitor, ExpressionNode.class);
   }
 
   @Override

--- a/vadl/main/vadl/viam/graph/control/MergeNode.java
+++ b/vadl/main/vadl/viam/graph/control/MergeNode.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -83,9 +83,7 @@ public class MergeNode extends AbstractBeginNode {
   @Override
   protected void applyOnInputsUnsafe(GraphVisitor.Applier<Node> visitor) {
     super.applyOnInputsUnsafe(visitor);
-    branchEnds = branchEnds.stream()
-        .map(e -> visitor.apply(this, e, BranchEndNode.class))
-        .collect(Collectors.toCollection(NodeList::new));
+    branchEnds = rewriteNodeList(branchEnds, visitor, BranchEndNode.class);
   }
 
   @Override

--- a/vadl/main/vadl/viam/graph/dependency/AbstractFunctionCallNode.java
+++ b/vadl/main/vadl/viam/graph/dependency/AbstractFunctionCallNode.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -17,7 +17,6 @@
 package vadl.viam.graph.dependency;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import vadl.javaannotations.viam.Input;
 import vadl.types.Type;
 import vadl.viam.graph.GraphVisitor;
@@ -65,8 +64,6 @@ public abstract class AbstractFunctionCallNode extends ExpressionNode {
   @Override
   protected void applyOnInputsUnsafe(GraphVisitor.Applier<Node> visitor) {
     super.applyOnInputsUnsafe(visitor);
-    args = args.stream()
-        .map((e) -> visitor.apply(this, e, ExpressionNode.class))
-        .collect(Collectors.toCollection(NodeList::new));
+    args = rewriteNodeList(args, visitor, ExpressionNode.class);
   }
 }

--- a/vadl/main/vadl/viam/graph/dependency/ProcCallNode.java
+++ b/vadl/main/vadl/viam/graph/dependency/ProcCallNode.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -17,7 +17,6 @@
 package vadl.viam.graph.dependency;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import javax.annotation.Nullable;
 import vadl.javaannotations.viam.DataValue;
@@ -110,8 +109,6 @@ public class ProcCallNode extends SideEffectNode {
   @Override
   protected void applyOnInputsUnsafe(GraphVisitor.Applier<Node> visitor) {
     super.applyOnInputsUnsafe(visitor);
-    arguments = arguments.stream().map(e ->
-            visitor.apply(this, e, ExpressionNode.class))
-        .collect(Collectors.toCollection(NodeList::new));
+    arguments = rewriteNodeList(arguments, visitor, ExpressionNode.class);
   }
 }

--- a/vadl/main/vadl/viam/graph/dependency/ReadResourceNode.java
+++ b/vadl/main/vadl/viam/graph/dependency/ReadResourceNode.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -19,7 +19,6 @@ package vadl.viam.graph.dependency;
 import com.google.common.collect.Streams;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import vadl.javaannotations.viam.Input;
 import vadl.types.DataType;
@@ -108,8 +107,7 @@ public abstract class ReadResourceNode extends ExpressionNode {
   public void applyOnInputsUnsafe(
       vadl.viam.graph.GraphVisitor.Applier<vadl.viam.graph.Node> visitor) {
     super.applyOnInputsUnsafe(visitor);
-    indices = indices.stream().map((e) -> visitor.apply(this, e, ExpressionNode.class))
-        .collect(Collectors.toCollection(NodeList::new));
+    indices = rewriteNodeList(indices, visitor, ExpressionNode.class);
   }
 
   /**

--- a/vadl/main/vadl/viam/graph/dependency/WriteResourceNode.java
+++ b/vadl/main/vadl/viam/graph/dependency/WriteResourceNode.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -19,7 +19,6 @@ package vadl.viam.graph.dependency;
 import com.google.common.collect.Streams;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import vadl.javaannotations.viam.Input;
 import vadl.types.DataType;
@@ -144,8 +143,7 @@ public abstract class WriteResourceNode extends SideEffectNode {
   public void applyOnInputsUnsafe(
       vadl.viam.graph.GraphVisitor.Applier<vadl.viam.graph.Node> visitor) {
     super.applyOnInputsUnsafe(visitor);
-    indices = indices.stream().map((e) -> visitor.apply(this, e, ExpressionNode.class))
-        .collect(Collectors.toCollection(NodeList::new));
+    indices = rewriteNodeList(indices, visitor, ExpressionNode.class);
     value = visitor.apply(this, value, ExpressionNode.class);
   }
 


### PR DESCRIPTION
This PR optimizes the VIAM Graph API and node implementations to reduce memory consumption.

1. Add specialized node iterator to directly filter nodes for the `Graph.getNodes` API (200dafe0c0786c9da6c199ad31ac07533a3f1bc8)
2. Change some inefficient client side usages of getNodes that collect all nodes into a list for existential checks (c1342f790ccbe7a55a1aedbe95643e2140185ad4)
3. Change NodeList input/successor application implementations to copy-on-write instead of always creating a copy on every application (f77ad3169742d9db6dc466ae77b04ebe8075d275)