### PR TITLE
lcb: Implement generation of indirect-call patterns for aarch64

### DIFF
--- a/vadl/main/vadl/gcb/passes/MachineInstructionLabel.java
+++ b/vadl/main/vadl/gcb/passes/MachineInstructionLabel.java
@@ -94,6 +94,7 @@ public enum MachineInstructionLabel {
   UNCONDITIONAL JUMPS
    */
   JALR, //  unconditional indirect jump without immediate. With linking register.
+  BLR, //  unconditional indirect jump without immediate. With linking register (aarch64-style).
   JAL, // the difference between JAL and J is that JAL also writes a linking register.
   J, // unconditional jump with no linking register.
   JR, //  unconditional indirect jump without immediate. No linking register.

--- a/vadl/main/vadl/lcb/passes/isaMatching/IsaMachineInstructionMatchingPass.java
+++ b/vadl/main/vadl/lcb/passes/isaMatching/IsaMachineInstructionMatchingPass.java
@@ -89,6 +89,7 @@ import vadl.viam.Constant;
 import vadl.viam.Counter;
 import vadl.viam.Instruction;
 import vadl.viam.InstructionSetArchitecture;
+import vadl.viam.RegisterResource;
 import vadl.viam.Specification;
 import vadl.viam.graph.Graph;
 import vadl.viam.graph.HasRegisterTensor;
@@ -108,6 +109,7 @@ import vadl.viam.graph.dependency.SelectNode;
 import vadl.viam.graph.dependency.SignExtendNode;
 import vadl.viam.graph.dependency.SliceNode;
 import vadl.viam.graph.dependency.TruncateNode;
+import vadl.viam.graph.dependency.WriteArtificialResNode;
 import vadl.viam.graph.dependency.WriteMemNode;
 import vadl.viam.graph.dependency.WriteRegTensorNode;
 import vadl.viam.graph.dependency.WriteResourceNode;
@@ -351,6 +353,8 @@ public class IsaMachineInstructionMatchingPass extends Pass implements IsaMatchi
       } else if (findLoadMem(behavior)) {
         instruction.attachExtension(
             new MachineInstructionCtx(MachineInstructionLabel.LOAD_MEM_WITH_IMMEDIATE, ty));
+      } else if (findBlr(behavior, pc)) {
+        instruction.attachExtension(new MachineInstructionCtx(MachineInstructionLabel.BLR, ty));
       } else if (findJalr(behavior, pc)) {
         instruction.attachExtension(new MachineInstructionCtx(MachineInstructionLabel.JALR, ty));
       } else if (findJal(behavior, pc)) {
@@ -860,6 +864,30 @@ public class IsaMachineInstructionMatchingPass extends Pass implements IsaMatchi
     }
 
     return true;
