### PR TITLE
frontend: More even further performance improvements

### DIFF
--- a/vadl/main/vadl/ast/BehaviorLowering.java
+++ b/vadl/main/vadl/ast/BehaviorLowering.java
@@ -312,12 +312,13 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
   @SuppressWarnings("Indentation")
   Function getRegisterAliasReadFunc(AliasDefinition definition,
                                     List<RegisterTensor.Dimension> dimensions) {
-    var graph = new Graph("%s Read Behavior".formatted(definition.viamId));
+    var graph = new Graph("%s Read Behavior".formatted(String.join("::", definition.viamId)));
     graph.setSourceLocation(definition.location());
     currentGraph = graph;
 
+    final var identifierParts = ViamLowering.append(definition.viamId, "read");
     final var identifier =
-        viamLowering.generateIdentifier(definition.viamId + "::read", definition.loc);
+        new vadl.viam.Identifier(identifierParts, definition.loc);
 
     DataType resultType;
     // Initially the indices are all fixed arguments specified in the alias definition.
@@ -332,8 +333,8 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
       // FIXME: Wrap input and output in casts
       for (int i = 0; i < tensorType.indexDims().size(); i++) {
         var param = new vadl.viam.Parameter(
-            viamLowering.generateIdentifier(
-                identifier.name() + "::index",
+            new vadl.viam.Identifier(
+                ViamLowering.append(identifierParts, "index"),
                 identifier.location()),
             Type.bits(BitsType.indexWidthFor(tensorType.indexDims().get(i))),
             0);
@@ -444,12 +445,13 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
   @SuppressWarnings("Indentation")
   Procedure getRegisterAliasWriteProc(AliasDefinition definition,
                                       List<RegisterTensor.Dimension> dimensions) {
-    final var graph = new Graph("%s Write Procedure".formatted(definition.viamId));
+    final var graph = new Graph("%s Write Procedure".formatted(String.join("::", definition.viamId)));
     graph.setSourceLocation(definition.location());
     currentGraph = graph;
 
+    final var identifierParts = ViamLowering.append(definition.viamId, "write");
     final var identifier =
-        viamLowering.generateIdentifier(definition.viamId + "::write", definition.loc);
+        new vadl.viam.Identifier(identifierParts, definition.loc);
     final var regFileDef = (RegisterDefinition) requireNonNull(definition.computedTarget);
     final var zeroConst = definition.getAnnotation("zero", ZeroConstraintAnnotation.class);
 
@@ -464,8 +466,8 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
       // FIXME: Wrap input and output in casts
       for (int i = 0; i < tensorType.indexDims().size(); i++) {
         var param = new vadl.viam.Parameter(
-            viamLowering.generateIdentifier(
-                identifier.name() + "::index",
+            new vadl.viam.Identifier(
+                ViamLowering.append(identifierParts, "index"),
                 identifier.location()),
             Type.bits(BitsType.indexWidthFor(tensorType.indexDims().get(i))),
             0);
@@ -478,8 +480,8 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
     }
 
     var valueParam = new vadl.viam.Parameter(
-        viamLowering.generateIdentifier(
-            identifier.name() + "::value",
+        new vadl.viam.Identifier(
+            ViamLowering.append(identifierParts, "value"),
             identifier.location()),
         getViamType(resultType),
         1);
@@ -689,7 +691,7 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
     } catch (ArithmeticException e) {
       throw new IllegalStateException(
           "Expansion alias mapping overflow for "
-              + definition.viamId
+              + String.join("::", definition.viamId)
               + ": while calculating covered bit width.",
           e
       );
@@ -697,7 +699,7 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
     if (coveredBits > sourceValueType.bitWidth()) {
       throw new IllegalStateException(
           "Invalid expansion alias mapping for "
-              + definition.viamId
+              + String.join("::", definition.viamId)
               + ": virtual alias indexing may address "
               + coveredBits
               + " bits, but source read provides only "
@@ -2143,9 +2145,10 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
       }
     } else {
       // FIXME: Add to a global store so that ISA can get a list of all exceptions
-      var name = statement.viamId + "::anonymousException";
+      var anonymousParts = ViamLowering.append(statement.viamId, "anonymousException");
+      var name = String.join("::", anonymousParts);
       exception = new ExceptionDef(
-          viamLowering.generateIdentifier(name, statement.statement),
+          new vadl.viam.Identifier(anonymousParts, statement.statement.location()),
           new vadl.viam.Parameter[] {},
           new BehaviorLowering(this.viamLowering).getProcedureGraph(statement.statement, name),
           ExceptionDef.Kind.ANONYMOUS

--- a/vadl/main/vadl/ast/BehaviorLowering.java
+++ b/vadl/main/vadl/ast/BehaviorLowering.java
@@ -445,7 +445,8 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
   @SuppressWarnings("Indentation")
   Procedure getRegisterAliasWriteProc(AliasDefinition definition,
                                       List<RegisterTensor.Dimension> dimensions) {
-    final var graph = new Graph("%s Write Procedure".formatted(String.join("::", definition.viamId)));
+    final var graph =
+        new Graph("%s Write Procedure".formatted(String.join("::", definition.viamId)));
     graph.setSourceLocation(definition.location());
     currentGraph = graph;
 

--- a/vadl/main/vadl/ast/Definition.java
+++ b/vadl/main/vadl/ast/Definition.java
@@ -51,7 +51,7 @@ abstract class Definition extends Node {
   List<AnnotationDefinition> annotations = new ArrayList<>();
 
   @LazyInit
-  String viamId;
+  List<String> viamId;
 
   Definition withAnnotations(List<AnnotationDefinition> annotations) {
     this.annotations = annotations;

--- a/vadl/main/vadl/ast/Expr.java
+++ b/vadl/main/vadl/ast/Expr.java
@@ -22,8 +22,8 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.StringJoiner;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import vadl.javaannotations.ast.Child;
 import vadl.types.BuiltInTable;
@@ -1555,10 +1555,11 @@ final class IdentifierPath extends Expr implements IsId {
 
   @Override
   public String pathToString() {
-    return this.segments.stream()
-        .map(id -> (Identifier) id)
-        .map(id -> id.name)
-        .collect(Collectors.joining("::"));
+    var builder = new StringJoiner("::");
+    for (var segment : segments) {
+      builder.add(((Identifier) segment).name);
+    }
+    return builder.toString();
   }
 
   @Nullable

--- a/vadl/main/vadl/ast/Expr.java
+++ b/vadl/main/vadl/ast/Expr.java
@@ -19,21 +19,16 @@ package vadl.ast;
 import static java.util.Objects.requireNonNull;
 
 import java.math.BigInteger;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import vadl.javaannotations.ast.Child;
-import vadl.types.BitsType;
-import vadl.types.BoolType;
 import vadl.types.BuiltInTable;
 import vadl.types.ConcreteRelationType;
-import vadl.types.SIntType;
 import vadl.types.StructType;
 import vadl.types.Type;
-import vadl.types.UIntType;
 import vadl.utils.SourceLocation;
 import vadl.utils.WithLocation;
 import vadl.viam.Constant;
@@ -1425,46 +1420,6 @@ final class TypeLiteral extends Expr {
     this.loc = symExpr.location();
   }
 
-  // A constructor used internally when the type is already known
-  public TypeLiteral(Type type, SourceLocation loc) {
-    this.type = type;
-    this.loc = loc;
-
-    if (type.getClass() == BoolType.class) {
-      this.baseType = new Identifier("Bool", SourceLocation.INVALID_SOURCE_LOCATION);
-      this.sizeIndices = List.of();
-    } else if (type.getClass() == BitsType.class) {
-      var bitsType = (BitsType) type;
-      this.baseType = new Identifier("Bits", SourceLocation.INVALID_SOURCE_LOCATION);
-      this.sizeIndices = List.of(new IntegerLiteral(bitsType.bitWidth(), loc));
-    } else if (type.getClass() == UIntType.class) {
-      var uintType = (UIntType) type;
-      this.baseType = new Identifier("UInt", SourceLocation.INVALID_SOURCE_LOCATION);
-      this.sizeIndices = List.of(new IntegerLiteral(uintType.bitWidth(), loc));
-    } else if (type.getClass() == SIntType.class) {
-      var sintType = (SIntType) type;
-      this.baseType = new Identifier("SInt", SourceLocation.INVALID_SOURCE_LOCATION);
-      this.sizeIndices = List.of(new IntegerLiteral(sintType.bitWidth(), loc));
-    } else if (type.getClass() == FormatType.class) {
-      var formatType = (FormatType) type;
-      this.baseType = new Identifier(formatType.format.identifier().name,
-          SourceLocation.INVALID_SOURCE_LOCATION);
-      this.sizeIndices = List.of();
-    } else if (type instanceof TensorType tensortype) {
-      var innerLiteral = new TypeLiteral(tensortype.innerType(), loc);
-      this.baseType = innerLiteral.baseType;
-      var indices =
-          new ArrayList<Expr>(tensortype.indexDims().size() + innerLiteral.sizeIndices.size());
-      for (var i : tensortype.indexDims()) {
-        indices.add(new IntegerLiteral(i, loc));
-      }
-      indices.addAll(innerLiteral.sizeIndices);
-      this.sizeIndices = indices;
-    } else {
-      throw new IllegalStateException("Unsupported type " + type.getClass().getSimpleName());
-    }
-  }
-
   /**
    * For builtin types this won't return anything, but for custom types it returns the definition
    * the type literal points to. For example users can introduce new custom types with
@@ -2271,8 +2226,17 @@ class LetExpr extends Expr {
 class CastExpr extends Expr {
   @Child
   Expr value;
+
+  /**
+   * The typeLiteral.
+   * The typechecker also expands implicit casts to explicit ones and often inserts new
+   * CastExpressions. Since these don't come from the source code, this field is left empty in
+   * such cases, and only the Type field is used.
+   */
+  @Nullable
   @Child
   TypeLiteral typeLiteral;
+
   SourceLocation location;
 
   public CastExpr(Expr value, TypeLiteral typeLiteral) {
@@ -2281,11 +2245,16 @@ class CastExpr extends Expr {
     this.location = value.location().join(typeLiteral.location());
   }
 
+  /**
+   * A syntetic constructor that doesn't originate from the source code.
+   *
+   * @param value to be cast.
+   * @param type to which it is cast.
+   */
   public CastExpr(Expr value, Type type) {
     this.value = value;
     this.type = type;
     this.location = value.location();
-    this.typeLiteral = new TypeLiteral(type, value.location());
   }
 
   @Override
@@ -2308,7 +2277,11 @@ class CastExpr extends Expr {
     wrapInGroup(parentPrec, builder, true, () -> {
       value.prettyPrintExpr(indent, builder, Precedence.CastOp);
       builder.append(" as ");
-      typeLiteral.prettyPrint(indent, builder);
+      if (typeLiteral != null) {
+        typeLiteral.prettyPrint(indent, builder);
+      } else {
+        builder.append(requireNonNull(type));
+      }
     });
   }
 
@@ -2328,7 +2301,7 @@ class CastExpr extends Expr {
     }
 
     CastExpr that = (CastExpr) o;
-    return value.equals(that.value) && typeLiteral.equals(that.typeLiteral);
+    return value.equals(that.value) && Objects.equals(typeLiteral, that.typeLiteral);
   }
 
   @Override

--- a/vadl/main/vadl/ast/Expr.java
+++ b/vadl/main/vadl/ast/Expr.java
@@ -19,6 +19,7 @@ package vadl.ast;
 import static java.util.Objects.requireNonNull;
 
 import java.math.BigInteger;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -1572,10 +1573,11 @@ final class IdentifierPath extends Expr implements IsId {
 
   //  @Override
   public List<String> pathToSegments() {
-    return this.segments.stream()
-        .map(id -> (Identifier) id)
-        .map(id -> id.name)
-        .toList();
+    var result = new ArrayList<String>();
+    for (var segment : segments) {
+      result.add(((Identifier) segment).name);
+    }
+    return result;
   }
 
   @Override

--- a/vadl/main/vadl/ast/MacroExpander.java
+++ b/vadl/main/vadl/ast/MacroExpander.java
@@ -16,6 +16,7 @@
 
 package vadl.ast;
 
+import static java.util.Objects.requireNonNull;
 import static vadl.error.Diagnostic.error;
 
 import java.util.ArrayList;
@@ -378,7 +379,7 @@ class MacroExpander
 
   @Override
   public Expr visit(CastExpr expr) {
-    return new CastExpr(expandExpr(expr.value), expandExpr(expr.typeLiteral));
+    return new CastExpr(expandExpr(expr.value), expandExpr(requireNonNull(expr.typeLiteral)));
   }
 
   @Override

--- a/vadl/main/vadl/ast/ParserUtils.java
+++ b/vadl/main/vadl/ast/ParserUtils.java
@@ -230,7 +230,7 @@ class ParserUtils {
     if (expr instanceof CastExpr castExpr) {
       if (castExpr.value instanceof BinaryExpr binExpr) {
         return new BinaryExpr(binExpr.left, binExpr.operator,
-            new CastExpr(binExpr.right, castExpr.typeLiteral));
+            new CastExpr(binExpr.right, requireNonNull(castExpr.typeLiteral)));
       }
     }
     return expr;

--- a/vadl/main/vadl/ast/Statement.java
+++ b/vadl/main/vadl/ast/Statement.java
@@ -396,7 +396,7 @@ final class RaiseStatement extends Statement {
   SourceLocation location;
 
   @LazyInit
-  String viamId;
+  List<String> viamId;
 
   RaiseStatement(Statement statement, SourceLocation location) {
     this.statement = statement;

--- a/vadl/main/vadl/ast/SymbolTable.java
+++ b/vadl/main/vadl/ast/SymbolTable.java
@@ -642,7 +642,7 @@ class SymbolTable {
       } else {
         viamPath.addLast("unknown");
       }
-      definition.viamId = String.join("::", viamPath);
+      definition.viamId = new ArrayList<>(viamPath);
 
       definition.symbolTable = currentSymbols();
     }
@@ -686,7 +686,7 @@ class SymbolTable {
       } else {
         viamPath.addLast("unknown");
       }
-      definition.viamId = String.join("::", viamPath);
+      definition.viamId = new ArrayList<>(viamPath);
 
       definition.symbolTable = currentSymbols().createChild();
       symbolTables.addLast(definition.symbolTable);

--- a/vadl/main/vadl/ast/TypeChecker.java
+++ b/vadl/main/vadl/ast/TypeChecker.java
@@ -4113,10 +4113,13 @@ public class TypeChecker
 
   @Override
   public Void visit(CastExpr expr) {
-    var valType = checkWith(expr.value, intermediateParseTypeLiteral(expr.typeLiteral));
+    // The typeliteral always exists for these expressions
+    var typeLiteral = requireNonNull(expr.typeLiteral);
 
-    expr.typeLiteral.type = parseTypeLiteral(expr.typeLiteral, preferredBitWidthOf(valType));
-    var litType = expr.typeLiteral.type();
+    var valType = checkWith(expr.value, intermediateParseTypeLiteral(typeLiteral));
+
+    typeLiteral.type = parseTypeLiteral(typeLiteral, preferredBitWidthOf(valType));
+    var litType = typeLiteral.type();
 
     if (!canExplicitCast(valType, litType)) {
       // No need to stop checking we can just assume it works and assign the declared type.

--- a/vadl/main/vadl/ast/ViamLowering.java
+++ b/vadl/main/vadl/ast/ViamLowering.java
@@ -1028,7 +1028,8 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
 
   @Override
   public Optional<vadl.viam.Definition> visit(CounterDefinition definition) {
-    var identifier = new vadl.viam.Identifier(definition.viamId, definition.identifier().location());
+    var identifier =
+        new vadl.viam.Identifier(definition.viamId, definition.identifier().location());
 
     var resultType = (DataType) getViamType(requireNonNull(definition.typeLiteral.type));
 
@@ -1203,7 +1204,8 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
         .filter(f -> f instanceof DerivedFormatField)
         .map(f -> (DerivedFormatField) f)
         .map(derivedField -> {
-          var identifier = new vadl.viam.Identifier(derivedField.viamId, derivedField.identifier().loc);
+          var identifier =
+              new vadl.viam.Identifier(derivedField.viamId, derivedField.identifier().loc);
           var access = getFieldAccessFunction(derivedField);
 
           var field = new Format.FieldAccess(identifier, access, null);
@@ -1260,7 +1262,8 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
   }
 
   private Function getFieldAccessFunction(DerivedFormatField derivedField) {
-    var accessIdentifier = new vadl.viam.Identifier(append(derivedField.viamId, "decode"), derivedField.identifier.location());
+    var accessIdentifier = new vadl.viam.Identifier(append(derivedField.viamId, "decode"),
+        derivedField.identifier.location());
     var accessGraph =
         new BehaviorLowering(this).getFunctionGraph(derivedField.expr, accessIdentifier.name());
     var access =
@@ -1291,7 +1294,8 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
     var lowered = (Format.FieldAccess) requireNonNull(formatFieldCache.get(derivedField));
     var fieldIdent = lowered.identifier;
 
-    var predIdent = new vadl.viam.Identifier(append(List.of(fieldIdent.parts()), "predicate"), derivedField.identifier.location());
+    var predIdent = new vadl.viam.Identifier(append(List.of(fieldIdent.parts()), "predicate"),
+        derivedField.identifier.location());
     var predName = predIdent.name();
     var behavior = new BehaviorLowering(this).getFunctionGraph(predField.expr, predName);
     checkNoResourceAccesses(behavior, "field access predicate");

--- a/vadl/main/vadl/ast/ViamLowering.java
+++ b/vadl/main/vadl/ast/ViamLowering.java
@@ -344,19 +344,17 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
     return astType;
   }
 
-  /**
-   * Generate a new viam Identifier from an ast Identifier.
-   *
-   * @param viamId    often the viam identifier have a different name than the ast
-   *                  (prepended by their "path")
-   * @param locatable the location of the identifier in the ast.
-   * @return the new identifier.
-   */
-  vadl.viam.Identifier generateIdentifier(String viamId, WithLocation locatable) {
-    var parts = viamId.split("::");
-    return new vadl.viam.Identifier(parts, locatable.location());
+  private vadl.viam.Identifier generateViamID(Identifier id) {
+    return new vadl.viam.Identifier(id.name, id.location());
   }
 
+  static <T> List<T> append(List<T> list, T... elements) {
+    var newList = new ArrayList<T>(list);
+    for (T element : elements) {
+      newList.add(element);
+    }
+    return newList;
+  }
 
   /**
    * A simple helper util that returns a copy of the list casted to the class provided.
@@ -388,7 +386,7 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
 
     if (definition.kind == AbiSequenceDefinition.SeqKind.CONSTANT) {
       var astIdentifier = new Identifier("constMat" + constantMatSequence, definition.loc);
-      var viamIdentifier = generateIdentifier("constMat" + constantMatSequence, definition.loc);
+      var viamIdentifier = generateViamID(astIdentifier);
       constantMatSequence++;
       var graph = new BehaviorLowering(this).getInstructionSequenceGraph(
           astIdentifier, definition);
@@ -402,8 +400,7 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
     } else if (definition.kind == AbiSequenceDefinition.SeqKind.REGISTER) {
       var astIdentifier =
           new Identifier("registerAdjustment" + registerAdjustmentSequence, definition.loc);
-      var viamIdentifier =
-          generateIdentifier("registerAdjustment" + registerAdjustmentSequence, definition.loc);
+      var viamIdentifier = generateViamID(astIdentifier);
       registerAdjustmentSequence++;
       var graph = new BehaviorLowering(this).getInstructionSequenceGraph(
           astIdentifier, definition);
@@ -423,7 +420,7 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
   @Override
   public Optional<vadl.viam.Definition> visit(AliasDefinition definition) {
 
-    var identifier = generateIdentifier(definition.viamId, definition.loc);
+    var identifier = new vadl.viam.Identifier(definition.viamId, definition.loc);
     var innerResource =
         (RegisterTensor) fetch(requireNonNull(definition.computedTarget)).orElseThrow();
 
@@ -588,7 +585,7 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
 
   @Override
   public Optional<vadl.viam.Definition> visit(ApplicationBinaryInterfaceDefinition definition) {
-    var id = generateIdentifier(definition.viamId, definition.identifier());
+    var id = new vadl.viam.Identifier(definition.viamId, definition.identifier().loc);
     var aliasLookup = aliasLookupTable(definition.definitions);
 
     // Special Registers
@@ -738,7 +735,7 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
   @Override
   public Optional<vadl.viam.Definition> visit(AsmDescriptionDefinition definition) {
 
-    var id = generateIdentifier(definition.viamId, definition.identifier());
+    var id = new vadl.viam.Identifier(definition.viamId, definition.identifier().loc);
 
     var modifiers = definition.modifiers.stream()
         .map(m -> (AsmModifier) fetch(m).orElseThrow()).toList();
@@ -769,7 +766,8 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
     var alignmentIsInBytes =
         directive != AsmDirective.ALIGN_POW2 && directive != AsmDirective.ALIGN32_POW2;
     return Optional.of(
-        new AsmDirectiveMapping(generateIdentifier(id, definition), id, directive.getAsmName(),
+        new AsmDirectiveMapping(new vadl.viam.Identifier(id, definition.loc), id,
+            directive.getAsmName(),
             alignmentIsInBytes, definition.location()));
   }
 
@@ -811,7 +809,7 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
 
   @Override
   public Optional<vadl.viam.Definition> visit(AsmGrammarRuleDefinition definition) {
-    var id = generateIdentifier(definition.identifier().name, definition.identifier());
+    var id = new vadl.viam.Identifier(definition.identifier().name, definition.identifier().loc);
     requireNonNull(definition.asmType);
     if (definition.isTerminalRule) {
       var literal =
@@ -859,7 +857,7 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
       var semanticPredicateGraph = new BehaviorLowering(this)
           .getFunctionGraph(semPredExpr, "semanticPredicate");
       semPredFunction =
-          new Function(generateIdentifier("semanticPredicate", semPredExpr.location()),
+          new Function(new vadl.viam.Identifier("semanticPredicate", semPredExpr.location()),
               new vadl.viam.Parameter[0], Type.bool(), semanticPredicateGraph);
     }
 
@@ -881,7 +879,7 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
       Function semPredFunction = null;
       if (semPredGraph != null) {
         semPredFunction = new Function(
-            generateIdentifier("semanticPredicate", definition.optionAlternatives.location()),
+            new vadl.viam.Identifier("semanticPredicate", definition.optionAlternatives.location()),
             new vadl.viam.Parameter[0], Type.bool(), semPredGraph);
       }
       var firstTokens =
@@ -895,7 +893,7 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
       Function semPredFunction = null;
       if (semPredGraph != null) {
         semPredFunction = new Function(
-            generateIdentifier("semanticPredicate",
+            new vadl.viam.Identifier("semanticPredicate",
                 definition.repetitionAlternatives.location()),
             new vadl.viam.Parameter[0], Type.bool(), semPredGraph);
       }
@@ -1002,7 +1000,7 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
     var id = ((StringLiteral) definition.stringLiteral).value;
 
     return Optional.of(
-        new AsmModifier(generateIdentifier(id, definition), relocation,
+        new AsmModifier(new vadl.viam.Identifier(id, definition.loc), relocation,
             definition.location()));
   }
 
@@ -1030,7 +1028,7 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
 
   @Override
   public Optional<vadl.viam.Definition> visit(CounterDefinition definition) {
-    var identifier = generateIdentifier(definition.viamId, definition.identifier().location());
+    var identifier = new vadl.viam.Identifier(definition.viamId, definition.identifier().location());
 
     var resultType = (DataType) getViamType(requireNonNull(definition.typeLiteral.type));
 
@@ -1070,7 +1068,7 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
 
     var memory = (Memory) fetch(definition.memoryNode()).get();
     var region = new MemoryRegion(
-        generateIdentifier(definition.viamId, definition),
+        new vadl.viam.Identifier(definition.viamId, definition.identifier().loc),
         kind,
         memory,
         behavior
@@ -1085,7 +1083,7 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
       Expr expr,
       Type returnType
   ) {
-    var identifier = generateIdentifier(definition.viamId, definition.identifier());
+    var identifier = new vadl.viam.Identifier(definition.viamId, definition.identifier().loc);
     var parameters = mapParameters(params);
     var behavior =
         new BehaviorLowering(this).getFunctionGraph(expr, identifier.simpleName() + " behavior");
@@ -1109,10 +1107,12 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
         new BehaviorLowering(this).getProcedureGraph(definition.statement, definition.kind.keyword);
 
     // FIXME: @flofriday, when remove this, it would end with `::unknown`
-    var viamId = definition.viamId.replace("::unknown", "::" + definition.kind.keyword);
+    var viamId = definition.viamId.stream()
+        .map(s -> s.equals("unknown") ? definition.kind.keyword : s)
+        .collect(Collectors.toList());
 
     var procedure = new Procedure(
-        generateIdentifier(viamId, definition),
+        new vadl.viam.Identifier(viamId, definition.loc),
         new vadl.viam.Parameter[] {},
         behavior
     );
@@ -1144,7 +1144,7 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
 
   @Override
   public Optional<vadl.viam.Definition> visit(ExceptionDefinition definition) {
-    var identifier = generateIdentifier(definition.viamId, definition.identifier());
+    var identifier = new vadl.viam.Identifier(definition.viamId, definition.identifier().loc);
     var parameters = mapParameters(definition.params);
     var behavior = new BehaviorLowering(this).getProcedureGraph(definition.statement, "exception");
     return Optional.of(new ExceptionDef(
@@ -1158,7 +1158,7 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
   @Override
   public Optional<vadl.viam.Definition> visit(FormatDefinition definition) {
     var format =
-        new Format(generateIdentifier(definition.viamId, definition.identifier()),
+        new Format(new vadl.viam.Identifier(definition.viamId, definition.identifier().loc),
             (BitsType) getViamType(definition.typeLiteral.type()));
 
     // first lower all format fields (that are not derived format fields).
@@ -1167,8 +1167,8 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
         .filter(f -> !(f instanceof DerivedFormatField))
         .map(fieldDefinition -> {
           var fieldIdent =
-              generateIdentifier(definition.viamId + "::" + fieldDefinition.identifier().name,
-                  fieldDefinition.identifier);
+              new vadl.viam.Identifier(append(definition.viamId, fieldDefinition.identifier().name),
+                  fieldDefinition.identifier.location());
 
           var field = switch (fieldDefinition) {
             case TypedFormatField typed -> {
@@ -1203,7 +1203,7 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
         .filter(f -> f instanceof DerivedFormatField)
         .map(f -> (DerivedFormatField) f)
         .map(derivedField -> {
-          var identifier = generateIdentifier(derivedField.viamId, derivedField.identifier());
+          var identifier = new vadl.viam.Identifier(derivedField.viamId, derivedField.identifier().loc);
           var access = getFieldAccessFunction(derivedField);
 
           var field = new Format.FieldAccess(identifier, access, null);
@@ -1260,11 +1260,11 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
   }
 
   private Function getFieldAccessFunction(DerivedFormatField derivedField) {
-    var accessName = derivedField.viamId + "::decode";
+    var accessIdentifier = new vadl.viam.Identifier(append(derivedField.viamId, "decode"), derivedField.identifier.location());
     var accessGraph =
-        new BehaviorLowering(this).getFunctionGraph(derivedField.expr, accessName);
+        new BehaviorLowering(this).getFunctionGraph(derivedField.expr, accessIdentifier.name());
     var access =
-        new Function(generateIdentifier(accessName, derivedField.identifier),
+        new Function(accessIdentifier,
             new vadl.viam.Parameter[0],
             getViamType(derivedField.expr.type()), accessGraph);
 
@@ -1291,9 +1291,8 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
     var lowered = (Format.FieldAccess) requireNonNull(formatFieldCache.get(derivedField));
     var fieldIdent = lowered.identifier;
 
-    var predName = fieldIdent.name() + "::predicate";
-    var predIdent = generateIdentifier(predName, derivedField.identifier);
-
+    var predIdent = new vadl.viam.Identifier(append(List.of(fieldIdent.parts()), "predicate"), derivedField.identifier.location());
+    var predName = predIdent.name();
     var behavior = new BehaviorLowering(this).getFunctionGraph(predField.expr, predName);
     checkNoResourceAccesses(behavior, "field access predicate");
     checkLeafNodes(behavior, (n) -> {
@@ -1442,8 +1441,9 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
   @Override
   public Optional<vadl.viam.Definition> visit(GroupDefinition definition) {
     final Group.Expression expr = definition.groupSequence.accept(this);
-    return Optional.of(new Group(generateIdentifier(definition.viamId, definition.identifier()),
-        expr));
+    return Optional.of(
+        new Group(new vadl.viam.Identifier(definition.viamId, definition.identifier().loc),
+            expr));
   }
 
   @Override
@@ -1495,9 +1495,9 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
         .map(i -> (Identifier) i)
         .filter(i -> i.name.equals(instructionDefinition.identifier().name))
         .findFirst().orElseThrow().location();
-    var identifierName = instructionDefinition.viamId + "::assembly";
+    var identifierParts = append(instructionDefinition.viamId, "assembly");
     var funcIdentifier =
-        new vadl.viam.Identifier(identifierName + "::func", identifierLoc);
+        new vadl.viam.Identifier(append(identifierParts, "func"), identifierLoc);
 
     var behavior =
         new BehaviorLowering(this).getFunctionGraph(definition.expr, funcIdentifier.name());
@@ -1506,7 +1506,7 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
     // assembly in the VIAM.
 
     return Optional.of(new Assembly(
-        new vadl.viam.Identifier(identifierName, identifierLoc),
+        new vadl.viam.Identifier(identifierParts, identifierLoc),
         new Function(funcIdentifier, new vadl.viam.Parameter[0], Type.string(), behavior)
     ));
   }
@@ -1520,8 +1520,9 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
       var formatField = (Format.Field) fetch(requireNonNull(definition.formatNode)
           .getField(encodingDef.identifier().name)).orElseThrow();
       var identifier =
-          generateIdentifier(definition.viamId + "::encoding::" + encodingDef.identifier().name,
-              encodingDef.field);
+          new vadl.viam.Identifier(
+              append(definition.viamId, "encoding", encodingDef.identifier().name),
+              encodingDef.field.location());
 
       // FIXME: Maybe cache it in the AST after typechecking?
       var evaluated = constantEvaluator.eval(encodingDef.value);
@@ -1530,7 +1531,8 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
     }
 
     return Optional.of(new Encoding(
-        generateIdentifier(instructionDefinition.viamId + "::encoding", definition.identifier()),
+        new vadl.viam.Identifier(append(instructionDefinition.viamId, "encoding"),
+            definition.identifier().location()),
         (Format) fetch(requireNonNull(definition.formatNode)).orElseThrow(),
         fields.toArray(new Encoding.Field[0])
     ));
@@ -1550,7 +1552,7 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
             .map(Encoding.class::cast).get();
 
     var instruction = new Instruction(
-        generateIdentifier(definition.viamId, definition.identifier()),
+        new vadl.viam.Identifier(definition.viamId, definition.identifier().location()),
         behavior,
         assembly,
         encoding
@@ -1567,7 +1569,7 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
 
     var mergedDef = mergeIsa(definition);
 
-    var identifier = generateIdentifier(mergedDef.identifier().name, mergedDef.identifier());
+    var identifier = generateViamID(mergedDef.identifier());
 
     // FIXME: make this togroup instead of toList
     var allDefinitions =
@@ -1635,7 +1637,7 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
 
   @Override
   public Optional<vadl.viam.Definition> visit(LogicDefinition definition) {
-    var id = generateIdentifier(definition.viamId, definition.identifier());
+    var id = new vadl.viam.Identifier(definition.viamId, definition.identifier().location());
     var logic = switch (definition.logicType) {
       case Forwarding -> new Logic.Forwarding(id);
       case Control -> new Logic.Control(id);
@@ -1664,7 +1666,8 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
 
   @Override
   public Optional<vadl.viam.Definition> visit(MemoryDefinition definition) {
-    var identifier = generateIdentifier(definition.viamId, definition.identifier());
+    var identifier =
+        new vadl.viam.Identifier(definition.viamId, definition.identifier().location());
     return Optional.of(new Memory(identifier,
         (DataType) getViamType(definition.addressTypeLiteral.type()),
         (DataType) getViamType(definition.dataTypeLiteral.type())));
@@ -1672,7 +1675,7 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
 
   @Override
   public Optional<vadl.viam.Definition> visit(MicroArchitectureDefinition definition) {
-    var identifier = generateIdentifier(definition.viamId, definition.identifier());
+    var identifier = new vadl.viam.Identifier(definition.viamId, definition.identifier().loc);
     var isa = visitAndMergeIsa(definition.isaNode());
 
     var children = definition.definitions.stream().map(this::fetch).filter(Optional::isPresent)
@@ -1706,7 +1709,7 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
 
   @Override
   public Optional<vadl.viam.Definition> visit(ProcessorDefinition definition) {
-    var identifier = generateIdentifier(definition.viamId, definition.identifier());
+    var identifier = new vadl.viam.Identifier(definition.viamId, definition.identifier().loc);
     // create empty list of ast definitions
     // for each isa in mip add definitions to definition list
     // create new isa ast node with list of definitions
@@ -1716,7 +1719,7 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
     var reset = (Procedure) definition.findCpuProcDef(CpuProcessDefinition.ProcessKind.RESET)
         .findFirst()
         .flatMap(this::fetch)
-        .orElseGet(() -> new Procedure(generateIdentifier("reset", definition),
+        .orElseGet(() -> new Procedure(new vadl.viam.Identifier("reset", definition.loc),
             new vadl.viam.Parameter[] {}, emptyProcedureGraph("reset behavior", definition)));
 
     var memRegions = definition.findMemoryRegionDefs().map(this::fetch)
@@ -1773,7 +1776,7 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
   @Override
   public Optional<vadl.viam.Definition> visit(OperationDefinition definition) {
     return Optional.of(new vadl.viam.Operation(
-        generateIdentifier(definition.identifier().name, definition.identifier()),
+        new vadl.viam.Identifier(definition.identifier().name, definition.identifier().location()),
         definition.instructions.stream()
             .map(def -> (Instruction) fetch(def).get())
             .collect(Collectors.toSet())
@@ -1783,7 +1786,7 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
   @Override
   public Optional<vadl.viam.Definition> visit(Parameter definition) {
     return Optional.of(new vadl.viam.Parameter(
-        generateIdentifier(definition.identifier().name, definition.name.location()),
+        new vadl.viam.Identifier(definition.identifier().name, definition.name.location()),
         getViamType(definition.typeLiteral.type()),
         -1));
     // FIXME: we need to know the parent to know the index (-1)
@@ -1822,7 +1825,7 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
 
   @Override
   public Optional<vadl.viam.Definition> visit(PseudoInstructionDefinition definition) {
-    var identifier = generateIdentifier(definition.viamId, definition.identifier());
+    var identifier = new vadl.viam.Identifier(definition.viamId, definition.identifier().loc);
     var parameters = mapParameters(definition.params);
 
     var graph =
@@ -1845,7 +1848,7 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
     for (int i = 0; i < definition.size(); i++) {
       var parameter = definition.get(i);
       var viamParam = new vadl.viam.Parameter(
-          generateIdentifier(parameter.identifier().name, parameter.name.location()),
+          new vadl.viam.Identifier(parameter.viamId, parameter.name.location()),
           getViamType(parameter.typeLiteral.type()),
           i);
       parameterCache.put(parameter, viamParam);
@@ -1905,7 +1908,7 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
     dimensions.add(dimFromType(dimensions.size(), (DataType) getViamType(resultType)));
 
     var reg = new RegisterTensor(
-        generateIdentifier(definition.viamId, definition.identifier()),
+        new vadl.viam.Identifier(definition.viamId, definition.identifier().loc),
         dimensions
     );
     return Optional.of(reg);
@@ -1913,7 +1916,7 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
 
   @Override
   public Optional<vadl.viam.Definition> visit(RelocationDefinition definition) {
-    var identifier = generateIdentifier(definition.viamId, definition.identifier());
+    var identifier = new vadl.viam.Identifier(definition.viamId, definition.identifier().loc);
     var parameters = mapParameters(definition.params);
     var graph =
         new BehaviorLowering(this).getFunctionGraph(definition.expr,
@@ -1951,9 +1954,9 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
 
   @Override
   public Optional<vadl.viam.Definition> visit(StageDefinition definition) {
-    var identifier = generateIdentifier(definition.viamId, definition.identifier());
+    var identifier = new vadl.viam.Identifier(definition.viamId, definition.identifier().loc);
     var behaivor = new BehaviorLowering(this).getStageGraph(definition.statement,
-        definition.viamId + "::behavior");
+        String.join("::", append(definition.viamId, "behavior")));
     return Optional.of(new Stage(identifier, behaivor, List.of()));
   }
 
@@ -1984,7 +1987,7 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
 
   @Override
   public Optional<vadl.viam.Definition> visit(StageOutputDefinition definition) {
-    var identifier = generateIdentifier(definition.viamId, definition.identifier());
+    var identifier = new vadl.viam.Identifier(definition.viamId, definition.identifier().loc);
     var type = getViamType(definition.typeLiteral.type());
     return Optional.of(
         new StageOutput(identifier, type));

--- a/vadl/main/vadl/types/BuiltInTable.java
+++ b/vadl/main/vadl/types/BuiltInTable.java
@@ -19,7 +19,6 @@ package vadl.types;
 import static org.slf4j.LoggerFactory.getLogger;
 import static vadl.types.Type.constructDataType;
 
-import com.google.common.collect.Streams;
 import com.google.errorprone.annotations.FormatMethod;
 import java.math.BigInteger;
 import java.util.Collections;
@@ -1627,28 +1626,30 @@ public class BuiltInTable {
       // to a constructed type of the parameter type, we return false.
       // otherwise true.
       // overrides should further constraint the properties of the given types.
-      return Streams.zip(argTypes.stream(), argTypeClasses.stream(),
-          (argType, argTypeClass) -> {
-            if (argType.getClass() == argTypeClass) {
-              // if the class is the same, we know that the argument type is correct
-              return true;
+      for (int i = 0; i < argTypes.size(); i++) {
+        var argType = argTypes.get(i);
+        var argTypeClass = argTypeClasses.get(i);
+        if (argType.getClass() == argTypeClass) {
+          // if the class is the same, we know that the argument type is correct
+          continue;
+        }
+        if (argType instanceof DataType argDataType) {
+          // if the concrete type is a data type we try to construct a data type
+          // with the same bit width from the built-ins argument type class.
+          // if this fails, we know that the type can't be correct.
+          var constructedType = constructDataType(argTypeClass, argDataType.bitWidth());
+          if (constructedType != null) {
+            // check that the argument type can be trivially cast to the constructed type
+            if (argDataType.isTrivialCastTo(argDataType)) {
+              continue;
             }
-            if (argType instanceof DataType argDataType) {
-              // if the concrete type is a data type we try to construct a data type
-              // with the same bit width from the built-ins argument type class.
-              // if this fails, we know that the type can't be correct.
-              var constructedType = constructDataType(argTypeClass, argDataType.bitWidth());
-              if (constructedType != null) {
-                // check that the argument type can be trivially cast to the constructed type
-                return argDataType.isTrivialCastTo(argDataType);
-              }
-              return false;
-            }
-            // if the concrete type is not a data type, we know that the given type is wrong
-            // as there is no way of trivially casting the argument type to the parameter type
-            return false;
           }
-      ).allMatch(p -> p);
+        }
+        // if the concrete type is not a data type, we know that the given type is wrong
+        // as there is no way of trivially casting the argument type to the parameter type
+        return false;
+      }
+      return true;
     }
 
     /**

--- a/vadl/test/resources/frontend-snapshots/annotation/zeroAnnotation.vadl
+++ b/vadl/test/resources/frontend-snapshots/annotation/zeroAnnotation.vadl
@@ -23,9 +23,6 @@ instruction set architecture TEST =
 //    . : ' | ArgsIndices
 //    . : ' | . CastExpr type: Bits<1>
 //    . : ' | . : IntegerLiteral literal: 0 (0) type: Const<0>
-//    . : ' | . : TypeLiteral type: Bits<1>
-//    . : ' | . : ' Identifier name: "Bits" type: null
-//    . : ' | . : ' IntegerLiteral literal: 1 (1) type: null
 //    . : TypeLiteral type: Bits<32>
 //    . : ' Identifier name: "Bits" type: null
 //    . : ' IntegerLiteral literal: 32 (32) type: Const<32>

--- a/vadl/test/resources/frontend-snapshots/lowering/aliasConstantRegister.vadl
+++ b/vadl/test/resources/frontend-snapshots/lowering/aliasConstantRegister.vadl
@@ -294,7 +294,7 @@ assembly Test = ""
 //    . : ' Inputs: A, B, C, D
 //    . : ' Outputs: A, B, C, D
 //    . : ' Encoding: encoding
-//    . : ' Assembly: TEST::Test::assembly
+//    . : ' Assembly: assembly
 //    . : ' Behavior Graph:
 //    . : ' | n0  ReadsRegisterTensor  in: ()              succ: ()      type: b13   reg: A   resource: W   baseReg: A
 //    . : ' | n1  FuncCall             in: (n0)            succ: ()      type: b13   func: func
@@ -312,10 +312,10 @@ assembly Test = ""
 //    . : ' | n13 WritesRegisterTensor in: (n3 n4 n12)     succ: ()      reg: D   resource: U
 //    . : ' | n14 InstrEnd             in: (n2 n7 n10 n13) succ: ()      effects: 4
 //    . : ' | n15 Start                in: ()              succ: (n14)   next: set
-//    . : ' Assembly name: "TEST::Test::assembly"
-//    . : ' | Function: TEST::Test::assembly::func
+//    . : ' Assembly name: "assembly"
+//    . : ' | Function: func
 //    . : ' | FieldAccesses: []
-//    . : ' | Function name: "TEST::Test::assembly::func"
+//    . : ' | Function name: "func"
 //    . : ' | . Type: ()->String
 //    . : ' | . Signature: () -> String
 //    . : ' | . Parameters: []

--- a/vadl/test/resources/frontend-snapshots/lowering/aliasRegisters.vadl
+++ b/vadl/test/resources/frontend-snapshots/lowering/aliasRegisters.vadl
@@ -134,7 +134,7 @@ instruction set architecture ISA = {
 //    . : ' Inputs: R1
 //    . : ' Outputs: R1
 //    . : ' Encoding: encoding
-//    . : ' Assembly: ISA::ReadE1::assembly
+//    . : ' Assembly: assembly
 //    . : ' Behavior Graph:
 //    . : ' | n0 Constant             in: ()      succ: ()     type: b2   const: 0x0: Bits<2>
 //    . : ' | n1 Constant             in: ()      succ: ()     type: b2   const: 0x1: Bits<2>
@@ -144,10 +144,10 @@ instruction set architecture ISA = {
 //    . : ' | n5 WritesRegisterTensor in: (n0 n4) succ: ()     reg: R1
 //    . : ' | n6 InstrEnd             in: (n5)    succ: ()     effects: 1
 //    . : ' | n7 Start                in: ()      succ: (n6)   next: set
-//    . : ' Assembly name: "ISA::ReadE1::assembly"
-//    . : ' | Function: ISA::ReadE1::assembly::func
+//    . : ' Assembly name: "assembly"
+//    . : ' | Function: func
 //    . : ' | FieldAccesses: []
-//    . : ' | Function name: "ISA::ReadE1::assembly::func"
+//    . : ' | Function name: "func"
 //    . : ' | . Type: ()->String
 //    . : ' | . Signature: () -> String
 //    . : ' | . Parameters: []

--- a/vadl/test/resources/frontend-snapshots/lowering/baselineIsa.vadl
+++ b/vadl/test/resources/frontend-snapshots/lowering/baselineIsa.vadl
@@ -42,9 +42,6 @@ instruction set architecture TEST = {
 //    . : Identifier name: "a" type: null
 //    . : CastExpr type: Bits<8>
 //    . : ' IntegerLiteral literal: 1 (1) type: Const<1>
-//    . : ' TypeLiteral type: Bits<8>
-//    . : ' | Identifier name: "Bits" type: null
-//    . : ' | IntegerLiteral literal: 8 (8) type: null
 //
 //
 // Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl/test/resources/frontend-snapshots/lowering/complexFoldOperatorFromMacro.vadl
+++ b/vadl/test/resources/frontend-snapshots/lowering/complexFoldOperatorFromMacro.vadl
@@ -65,7 +65,7 @@ instruction set architecture ISA = {
 //    . : ' Inputs: X
 //    . : ' Outputs: X
 //    . : ' Encoding: encoding
-//    . : ' Assembly: ISA::ADD::assembly
+//    . : ' Assembly: assembly
 //    . : ' Behavior Graph:
 //    . : ' | n0 Constant             in: ()      succ: ()     type: b4    const: 0x0: Bits<4>
 //    . : ' | n1 ForIdx               in: ()      succ: ()     type: b4    from: 0   to: 3
@@ -74,10 +74,10 @@ instruction set architecture ISA = {
 //    . : ' | n4 WritesRegisterTensor in: (n0 n3) succ: ()     reg: X
 //    . : ' | n5 InstrEnd             in: (n4)    succ: ()     effects: 1
 //    . : ' | n6 Start                in: ()      succ: (n5)   next: set
-//    . : ' Assembly name: "ISA::ADD::assembly"
-//    . : ' | Function: ISA::ADD::assembly::func
+//    . : ' Assembly name: "assembly"
+//    . : ' | Function: func
 //    . : ' | FieldAccesses: []
-//    . : ' | Function name: "ISA::ADD::assembly::func"
+//    . : ' | Function name: "func"
 //    . : ' | . Type: ()->String
 //    . : ' | . Signature: () -> String
 //    . : ' | . Parameters: []

--- a/vadl/test/resources/frontend-snapshots/lowering/dynamicIndexingForAllDo.vadl
+++ b/vadl/test/resources/frontend-snapshots/lowering/dynamicIndexingForAllDo.vadl
@@ -65,7 +65,7 @@ instruction set architecture Tensor = {
 //    . : ' Inputs: X
 //    . : ' Outputs: X
 //    . : ' Encoding: encoding
-//    . : ' Assembly: Tensor::ReadIndex::assembly
+//    . : ' Assembly: assembly
 //    . : ' Behavior Graph:
 //    . : ' | n0  ReadsRegisterTensor  in: ()         succ: ()     type: b32   reg: X
 //    . : ' | n1  ForIdx               in: ()         succ: ()     type: b4    from: 0   to: 3
@@ -78,10 +78,10 @@ instruction set architecture Tensor = {
 //    . : ' | n8  Forall               in: (n1)       succ: (n7)   range: 0..3
 //    . : ' | n9  InstrEnd             in: ()         succ: ()     effects: 0
 //    . : ' | n10 Start                in: ()         succ: (n8)   next: set
-//    . : ' Assembly name: "Tensor::ReadIndex::assembly"
-//    . : ' | Function: Tensor::ReadIndex::assembly::func
+//    . : ' Assembly name: "assembly"
+//    . : ' | Function: func
 //    . : ' | FieldAccesses: []
-//    . : ' | Function name: "Tensor::ReadIndex::assembly::func"
+//    . : ' | Function name: "func"
 //    . : ' | . Type: ()->String
 //    . : ' | . Signature: () -> String
 //    . : ' | . Parameters: []
@@ -117,7 +117,7 @@ instruction set architecture Tensor = {
 //    . : ' Inputs: X
 //    . : ' Outputs: X
 //    . : ' Encoding: encoding
-//    . : ' Assembly: Tensor::WriteIndex::assembly
+//    . : ' Assembly: assembly
 //    . : ' Behavior Graph:
 //    . : ' | n0  ReadsRegisterTensor  in: ()      succ: ()      type: b32   reg: X
 //    . : ' | n1  Constant             in: ()      succ: ()      type: b32   const: 0x1: Bits<32>
@@ -136,10 +136,10 @@ instruction set architecture Tensor = {
 //    . : ' | n14 Forall               in: (n2)    succ: (n13)   range: 0..3
 //    . : ' | n15 InstrEnd             in: ()      succ: ()      effects: 0
 //    . : ' | n16 Start                in: ()      succ: (n14)   next: set
-//    . : ' Assembly name: "Tensor::WriteIndex::assembly"
-//    . : ' | Function: Tensor::WriteIndex::assembly::func
+//    . : ' Assembly name: "assembly"
+//    . : ' | Function: func
 //    . : ' | FieldAccesses: []
-//    . : ' | Function name: "Tensor::WriteIndex::assembly::func"
+//    . : ' | Function name: "func"
 //    . : ' | . Type: ()->String
 //    . : ' | . Signature: () -> String
 //    . : ' | . Parameters: []

--- a/vadl/test/resources/frontend-snapshots/lowering/dynamicTensorSlicingForAllDo.vadl
+++ b/vadl/test/resources/frontend-snapshots/lowering/dynamicTensorSlicingForAllDo.vadl
@@ -60,7 +60,7 @@ instruction set architecture Tensor = {
 //    . : ' Inputs: rs1, rs2
 //    . : ' Outputs: rd
 //    . : ' Encoding: encoding
-//    . : ' Assembly: Tensor::ADD4V::assembly
+//    . : ' Assembly: assembly
 //    . : ' Behavior Graph:
 //    . : ' | n0  FieldRef             in: ()         succ: ()      type: b4    field: rd    format: F
 //    . : ' | n1  ForIdx               in: ()         succ: ()      type: b4    from: 0   to: 3
@@ -77,10 +77,10 @@ instruction set architecture Tensor = {
 //    . : ' | n12 Forall               in: (n1)       succ: (n11)   range: 0..3
 //    . : ' | n13 InstrEnd             in: ()         succ: ()      effects: 0
 //    . : ' | n14 Start                in: ()         succ: (n12)   next: set
-//    . : ' Assembly name: "Tensor::ADD4V::assembly"
-//    . : ' | Function: Tensor::ADD4V::assembly::func
+//    . : ' Assembly name: "assembly"
+//    . : ' | Function: func
 //    . : ' | FieldAccesses: []
-//    . : ' | Function name: "Tensor::ADD4V::assembly::func"
+//    . : ' | Function name: "func"
 //    . : ' | . Type: ()->String
 //    . : ' | . Signature: () -> String
 //    . : ' | . Parameters: []

--- a/vadl/test/resources/frontend-snapshots/lowering/dynamicTensorSlicingForAllTensor.vadl
+++ b/vadl/test/resources/frontend-snapshots/lowering/dynamicTensorSlicingForAllTensor.vadl
@@ -66,7 +66,7 @@ instruction set architecture Tensor = {
 //    . : ' Inputs: rs1, rs2
 //    . : ' Outputs: rd
 //    . : ' Encoding: encoding
-//    . : ' Assembly: Tensor::QADD::assembly
+//    . : ' Assembly: assembly
 //    . : ' Behavior Graph:
 //    . : ' | n0  FieldRef             in: ()                succ: ()      type: b4     field: rd    format: F
 //    . : ' | n1  Constant             in: ()                succ: ()      type: b2     const: 0x0: Bits<2>
@@ -112,10 +112,10 @@ instruction set architecture Tensor = {
 //    . : ' | n41 WritesRegisterTensor in: (n0 n4 n40)       succ: ()      reg: Q
 //    . : ' | n42 InstrEnd             in: (n35 n37 n39 n41) succ: ()      effects: 4
 //    . : ' | n43 Start                in: ()                succ: (n42)   next: set
-//    . : ' Assembly name: "Tensor::QADD::assembly"
-//    . : ' | Function: Tensor::QADD::assembly::func
+//    . : ' Assembly name: "assembly"
+//    . : ' | Function: func
 //    . : ' | FieldAccesses: []
-//    . : ' | Function name: "Tensor::QADD::assembly::func"
+//    . : ' | Function name: "func"
 //    . : ' | . Type: ()->String
 //    . : ' | . Signature: () -> String
 //    . : ' | . Parameters: []

--- a/vadl/test/resources/frontend-snapshots/lowering/groupDefinition.vadl
+++ b/vadl/test/resources/frontend-snapshots/lowering/groupDefinition.vadl
@@ -64,16 +64,16 @@ instruction set architecture ISA = {
 //    . : ' Inputs: -
 //    . : ' Outputs: PC
 //    . : ' Encoding: encoding
-//    . : ' Assembly: ISA::A::assembly
+//    . : ' Assembly: assembly
 //    . : ' Behavior Graph:
 //    . : ' | n0 Constant             in: ()   succ: ()     type: b32   const: 0x0: Bits<32>
 //    . : ' | n1 WritesRegisterTensor in: (n0) succ: ()     reg: PC
 //    . : ' | n2 InstrEnd             in: (n1) succ: ()     effects: 1
 //    . : ' | n3 Start                in: ()   succ: (n2)   next: set
-//    . : ' Assembly name: "ISA::A::assembly"
-//    . : ' | Function: ISA::A::assembly::func
+//    . : ' Assembly name: "assembly"
+//    . : ' | Function: func
 //    . : ' | FieldAccesses: []
-//    . : ' | Function name: "ISA::A::assembly::func"
+//    . : ' | Function name: "func"
 //    . : ' | . Type: ()->String
 //    . : ' | . Signature: () -> String
 //    . : ' | . Parameters: []
@@ -97,16 +97,16 @@ instruction set architecture ISA = {
 //    . : ' Inputs: -
 //    . : ' Outputs: PC
 //    . : ' Encoding: encoding
-//    . : ' Assembly: ISA::B::assembly
+//    . : ' Assembly: assembly
 //    . : ' Behavior Graph:
 //    . : ' | n0 Constant             in: ()   succ: ()     type: b32   const: 0x0: Bits<32>
 //    . : ' | n1 WritesRegisterTensor in: (n0) succ: ()     reg: PC
 //    . : ' | n2 InstrEnd             in: (n1) succ: ()     effects: 1
 //    . : ' | n3 Start                in: ()   succ: (n2)   next: set
-//    . : ' Assembly name: "ISA::B::assembly"
-//    . : ' | Function: ISA::B::assembly::func
+//    . : ' Assembly name: "assembly"
+//    . : ' | Function: func
 //    . : ' | FieldAccesses: []
-//    . : ' | Function name: "ISA::B::assembly::func"
+//    . : ' | Function name: "func"
 //    . : ' | . Type: ()->String
 //    . : ' | . Signature: () -> String
 //    . : ' | . Parameters: []

--- a/vadl/test/resources/frontend-snapshots/lowering/operation.vadl
+++ b/vadl/test/resources/frontend-snapshots/lowering/operation.vadl
@@ -62,7 +62,7 @@ instruction set architecture ISA = {
 //    . : ' Inputs: PC
 //    . : ' Outputs: PC
 //    . : ' Encoding: encoding
-//    . : ' Assembly: ISA::Branch::assembly
+//    . : ' Assembly: assembly
 //    . : ' Behavior Graph:
 //    . : ' | n0 ReadsRegisterTensor  in: ()      succ: ()     type: b32   reg: PC
 //    . : ' | n1 FieldRef             in: ()      succ: ()     type: i24   field: offset   format: B_Type
@@ -73,10 +73,10 @@ instruction set architecture ISA = {
 //    . : ' | n6 WritesRegisterTensor in: (n5)    succ: ()     reg: PC
 //    . : ' | n7 InstrEnd             in: (n6)    succ: ()     effects: 1
 //    . : ' | n8 Start                in: ()      succ: (n7)   next: set
-//    . : ' Assembly name: "ISA::Branch::assembly"
-//    . : ' | Function: ISA::Branch::assembly::func
+//    . : ' Assembly name: "assembly"
+//    . : ' | Function: func
 //    . : ' | FieldAccesses: []
-//    . : ' | Function name: "ISA::Branch::assembly::func"
+//    . : ' | Function name: "func"
 //    . : ' | . Type: ()->String
 //    . : ' | . Signature: () -> String
 //    . : ' | . Parameters: []

--- a/vadl/test/resources/frontend-snapshots/lowering/operationContainingOperation.vadl
+++ b/vadl/test/resources/frontend-snapshots/lowering/operationContainingOperation.vadl
@@ -79,16 +79,16 @@ instruction set architecture ISA = {
 //    . : ' Inputs: -
 //    . : ' Outputs: PC
 //    . : ' Encoding: encoding
-//    . : ' Assembly: ISA::A::assembly
+//    . : ' Assembly: assembly
 //    . : ' Behavior Graph:
 //    . : ' | n0 Constant             in: ()   succ: ()     type: b32   const: 0x1: Bits<32>
 //    . : ' | n1 WritesRegisterTensor in: (n0) succ: ()     reg: PC
 //    . : ' | n2 InstrEnd             in: (n1) succ: ()     effects: 1
 //    . : ' | n3 Start                in: ()   succ: (n2)   next: set
-//    . : ' Assembly name: "ISA::A::assembly"
-//    . : ' | Function: ISA::A::assembly::func
+//    . : ' Assembly name: "assembly"
+//    . : ' | Function: func
 //    . : ' | FieldAccesses: []
-//    . : ' | Function name: "ISA::A::assembly::func"
+//    . : ' | Function name: "func"
 //    . : ' | . Type: ()->String
 //    . : ' | . Signature: () -> String
 //    . : ' | . Parameters: []
@@ -110,16 +110,16 @@ instruction set architecture ISA = {
 //    . : ' Inputs: -
 //    . : ' Outputs: PC
 //    . : ' Encoding: encoding
-//    . : ' Assembly: ISA::B::assembly
+//    . : ' Assembly: assembly
 //    . : ' Behavior Graph:
 //    . : ' | n0 Constant             in: ()   succ: ()     type: b32   const: 0x2: Bits<32>
 //    . : ' | n1 WritesRegisterTensor in: (n0) succ: ()     reg: PC
 //    . : ' | n2 InstrEnd             in: (n1) succ: ()     effects: 1
 //    . : ' | n3 Start                in: ()   succ: (n2)   next: set
-//    . : ' Assembly name: "ISA::B::assembly"
-//    . : ' | Function: ISA::B::assembly::func
+//    . : ' Assembly name: "assembly"
+//    . : ' | Function: func
 //    . : ' | FieldAccesses: []
-//    . : ' | Function name: "ISA::B::assembly::func"
+//    . : ' | Function name: "func"
 //    . : ' | . Type: ()->String
 //    . : ' | . Signature: () -> String
 //    . : ' | . Parameters: []
@@ -141,16 +141,16 @@ instruction set architecture ISA = {
 //    . : ' Inputs: -
 //    . : ' Outputs: PC
 //    . : ' Encoding: encoding
-//    . : ' Assembly: ISA::C::assembly
+//    . : ' Assembly: assembly
 //    . : ' Behavior Graph:
 //    . : ' | n0 Constant             in: ()   succ: ()     type: b32   const: 0x3: Bits<32>
 //    . : ' | n1 WritesRegisterTensor in: (n0) succ: ()     reg: PC
 //    . : ' | n2 InstrEnd             in: (n1) succ: ()     effects: 1
 //    . : ' | n3 Start                in: ()   succ: (n2)   next: set
-//    . : ' Assembly name: "ISA::C::assembly"
-//    . : ' | Function: ISA::C::assembly::func
+//    . : ' Assembly name: "assembly"
+//    . : ' | Function: func
 //    . : ' | FieldAccesses: []
-//    . : ' | Function name: "ISA::C::assembly::func"
+//    . : ' | Function name: "func"
 //    . : ' | . Type: ()->String
 //    . : ' | . Signature: () -> String
 //    . : ' | . Parameters: []

--- a/vadl/test/resources/frontend-snapshots/lowering/operationInMia.vadl
+++ b/vadl/test/resources/frontend-snapshots/lowering/operationInMia.vadl
@@ -73,7 +73,7 @@ micro architecture MIA implements ISA = {
 //    . : ' | Inputs: PC
 //    . : ' | Outputs: PC
 //    . : ' | Encoding: encoding
-//    . : ' | Assembly: ISA::Branch::assembly
+//    . : ' | Assembly: assembly
 //    . : ' | Behavior Graph:
 //    . : ' | . n0 ReadsRegisterTensor  in: ()      succ: ()     type: b32   reg: PC
 //    . : ' | . n1 FieldRef             in: ()      succ: ()     type: i24   field: offset   format: B_Type
@@ -84,10 +84,10 @@ micro architecture MIA implements ISA = {
 //    . : ' | . n6 WritesRegisterTensor in: (n5)    succ: ()     reg: PC
 //    . : ' | . n7 InstrEnd             in: (n6)    succ: ()     effects: 1
 //    . : ' | . n8 Start                in: ()      succ: (n7)   next: set
-//    . : ' | Assembly name: "ISA::Branch::assembly"
-//    . : ' | . Function: ISA::Branch::assembly::func
+//    . : ' | Assembly name: "assembly"
+//    . : ' | . Function: func
 //    . : ' | . FieldAccesses: []
-//    . : ' | . Function name: "ISA::Branch::assembly::func"
+//    . : ' | . Function name: "func"
 //    . : ' | . : Type: ()->String
 //    . : ' | . : Signature: () -> String
 //    . : ' | . : Parameters: []

--- a/vadl/test/resources/frontend-snapshots/lowering/operationViaAnnotation.vadl
+++ b/vadl/test/resources/frontend-snapshots/lowering/operationViaAnnotation.vadl
@@ -65,7 +65,7 @@ instruction set architecture ISA = {
 //    . : ' Inputs: PC
 //    . : ' Outputs: PC
 //    . : ' Encoding: encoding
-//    . : ' Assembly: ISA::Branch::assembly
+//    . : ' Assembly: assembly
 //    . : ' Behavior Graph:
 //    . : ' | n0 ReadsRegisterTensor  in: ()      succ: ()     type: b32   reg: PC
 //    . : ' | n1 FieldRef             in: ()      succ: ()     type: i24   field: offset   format: B_Type
@@ -76,10 +76,10 @@ instruction set architecture ISA = {
 //    . : ' | n6 WritesRegisterTensor in: (n5)    succ: ()     reg: PC
 //    . : ' | n7 InstrEnd             in: (n6)    succ: ()     effects: 1
 //    . : ' | n8 Start                in: ()      succ: (n7)   next: set
-//    . : ' Assembly name: "ISA::Branch::assembly"
-//    . : ' | Function: ISA::Branch::assembly::func
+//    . : ' Assembly name: "assembly"
+//    . : ' | Function: func
 //    . : ' | FieldAccesses: []
-//    . : ' | Function name: "ISA::Branch::assembly::func"
+//    . : ' | Function name: "func"
 //    . : ' | . Type: ()->String
 //    . : ' | . Signature: () -> String
 //    . : ' | . Parameters: []

--- a/vadl/test/resources/frontend-snapshots/lowering/readProgramCounterStates.vadl
+++ b/vadl/test/resources/frontend-snapshots/lowering/readProgramCounterStates.vadl
@@ -63,7 +63,7 @@ instruction set architecture TEST = {
 //    . : ' Inputs: PC
 //    . : ' Outputs: X
 //    . : ' Encoding: encoding
-//    . : ' Assembly: TEST::CurrentInstr::assembly
+//    . : ' Assembly: assembly
 //    . : ' Behavior Graph:
 //    . : ' | n0 Constant             in: ()      succ: ()     type: b3   const: 0x0: Bits<3>
 //    . : ' | n1 ReadsRegisterTensor  in: ()      succ: ()     type: b8   reg: PC
@@ -72,10 +72,10 @@ instruction set architecture TEST = {
 //    . : ' | n4 WritesRegisterTensor in: (n0 n3) succ: ()     reg: X
 //    . : ' | n5 InstrEnd             in: (n4)    succ: ()     effects: 1
 //    . : ' | n6 Start                in: ()      succ: (n5)   next: set
-//    . : ' Assembly name: "TEST::CurrentInstr::assembly"
-//    . : ' | Function: TEST::CurrentInstr::assembly::func
+//    . : ' Assembly name: "assembly"
+//    . : ' | Function: func
 //    . : ' | FieldAccesses: []
-//    . : ' | Function name: "TEST::CurrentInstr::assembly::func"
+//    . : ' | Function name: "func"
 //    . : ' | . Type: ()->String
 //    . : ' | . Signature: () -> String
 //    . : ' | . Parameters: []
@@ -97,7 +97,7 @@ instruction set architecture TEST = {
 //    . : ' Inputs: PC
 //    . : ' Outputs: X
 //    . : ' Encoding: encoding
-//    . : ' Assembly: TEST::Nextnstr::assembly
+//    . : ' Assembly: assembly
 //    . : ' Behavior Graph:
 //    . : ' | n0 Constant             in: ()      succ: ()     type: b3   const: 0x0: Bits<3>
 //    . : ' | n1 ReadsRegisterTensor  in: ()      succ: ()     type: b8   reg: PC
@@ -106,10 +106,10 @@ instruction set architecture TEST = {
 //    . : ' | n4 WritesRegisterTensor in: (n0 n3) succ: ()     reg: X
 //    . : ' | n5 InstrEnd             in: (n4)    succ: ()     effects: 1
 //    . : ' | n6 Start                in: ()      succ: (n5)   next: set
-//    . : ' Assembly name: "TEST::Nextnstr::assembly"
-//    . : ' | Function: TEST::Nextnstr::assembly::func
+//    . : ' Assembly name: "assembly"
+//    . : ' | Function: func
 //    . : ' | FieldAccesses: []
-//    . : ' | Function name: "TEST::Nextnstr::assembly::func"
+//    . : ' | Function name: "func"
 //    . : ' | . Type: ()->String
 //    . : ' | . Signature: () -> String
 //    . : ' | . Parameters: []
@@ -131,7 +131,7 @@ instruction set architecture TEST = {
 //    . : ' Inputs: PC
 //    . : ' Outputs: X
 //    . : ' Encoding: encoding
-//    . : ' Assembly: TEST::NextNextInstr::assembly
+//    . : ' Assembly: assembly
 //    . : ' Behavior Graph:
 //    . : ' | n0 Constant             in: ()      succ: ()     type: b3   const: 0x0: Bits<3>
 //    . : ' | n1 ReadsRegisterTensor  in: ()      succ: ()     type: b8   reg: PC
@@ -140,10 +140,10 @@ instruction set architecture TEST = {
 //    . : ' | n4 WritesRegisterTensor in: (n0 n3) succ: ()     reg: X
 //    . : ' | n5 InstrEnd             in: (n4)    succ: ()     effects: 1
 //    . : ' | n6 Start                in: ()      succ: (n5)   next: set
-//    . : ' Assembly name: "TEST::NextNextInstr::assembly"
-//    . : ' | Function: TEST::NextNextInstr::assembly::func
+//    . : ' Assembly name: "assembly"
+//    . : ' | Function: func
 //    . : ' | FieldAccesses: []
-//    . : ' | Function name: "TEST::NextNextInstr::assembly::func"
+//    . : ' | Function name: "func"
 //    . : ' | . Type: ()->String
 //    . : ' | . Signature: () -> String
 //    . : ' | . Parameters: []

--- a/vadl/test/resources/frontend-snapshots/macro/assemblyExpandedToMultipleDefinitions.vadl
+++ b/vadl/test/resources/frontend-snapshots/macro/assemblyExpandedToMultipleDefinitions.vadl
@@ -62,14 +62,8 @@ instruction set architecture TEST = {
 //    . : ' | ArgsIndices
 //    . : ' | . CastExpr type: Bits<5>
 //    . : ' | . : IntegerLiteral literal: 0 (0) type: Const<0>
-//    . : ' | . : TypeLiteral type: Bits<5>
-//    . : ' | . : ' Identifier name: "Bits" type: null
-//    . : ' | . : ' IntegerLiteral literal: 5 (5) type: null
 //    . : ' CastExpr type: Bits<32>
 //    . : ' | IntegerLiteral literal: 1 (1) type: Const<1>
-//    . : ' | TypeLiteral type: Bits<32>
-//    . : ' | . Identifier name: "Bits" type: null
-//    . : ' | . IntegerLiteral literal: 32 (32) type: null
 //    . InstructionDefinition name: "Two"
 //    . : Identifier name: "Fb" type: null
 //    . : AssignmentStatement
@@ -78,30 +72,18 @@ instruction set architecture TEST = {
 //    . : ' | ArgsIndices
 //    . : ' | . CastExpr type: Bits<5>
 //    . : ' | . : IntegerLiteral literal: 0 (0) type: Const<0>
-//    . : ' | . : TypeLiteral type: Bits<5>
-//    . : ' | . : ' Identifier name: "Bits" type: null
-//    . : ' | . : ' IntegerLiteral literal: 5 (5) type: null
 //    . : ' CastExpr type: Bits<32>
 //    . : ' | IntegerLiteral literal: 2 (2) type: Const<2>
-//    . : ' | TypeLiteral type: Bits<32>
-//    . : ' | . Identifier name: "Bits" type: null
-//    . : ' | . IntegerLiteral literal: 32 (32) type: null
 //    . EncodingDefinition
 //    . : Identifier name: "One" type: null
 //    . : Identifier name: "field" type: null
 //    . : CastExpr type: Bits<32>
 //    . : ' IntegerLiteral literal: 1 (1) type: Const<1>
-//    . : ' TypeLiteral type: Bits<32>
-//    . : ' | Identifier name: "Bits" type: null
-//    . : ' | IntegerLiteral literal: 32 (32) type: null
 //    . EncodingDefinition
 //    . : Identifier name: "Two" type: null
 //    . : Identifier name: "field" type: null
 //    . : CastExpr type: Bits<64>
 //    . : ' IntegerLiteral literal: 2 (2) type: Const<2>
-//    . : ' TypeLiteral type: Bits<64>
-//    . : ' | Identifier name: "Bits" type: null
-//    . : ' | IntegerLiteral literal: 64 (64) type: null
 //    . AssemblyDefinition
 //    . : GroupedExpr type: String
 //    . : ' Identifier name: "mnemonic" type: String

--- a/vadl/test/resources/frontend-snapshots/macro/expandedLetStatementCorrectType.vadl
+++ b/vadl/test/resources/frontend-snapshots/macro/expandedLetStatementCorrectType.vadl
@@ -74,9 +74,6 @@ instruction set architecture RV3264I = {
 //    . : ' | . ArgsIndices
 //    . : ' | . : CastExpr type: Bits<5>
 //    . : ' | . : ' IntegerLiteral literal: 1 (1) type: Const<1>
-//    . : ' | . : ' TypeLiteral type: Bits<5>
-//    . : ' | . : ' | Identifier name: "Bits" type: null
-//    . : ' | . : ' | IntegerLiteral literal: 5 (5) type: null
 //    . : ' | CastExpr type: Bits<32>
 //    . : ' | . Identifier name: "x" type: Bits<32>
 //    . : ' | . TypeLiteral type: Bits<32>
@@ -87,9 +84,6 @@ instruction set architecture RV3264I = {
 //    . : Identifier name: "op" type: null
 //    . : CastExpr type: Bits<32>
 //    . : ' IntegerLiteral literal: 1 (1) type: Const<1>
-//    . : ' TypeLiteral type: Bits<32>
-//    . : ' | Identifier name: "Bits" type: null
-//    . : ' | IntegerLiteral literal: 32 (32) type: null
 //    . AssemblyDefinition
 //    . : StringLiteral literal: "add1" ("add1") type: String
 //    . InstructionDefinition name: "add2"
@@ -106,9 +100,6 @@ instruction set architecture RV3264I = {
 //    . : ' | . ArgsIndices
 //    . : ' | . : CastExpr type: Bits<5>
 //    . : ' | . : ' IntegerLiteral literal: 1 (1) type: Const<1>
-//    . : ' | . : ' TypeLiteral type: Bits<5>
-//    . : ' | . : ' | Identifier name: "Bits" type: null
-//    . : ' | . : ' | IntegerLiteral literal: 5 (5) type: null
 //    . : ' | CastExpr type: Bits<32>
 //    . : ' | . Identifier name: "x" type: Bits<64>
 //    . : ' | . TypeLiteral type: Bits<32>
@@ -119,9 +110,6 @@ instruction set architecture RV3264I = {
 //    . : Identifier name: "op" type: null
 //    . : CastExpr type: Bits<32>
 //    . : ' IntegerLiteral literal: 2 (2) type: Const<2>
-//    . : ' TypeLiteral type: Bits<32>
-//    . : ' | Identifier name: "Bits" type: null
-//    . : ' | IntegerLiteral literal: 32 (32) type: null
 //    . AssemblyDefinition
 //    . : StringLiteral literal: "add2" ("add2") type: String
 //

--- a/vadl/test/resources/frontend-snapshots/macro/macroInEnumerationDefinition.vadl
+++ b/vadl/test/resources/frontend-snapshots/macro/macroInEnumerationDefinition.vadl
@@ -22,21 +22,12 @@ enumeration $echo(Color): Bits<8> = {
 //    . Identifier name: "RED" type: null
 //    . CastExpr type: Bits<8>
 //    . : IntegerLiteral literal: 0 (0) type: Const<0>
-//    . : TypeLiteral type: Bits<8>
-//    . : ' Identifier name: "Bits" type: null
-//    . : ' IntegerLiteral literal: 8 (8) type: null
 //    . Identifier name: "GREEN" type: null
 //    . CastExpr type: Bits<8>
 //    . : IntegerLiteral literal: 1 (1) type: Const<1>
-//    . : TypeLiteral type: Bits<8>
-//    . : ' Identifier name: "Bits" type: null
-//    . : ' IntegerLiteral literal: 8 (8) type: null
 //    . Identifier name: "BLUE" type: null
 //    . CastExpr type: Bits<8>
 //    . : IntegerLiteral literal: 2 (2) type: Const<2>
-//    . : TypeLiteral type: Bits<8>
-//    . : ' Identifier name: "Bits" type: null
-//    . : ' IntegerLiteral literal: 8 (8) type: null
 //
 //
 // Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl/test/resources/frontend-snapshots/macro/macroInForallStatementExpression.vadl
+++ b/vadl/test/resources/frontend-snapshots/macro/macroInForallStatementExpression.vadl
@@ -55,9 +55,6 @@ instruction set architecture TEST = {
 //    . : ' | . ArgsIndices
 //    . : ' | . : CastExpr type: Bits<3>
 //    . : ' | . : ' IntegerLiteral literal: 0 (0) type: Const<0>
-//    . : ' | . : ' TypeLiteral type: Bits<3>
-//    . : ' | . : ' | Identifier name: "Bits" type: null
-//    . : ' | . : ' | IntegerLiteral literal: 3 (3) type: null
 //    . : ' | ForallExpr keyword: fold, type: Bits<8> type: Bits<8>
 //    . : ' | . Identifier name: "i" type: Bits<8>
 //    . : ' | . TypeLiteral type: Bits<8>
@@ -70,9 +67,6 @@ instruction set architecture TEST = {
 //    . : ' | . : Identifier name: "i" type: Bits<8>
 //    . : ' | . : CastExpr type: Bits<8>
 //    . : ' | . : ' IntegerLiteral literal: 0 (0) type: Const<0>
-//    . : ' | . : ' TypeLiteral type: Bits<8>
-//    . : ' | . : ' | Identifier name: "Bits" type: null
-//    . : ' | . : ' | IntegerLiteral literal: 8 (8) type: null
 //    . AssemblyDefinition
 //    . : StringLiteral literal: "" ('') type: String
 //    . EncodingDefinition
@@ -80,9 +74,6 @@ instruction set architecture TEST = {
 //    . : Identifier name: "a" type: null
 //    . : CastExpr type: Bits<8>
 //    . : ' IntegerLiteral literal: 1 (1) type: Const<1>
-//    . : ' TypeLiteral type: Bits<8>
-//    . : ' | Identifier name: "Bits" type: null
-//    . : ' | IntegerLiteral literal: 8 (8) type: null
 //    . InstructionDefinition name: "Instr2"
 //    . : Identifier name: "Frmt" type: null
 //    . : BlockStatement
@@ -100,14 +91,8 @@ instruction set architecture TEST = {
 //    . : ' | . : ArgsIndices
 //    . : ' | . : ' CastExpr type: Bits<3>
 //    . : ' | . : ' | Identifier name: "i" type: Bits<5>
-//    . : ' | . : ' | TypeLiteral type: Bits<3>
-//    . : ' | . : ' | . Identifier name: "Bits" type: null
-//    . : ' | . : ' | . IntegerLiteral literal: 3 (3) type: null
 //    . : ' | . CastExpr type: Bits<8>
 //    . : ' | . : IntegerLiteral literal: 0 (0) type: Const<0>
-//    . : ' | . : TypeLiteral type: Bits<8>
-//    . : ' | . : ' Identifier name: "Bits" type: null
-//    . : ' | . : ' IntegerLiteral literal: 8 (8) type: null
 //    . AssemblyDefinition
 //    . : StringLiteral literal: "" ('') type: String
 //    . EncodingDefinition
@@ -115,9 +100,6 @@ instruction set architecture TEST = {
 //    . : Identifier name: "a" type: null
 //    . : CastExpr type: Bits<8>
 //    . : ' IntegerLiteral literal: 2 (2) type: Const<2>
-//    . : ' TypeLiteral type: Bits<8>
-//    . : ' | Identifier name: "Bits" type: null
-//    . : ' | IntegerLiteral literal: 8 (8) type: null
 //
 //
 // Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl/test/resources/frontend-snapshots/macro/macroInInstructionCall.vadl
+++ b/vadl/test/resources/frontend-snapshots/macro/macroInInstructionCall.vadl
@@ -57,9 +57,6 @@ instruction set architecture TEST = {
 //    . : Identifier name: "a" type: null
 //    . : CastExpr type: Bits<4>
 //    . : ' IntegerLiteral literal: 1 (1) type: Const<1>
-//    . : ' TypeLiteral type: Bits<4>
-//    . : ' | Identifier name: "Bits" type: null
-//    . : ' | IntegerLiteral literal: 4 (4) type: null
 //    . PseudoInstructionDefinition name: "abc"
 //    . : Parameter name: "arg"
 //    . : ' TypeLiteral type: Bits<4>

--- a/vadl/test/resources/frontend-snapshots/macro/macroInLetStatementExpr.vadl
+++ b/vadl/test/resources/frontend-snapshots/macro/macroInLetStatementExpr.vadl
@@ -55,9 +55,6 @@ instruction set architecture TEST = {
 //    . : ' | . ArgsIndices
 //    . : ' | . : CastExpr type: Bits<3>
 //    . : ' | . : ' IntegerLiteral literal: 0 (0) type: Const<0>
-//    . : ' | . : ' TypeLiteral type: Bits<3>
-//    . : ' | . : ' | Identifier name: "Bits" type: null
-//    . : ' | . : ' | IntegerLiteral literal: 3 (3) type: null
 //    . : ' | LetExpr type: Bits<8>
 //    . : ' | . Identifier name: "zwetschkenfleck" type: Bits<8>
 //    . : ' | . CallIndexExpr type: Bits<8>
@@ -65,16 +62,10 @@ instruction set architecture TEST = {
 //    . : ' | . : ArgsIndices
 //    . : ' | . : ' CastExpr type: Bits<3>
 //    . : ' | . : ' | IntegerLiteral literal: 1 (1) type: Const<1>
-//    . : ' | . : ' | TypeLiteral type: Bits<3>
-//    . : ' | . : ' | . Identifier name: "Bits" type: null
-//    . : ' | . : ' | . IntegerLiteral literal: 3 (3) type: null
 //    . : ' | . BinaryExpr operator: + type: Bits<8>
 //    . : ' | . : Identifier name: "zwetschkenfleck" type: Bits<8>
 //    . : ' | . : CastExpr type: Bits<8>
 //    . : ' | . : ' IntegerLiteral literal: 1 (1) type: Const<1>
-//    . : ' | . : ' TypeLiteral type: Bits<8>
-//    . : ' | . : ' | Identifier name: "Bits" type: null
-//    . : ' | . : ' | IntegerLiteral literal: 8 (8) type: null
 //    . AssemblyDefinition
 //    . : StringLiteral literal: "" ('') type: String
 //    . EncodingDefinition
@@ -82,9 +73,6 @@ instruction set architecture TEST = {
 //    . : Identifier name: "a" type: null
 //    . : CastExpr type: Bits<8>
 //    . : ' IntegerLiteral literal: 1 (1) type: Const<1>
-//    . : ' TypeLiteral type: Bits<8>
-//    . : ' | Identifier name: "Bits" type: null
-//    . : ' | IntegerLiteral literal: 8 (8) type: null
 //    . InstructionDefinition name: "Instr2"
 //    . : Identifier name: "Frmt" type: null
 //    . : BlockStatement
@@ -95,25 +83,16 @@ instruction set architecture TEST = {
 //    . : ' | . ArgsIndices
 //    . : ' | . : CastExpr type: Bits<3>
 //    . : ' | . : ' IntegerLiteral literal: 1 (1) type: Const<1>
-//    . : ' | . : ' TypeLiteral type: Bits<3>
-//    . : ' | . : ' | Identifier name: "Bits" type: null
-//    . : ' | . : ' | IntegerLiteral literal: 3 (3) type: null
 //    . : ' | AssignmentStatement
 //    . : ' | . CallIndexExpr type: Bits<8>
 //    . : ' | . : Identifier name: "X" type: null
 //    . : ' | . : ArgsIndices
 //    . : ' | . : ' CastExpr type: Bits<3>
 //    . : ' | . : ' | IntegerLiteral literal: 0 (0) type: Const<0>
-//    . : ' | . : ' | TypeLiteral type: Bits<3>
-//    . : ' | . : ' | . Identifier name: "Bits" type: null
-//    . : ' | . : ' | . IntegerLiteral literal: 3 (3) type: null
 //    . : ' | . BinaryExpr operator: + type: Bits<8>
 //    . : ' | . : Identifier name: "zwetschkenfleck" type: Bits<8>
 //    . : ' | . : CastExpr type: Bits<8>
 //    . : ' | . : ' IntegerLiteral literal: 1 (1) type: Const<1>
-//    . : ' | . : ' TypeLiteral type: Bits<8>
-//    . : ' | . : ' | Identifier name: "Bits" type: null
-//    . : ' | . : ' | IntegerLiteral literal: 8 (8) type: null
 //    . AssemblyDefinition
 //    . : StringLiteral literal: "" ('') type: String
 //    . EncodingDefinition
@@ -121,9 +100,6 @@ instruction set architecture TEST = {
 //    . : Identifier name: "a" type: null
 //    . : CastExpr type: Bits<8>
 //    . : ' IntegerLiteral literal: 2 (2) type: Const<2>
-//    . : ' TypeLiteral type: Bits<8>
-//    . : ' | Identifier name: "Bits" type: null
-//    . : ' | IntegerLiteral literal: 8 (8) type: null
 //
 //
 // Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl/test/resources/frontend-snapshots/parser/doubleQuotedString.vadl
+++ b/vadl/test/resources/frontend-snapshots/parser/doubleQuotedString.vadl
@@ -34,9 +34,6 @@ instruction set architecture TEST = {
 //    . : Identifier name: "a" type: null
 //    . : CastExpr type: Bits<1>
 //    . : ' IntegerLiteral literal: 1 (1) type: Const<1>
-//    . : ' TypeLiteral type: Bits<1>
-//    . : ' | Identifier name: "Bits" type: null
-//    . : ' | IntegerLiteral literal: 1 (1) type: null
 //
 //
 // Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl/test/resources/frontend-snapshots/parser/ifstatement.vadl
+++ b/vadl/test/resources/frontend-snapshots/parser/ifstatement.vadl
@@ -53,9 +53,6 @@ instruction set architecture ISA = {
 //    . : ' | . : Identifier name: "PC" type: Bits<32>
 //    . : ' | . : CastExpr type: Bits<32>
 //    . : ' | . : ' IntegerLiteral literal: 4 (4) type: Const<4>
-//    . : ' | . : ' TypeLiteral type: Bits<32>
-//    . : ' | . : ' | Identifier name: "Bits" type: null
-//    . : ' | . : ' | IntegerLiteral literal: 32 (32) type: null
 //    . AssemblyDefinition
 //    . : Identifier name: "mnemonic" type: String
 //    . EncodingDefinition
@@ -63,9 +60,6 @@ instruction set architecture ISA = {
 //    . : Identifier name: "bits" type: null
 //    . : CastExpr type: Bits<32>
 //    . : ' IntegerLiteral literal: 0 (0) type: Const<0>
-//    . : ' TypeLiteral type: Bits<32>
-//    . : ' | Identifier name: "Bits" type: null
-//    . : ' | IntegerLiteral literal: 32 (32) type: null
 //
 //
 // Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl/test/resources/frontend-snapshots/parser/letStatement.vadl
+++ b/vadl/test/resources/frontend-snapshots/parser/letStatement.vadl
@@ -43,9 +43,6 @@ instruction set architecture ISA = {
 //    . : ' | . Identifier name: "PC" type: Bits<32>
 //    . : ' | . CastExpr type: Bits<32>
 //    . : ' | . : IntegerLiteral literal: 4 (4) type: Const<4>
-//    . : ' | . : TypeLiteral type: Bits<32>
-//    . : ' | . : ' Identifier name: "Bits" type: null
-//    . : ' | . : ' IntegerLiteral literal: 32 (32) type: null
 //    . : ' | AssignmentStatement
 //    . : ' | . Identifier name: "PC" type: Bits<32>
 //    . : ' | . Identifier name: "next" type: Bits<32>
@@ -56,9 +53,6 @@ instruction set architecture ISA = {
 //    . : Identifier name: "bits" type: null
 //    . : CastExpr type: Bits<32>
 //    . : ' IntegerLiteral literal: 0 (0) type: Const<0>
-//    . : ' TypeLiteral type: Bits<32>
-//    . : ' | Identifier name: "Bits" type: null
-//    . : ' | IntegerLiteral literal: 32 (32) type: null
 //
 //
 // Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl/test/resources/frontend-snapshots/parser/letStatementWithMultipleVariables.vadl
+++ b/vadl/test/resources/frontend-snapshots/parser/letStatementWithMultipleVariables.vadl
@@ -65,9 +65,6 @@ instruction set architecture ISA = {
 //    . : Identifier name: "bits" type: null
 //    . : CastExpr type: Bits<32>
 //    . : ' IntegerLiteral literal: 0 (0) type: Const<0>
-//    . : ' TypeLiteral type: Bits<32>
-//    . : ' | Identifier name: "Bits" type: null
-//    . : ' | IntegerLiteral literal: 32 (32) type: null
 //
 //
 // Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl/test/resources/frontend-snapshots/parser/mini.vadl
+++ b/vadl/test/resources/frontend-snapshots/parser/mini.vadl
@@ -85,9 +85,6 @@ instruction set architecture RV3264I = {
 //    . : ' | ArgsIndices
 //    . : ' | . CastExpr type: Bits<5>
 //    . : ' | . : IntegerLiteral literal: 0 (0) type: Const<0>
-//    . : ' | . : TypeLiteral type: Bits<5>
-//    . : ' | . : ' Identifier name: "Bits" type: null
-//    . : ' | . : ' IntegerLiteral literal: 5 (5) type: null
 //    . : TypeLiteral type: Bits<5>
 //    . : ' Identifier name: "Index" type: null
 //    . : TypeLiteral type: Bits<32>
@@ -176,9 +173,6 @@ instruction set architecture RV3264I = {
 //    . : Identifier name: "rs2" type: null
 //    . : CastExpr type: Bits<5>
 //    . : ' IntegerLiteral literal: 0 (0) type: Const<0>
-//    . : ' TypeLiteral type: Bits<5>
-//    . : ' | Identifier name: "Bits" type: null
-//    . : ' | IntegerLiteral literal: 5 (5) type: null
 //    . AssemblyDefinition
 //    . : StringLiteral literal: "" ("") type: String
 //    . EncodingDefinition
@@ -186,9 +180,6 @@ instruction set architecture RV3264I = {
 //    . : Identifier name: "rs2" type: null
 //    . : CastExpr type: Bits<5>
 //    . : ' IntegerLiteral literal: 1 (1) type: Const<1>
-//    . : ' TypeLiteral type: Bits<5>
-//    . : ' | Identifier name: "Bits" type: null
-//    . : ' | IntegerLiteral literal: 5 (5) type: null
 //
 //
 // Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl/test/resources/frontend-snapshots/parser/noneIsValidEncodingKeyword.vadl
+++ b/vadl/test/resources/frontend-snapshots/parser/noneIsValidEncodingKeyword.vadl
@@ -54,27 +54,15 @@ instruction set architecture TEST = {
 //    . : Identifier name: "a" type: null
 //    . : CastExpr type: Bits<8>
 //    . : ' IntegerLiteral literal: 1 (1) type: Const<1>
-//    . : ' TypeLiteral type: Bits<8>
-//    . : ' | Identifier name: "Bits" type: null
-//    . : ' | IntegerLiteral literal: 8 (8) type: null
 //    . : Identifier name: "b" type: null
 //    . : CastExpr type: Bits<8>
 //    . : ' IntegerLiteral literal: 2 (2) type: Const<2>
-//    . : ' TypeLiteral type: Bits<8>
-//    . : ' | Identifier name: "Bits" type: null
-//    . : ' | IntegerLiteral literal: 8 (8) type: null
 //    . : Identifier name: "c" type: null
 //    . : CastExpr type: Bits<8>
 //    . : ' IntegerLiteral literal: 3 (3) type: Const<3>
-//    . : ' TypeLiteral type: Bits<8>
-//    . : ' | Identifier name: "Bits" type: null
-//    . : ' | IntegerLiteral literal: 8 (8) type: null
 //    . : Identifier name: "d" type: null
 //    . : CastExpr type: Bits<8>
 //    . : ' IntegerLiteral literal: 4 (4) type: Const<4>
-//    . : ' TypeLiteral type: Bits<8>
-//    . : ' | Identifier name: "Bits" type: null
-//    . : ' | IntegerLiteral literal: 8 (8) type: null
 //    . AssemblyDefinition
 //    . : StringLiteral literal: "" ("") type: String
 //

--- a/vadl/test/resources/frontend-snapshots/parser/onlyParseStringUntilClosingQuote.vadl
+++ b/vadl/test/resources/frontend-snapshots/parser/onlyParseStringUntilClosingQuote.vadl
@@ -38,9 +38,6 @@ instruction set architecture TEST = {
 //    . : Identifier name: "a" type: null
 //    . : CastExpr type: Bits<1>
 //    . : ' IntegerLiteral literal: 1 (1) type: Const<1>
-//    . : ' TypeLiteral type: Bits<1>
-//    . : ' | Identifier name: "Bits" type: null
-//    . : ' | IntegerLiteral literal: 1 (1) type: null
 //
 //
 // Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl/test/resources/frontend-snapshots/parser/singleQuotedString.vadl
+++ b/vadl/test/resources/frontend-snapshots/parser/singleQuotedString.vadl
@@ -34,9 +34,6 @@ instruction set architecture TEST = {
 //    . : Identifier name: "a" type: null
 //    . : CastExpr type: Bits<1>
 //    . : ' IntegerLiteral literal: 1 (1) type: Const<1>
-//    . : ' TypeLiteral type: Bits<1>
-//    . : ' | Identifier name: "Bits" type: null
-//    . : ' | IntegerLiteral literal: 1 (1) type: null
 //
 //
 // Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl/test/resources/frontend-snapshots/parser/stringEscapeSequences.vadl
+++ b/vadl/test/resources/frontend-snapshots/parser/stringEscapeSequences.vadl
@@ -35,9 +35,6 @@ instruction set architecture TEST = {
 //    . : Identifier name: "a" type: null
 //    . : CastExpr type: Bits<1>
 //    . : ' IntegerLiteral literal: 1 (1) type: Const<1>
-//    . : ' TypeLiteral type: Bits<1>
-//    . : ' | Identifier name: "Bits" type: null
-//    . : ' | IntegerLiteral literal: 1 (1) type: null
 //
 //
 // Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl/test/resources/frontend-snapshots/typechecker/bidirectionalTypechecking.vadl
+++ b/vadl/test/resources/frontend-snapshots/typechecker/bidirectionalTypechecking.vadl
@@ -74,14 +74,8 @@ function DecodePredCount (pattern: Bits5) -> BitsX =
 //    . : Identifier name: "cond" type: Bool
 //    . : CastExpr type: Bits<32>
 //    . : ' IntegerLiteral literal: 9 (9) type: Const<9>
-//    . : ' TypeLiteral type: Bits<32>
-//    . : ' | Identifier name: "Bits" type: null
-//    . : ' | IntegerLiteral literal: 32 (32) type: null
 //    . : CastExpr type: Bits<32>
 //    . : ' IntegerLiteral literal: 8 (8) type: Const<8>
-//    . : ' TypeLiteral type: Bits<32>
-//    . : ' | Identifier name: "Bits" type: null
-//    . : ' | IntegerLiteral literal: 32 (32) type: null
 //    FunctionDefinition name: "abc2"
 //    . Parameter name: "num"
 //    . : TypeLiteral type: Bits<32>
@@ -94,39 +88,18 @@ function DecodePredCount (pattern: Bits5) -> BitsX =
 //    . : Identifier name: "num" type: Bits<32>
 //    . : CastExpr type: Bits<32>
 //    . : ' IntegerLiteral literal: 0 (0) type: Const<0>
-//    . : ' TypeLiteral type: Bits<32>
-//    . : ' | Identifier name: "Bits" type: null
-//    . : ' | IntegerLiteral literal: 32 (32) type: null
 //    . : CastExpr type: Bits<32>
 //    . : ' IntegerLiteral literal: 0 (0) type: Const<0>
-//    . : ' TypeLiteral type: Bits<32>
-//    . : ' | Identifier name: "Bits" type: null
-//    . : ' | IntegerLiteral literal: 32 (32) type: null
 //    . : CastExpr type: Bits<32>
 //    . : ' IntegerLiteral literal: 1 (1) type: Const<1>
-//    . : ' TypeLiteral type: Bits<32>
-//    . : ' | Identifier name: "Bits" type: null
-//    . : ' | IntegerLiteral literal: 32 (32) type: null
 //    . : CastExpr type: Bits<32>
 //    . : ' IntegerLiteral literal: 2 (2) type: Const<2>
-//    . : ' TypeLiteral type: Bits<32>
-//    . : ' | Identifier name: "Bits" type: null
-//    . : ' | IntegerLiteral literal: 32 (32) type: null
 //    . : CastExpr type: Bits<32>
 //    . : ' IntegerLiteral literal: 2 (2) type: Const<2>
-//    . : ' TypeLiteral type: Bits<32>
-//    . : ' | Identifier name: "Bits" type: null
-//    . : ' | IntegerLiteral literal: 32 (32) type: null
 //    . : CastExpr type: Bits<32>
 //    . : ' IntegerLiteral literal: 4 (4) type: Const<4>
-//    . : ' TypeLiteral type: Bits<32>
-//    . : ' | Identifier name: "Bits" type: null
-//    . : ' | IntegerLiteral literal: 32 (32) type: null
 //    . : CastExpr type: Bits<32>
 //    . : ' IntegerLiteral literal: 8 (8) type: Const<8>
-//    . : ' TypeLiteral type: Bits<32>
-//    . : ' | Identifier name: "Bits" type: null
-//    . : ' | IntegerLiteral literal: 32 (32) type: null
 //    UsingDefinition name: "BitsX"
 //    . TypeLiteral type: Bits<64>
 //    . : Identifier name: "Bits" type: null
@@ -147,26 +120,14 @@ function DecodePredCount (pattern: Bits5) -> BitsX =
 //    . : ' | Identifier name: "val" type: Bits<64>
 //    . : ' | CastExpr type: Bits<64>
 //    . : ' | . IntegerLiteral literal: 0 (0) type: Const<0>
-//    . : ' | . TypeLiteral type: Bits<64>
-//    . : ' | . : Identifier name: "Bits" type: null
-//    . : ' | . : IntegerLiteral literal: 64 (64) type: null
 //    . : ' BinaryExpr operator: = type: Bool
 //    . : ' | CastExpr type: SInt<64>
 //    . : ' | . Identifier name: "val" type: Bits<64>
-//    . : ' | . TypeLiteral type: SInt<64>
-//    . : ' | . : Identifier name: "SInt" type: null
-//    . : ' | . : IntegerLiteral literal: 64 (64) type: null
 //    . : ' | CastExpr type: SInt<64>
 //    . : ' | . UnaryExpr operator: UnOp - type: Const<-1>
 //    . : ' | . : IntegerLiteral literal: 1 (1) type: Const<1>
-//    . : ' | . TypeLiteral type: SInt<64>
-//    . : ' | . : Identifier name: "SInt" type: null
-//    . : ' | . : IntegerLiteral literal: 64 (64) type: null
 //    . : CastExpr type: SInt<32>
 //    . : ' IntegerLiteral literal: 0 (0) type: Const<0>
-//    . : ' TypeLiteral type: SInt<32>
-//    . : ' | Identifier name: "SInt" type: null
-//    . : ' | IntegerLiteral literal: 32 (32) type: null
 //    . : IfExpr type: SInt<32>
 //    . : ' BinaryExpr operator: != type: Bool
 //    . : ' | CallIndexExpr type: Bits<32>
@@ -183,9 +144,6 @@ function DecodePredCount (pattern: Bits5) -> BitsX =
 //    . : ' | . : ' IntegerLiteral literal: 0 (0) type: Const<0>
 //    . : ' CastExpr type: SInt<32>
 //    . : ' | IntegerLiteral literal: 64 (64) type: Const<64>
-//    . : ' | TypeLiteral type: SInt<32>
-//    . : ' | . Identifier name: "SInt" type: null
-//    . : ' | . IntegerLiteral literal: 32 (32) type: null
 //    . : ' IfExpr type: SInt<32>
 //    . : ' | BinaryExpr operator: != type: Bool
 //    . : ' | . CallIndexExpr type: Bits<16>
@@ -202,9 +160,6 @@ function DecodePredCount (pattern: Bits5) -> BitsX =
 //    . : ' | . : ' | IntegerLiteral literal: 0 (0) type: Const<0>
 //    . : ' | CastExpr type: SInt<32>
 //    . : ' | . IntegerLiteral literal: 32 (32) type: Const<32>
-//    . : ' | . TypeLiteral type: SInt<32>
-//    . : ' | . : Identifier name: "SInt" type: null
-//    . : ' | . : IntegerLiteral literal: 32 (32) type: null
 //    . : ' | IfExpr type: SInt<32>
 //    . : ' | . BinaryExpr operator: != type: Bool
 //    . : ' | . : CallIndexExpr type: Bits<8>
@@ -221,9 +176,6 @@ function DecodePredCount (pattern: Bits5) -> BitsX =
 //    . : ' | . : ' | . IntegerLiteral literal: 0 (0) type: Const<0>
 //    . : ' | . CastExpr type: SInt<32>
 //    . : ' | . : IntegerLiteral literal: 16 (16) type: Const<16>
-//    . : ' | . : TypeLiteral type: SInt<32>
-//    . : ' | . : ' Identifier name: "SInt" type: null
-//    . : ' | . : ' IntegerLiteral literal: 32 (32) type: null
 //    . : ' | . IfExpr type: SInt<32>
 //    . : ' | . : BinaryExpr operator: != type: Bool
 //    . : ' | . : ' CallIndexExpr type: Bits<4>
@@ -240,9 +192,6 @@ function DecodePredCount (pattern: Bits5) -> BitsX =
 //    . : ' | . : ' | . : IntegerLiteral literal: 0 (0) type: Const<0>
 //    . : ' | . : CastExpr type: SInt<32>
 //    . : ' | . : ' IntegerLiteral literal: 8 (8) type: Const<8>
-//    . : ' | . : ' TypeLiteral type: SInt<32>
-//    . : ' | . : ' | Identifier name: "SInt" type: null
-//    . : ' | . : ' | IntegerLiteral literal: 32 (32) type: null
 //    . : ' | . : IfExpr type: SInt<32>
 //    . : ' | . : ' BinaryExpr operator: != type: Bool
 //    . : ' | . : ' | CallIndexExpr type: Bits<2>
@@ -259,14 +208,8 @@ function DecodePredCount (pattern: Bits5) -> BitsX =
 //    . : ' | . : ' | . : ' IntegerLiteral literal: 0 (0) type: Const<0>
 //    . : ' | . : ' CastExpr type: SInt<32>
 //    . : ' | . : ' | IntegerLiteral literal: 4 (4) type: Const<4>
-//    . : ' | . : ' | TypeLiteral type: SInt<32>
-//    . : ' | . : ' | . Identifier name: "SInt" type: null
-//    . : ' | . : ' | . IntegerLiteral literal: 32 (32) type: null
 //    . : ' | . : ' CastExpr type: SInt<32>
 //    . : ' | . : ' | IntegerLiteral literal: 2 (2) type: Const<2>
-//    . : ' | . : ' | TypeLiteral type: SInt<32>
-//    . : ' | . : ' | . Identifier name: "SInt" type: null
-//    . : ' | . : ' | . IntegerLiteral literal: 32 (32) type: null
 //    ConstantDefinition name: "VL" evaluatedValue: 128
 //    . IntegerLiteral literal: 128 (128) type: Const<128>
 //    UsingDefinition name: "Bits5"
@@ -290,355 +233,175 @@ function DecodePredCount (pattern: Bits5) -> BitsX =
 //    . : ' | BinaryExpr operator: + type: Const<3>
 //    . : ' | . IntegerLiteral literal: 3 (3) type: Const<3>
 //    . : ' | . IntegerLiteral literal: 0 (0) type: Const<0>
-//    . : ' | TypeLiteral type: UInt<2>
-//    . : ' | . Identifier name: "UInt" type: null
-//    . : ' | . IntegerLiteral literal: 2 (2) type: null
 //    . : MatchExpr type: Bits<64>
 //    . : ' Identifier name: "pattern" type: Bits<5>
 //    . : ' CastExpr type: Bits<5>
 //    . : ' | BinaryLiteral literal: 0b00000 (0) type: Const<0>
-//    . : ' | TypeLiteral type: Bits<5>
-//    . : ' | . Identifier name: "Bits" type: null
-//    . : ' | . IntegerLiteral literal: 5 (5) type: null
 //    . : ' Identifier name: "elCount" type: Bits<64>
 //    . : ' CastExpr type: Bits<5>
 //    . : ' | BinaryLiteral literal: 0b00001 (1) type: Const<1>
-//    . : ' | TypeLiteral type: Bits<5>
-//    . : ' | . Identifier name: "Bits" type: null
-//    . : ' | . IntegerLiteral literal: 5 (5) type: null
 //    . : ' IfExpr type: Bits<64>
 //    . : ' | BinaryExpr operator: >= type: Bool
 //    . : ' | . Identifier name: "elCount" type: Bits<64>
 //    . : ' | . CastExpr type: Bits<64>
 //    . : ' | . : IntegerLiteral literal: 1 (1) type: Const<1>
-//    . : ' | . : TypeLiteral type: Bits<64>
-//    . : ' | . : ' Identifier name: "Bits" type: null
-//    . : ' | . : ' IntegerLiteral literal: 64 (64) type: null
 //    . : ' | CastExpr type: Bits<64>
 //    . : ' | . IntegerLiteral literal: 1 (1) type: Const<1>
-//    . : ' | . TypeLiteral type: Bits<64>
-//    . : ' | . : Identifier name: "Bits" type: null
-//    . : ' | . : IntegerLiteral literal: 64 (64) type: null
 //    . : ' | CastExpr type: Bits<64>
 //    . : ' | . IntegerLiteral literal: 0 (0) type: Const<0>
-//    . : ' | . TypeLiteral type: Bits<64>
-//    . : ' | . : Identifier name: "Bits" type: null
-//    . : ' | . : IntegerLiteral literal: 64 (64) type: null
 //    . : ' CastExpr type: Bits<5>
 //    . : ' | BinaryLiteral literal: 0b00010 (2) type: Const<2>
-//    . : ' | TypeLiteral type: Bits<5>
-//    . : ' | . Identifier name: "Bits" type: null
-//    . : ' | . IntegerLiteral literal: 5 (5) type: null
 //    . : ' IfExpr type: Bits<64>
 //    . : ' | BinaryExpr operator: >= type: Bool
 //    . : ' | . Identifier name: "elCount" type: Bits<64>
 //    . : ' | . CastExpr type: Bits<64>
 //    . : ' | . : IntegerLiteral literal: 2 (2) type: Const<2>
-//    . : ' | . : TypeLiteral type: Bits<64>
-//    . : ' | . : ' Identifier name: "Bits" type: null
-//    . : ' | . : ' IntegerLiteral literal: 64 (64) type: null
 //    . : ' | CastExpr type: Bits<64>
 //    . : ' | . IntegerLiteral literal: 2 (2) type: Const<2>
-//    . : ' | . TypeLiteral type: Bits<64>
-//    . : ' | . : Identifier name: "Bits" type: null
-//    . : ' | . : IntegerLiteral literal: 64 (64) type: null
 //    . : ' | CastExpr type: Bits<64>
 //    . : ' | . IntegerLiteral literal: 0 (0) type: Const<0>
-//    . : ' | . TypeLiteral type: Bits<64>
-//    . : ' | . : Identifier name: "Bits" type: null
-//    . : ' | . : IntegerLiteral literal: 64 (64) type: null
 //    . : ' CastExpr type: Bits<5>
 //    . : ' | BinaryLiteral literal: 0b00011 (3) type: Const<3>
-//    . : ' | TypeLiteral type: Bits<5>
-//    . : ' | . Identifier name: "Bits" type: null
-//    . : ' | . IntegerLiteral literal: 5 (5) type: null
 //    . : ' IfExpr type: Bits<64>
 //    . : ' | BinaryExpr operator: >= type: Bool
 //    . : ' | . Identifier name: "elCount" type: Bits<64>
 //    . : ' | . CastExpr type: Bits<64>
 //    . : ' | . : IntegerLiteral literal: 3 (3) type: Const<3>
-//    . : ' | . : TypeLiteral type: Bits<64>
-//    . : ' | . : ' Identifier name: "Bits" type: null
-//    . : ' | . : ' IntegerLiteral literal: 64 (64) type: null
 //    . : ' | CastExpr type: Bits<64>
 //    . : ' | . IntegerLiteral literal: 3 (3) type: Const<3>
-//    . : ' | . TypeLiteral type: Bits<64>
-//    . : ' | . : Identifier name: "Bits" type: null
-//    . : ' | . : IntegerLiteral literal: 64 (64) type: null
 //    . : ' | CastExpr type: Bits<64>
 //    . : ' | . IntegerLiteral literal: 0 (0) type: Const<0>
-//    . : ' | . TypeLiteral type: Bits<64>
-//    . : ' | . : Identifier name: "Bits" type: null
-//    . : ' | . : IntegerLiteral literal: 64 (64) type: null
 //    . : ' CastExpr type: Bits<5>
 //    . : ' | BinaryLiteral literal: 0b00100 (4) type: Const<4>
-//    . : ' | TypeLiteral type: Bits<5>
-//    . : ' | . Identifier name: "Bits" type: null
-//    . : ' | . IntegerLiteral literal: 5 (5) type: null
 //    . : ' IfExpr type: Bits<64>
 //    . : ' | BinaryExpr operator: >= type: Bool
 //    . : ' | . Identifier name: "elCount" type: Bits<64>
 //    . : ' | . CastExpr type: Bits<64>
 //    . : ' | . : IntegerLiteral literal: 4 (4) type: Const<4>
-//    . : ' | . : TypeLiteral type: Bits<64>
-//    . : ' | . : ' Identifier name: "Bits" type: null
-//    . : ' | . : ' IntegerLiteral literal: 64 (64) type: null
 //    . : ' | CastExpr type: Bits<64>
 //    . : ' | . IntegerLiteral literal: 4 (4) type: Const<4>
-//    . : ' | . TypeLiteral type: Bits<64>
-//    . : ' | . : Identifier name: "Bits" type: null
-//    . : ' | . : IntegerLiteral literal: 64 (64) type: null
 //    . : ' | CastExpr type: Bits<64>
 //    . : ' | . IntegerLiteral literal: 0 (0) type: Const<0>
-//    . : ' | . TypeLiteral type: Bits<64>
-//    . : ' | . : Identifier name: "Bits" type: null
-//    . : ' | . : IntegerLiteral literal: 64 (64) type: null
 //    . : ' CastExpr type: Bits<5>
 //    . : ' | BinaryLiteral literal: 0b00101 (5) type: Const<5>
-//    . : ' | TypeLiteral type: Bits<5>
-//    . : ' | . Identifier name: "Bits" type: null
-//    . : ' | . IntegerLiteral literal: 5 (5) type: null
 //    . : ' IfExpr type: Bits<64>
 //    . : ' | BinaryExpr operator: >= type: Bool
 //    . : ' | . Identifier name: "elCount" type: Bits<64>
 //    . : ' | . CastExpr type: Bits<64>
 //    . : ' | . : IntegerLiteral literal: 5 (5) type: Const<5>
-//    . : ' | . : TypeLiteral type: Bits<64>
-//    . : ' | . : ' Identifier name: "Bits" type: null
-//    . : ' | . : ' IntegerLiteral literal: 64 (64) type: null
 //    . : ' | CastExpr type: Bits<64>
 //    . : ' | . IntegerLiteral literal: 5 (5) type: Const<5>
-//    . : ' | . TypeLiteral type: Bits<64>
-//    . : ' | . : Identifier name: "Bits" type: null
-//    . : ' | . : IntegerLiteral literal: 64 (64) type: null
 //    . : ' | CastExpr type: Bits<64>
 //    . : ' | . IntegerLiteral literal: 0 (0) type: Const<0>
-//    . : ' | . TypeLiteral type: Bits<64>
-//    . : ' | . : Identifier name: "Bits" type: null
-//    . : ' | . : IntegerLiteral literal: 64 (64) type: null
 //    . : ' CastExpr type: Bits<5>
 //    . : ' | BinaryLiteral literal: 0b00110 (6) type: Const<6>
-//    . : ' | TypeLiteral type: Bits<5>
-//    . : ' | . Identifier name: "Bits" type: null
-//    . : ' | . IntegerLiteral literal: 5 (5) type: null
 //    . : ' IfExpr type: Bits<64>
 //    . : ' | BinaryExpr operator: >= type: Bool
 //    . : ' | . Identifier name: "elCount" type: Bits<64>
 //    . : ' | . CastExpr type: Bits<64>
 //    . : ' | . : IntegerLiteral literal: 6 (6) type: Const<6>
-//    . : ' | . : TypeLiteral type: Bits<64>
-//    . : ' | . : ' Identifier name: "Bits" type: null
-//    . : ' | . : ' IntegerLiteral literal: 64 (64) type: null
 //    . : ' | CastExpr type: Bits<64>
 //    . : ' | . IntegerLiteral literal: 6 (6) type: Const<6>
-//    . : ' | . TypeLiteral type: Bits<64>
-//    . : ' | . : Identifier name: "Bits" type: null
-//    . : ' | . : IntegerLiteral literal: 64 (64) type: null
 //    . : ' | CastExpr type: Bits<64>
 //    . : ' | . IntegerLiteral literal: 0 (0) type: Const<0>
-//    . : ' | . TypeLiteral type: Bits<64>
-//    . : ' | . : Identifier name: "Bits" type: null
-//    . : ' | . : IntegerLiteral literal: 64 (64) type: null
 //    . : ' CastExpr type: Bits<5>
 //    . : ' | BinaryLiteral literal: 0b00111 (7) type: Const<7>
-//    . : ' | TypeLiteral type: Bits<5>
-//    . : ' | . Identifier name: "Bits" type: null
-//    . : ' | . IntegerLiteral literal: 5 (5) type: null
 //    . : ' IfExpr type: Bits<64>
 //    . : ' | BinaryExpr operator: >= type: Bool
 //    . : ' | . Identifier name: "elCount" type: Bits<64>
 //    . : ' | . CastExpr type: Bits<64>
 //    . : ' | . : IntegerLiteral literal: 7 (7) type: Const<7>
-//    . : ' | . : TypeLiteral type: Bits<64>
-//    . : ' | . : ' Identifier name: "Bits" type: null
-//    . : ' | . : ' IntegerLiteral literal: 64 (64) type: null
 //    . : ' | CastExpr type: Bits<64>
 //    . : ' | . IntegerLiteral literal: 7 (7) type: Const<7>
-//    . : ' | . TypeLiteral type: Bits<64>
-//    . : ' | . : Identifier name: "Bits" type: null
-//    . : ' | . : IntegerLiteral literal: 64 (64) type: null
 //    . : ' | CastExpr type: Bits<64>
 //    . : ' | . IntegerLiteral literal: 0 (0) type: Const<0>
-//    . : ' | . TypeLiteral type: Bits<64>
-//    . : ' | . : Identifier name: "Bits" type: null
-//    . : ' | . : IntegerLiteral literal: 64 (64) type: null
 //    . : ' CastExpr type: Bits<5>
 //    . : ' | BinaryLiteral literal: 0b01000 (8) type: Const<8>
-//    . : ' | TypeLiteral type: Bits<5>
-//    . : ' | . Identifier name: "Bits" type: null
-//    . : ' | . IntegerLiteral literal: 5 (5) type: null
 //    . : ' IfExpr type: Bits<64>
 //    . : ' | BinaryExpr operator: >= type: Bool
 //    . : ' | . Identifier name: "elCount" type: Bits<64>
 //    . : ' | . CastExpr type: Bits<64>
 //    . : ' | . : IntegerLiteral literal: 8 (8) type: Const<8>
-//    . : ' | . : TypeLiteral type: Bits<64>
-//    . : ' | . : ' Identifier name: "Bits" type: null
-//    . : ' | . : ' IntegerLiteral literal: 64 (64) type: null
 //    . : ' | CastExpr type: Bits<64>
 //    . : ' | . IntegerLiteral literal: 8 (8) type: Const<8>
-//    . : ' | . TypeLiteral type: Bits<64>
-//    . : ' | . : Identifier name: "Bits" type: null
-//    . : ' | . : IntegerLiteral literal: 64 (64) type: null
 //    . : ' | CastExpr type: Bits<64>
 //    . : ' | . IntegerLiteral literal: 0 (0) type: Const<0>
-//    . : ' | . TypeLiteral type: Bits<64>
-//    . : ' | . : Identifier name: "Bits" type: null
-//    . : ' | . : IntegerLiteral literal: 64 (64) type: null
 //    . : ' CastExpr type: Bits<5>
 //    . : ' | BinaryLiteral literal: 0b01001 (9) type: Const<9>
-//    . : ' | TypeLiteral type: Bits<5>
-//    . : ' | . Identifier name: "Bits" type: null
-//    . : ' | . IntegerLiteral literal: 5 (5) type: null
 //    . : ' IfExpr type: Bits<64>
 //    . : ' | BinaryExpr operator: >= type: Bool
 //    . : ' | . Identifier name: "elCount" type: Bits<64>
 //    . : ' | . CastExpr type: Bits<64>
 //    . : ' | . : IntegerLiteral literal: 16 (16) type: Const<16>
-//    . : ' | . : TypeLiteral type: Bits<64>
-//    . : ' | . : ' Identifier name: "Bits" type: null
-//    . : ' | . : ' IntegerLiteral literal: 64 (64) type: null
 //    . : ' | CastExpr type: Bits<64>
 //    . : ' | . IntegerLiteral literal: 16 (16) type: Const<16>
-//    . : ' | . TypeLiteral type: Bits<64>
-//    . : ' | . : Identifier name: "Bits" type: null
-//    . : ' | . : IntegerLiteral literal: 64 (64) type: null
 //    . : ' | CastExpr type: Bits<64>
 //    . : ' | . IntegerLiteral literal: 0 (0) type: Const<0>
-//    . : ' | . TypeLiteral type: Bits<64>
-//    . : ' | . : Identifier name: "Bits" type: null
-//    . : ' | . : IntegerLiteral literal: 64 (64) type: null
 //    . : ' CastExpr type: Bits<5>
 //    . : ' | BinaryLiteral literal: 0b01010 (10) type: Const<10>
-//    . : ' | TypeLiteral type: Bits<5>
-//    . : ' | . Identifier name: "Bits" type: null
-//    . : ' | . IntegerLiteral literal: 5 (5) type: null
 //    . : ' IfExpr type: Bits<64>
 //    . : ' | BinaryExpr operator: >= type: Bool
 //    . : ' | . Identifier name: "elCount" type: Bits<64>
 //    . : ' | . CastExpr type: Bits<64>
 //    . : ' | . : IntegerLiteral literal: 32 (32) type: Const<32>
-//    . : ' | . : TypeLiteral type: Bits<64>
-//    . : ' | . : ' Identifier name: "Bits" type: null
-//    . : ' | . : ' IntegerLiteral literal: 64 (64) type: null
 //    . : ' | CastExpr type: Bits<64>
 //    . : ' | . IntegerLiteral literal: 32 (32) type: Const<32>
-//    . : ' | . TypeLiteral type: Bits<64>
-//    . : ' | . : Identifier name: "Bits" type: null
-//    . : ' | . : IntegerLiteral literal: 64 (64) type: null
 //    . : ' | CastExpr type: Bits<64>
 //    . : ' | . IntegerLiteral literal: 0 (0) type: Const<0>
-//    . : ' | . TypeLiteral type: Bits<64>
-//    . : ' | . : Identifier name: "Bits" type: null
-//    . : ' | . : IntegerLiteral literal: 64 (64) type: null
 //    . : ' CastExpr type: Bits<5>
 //    . : ' | BinaryLiteral literal: 0b01011 (11) type: Const<11>
-//    . : ' | TypeLiteral type: Bits<5>
-//    . : ' | . Identifier name: "Bits" type: null
-//    . : ' | . IntegerLiteral literal: 5 (5) type: null
 //    . : ' IfExpr type: Bits<64>
 //    . : ' | BinaryExpr operator: >= type: Bool
 //    . : ' | . Identifier name: "elCount" type: Bits<64>
 //    . : ' | . CastExpr type: Bits<64>
 //    . : ' | . : IntegerLiteral literal: 64 (64) type: Const<64>
-//    . : ' | . : TypeLiteral type: Bits<64>
-//    . : ' | . : ' Identifier name: "Bits" type: null
-//    . : ' | . : ' IntegerLiteral literal: 64 (64) type: null
 //    . : ' | CastExpr type: Bits<64>
 //    . : ' | . IntegerLiteral literal: 64 (64) type: Const<64>
-//    . : ' | . TypeLiteral type: Bits<64>
-//    . : ' | . : Identifier name: "Bits" type: null
-//    . : ' | . : IntegerLiteral literal: 64 (64) type: null
 //    . : ' | CastExpr type: Bits<64>
 //    . : ' | . IntegerLiteral literal: 0 (0) type: Const<0>
-//    . : ' | . TypeLiteral type: Bits<64>
-//    . : ' | . : Identifier name: "Bits" type: null
-//    . : ' | . : IntegerLiteral literal: 64 (64) type: null
 //    . : ' CastExpr type: Bits<5>
 //    . : ' | BinaryLiteral literal: 0b01100 (12) type: Const<12>
-//    . : ' | TypeLiteral type: Bits<5>
-//    . : ' | . Identifier name: "Bits" type: null
-//    . : ' | . IntegerLiteral literal: 5 (5) type: null
 //    . : ' IfExpr type: Bits<64>
 //    . : ' | BinaryExpr operator: >= type: Bool
 //    . : ' | . Identifier name: "elCount" type: Bits<64>
 //    . : ' | . CastExpr type: Bits<64>
 //    . : ' | . : IntegerLiteral literal: 128 (128) type: Const<128>
-//    . : ' | . : TypeLiteral type: Bits<64>
-//    . : ' | . : ' Identifier name: "Bits" type: null
-//    . : ' | . : ' IntegerLiteral literal: 64 (64) type: null
 //    . : ' | CastExpr type: Bits<64>
 //    . : ' | . IntegerLiteral literal: 128 (128) type: Const<128>
-//    . : ' | . TypeLiteral type: Bits<64>
-//    . : ' | . : Identifier name: "Bits" type: null
-//    . : ' | . : IntegerLiteral literal: 64 (64) type: null
 //    . : ' | CastExpr type: Bits<64>
 //    . : ' | . IntegerLiteral literal: 0 (0) type: Const<0>
-//    . : ' | . TypeLiteral type: Bits<64>
-//    . : ' | . : Identifier name: "Bits" type: null
-//    . : ' | . : IntegerLiteral literal: 64 (64) type: null
 //    . : ' CastExpr type: Bits<5>
 //    . : ' | BinaryLiteral literal: 0b01101 (13) type: Const<13>
-//    . : ' | TypeLiteral type: Bits<5>
-//    . : ' | . Identifier name: "Bits" type: null
-//    . : ' | . IntegerLiteral literal: 5 (5) type: null
 //    . : ' IfExpr type: Bits<64>
 //    . : ' | BinaryExpr operator: >= type: Bool
 //    . : ' | . Identifier name: "elCount" type: Bits<64>
 //    . : ' | . CastExpr type: Bits<64>
 //    . : ' | . : IntegerLiteral literal: 256 (256) type: Const<256>
-//    . : ' | . : TypeLiteral type: Bits<64>
-//    . : ' | . : ' Identifier name: "Bits" type: null
-//    . : ' | . : ' IntegerLiteral literal: 64 (64) type: null
 //    . : ' | CastExpr type: Bits<64>
 //    . : ' | . IntegerLiteral literal: 256 (256) type: Const<256>
-//    . : ' | . TypeLiteral type: Bits<64>
-//    . : ' | . : Identifier name: "Bits" type: null
-//    . : ' | . : IntegerLiteral literal: 64 (64) type: null
 //    . : ' | CastExpr type: Bits<64>
 //    . : ' | . IntegerLiteral literal: 0 (0) type: Const<0>
-//    . : ' | . TypeLiteral type: Bits<64>
-//    . : ' | . : Identifier name: "Bits" type: null
-//    . : ' | . : IntegerLiteral literal: 64 (64) type: null
 //    . : ' CastExpr type: Bits<5>
 //    . : ' | BinaryLiteral literal: 0b11101 (29) type: Const<29>
-//    . : ' | TypeLiteral type: Bits<5>
-//    . : ' | . Identifier name: "Bits" type: null
-//    . : ' | . IntegerLiteral literal: 5 (5) type: null
 //    . : ' BinaryExpr operator: - type: Bits<64>
 //    . : ' | Identifier name: "elCount" type: Bits<64>
 //    . : ' | BinaryExpr operator: % type: Bits<64>
 //    . : ' | . Identifier name: "elCount" type: Bits<64>
 //    . : ' | . CastExpr type: Bits<64>
 //    . : ' | . : IntegerLiteral literal: 4 (4) type: Const<4>
-//    . : ' | . : TypeLiteral type: Bits<64>
-//    . : ' | . : ' Identifier name: "Bits" type: null
-//    . : ' | . : ' IntegerLiteral literal: 64 (64) type: null
 //    . : ' CastExpr type: Bits<5>
 //    . : ' | BinaryLiteral literal: 0b11110 (30) type: Const<30>
-//    . : ' | TypeLiteral type: Bits<5>
-//    . : ' | . Identifier name: "Bits" type: null
-//    . : ' | . IntegerLiteral literal: 5 (5) type: null
 //    . : ' BinaryExpr operator: - type: Bits<64>
 //    . : ' | Identifier name: "elCount" type: Bits<64>
 //    . : ' | BinaryExpr operator: % type: Bits<64>
 //    . : ' | . Identifier name: "elCount" type: Bits<64>
 //    . : ' | . CastExpr type: Bits<64>
 //    . : ' | . : IntegerLiteral literal: 3 (3) type: Const<3>
-//    . : ' | . : TypeLiteral type: Bits<64>
-//    . : ' | . : ' Identifier name: "Bits" type: null
-//    . : ' | . : ' IntegerLiteral literal: 64 (64) type: null
 //    . : ' CastExpr type: Bits<5>
 //    . : ' | BinaryLiteral literal: 0b11111 (31) type: Const<31>
-//    . : ' | TypeLiteral type: Bits<5>
-//    . : ' | . Identifier name: "Bits" type: null
-//    . : ' | . IntegerLiteral literal: 5 (5) type: null
 //    . : ' Identifier name: "elCount" type: Bits<64>
 //    . : ' CastExpr type: Bits<64>
 //    . : ' | IntegerLiteral literal: 0 (0) type: Const<0>
-//    . : ' | TypeLiteral type: Bits<64>
-//    . : ' | . Identifier name: "Bits" type: null
-//    . : ' | . IntegerLiteral literal: 64 (64) type: null
 //
 //
 // Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl/test/resources/frontend-snapshots/typechecker/binaryOperationsImplicitCasting.vadl
+++ b/vadl/test/resources/frontend-snapshots/typechecker/binaryOperationsImplicitCasting.vadl
@@ -79,16 +79,10 @@ constant l = b32 + cn
 //    . : Identifier name: "u32" type: UInt<32>
 //    . : CastExpr type: UInt<32>
 //    . : ' Identifier name: "cp" type: Const<16>
-//    . : ' TypeLiteral type: UInt<32>
-//    . : ' | Identifier name: "UInt" type: null
-//    . : ' | IntegerLiteral literal: 32 (32) type: null
 //    ConstantDefinition name: "c" evaluatedValue: 18
 //    . BinaryExpr operator: + type: UInt<32>
 //    . : CastExpr type: UInt<32>
 //    . : ' Identifier name: "cp" type: Const<16>
-//    . : ' TypeLiteral type: UInt<32>
-//    . : ' | Identifier name: "UInt" type: null
-//    . : ' | IntegerLiteral literal: 32 (32) type: null
 //    . : Identifier name: "u32" type: UInt<32>
 //    ConstantDefinition name: "d" evaluatedValue: 8
 //    . BinaryExpr operator: + type: SInt<32>
@@ -98,74 +92,44 @@ constant l = b32 + cn
 //    . BinaryExpr operator: + type: SInt<32>
 //    . : CastExpr type: SInt<32>
 //    . : ' Identifier name: "cp" type: Const<16>
-//    . : ' TypeLiteral type: SInt<32>
-//    . : ' | Identifier name: "SInt" type: null
-//    . : ' | IntegerLiteral literal: 32 (32) type: null
 //    . : Identifier name: "s32" type: SInt<32>
 //    ConstantDefinition name: "f" evaluatedValue: -28
 //    . BinaryExpr operator: + type: SInt<32>
 //    . : Identifier name: "s32" type: SInt<32>
 //    . : CastExpr type: SInt<32>
 //    . : ' Identifier name: "cn" type: Const<-32>
-//    . : ' TypeLiteral type: SInt<32>
-//    . : ' | Identifier name: "SInt" type: null
-//    . : ' | IntegerLiteral literal: 32 (32) type: null
 //    ConstantDefinition name: "g" evaluatedValue: 10
 //    . BinaryExpr operator: + type: UInt<32>
 //    . : Identifier name: "u32" type: UInt<32>
 //    . : CastExpr type: UInt<32>
 //    . : ' Identifier name: "b32" type: Bits<32>
-//    . : ' TypeLiteral type: UInt<32>
-//    . : ' | Identifier name: "UInt" type: null
-//    . : ' | IntegerLiteral literal: 32 (32) type: null
 //    ConstantDefinition name: "h" evaluatedValue: 10
 //    . BinaryExpr operator: + type: UInt<32>
 //    . : CastExpr type: UInt<32>
 //    . : ' Identifier name: "b32" type: Bits<32>
-//    . : ' TypeLiteral type: UInt<32>
-//    . : ' | Identifier name: "UInt" type: null
-//    . : ' | IntegerLiteral literal: 32 (32) type: null
 //    . : Identifier name: "u32" type: UInt<32>
 //    ConstantDefinition name: "i" evaluatedValue: 12
 //    . BinaryExpr operator: + type: SInt<32>
 //    . : Identifier name: "s32" type: SInt<32>
 //    . : CastExpr type: SInt<32>
 //    . : ' Identifier name: "b32" type: Bits<32>
-//    . : ' TypeLiteral type: SInt<32>
-//    . : ' | Identifier name: "SInt" type: null
-//    . : ' | IntegerLiteral literal: 32 (32) type: null
 //    ConstantDefinition name: "j" evaluatedValue: -24
 //    . BinaryExpr operator: + type: SInt<32>
 //    . : CastExpr type: SInt<32>
 //    . : ' Identifier name: "cn" type: Const<-32>
-//    . : ' TypeLiteral type: SInt<32>
-//    . : ' | Identifier name: "SInt" type: null
-//    . : ' | IntegerLiteral literal: 32 (32) type: null
 //    . : CastExpr type: SInt<32>
 //    . : ' Identifier name: "b32" type: Bits<32>
-//    . : ' TypeLiteral type: SInt<32>
-//    . : ' | Identifier name: "SInt" type: null
-//    . : ' | IntegerLiteral literal: 32 (32) type: null
 //    ConstantDefinition name: "k" evaluatedValue: 12
 //    . BinaryExpr operator: + type: SInt<32>
 //    . : CastExpr type: SInt<32>
 //    . : ' Identifier name: "b32" type: Bits<32>
-//    . : ' TypeLiteral type: SInt<32>
-//    . : ' | Identifier name: "SInt" type: null
-//    . : ' | IntegerLiteral literal: 32 (32) type: null
 //    . : Identifier name: "s32" type: SInt<32>
 //    ConstantDefinition name: "l" evaluatedValue: -24
 //    . BinaryExpr operator: + type: SInt<32>
 //    . : CastExpr type: SInt<32>
 //    . : ' Identifier name: "b32" type: Bits<32>
-//    . : ' TypeLiteral type: SInt<32>
-//    . : ' | Identifier name: "SInt" type: null
-//    . : ' | IntegerLiteral literal: 32 (32) type: null
 //    . : CastExpr type: SInt<32>
 //    . : ' Identifier name: "cn" type: Const<-32>
-//    . : ' TypeLiteral type: SInt<32>
-//    . : ' | Identifier name: "SInt" type: null
-//    . : ' | IntegerLiteral literal: 32 (32) type: null
 //
 //
 // Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl/test/resources/frontend-snapshots/typechecker/binaryOperationsOnConstantTypes.vadl
+++ b/vadl/test/resources/frontend-snapshots/typechecker/binaryOperationsOnConstantTypes.vadl
@@ -83,17 +83,11 @@ constant t = b % 20             // 2
 //    . : Identifier name: "b" type: Const<42>
 //    . : CastExpr type: UInt<2>
 //    . : ' IntegerLiteral literal: 2 (2) type: Const<2>
-//    . : ' TypeLiteral type: UInt<2>
-//    . : ' | Identifier name: "UInt" type: null
-//    . : ' | IntegerLiteral literal: 2 (2) type: null
 //    ConstantDefinition name: "o" evaluatedValue: 10
 //    . BinaryExpr operator: >> type: Const<10>
 //    . : Identifier name: "b" type: Const<42>
 //    . : CastExpr type: UInt<2>
 //    . : ' IntegerLiteral literal: 2 (2) type: Const<2>
-//    . : ' TypeLiteral type: UInt<2>
-//    . : ' | Identifier name: "UInt" type: null
-//    . : ' | IntegerLiteral literal: 2 (2) type: null
 //    ConstantDefinition name: "p" evaluatedValue: 93
 //    . BinaryExpr operator: + type: Const<93>
 //    . : Identifier name: "a" type: Const<51>

--- a/vadl/test/resources/frontend-snapshots/typechecker/binaryOperationsOnDataTypes.vadl
+++ b/vadl/test/resources/frontend-snapshots/typechecker/binaryOperationsOnDataTypes.vadl
@@ -97,17 +97,11 @@ constant t = b % 20               // 2
 //    . : Identifier name: "b" type: Bits<32>
 //    . : CastExpr type: UInt<2>
 //    . : ' IntegerLiteral literal: 2 (2) type: Const<2>
-//    . : ' TypeLiteral type: UInt<2>
-//    . : ' | Identifier name: "UInt" type: null
-//    . : ' | IntegerLiteral literal: 2 (2) type: null
 //    ConstantDefinition name: "o" evaluatedValue: 10
 //    . BinaryExpr operator: >> type: Bits<32>
 //    . : Identifier name: "b" type: Bits<32>
 //    . : CastExpr type: UInt<2>
 //    . : ' IntegerLiteral literal: 2 (2) type: Const<2>
-//    . : ' TypeLiteral type: UInt<2>
-//    . : ' | Identifier name: "UInt" type: null
-//    . : ' | IntegerLiteral literal: 2 (2) type: null
 //    ConstantDefinition name: "p" evaluatedValue: 93
 //    . BinaryExpr operator: + type: Bits<32>
 //    . : Identifier name: "a" type: Bits<32>
@@ -125,17 +119,11 @@ constant t = b % 20               // 2
 //    . : Identifier name: "a" type: Bits<32>
 //    . : CastExpr type: Bits<32>
 //    . : ' IntegerLiteral literal: 5 (5) type: Const<5>
-//    . : ' TypeLiteral type: Bits<32>
-//    . : ' | Identifier name: "Bits" type: null
-//    . : ' | IntegerLiteral literal: 32 (32) type: null
 //    ConstantDefinition name: "t" evaluatedValue: 2
 //    . BinaryExpr operator: % type: Bits<32>
 //    . : Identifier name: "b" type: Bits<32>
 //    . : CastExpr type: Bits<32>
 //    . : ' IntegerLiteral literal: 20 (20) type: Const<20>
-//    . : ' TypeLiteral type: Bits<32>
-//    . : ' | Identifier name: "Bits" type: null
-//    . : ' | IntegerLiteral literal: 32 (32) type: null
 //
 //
 // Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl/test/resources/frontend-snapshots/typechecker/builtinOnConstantTypes.vadl
+++ b/vadl/test/resources/frontend-snapshots/typechecker/builtinOnConstantTypes.vadl
@@ -101,9 +101,6 @@ constant z = VADL::umax(a, b)         // 51
 //    . : ' Identifier name: "b" type: Const<42>
 //    . : ' CastExpr type: UInt<2>
 //    . : ' | IntegerLiteral literal: 2 (2) type: Const<2>
-//    . : ' | TypeLiteral type: UInt<2>
-//    . : ' | . Identifier name: "UInt" type: null
-//    . : ' | . IntegerLiteral literal: 2 (2) type: null
 //    ConstantDefinition name: "o" evaluatedValue: 10
 //    . CallIndexExpr type: Const<10>
 //    . : IdentifierPath name: "VADL::lsr" type: null
@@ -111,9 +108,6 @@ constant z = VADL::umax(a, b)         // 51
 //    . : ' Identifier name: "b" type: Const<42>
 //    . : ' CastExpr type: UInt<2>
 //    . : ' | IntegerLiteral literal: 2 (2) type: Const<2>
-//    . : ' | TypeLiteral type: UInt<2>
-//    . : ' | . Identifier name: "UInt" type: null
-//    . : ' | . IntegerLiteral literal: 2 (2) type: null
 //    ConstantDefinition name: "p" evaluatedValue: 93
 //    . CallIndexExpr type: Const<93>
 //    . : IdentifierPath name: "VADL::add" type: null

--- a/vadl/test/resources/frontend-snapshots/typechecker/dynamicTensorSlicingForAllDo.vadl
+++ b/vadl/test/resources/frontend-snapshots/typechecker/dynamicTensorSlicingForAllDo.vadl
@@ -64,35 +64,20 @@ instruction set architecture Tensor = {
 //    . : ' | . : Identifier name: "i" type: Bits<4>
 //    . : ' | CastExpr type: Bits<32>
 //    . : ' | . IntegerLiteral literal: 0 (0) type: Const<0>
-//    . : ' | . TypeLiteral type: Bits<32>
-//    . : ' | . : Identifier name: "Bits" type: null
-//    . : ' | . : IntegerLiteral literal: 32 (32) type: null
 //    . EncodingDefinition
 //    . : Identifier name: "Init4X" type: null
 //    . : Identifier name: "opcode" type: null
 //    . : CastExpr type: Bits<4>
 //    . : ' BinaryLiteral literal: 0b1100 (12) type: Const<12>
-//    . : ' TypeLiteral type: Bits<4>
-//    . : ' | Identifier name: "Bits" type: null
-//    . : ' | IntegerLiteral literal: 4 (4) type: null
 //    . : Identifier name: "rs2" type: null
 //    . : CastExpr type: Bits<4>
 //    . : ' BinaryLiteral literal: 0b0000 (0) type: Const<0>
-//    . : ' TypeLiteral type: Bits<4>
-//    . : ' | Identifier name: "Bits" type: null
-//    . : ' | IntegerLiteral literal: 4 (4) type: null
 //    . : Identifier name: "rs1" type: null
 //    . : CastExpr type: Bits<4>
 //    . : ' BinaryLiteral literal: 0b0000 (0) type: Const<0>
-//    . : ' TypeLiteral type: Bits<4>
-//    . : ' | Identifier name: "Bits" type: null
-//    . : ' | IntegerLiteral literal: 4 (4) type: null
 //    . : Identifier name: "rd" type: null
 //    . : CastExpr type: Bits<4>
 //    . : ' BinaryLiteral literal: 0b0000 (0) type: Const<0>
-//    . : ' TypeLiteral type: Bits<4>
-//    . : ' | Identifier name: "Bits" type: null
-//    . : ' | IntegerLiteral literal: 4 (4) type: null
 //    . AssemblyDefinition
 //    . : GroupedExpr type: String
 //    . : ' Identifier name: "mnemonic" type: String

--- a/vadl/test/resources/frontend-snapshots/typechecker/enumEntryReferenceBeforeDefinition.vadl
+++ b/vadl/test/resources/frontend-snapshots/typechecker/enumEntryReferenceBeforeDefinition.vadl
@@ -30,15 +30,9 @@ enumeration Nums : Bits<4> =
 //    . Identifier name: "first" type: null
 //    . CastExpr type: Bits<4>
 //    . : IntegerLiteral literal: 10 (10) type: Const<10>
-//    . : TypeLiteral type: Bits<4>
-//    . : ' Identifier name: "Bits" type: null
-//    . : ' IntegerLiteral literal: 4 (4) type: null
 //    . Identifier name: "second" type: null
 //    . CastExpr type: Bits<4>
 //    . : IntegerLiteral literal: 11 (11) type: Const<11>
-//    . : TypeLiteral type: Bits<4>
-//    . : ' Identifier name: "Bits" type: null
-//    . : ' IntegerLiteral literal: 4 (4) type: null
 //
 //
 // Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl/test/resources/frontend-snapshots/typechecker/enumWithTypes.vadl
+++ b/vadl/test/resources/frontend-snapshots/typechecker/enumWithTypes.vadl
@@ -20,21 +20,12 @@
 //    . : BinaryExpr operator: + type: Const<1>
 //    . : ' BinaryLiteral literal: 0b00 (0) type: Const<0>
 //    . : ' BinaryLiteral literal: 0b01 (1) type: Const<1>
-//    . : TypeLiteral type: Bits<2>
-//    . : ' Identifier name: "Bits" type: null
-//    . : ' IntegerLiteral literal: 2 (2) type: null
 //    . Identifier name: "B" type: null
 //    . CastExpr type: Bits<2>
 //    . : BinaryLiteral literal: 0b01 (1) type: Const<1>
-//    . : TypeLiteral type: Bits<2>
-//    . : ' Identifier name: "Bits" type: null
-//    . : ' IntegerLiteral literal: 2 (2) type: null
 //    . Identifier name: "C" type: null
 //    . CastExpr type: Bits<2>
 //    . : BinaryLiteral literal: 0b10 (2) type: Const<2>
-//    . : TypeLiteral type: Bits<2>
-//    . : ' Identifier name: "Bits" type: null
-//    . : ' IntegerLiteral literal: 2 (2) type: null
 //
 //
 // Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl/test/resources/frontend-snapshots/typechecker/evalNestedFunctions.vadl
+++ b/vadl/test/resources/frontend-snapshots/typechecker/evalNestedFunctions.vadl
@@ -20,9 +20,6 @@ function inner(a: Bits<32>) -> Bits<32> = a + 1
 //    . : ArgsIndices
 //    . : ' CastExpr type: Bits<32>
 //    . : ' | IntegerLiteral literal: 5 (5) type: Const<5>
-//    . : ' | TypeLiteral type: Bits<32>
-//    . : ' | . Identifier name: "Bits" type: null
-//    . : ' | . IntegerLiteral literal: 32 (32) type: null
 //    FunctionDefinition name: "outer"
 //    . Parameter name: "b"
 //    . : TypeLiteral type: Bits<32>
@@ -38,9 +35,6 @@ function inner(a: Bits<32>) -> Bits<32> = a + 1
 //    . : ' | Identifier name: "b" type: Bits<32>
 //    . : CastExpr type: Bits<32>
 //    . : ' IntegerLiteral literal: 2 (2) type: Const<2>
-//    . : ' TypeLiteral type: Bits<32>
-//    . : ' | Identifier name: "Bits" type: null
-//    . : ' | IntegerLiteral literal: 32 (32) type: null
 //    FunctionDefinition name: "inner"
 //    . Parameter name: "a"
 //    . : TypeLiteral type: Bits<32>
@@ -53,9 +47,6 @@ function inner(a: Bits<32>) -> Bits<32> = a + 1
 //    . : Identifier name: "a" type: Bits<32>
 //    . : CastExpr type: Bits<32>
 //    . : ' IntegerLiteral literal: 1 (1) type: Const<1>
-//    . : ' TypeLiteral type: Bits<32>
-//    . : ' | Identifier name: "Bits" type: null
-//    . : ' | IntegerLiteral literal: 32 (32) type: null
 //
 //
 // Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl/test/resources/frontend-snapshots/typechecker/functionDefinition.vadl
+++ b/vadl/test/resources/frontend-snapshots/typechecker/functionDefinition.vadl
@@ -22,9 +22,6 @@ function addOne(n: SInt<8>) -> SInt<8> = n + 1
 //    . : Identifier name: "n" type: SInt<8>
 //    . : CastExpr type: SInt<8>
 //    . : ' IntegerLiteral literal: 1 (1) type: Const<1>
-//    . : ' TypeLiteral type: SInt<8>
-//    . : ' | Identifier name: "SInt" type: null
-//    . : ' | IntegerLiteral literal: 8 (8) type: null
 //
 //
 // Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl/test/resources/frontend-snapshots/typechecker/matchExprBranchesDifferentTypeInConstantTest.vadl
+++ b/vadl/test/resources/frontend-snapshots/typechecker/matchExprBranchesDifferentTypeInConstantTest.vadl
@@ -25,9 +25,6 @@
 //    . : ' | IntegerLiteral literal: 32 (32) type: Const<32>
 //    . : CastExpr type: Bits<32>
 //    . : ' IntegerLiteral literal: 1 (1) type: Const<1>
-//    . : ' TypeLiteral type: Bits<32>
-//    . : ' | Identifier name: "Bits" type: null
-//    . : ' | IntegerLiteral literal: 32 (32) type: null
 //    . : CastExpr type: Bits<16>
 //    . : ' IntegerLiteral literal: 2 (2) type: Const<2>
 //    . : ' TypeLiteral type: Bits<16>
@@ -35,9 +32,6 @@
 //    . : ' | IntegerLiteral literal: 16 (16) type: Const<16>
 //    . : CastExpr type: Bits<32>
 //    . : ' IntegerLiteral literal: 2 (2) type: Const<2>
-//    . : ' TypeLiteral type: Bits<32>
-//    . : ' | Identifier name: "Bits" type: null
-//    . : ' | IntegerLiteral literal: 32 (32) type: null
 //    . : CastExpr type: Bits<32>
 //    . : ' IntegerLiteral literal: 4 (4) type: Const<4>
 //    . : ' TypeLiteral type: Bits<32>
@@ -45,9 +39,6 @@
 //    . : ' | IntegerLiteral literal: 32 (32) type: Const<32>
 //    . : CastExpr type: Bits<32>
 //    . : ' IntegerLiteral literal: 3 (3) type: Const<3>
-//    . : ' TypeLiteral type: Bits<32>
-//    . : ' | Identifier name: "Bits" type: null
-//    . : ' | IntegerLiteral literal: 32 (32) type: null
 //    . : CastExpr type: Bits<8>
 //    . : ' IntegerLiteral literal: 6 (6) type: Const<6>
 //    . : ' TypeLiteral type: Bits<8>

--- a/vadl/test/resources/frontend-snapshots/typechecker/multiplierWithConstantBinaryExpression.vadl
+++ b/vadl/test/resources/frontend-snapshots/typechecker/multiplierWithConstantBinaryExpression.vadl
@@ -53,9 +53,6 @@ instruction set architecture Test = {
 //    . : ' | ArgsIndices
 //    . : ' | . CastExpr type: Bits<3>
 //    . : ' | . : IntegerLiteral literal: 7 (7) type: Const<7>
-//    . : ' | . : TypeLiteral type: Bits<3>
-//    . : ' | . : ' Identifier name: "Bits" type: null
-//    . : ' | . : ' IntegerLiteral literal: 3 (3) type: null
 //    . : ' CallIndexExpr type: Bits<64>
 //    . : ' | SymbolExpr type: null
 //    . : ' | . Identifier name: "MEM" type: null
@@ -63,26 +60,17 @@ instruction set architecture Test = {
 //    . : ' | . : IntegerLiteral literal: 1 (1) type: Const<1>
 //    . : ' | . : CastExpr type: UInt<2>
 //    . : ' | . : ' IntegerLiteral literal: 3 (3) type: Const<3>
-//    . : ' | . : ' TypeLiteral type: UInt<2>
-//    . : ' | . : ' | Identifier name: "UInt" type: null
-//    . : ' | . : ' | IntegerLiteral literal: 2 (2) type: null
 //    . : ' | ArgsIndices
 //    . : ' | . CallIndexExpr type: Bits<64>
 //    . : ' | . : Identifier name: "Reg" type: null
 //    . : ' | . : ArgsIndices
 //    . : ' | . : ' CastExpr type: Bits<3>
 //    . : ' | . : ' | IntegerLiteral literal: 0 (0) type: Const<0>
-//    . : ' | . : ' | TypeLiteral type: Bits<3>
-//    . : ' | . : ' | . Identifier name: "Bits" type: null
-//    . : ' | . : ' | . IntegerLiteral literal: 3 (3) type: null
 //    . EncodingDefinition
 //    . : Identifier name: "t" type: null
 //    . : Identifier name: "op" type: null
 //    . : CastExpr type: Bits<4>
 //    . : ' IntegerLiteral literal: 0 (0) type: Const<0>
-//    . : ' TypeLiteral type: Bits<4>
-//    . : ' | Identifier name: "Bits" type: null
-//    . : ' | IntegerLiteral literal: 4 (4) type: null
 //    . AssemblyDefinition
 //    . : GroupedExpr type: String
 //    . : ' StringLiteral literal: "load" ("load") type: String

--- a/vadl/test/resources/frontend-snapshots/typechecker/signedTensorValuesTest.vadl
+++ b/vadl/test/resources/frontend-snapshots/typechecker/signedTensorValuesTest.vadl
@@ -24,15 +24,9 @@ constant d = a(2)
 //    . : ' | . IntegerLiteral literal: 8 (8) type: Const<8>
 //    . : ' CastExpr type: SInt<8>
 //    . : ' | IntegerLiteral literal: 8 (8) type: Const<8>
-//    . : ' | TypeLiteral type: SInt<8>
-//    . : ' | . Identifier name: "SInt" type: null
-//    . : ' | . IntegerLiteral literal: 8 (8) type: null
 //    . : ' CastExpr type: SInt<8>
 //    . : ' | UnaryExpr operator: UnOp - type: Const<-9>
 //    . : ' | . IntegerLiteral literal: 9 (9) type: Const<9>
-//    . : ' | TypeLiteral type: SInt<8>
-//    . : ' | . Identifier name: "SInt" type: null
-//    . : ' | . IntegerLiteral literal: 8 (8) type: null
 //    . : TypeLiteral type: SInt<3><8>
 //    . : ' Identifier name: "SInt" type: null
 //    . : ' IntegerLiteral literal: 3 (3) type: Const<3>

--- a/vadl/test/resources/frontend-snapshots/typechecker/tensorValuesTest.vadl
+++ b/vadl/test/resources/frontend-snapshots/typechecker/tensorValuesTest.vadl
@@ -44,9 +44,6 @@ constant j = i as Dim_2_a
 //    . : ' Identifier name: "a" type: Bits<6>
 //    . : ' CastExpr type: Bits<6>
 //    . : ' | IntegerLiteral literal: 2 (2) type: Const<2>
-//    . : ' | TypeLiteral type: Bits<6>
-//    . : ' | . Identifier name: "Bits" type: null
-//    . : ' | . IntegerLiteral literal: 6 (6) type: null
 //    FunctionDefinition name: "flo"
 //    . TypeLiteral type: Bits<6>
 //    . : Identifier name: "Bits" type: null
@@ -83,19 +80,10 @@ constant j = i as Dim_2_a
 //    . : ' | . Identifier name: "Dim_1_a" type: null
 //    . : ' CastExpr type: Bits<16>
 //    . : ' | IntegerLiteral literal: 2 (2) type: Const<2>
-//    . : ' | TypeLiteral type: Bits<16>
-//    . : ' | . Identifier name: "Bits" type: null
-//    . : ' | . IntegerLiteral literal: 16 (16) type: null
 //    . : ' CastExpr type: Bits<16>
 //    . : ' | IntegerLiteral literal: 1 (1) type: Const<1>
-//    . : ' | TypeLiteral type: Bits<16>
-//    . : ' | . Identifier name: "Bits" type: null
-//    . : ' | . IntegerLiteral literal: 16 (16) type: null
 //    . : ' CastExpr type: Bits<16>
 //    . : ' | IntegerLiteral literal: 0 (0) type: Const<0>
-//    . : ' | TypeLiteral type: Bits<16>
-//    . : ' | . Identifier name: "Bits" type: null
-//    . : ' | . IntegerLiteral literal: 16 (16) type: null
 //    . : TypeLiteral type: Bits<4><16>
 //    . : ' Identifier name: "Dim_2_a" type: null
 //    ConstantDefinition name: "d3" evaluatedValue: 36346553384763581871632909800112128
@@ -110,19 +98,10 @@ constant j = i as Dim_2_a
 //    . : ' | . : ' IntegerLiteral literal: 16 (16) type: Const<16>
 //    . : ' | . CastExpr type: Bits<16>
 //    . : ' | . : IntegerLiteral literal: 6 (6) type: Const<6>
-//    . : ' | . : TypeLiteral type: Bits<16>
-//    . : ' | . : ' Identifier name: "Bits" type: null
-//    . : ' | . : ' IntegerLiteral literal: 16 (16) type: null
 //    . : ' | . CastExpr type: Bits<16>
 //    . : ' | . : IntegerLiteral literal: 5 (5) type: Const<5>
-//    . : ' | . : TypeLiteral type: Bits<16>
-//    . : ' | . : ' Identifier name: "Bits" type: null
-//    . : ' | . : ' IntegerLiteral literal: 16 (16) type: null
 //    . : ' | . CastExpr type: Bits<16>
 //    . : ' | . : IntegerLiteral literal: 4 (4) type: Const<4>
-//    . : ' | . : TypeLiteral type: Bits<16>
-//    . : ' | . : ' Identifier name: "Bits" type: null
-//    . : ' | . : ' IntegerLiteral literal: 16 (16) type: null
 //    . : ' | TypeLiteral type: Bits<4><16>
 //    . : ' | . Identifier name: "Dim_2_a" type: null
 //    . : ' CastExpr type: Bits<4><16>
@@ -134,19 +113,10 @@ constant j = i as Dim_2_a
 //    . : ' | . : ' IntegerLiteral literal: 16 (16) type: Const<16>
 //    . : ' | . CastExpr type: Bits<16>
 //    . : ' | . : IntegerLiteral literal: 2 (2) type: Const<2>
-//    . : ' | . : TypeLiteral type: Bits<16>
-//    . : ' | . : ' Identifier name: "Bits" type: null
-//    . : ' | . : ' IntegerLiteral literal: 16 (16) type: null
 //    . : ' | . CastExpr type: Bits<16>
 //    . : ' | . : IntegerLiteral literal: 1 (1) type: Const<1>
-//    . : ' | . : TypeLiteral type: Bits<16>
-//    . : ' | . : ' Identifier name: "Bits" type: null
-//    . : ' | . : ' IntegerLiteral literal: 16 (16) type: null
 //    . : ' | . CastExpr type: Bits<16>
 //    . : ' | . : IntegerLiteral literal: 0 (0) type: Const<0>
-//    . : ' | . : TypeLiteral type: Bits<16>
-//    . : ' | . : ' Identifier name: "Bits" type: null
-//    . : ' | . : ' IntegerLiteral literal: 16 (16) type: null
 //    . : ' | TypeLiteral type: Bits<4><16>
 //    . : ' | . Identifier name: "Dim_2_a" type: null
 //    . : TypeLiteral type: Bits<2><4><16>

--- a/vadl/test/resources/frontend-snapshots/typechecker/validMatchExprTest.vadl
+++ b/vadl/test/resources/frontend-snapshots/typechecker/validMatchExprTest.vadl
@@ -24,9 +24,6 @@
 //    . : ' | IntegerLiteral literal: 32 (32) type: Const<32>
 //    . : CastExpr type: Bits<32>
 //    . : ' IntegerLiteral literal: 1 (1) type: Const<1>
-//    . : ' TypeLiteral type: Bits<32>
-//    . : ' | Identifier name: "Bits" type: null
-//    . : ' | IntegerLiteral literal: 32 (32) type: null
 //    . : CastExpr type: Bits<16>
 //    . : ' IntegerLiteral literal: 2 (2) type: Const<2>
 //    . : ' TypeLiteral type: Bits<16>
@@ -34,9 +31,6 @@
 //    . : ' | IntegerLiteral literal: 16 (16) type: Const<16>
 //    . : CastExpr type: Bits<32>
 //    . : ' IntegerLiteral literal: 2 (2) type: Const<2>
-//    . : ' TypeLiteral type: Bits<32>
-//    . : ' | Identifier name: "Bits" type: null
-//    . : ' | IntegerLiteral literal: 32 (32) type: null
 //    . : CastExpr type: Bits<16>
 //    . : ' IntegerLiteral literal: 4 (4) type: Const<4>
 //    . : ' TypeLiteral type: Bits<16>
@@ -44,14 +38,8 @@
 //    . : ' | IntegerLiteral literal: 16 (16) type: Const<16>
 //    . : CastExpr type: Bits<32>
 //    . : ' IntegerLiteral literal: 3 (3) type: Const<3>
-//    . : ' TypeLiteral type: Bits<32>
-//    . : ' | Identifier name: "Bits" type: null
-//    . : ' | IntegerLiteral literal: 32 (32) type: null
 //    . : CastExpr type: Bits<32>
 //    . : ' IntegerLiteral literal: 9 (9) type: Const<9>
-//    . : ' TypeLiteral type: Bits<32>
-//    . : ' | Identifier name: "Bits" type: null
-//    . : ' | IntegerLiteral literal: 32 (32) type: null
 //    . : CastExpr type: Bits<16>
 //    . : ' IntegerLiteral literal: 6 (6) type: Const<6>
 //    . : ' TypeLiteral type: Bits<16>

--- a/vadl/test/resources/viam-snapshots/instructionEncodingAssembly.vadl
+++ b/vadl/test/resources/viam-snapshots/instructionEncodingAssembly.vadl
@@ -222,7 +222,7 @@ instruction set architecture Mini = {
 //    . : ' Inputs: rs1, rs2
 //    . : ' Outputs: rd
 //    . : ' Encoding: encoding
-//    . : ' Assembly: Mini::ADD::assembly
+//    . : ' Assembly: assembly
 //    . : ' Behavior Graph:
 //    . : ' | n0 FieldRef             in: ()      succ: ()     type: b5    field: rd    format: Rtype
 //    . : ' | n1 FieldRef             in: ()      succ: ()     type: b5    field: rs1   format: Rtype
@@ -233,10 +233,10 @@ instruction set architecture Mini = {
 //    . : ' | n6 WritesRegisterTensor in: (n0 n5) succ: ()     reg: X
 //    . : ' | n7 InstrEnd             in: (n6)    succ: ()     effects: 1
 //    . : ' | n8 Start                in: ()      succ: (n7)   next: set
-//    . : ' Assembly name: "Mini::ADD::assembly"
-//    . : ' | Function: Mini::ADD::assembly::func
+//    . : ' Assembly name: "assembly"
+//    . : ' | Function: func
 //    . : ' | FieldAccesses: []
-//    . : ' | Function name: "Mini::ADD::assembly::func"
+//    . : ' | Function name: "func"
 //    . : ' | . Type: ()->String
 //    . : ' | . Signature: () -> String
 //    . : ' | . Parameters: []

--- a/vadl/test/vadl/ast/CallIndexExprTest.java
+++ b/vadl/test/vadl/ast/CallIndexExprTest.java
@@ -19,6 +19,7 @@ package vadl.ast;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
+import java.util.Arrays;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -129,7 +130,7 @@ public class CallIndexExprTest {
     var spec = Frontend.compileToViam(wrapProg(prog));
     ViamVerifier.verifyAllIn(spec);
     var testFuncs = ViamUtils.findDefinitionsByFilter(spec,
-            d -> d instanceof Function && d.simpleName().startsWith("T"))
+            d -> d instanceof Function && Arrays.asList(d.identifier.parts()).contains("T"))
         .stream().toList();
     assertThat(testFuncs).size().isEqualTo(1);
   }


### PR DESCRIPTION
Again even more performance improvements focused on memory pressure.

**Protocol:**
```
master:
1804M

Improve synthetic cast expression creation
1790M

Avoid redundant string concat and spliting
1734M

Optimize pathToSegments method
1730M

Optimize pathToString method on IdentifierPath:
1724M

Optimize hot BuiltinTable:argsCompatible method:
1651M
```