+  }
+
+  /**
+   * Match indirect branch-and-link without immediate (aarch64-style BLR) when
+   * {@link Instruction} writes PC, writes a register file (the link register), has no
+   * immediate operand, and the PC's assigned value is a direct register-file read.
+   */
+  private boolean findBlr(UninlinedGraph behavior, Counter pcRegister) {
+    var writesPc = behavior.getNodes(WriteRegTensorNode.class)
+        .filter(x -> x.regTensor().equals(pcRegister.registerTensor())).toList();
+    var writesRegFile = behavior.getNodes(WritesRegisterTensor.class)
+        .filter(w -> !w.registerTensor().equals(pcRegister.registerTensor())).toList();
+
+    if (writesPc.size() != 1 || writesRegFile.size() != 1) {
+      return false;
+    }
+
+    if (behavior.getNodes(FieldAccessRefNode.class).findAny().isPresent()) {
+      return false;
+    }
+
+    var pcValue = writesPc.get(0).value();
+    var writesPcWithRegFile = pcValue instanceof ReadsRegisterTensor;
+    return writesPcWithRegFile;
   }
 
   /**

--- a/vadl/main/vadl/lcb/passes/llvmLowering/LlvmLoweringPass.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/LlvmLoweringPass.java
@@ -48,6 +48,7 @@ import vadl.lcb.passes.llvmLowering.strategies.instruction.LlvmInstructionLoweri
 import vadl.lcb.passes.llvmLowering.strategies.instruction.LlvmInstructionLoweringConditionalBranchesStrategyImpl;
 import vadl.lcb.passes.llvmLowering.strategies.instruction.LlvmInstructionLoweringConditionalBranchesWithStatusRegistersStrategyImpl;
 import vadl.lcb.passes.llvmLowering.strategies.instruction.LlvmInstructionLoweringDefaultStrategyImpl;
+import vadl.lcb.passes.llvmLowering.strategies.instruction.LlvmInstructionLoweringIndirectJumpAndLinkNoImmediateStrategyImpl;
 import vadl.lcb.passes.llvmLowering.strategies.instruction.LlvmInstructionLoweringIndirectJumpAndLinkStrategyImpl;
 import vadl.lcb.passes.llvmLowering.strategies.instruction.LlvmInstructionLoweringLoadUpperImmediateStrategyImpl;
 import vadl.lcb.passes.llvmLowering.strategies.instruction.LlvmInstructionLoweringMemoryLoadStrategyImpl;
@@ -313,7 +314,9 @@ public class LlvmLoweringPass extends Pass {
                 smallestRegisterClassType),
             new LlvmInstructionLoweringConditionalBranchesWithStatusRegistersStrategyImpl(
                 architectureType, smallestRegisterClassType),
-            new LlvmInstructionLoweringIndirectJumpAndLinkStrategyImpl(architectureType, 
+            new LlvmInstructionLoweringIndirectJumpAndLinkStrategyImpl(architectureType,
+                smallestRegisterClassType),
+            new LlvmInstructionLoweringIndirectJumpAndLinkNoImmediateStrategyImpl(architectureType,
                 smallestRegisterClassType),
             new LlvmInstructionLoweringMemoryStoreStrategyImpl(architectureType, 
                 smallestRegisterClassType),

--- a/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/LlvmInstructionLoweringIndirectJumpAndLinkNoImmediateStrategyImpl.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/strategies/instruction/LlvmInstructionLoweringIndirectJumpAndLinkNoImmediateStrategyImpl.java
@@ -1,0 +1,198 @@
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.lcb.passes.llvmLowering.strategies.instruction;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import vadl.gcb.passes.MachineInstructionLabel;
+import vadl.gcb.passes.RegisterRef;
+import vadl.gcb.passes.operands.model.GcbInstructionOperand;
+import vadl.gcb.passes.operands.model.GcbInstructionRegisterFileOperand;
+import vadl.gcb.valuetypes.ValueType;
+import vadl.lcb.passes.isaMatching.IsaMachineInstructionMatchingPass;
+import vadl.lcb.passes.isaMatching.database.Database;
+import vadl.lcb.passes.isaMatching.database.Query;
+import vadl.lcb.passes.llvmLowering.domain.LlvmLoweringRecord;
+import vadl.lcb.passes.llvmLowering.domain.machineDag.LcbMachineInstructionNode;
+import vadl.lcb.passes.llvmLowering.domain.machineDag.OutputInstructionName;
+import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmBrindSD;
+import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmReadResourceFactory;
+import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmTargetCallSD;
+import vadl.lcb.passes.llvmLowering.tablegen.model.TableGenPattern;
+import vadl.lcb.passes.llvmLowering.tablegen.model.TableGenPseudoInstExpansionPattern;
+import vadl.lcb.passes.llvmLowering.tablegen.model.TableGenSelectionWithOutputPattern;
+import vadl.types.Type;
+import vadl.viam.Abi;
+import vadl.viam.Constant;
+import vadl.viam.Instruction;
+import vadl.viam.graph.Graph;
+import vadl.viam.graph.NodeList;
+import vadl.viam.graph.ReadsRegisterTensor;
+import vadl.viam.graph.dependency.FieldRefNode;
+import vadl.viam.graph.dependency.ReadArtificialResNode;
+import vadl.viam.graph.dependency.ReadRegTensorNode;
+
+/**
+ * Generates the {@link LlvmLoweringRecord} for {@link MachineInstructionLabel#BLR}
+ * instructions: indirect branch-and-link without an immediate operand (aarch64-style).
+ * The structural difference from {@link MachineInstructionLabel#JALR} is the absence
+ * of an immediate, so the emitted machine pattern has a single register operand.
+ */
+public class LlvmInstructionLoweringIndirectJumpAndLinkNoImmediateStrategyImpl
+    extends LlvmInstructionLoweringIndirectJumpAndLinkStrategyImpl {
+  public LlvmInstructionLoweringIndirectJumpAndLinkNoImmediateStrategyImpl(
+      ValueType architectureType, ValueType smallestRegisterClassType) {
+    super(architectureType, smallestRegisterClassType);
+  }
+
+  @Override
+  protected Set<MachineInstructionLabel> getSupportedInstructionLabels() {
+    return Set.of(MachineInstructionLabel.BLR);
+  }
+
+  @Override
+  protected List<TableGenPattern> generatePatternVariations(
+      Instruction instruction,
+      IsaMachineInstructionMatchingPass.Result supportedInstructions,
+      Graph behavior,
+      List<GcbInstructionOperand> inputOperands,
+      List<GcbInstructionOperand> outputOperands,
+      List<TableGenPattern> patterns,
+      Abi abi) {
+    var result = new ArrayList<TableGenPattern>();
+    inputOperands.stream().filter(x -> x instanceof GcbInstructionRegisterFileOperand)
+        .findFirst()
+        .ifPresent((uncastInputRegister) -> {
+          var inputRegister = (GcbInstructionRegisterFileOperand) uncastInputRegister;
+          result.add(generateIndirectCall(supportedInstructions, abi, inputRegister));
+          result.add(generateBranchIndirectExpansion(supportedInstructions, inputRegister));
+          result.add(generateBranchIndirectSelection(inputRegister));
+        });
+
+    return result;
+  }
+
+  private static @Nonnull TableGenPseudoInstExpansionPattern generateIndirectCall(
+      IsaMachineInstructionMatchingPass.Result supportedInstructions,
+      Abi abi,
+      GcbInstructionRegisterFileOperand inputRegister) {
+    var selector = new Graph("selector");
+    var machine = new Graph("machine");
+
+    var ref = (ReadsRegisterTensor) inputRegister.origin().copy();
+    var address = (FieldRefNode) ref.indices().getFirst().copy();
+    var counter = ref instanceof ReadRegTensorNode rn 
+        ? rn.staticCounterAccess()
+        : null;
+    var llvmReadRegFileNode = new LlvmReadResourceFactory().create(ref.registerResource(), address,
+        ref.type(), counter);
+
+    var database = new Database(supportedInstructions);
+    var blr =
+        database.run(
+                new Query.Builder().machineInstructionLabel(MachineInstructionLabel.BLR).build())
+            .firstMachineInstruction();
+
+    selector.addWithInputs(new LlvmTargetCallSD(
+        new NodeList<>(llvmReadRegFileNode),
+        Type.dummy()));
+    machine.addWithInputs(new LcbMachineInstructionNode(
+        new NodeList<>(llvmReadRegFileNode.copy()), blr));
+    return new TableGenPseudoInstExpansionPattern("PseudoCALLIndirect",
+        selector,
+        machine,
+        true,
+        false,
+        false,
+        false,
+        false,
+        List.of(
+          llvmReadRegFileNode instanceof ReadRegTensorNode rn
+            ? new GcbInstructionRegisterFileOperand(rn, address.formatField())
+            : new GcbInstructionRegisterFileOperand((ReadArtificialResNode) llvmReadRegFileNode,
+                address.formatField())),
+        Collections.emptyList(),
+        List.of(
+            new RegisterRef(abi.returnAddress().registerFile(),
+                Constant.Value.of(abi.returnAddress().addr(),
+                    abi.returnAddress().registerFile().resultType())))
+    );
+  }
+
+  private static @Nonnull TableGenPseudoInstExpansionPattern generateBranchIndirectExpansion(
+      IsaMachineInstructionMatchingPass.Result supportedInstructions,
+      GcbInstructionRegisterFileOperand inputRegister) {
+    var machine = new Graph("machine");
+    var selector = new Graph("selector");
+    var ref = (ReadsRegisterTensor) inputRegister.origin();
+    var address = (FieldRefNode) ref.indices().getFirst().copy();
+    var counter = ref instanceof ReadRegTensorNode rn
+        ? rn.staticCounterAccess()
+        : null;
+    var llvmReadRegFileNode = new LlvmReadResourceFactory().create(ref.registerResource(), address,
+        ref.type(), counter);
+
+    var database = new Database(supportedInstructions);
+    var blr =
+        database.run(
+                new Query.Builder().machineInstructionLabel(MachineInstructionLabel.BLR).build())
+            .firstMachineInstruction();
+    machine.addWithInputs(new LcbMachineInstructionNode(
+        new NodeList<>(llvmReadRegFileNode.copy()), 
+        blr));
+    return new TableGenPseudoInstExpansionPattern("PseudoBRIND",
+        selector,
+        machine,
+        false,
+        true,
+        true,
+        true,
+        true,
+        List.of(
+          llvmReadRegFileNode instanceof ReadRegTensorNode rn
+            ? new GcbInstructionRegisterFileOperand(rn, address.formatField())
+            : new GcbInstructionRegisterFileOperand((ReadArtificialResNode) llvmReadRegFileNode,
+                address.formatField())),
+        Collections.emptyList(),
+        Collections.emptyList());
+  }
+
+  private TableGenPattern generateBranchIndirectSelection(
+      GcbInstructionRegisterFileOperand inputRegister) {
+    var selector = new Graph("selector");
+    var ref = (ReadsRegisterTensor) inputRegister.origin();
+    var address = (FieldRefNode) ref.indices().getFirst().copy();
+    var factory = new LlvmReadResourceFactory();
+    var counter = ref instanceof ReadRegTensorNode rn
+        ? rn.staticCounterAccess()
+        : null;
+    var llvmReadRegFileNode = factory.create(
+        ref.registerResource(), address, inputRegister.formatField().type(),
+        counter);
+    selector.addWithInputs(new LlvmBrindSD(new NodeList<>(llvmReadRegFileNode), Type.dummy()));
+
+    var machine = new Graph("machine");
+    machine.addWithInputs(new LcbMachineInstructionNode(
+        new NodeList<>(llvmReadRegFileNode.copy()),
+        new OutputInstructionName("PseudoBRIND")));
+
+    return new TableGenSelectionWithOutputPattern(selector, machine);
+  }
+}

--- a/vadl/main/vadl/lcb/passes/llvmLowering/strategies/visitors/TableGenMachineInstructionVisitor.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/strategies/visitors/TableGenMachineInstructionVisitor.java
@@ -22,6 +22,7 @@ import vadl.lcb.passes.llvmLowering.domain.machineDag.LcbMachineInstructionValue
 import vadl.lcb.passes.llvmLowering.domain.machineDag.LcbPseudoInstructionNode;
 import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmBasicBlockSD;
 import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmFieldAccessRefNode;
+import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmReadArtificialResourceNode;
 import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmReadRegFileNode;
 import vadl.viam.graph.Graph;
 import vadl.viam.graph.GraphNodeVisitor;
@@ -64,4 +65,9 @@ public interface TableGenMachineInstructionVisitor extends GraphNodeVisitor {
    * Visit {@link LlvmReadRegFileNode}.
    */
   void visit(LlvmReadRegFileNode llvmReadRegFileNode);
+
+  /**
+   * Visit {@link LlvmReadArtificialResourceNode}.
+   */
+  void visit(LlvmReadArtificialResourceNode llvmReadArtificialResourceNode);
 }

--- a/vadl/main/vadl/lcb/passes/llvmLowering/tablegen/lowering/TableGenMachineInstructionPrinterVisitor.java
+++ b/vadl/main/vadl/lcb/passes/llvmLowering/tablegen/lowering/TableGenMachineInstructionPrinterVisitor.java
@@ -25,6 +25,7 @@ import vadl.lcb.passes.llvmLowering.domain.machineDag.LcbMachineInstructionValue
 import vadl.lcb.passes.llvmLowering.domain.machineDag.LcbPseudoInstructionNode;
 import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmBasicBlockSD;
 import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmFieldAccessRefNode;
+import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmReadArtificialResourceNode;
 import vadl.lcb.passes.llvmLowering.domain.selectionDag.LlvmReadRegFileNode;
 import vadl.lcb.passes.llvmLowering.strategies.LlvmInstructionLoweringStrategy;
 import vadl.lcb.passes.llvmLowering.strategies.visitors.TableGenMachineInstructionVisitor;
@@ -136,6 +137,13 @@ public class TableGenMachineInstructionPrinterVisitor implements TableGenMachine
   @Override
   public void visit(LlvmReadRegFileNode llvmReadRegFileNode) {
     var operand = LlvmInstructionLoweringStrategy.generateTableGenInputOutput(llvmReadRegFileNode);
+    writer.write(operand.render());
+  }
+
+  @Override
+  public void visit(LlvmReadArtificialResourceNode llvmReadArtificialResourceNode) {
+    var operand = LlvmInstructionLoweringStrategy
+        .generateTableGenInputOutput(llvmReadArtificialResourceNode);
     writer.write(operand.render());
   }
 

--- a/vadl/test/resources/snapshots/aarch64/InstrInfoTableGen.td
+++ b/vadl/test/resources/snapshots/aarch64/InstrInfoTableGen.td
@@ -14669,7 +14669,7 @@ let Inst{4-0} = op{4-0};
 let Inst{31-10} = op{26-5};
 let Inst{9-5} = rn{4-0};
 
-let isTerminator       = 1;
+let isTerminator       = 0;
 let isBranch           = 0;
 let isCall             = 0;
 let isReturn           = 0;
@@ -52069,6 +52069,20 @@ let Defs = [  ];
 
 
 
+let isCall = 1, isBranch = 0, isIndirectBranch = 0, isTerminator = 0,
+isBarrier = 0, Defs = [S30]
+in
+    def PseudoCALLIndirect : Pseudo<(outs ), (ins X:$rn),
+                        [(target_call X:$rn)]>,
+                 PseudoInstExpansion<(BLR X:$rn)>;
+
+let isCall = 0, isBranch = 1, isIndirectBranch = 1, isTerminator = 1,
+isBarrier = 1
+in
+    def PseudoBRIND : Pseudo<(outs ), (ins X:$rn),
+                        []>,
+                 PseudoInstExpansion<(BLR X:$rn)>;
+
 def : Pat<(add W:$rn, W:$rm),
         (ADDW W:$rn, W:$rm)>;
 
@@ -52274,6 +52288,10 @@ def : Pat<(sra X:$rn, X:$rm),
 
 def : Pat<(br bb:$offset),
         (B bb:$offset)>;
+
+
+def : Pat<(brind X:$rn),
+        (PseudoBRIND X:$rn)>;
 
 
 def : Pat<(br bb:$offset),


### PR DESCRIPTION
This PR adds a new MachineInstructionLabel `BLR`, which describes instructions, which represent an unconditional jump with a register, which sets the linking register. Additionally, a new LlvmInstructionLowering-Strategy is added, which implements the generation of LLVM "PseudoCALLIndirect" and "BRIND" patterns for instructions labeled as `BLR`.