### PR TITLE
frontend: Group Array Type

### DIFF
--- a/vadl-frontend/main/vadl/ast/AnnotationTable.java
+++ b/vadl-frontend/main/vadl/ast/AnnotationTable.java
@@ -1533,6 +1533,9 @@ class ExprAnnotation extends Annotation {
   }
 
   public void verifyExprType(Type type) {
+    Diagnostic.ensure(expr.type != null, () -> error("Invalid annotation expression", expr)
+        .locationDescription(expr, "Unable to determine type")
+        .help("Check additional errors which may have caused the type to be missing"));
     Diagnostic.ensure(expr.type() == type, () -> error("Invalid annotation expression", expr)
         .locationDescription(expr, "Expression must be a %s", type));
   }

--- a/vadl-frontend/main/vadl/ast/AnnotationTable.java
+++ b/vadl-frontend/main/vadl/ast/AnnotationTable.java
@@ -59,6 +59,7 @@ import vadl.ast.nodes.RegisterDefinition;
 import vadl.ast.nodes.RelocationDefinition;
 import vadl.ast.nodes.StringLiteral;
 import vadl.ast.nodes.TypedNode;
+import vadl.error.DeferredDiagnosticStore;
 import vadl.error.Diagnostic;
 import vadl.error.DiagnosticBuilder;
 import vadl.gcb.annotations.OnlyNegativeNumbersAnnotation;
@@ -236,7 +237,7 @@ public class AnnotationTable {
         .build();
 
     annotationOn(EncodingDefinition.class, "select when", EncodingConstraintAnnotation::new)
-        .check((def, annotation, lowering) -> annotation.verifyExprType(Type.bool()))
+        .check((def, annotation, tc) -> annotation.verifyExprType(tc, Type.bool()))
         .applyViam((def, annotation, lowering) -> {
           // The actual formular checks are done in the VdtEncodingConstraintValidationPass.
           var encoding = (Encoding) def;
@@ -248,7 +249,7 @@ public class AnnotationTable {
         .build();
 
     annotationOn(InstructionDefinition.class, "undefined when", InstructionUndefinedAnnotation::new)
-        .check((def, annotation, lowering) -> annotation.verifyExprType(Type.bool()))
+        .check((def, annotation, tc) -> annotation.verifyExprType(tc, Type.bool()))
         .applyViam((def, annotation, lowering) -> {
           var instr = (Instruction) def;
           var graph = new BehaviorLowering(lowering).getFunctionGraph(annotation.expr,
@@ -308,7 +309,7 @@ public class AnnotationTable {
         }).build();
 
     annotationOn(GroupDefinition.class, "assert", () -> new ExprAnnotation(true))
-        .check((def, annotation, lowering) -> annotation.verifyExprType(Type.bool()))
+        .check((def, annotation, tc) -> annotation.verifyExprType(tc, Type.bool()))
         .applyViam((def, annotation, lowering) -> {
           var group = (Group) def;
           var graph = new BehaviorLowering(lowering)
@@ -319,7 +320,7 @@ public class AnnotationTable {
         .build();
 
     annotationOn(GroupDefinition.class, "stop", () -> new ExprAnnotation(true))
-        .check((def, annotation, lowering) -> annotation.verifyExprType(Type.bool()))
+        .check((def, annotation, tc) -> annotation.verifyExprType(tc, Type.bool()))
         .applyViam((def, annotation, lowering) -> {
           var group = (Group) def;
           var graph = new BehaviorLowering(lowering)
@@ -1532,12 +1533,18 @@ class ExprAnnotation extends Annotation {
     return "[ " + name + " : <expr> ]";
   }
 
-  public void verifyExprType(Type type) {
-    Diagnostic.ensure(expr.type != null, () -> error("Invalid annotation expression", expr)
-        .locationDescription(expr, "Unable to determine type")
-        .help("Check additional errors which may have caused the type to be missing"));
-    Diagnostic.ensure(expr.type() == type, () -> error("Invalid annotation expression", expr)
-        .locationDescription(expr, "Expression must be a %s", type));
+  public void verifyExprType(final TypeChecker tc, final Type type) {
+
+    // Suppress these generic error messages, in case more specific errors already exist.
+    // (this assumes that existing errors are related)
+    final var hasError =  !tc.getErrors().isEmpty() || DeferredDiagnosticStore.hasError();
+
+    Diagnostic.ensure(hasError || expr.type != null,
+        () -> error("Invalid annotation expression", expr)
+            .locationDescription(expr, "Unable to determine type"));
+    Diagnostic.ensure(hasError || expr.type() == type,
+        () -> error("Invalid annotation expression", expr)
+            .locationDescription(expr, "Expression must be a %s", type));
   }
 }
 

--- a/vadl-frontend/main/vadl/ast/BehaviorLowering.java
+++ b/vadl-frontend/main/vadl/ast/BehaviorLowering.java
@@ -67,6 +67,7 @@ import vadl.ast.nodes.ForallExpr;
 import vadl.ast.nodes.ForallStatement;
 import vadl.ast.nodes.ForallThenExpr;
 import vadl.ast.nodes.FunctionDefinition;
+import vadl.ast.nodes.GroupDefinition;
 import vadl.ast.nodes.GroupedExpr;
 import vadl.ast.nodes.Identifier;
 import vadl.ast.nodes.IdentifierPath;
@@ -115,6 +116,7 @@ import vadl.types.BitsType;
 import vadl.types.BoolType;
 import vadl.types.BuiltInTable;
 import vadl.types.DataType;
+import vadl.types.GroupType;
 import vadl.types.MicroArchitectureType;
 import vadl.types.SIntType;
 import vadl.types.StructType;
@@ -123,6 +125,7 @@ import vadl.types.UIntType;
 import vadl.utils.BigIntUtils;
 import vadl.utils.Either;
 import vadl.utils.Pair;
+import vadl.utils.SourceLocation;
 import vadl.utils.WithLocation;
 import vadl.viam.ArtificialResource;
 import vadl.viam.Constant;
@@ -166,6 +169,7 @@ import vadl.viam.graph.dependency.FoldNode;
 import vadl.viam.graph.dependency.ForIdxNode;
 import vadl.viam.graph.dependency.FuncCallNode;
 import vadl.viam.graph.dependency.FuncParamNode;
+import vadl.viam.graph.dependency.GroupRef;
 import vadl.viam.graph.dependency.InstructionWidthNode;
 import vadl.viam.graph.dependency.LetNode;
 import vadl.viam.graph.dependency.MiaBuiltInCall;
@@ -885,7 +889,7 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
   /**
    * Identifier and IdentifierPath are quite similar in what they do, so let's resolve both here.
    */
-  private ExpressionNode visitIdentifyable(Expr expr) {
+  private ExpressionNode visitIdentifiable(Expr expr) {
 
     Node computedTarget;
     String innerName;
@@ -1055,6 +1059,11 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
       return new OperationForAllNode.Index(getViamType(format), ops);
     }
 
+    // Reference to a Group Definition
+    if (computedTarget instanceof GroupDefinition) {
+      return new GroupRef(expr.type());
+    }
+
     // Function call without arguments (and no parenthesis)
     if (computedTarget instanceof FunctionDefinition functionDefinition) {
       var function = (Function) viamLowering.fetch(functionDefinition).orElseThrow();
@@ -1069,8 +1078,8 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
         .toList();
 
     if (matchingBuiltins.size() == 1) {
-      var builtin = matchingBuiltins.get(0);
-      return new BuiltInCall(builtin, new NodeList<ExpressionNode>(),
+      var builtin = matchingBuiltins.getFirst();
+      return new BuiltInCall(builtin, new NodeList<>(),
           getViamType(expr.type()));
     }
 
@@ -1082,7 +1091,7 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
 
   @Override
   public ExpressionNode visit(Identifier expr) {
-    return visitIdentifyable(expr);
+    return visitIdentifiable(expr);
   }
 
   @Override
@@ -1190,7 +1199,7 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
 
   @Override
   public ExpressionNode visit(IdentifierPath expr) {
-    return visitIdentifyable(expr);
+    return visitIdentifiable(expr);
   }
 
   @Override
@@ -1223,9 +1232,11 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
                 (DataType) getViamType(requireNonNull(subCall.formatFieldType)));
         resultExpr =
             visitSliceIndexCall(slice, subCall.formatFieldType, subCall.argsIndices);
-      } else if (exprBeforeSubcall.type() instanceof StructType) {
-        var indexing = new StructGetFieldNode(subCall.identifier().name, resultExpr, Type.bool());
-        resultExpr = visitSliceIndexCall(indexing, Type.bool(), subCall.argsIndices);
+      } else if (exprBeforeSubcall.type() instanceof StructType structType) {
+        var fieldName = subCall.identifier().name;
+        var fieldType = structType.get(fieldName);
+        var indexing = new StructGetFieldNode(fieldName, resultExpr, fieldType);
+        resultExpr = visitSliceIndexCall(indexing, fieldType, subCall.argsIndices);
       } else if (exprBeforeSubcall.type() == MicroArchitectureType.instruction()) {
         // There is weired way to call functions on instructions
         var builtin =
@@ -1287,6 +1298,20 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
             resultExpr = BuiltInTable.ADD.call(resRead, offsetNode);
           }
         }
+      } else if (exprBeforeSubcall instanceof GroupRef groupRef) {
+        var fieldName = subCall.identifier().name;
+        resultExpr = switch (fieldName) {
+          case "length" -> {
+            final var resType = ((GroupType) groupRef.type()).lengthType();
+            yield new StructGetFieldNode("length", groupRef, resType);
+          }
+          case "bitLength" -> {
+            final var resType = ((GroupType) groupRef.type()).bitLengthType();
+            yield new StructGetFieldNode("bitLength", groupRef, resType);
+          }
+          default ->
+              throw error("Unknown group field: `%s`".formatted(fieldName), subCall).build();
+        };
       } else {
         throw new IllegalStateException();
       }
@@ -1332,8 +1357,8 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
           lsb = msb;
         }
 
-        result = new DynSliceNode(exprBeforeSlice, msb, lsb, (DataType) getViamType(slice.type()));
-        typeBefore = (DataType) slice.type();
+        result = new DynSliceNode(exprBeforeSlice, msb, lsb, getViamType(slice.type()));
+        typeBefore = slice.type();
       }
     }
 

--- a/vadl-frontend/main/vadl/ast/GroupDefUtils.java
+++ b/vadl-frontend/main/vadl/ast/GroupDefUtils.java
@@ -18,7 +18,9 @@ package vadl.ast;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import vadl.ast.nodes.Group;
+import vadl.ast.nodes.InstructionDefinition;
 import vadl.ast.nodes.OperationDefinition;
 import vadl.ast.nodes.RangeExpr;
 
@@ -31,6 +33,10 @@ public interface GroupDefUtils {
    * Collect all operations occurring in a group expression.
    */
   class OperationCollector implements Group.GroupVisitor<List<OperationDefinition>> {
+
+    private OperationCollector() {
+      // Direct instantiation not allowed
+    }
 
     /**
      * Collect all operations occurring in a group expression.
@@ -126,6 +132,68 @@ public interface GroupDefUtils {
       }
       final var constant = constantEvaluator.eval(range.to);
       return constant.value().intValueExact();
+    }
+
+  }
+
+  /**
+   * Determine the maximum bitlength of a group expression.
+   */
+  class GroupExprBitLengthCollector implements Group.GroupVisitor<Integer> {
+
+    private final ConstantEvaluator constantEvaluator;
+
+    private GroupExprBitLengthCollector(ConstantEvaluator constantEvaluator) {
+      this.constantEvaluator = constantEvaluator;
+    }
+
+    static int maxBitLength(ConstantEvaluator constantEvaluator, Group group) {
+      return group.accept(new GroupExprBitLengthCollector(constantEvaluator));
+    }
+
+    @Override
+    public Integer visit(Group.Sequence seq) {
+      int len = 0;
+      for (Group group : seq.groups) {
+        len += group.accept(this);
+      }
+      return len;
+    }
+
+    @Override
+    public Integer visit(Group.Alternative alt) {
+      int len = 0;
+      for (Group.Sequence seq : alt.sequences) {
+        len = Math.max(len, seq.accept(this));
+      }
+      return len;
+    }
+
+    @Override
+    public Integer visit(Group.Permutation perm) {
+      int len = 0;
+      for (Group.Sequence seq : perm.sequences) {
+        len += seq.accept(this);
+      }
+      return len;
+    }
+
+    @Override
+    public Integer visit(Group.Literal lit) {
+
+      int bitLen = 0;
+      for (InstructionDefinition insn : lit.getOperation().instructions) {
+        final int formatWidth =
+            Objects.requireNonNull(insn.formatNode).type().asDataType().bitWidth();
+        bitLen = Math.max(bitLen, formatWidth);
+      }
+
+      if (!(lit.size instanceof RangeExpr range)) {
+        return bitLen;
+      }
+
+      final var constant = constantEvaluator.eval(range.to);
+      return bitLen * constant.value().intValueExact();
     }
 
   }

--- a/vadl-frontend/main/vadl/ast/GroupDefUtils.java
+++ b/vadl-frontend/main/vadl/ast/GroupDefUtils.java
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText : © 2026 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.ast;
+
+import java.util.ArrayList;
+import java.util.List;
+import vadl.ast.nodes.Group;
+import vadl.ast.nodes.OperationDefinition;
+import vadl.ast.nodes.RangeExpr;
+
+/**
+ * Utilities for working with group definitions.
+ */
+public interface GroupDefUtils {
+
+  /**
+   * Collect all operations occurring in a group expression.
+   */
+  class OperationCollector implements Group.GroupVisitor<List<OperationDefinition>> {
+
+    /**
+     * Collect all operations occurring in a group expression.
+     *
+     * @param group the group expression
+     * @return the list of operations
+     */
+    public static List<OperationDefinition> operations(Group group) {
+      return group.accept(new OperationCollector());
+    }
+
+    @Override
+    public List<OperationDefinition> visit(Group.Sequence seq) {
+      final var operations = new ArrayList<OperationDefinition>();
+      for (Group group : seq.groups) {
+        operations.addAll(group.accept(this));
+      }
+      return operations;
+    }
+
+    @Override
+    public List<OperationDefinition> visit(Group.Alternative alt) {
+      final var operations = new ArrayList<OperationDefinition>();
+      for (Group.Sequence sequence : alt.sequences) {
+        operations.addAll(sequence.accept(this));
+      }
+      return operations;
+    }
+
+    @Override
+    public List<OperationDefinition> visit(Group.Permutation perm) {
+      final var operations = new ArrayList<OperationDefinition>();
+      for (Group.Sequence sequence : perm.sequences) {
+        operations.addAll(sequence.accept(this));
+      }
+      return operations;
+    }
+
+    @Override
+    public List<OperationDefinition> visit(Group.Literal lit) {
+      return List.of(lit.getOperation());
+    }
+
+  }
+
+  /**
+   * Determine the maximum length of a group expression, i.e., the maximum number of literals that
+   * can be matched by the group.
+   */
+  class GroupExprLengthCollector implements Group.GroupVisitor<Integer> {
+
+    private final ConstantEvaluator constantEvaluator;
+
+    private GroupExprLengthCollector(ConstantEvaluator constantEvaluator) {
+      this.constantEvaluator = constantEvaluator;
+    }
+
+    static int maxLength(ConstantEvaluator constantEvaluator, Group group) {
+      return group.accept(new GroupExprLengthCollector(constantEvaluator));
+    }
+
+    @Override
+    public Integer visit(Group.Sequence seq) {
+      int len = 0;
+      for (Group group : seq.groups) {
+        len += group.accept(this);
+      }
+      return len;
+    }
+
+    @Override
+    public Integer visit(Group.Alternative alt) {
+      int len = 0;
+      for (Group.Sequence seq : alt.sequences) {
+        len = Math.max(len, seq.accept(this));
+      }
+      return len;
+    }
+
+    @Override
+    public Integer visit(Group.Permutation perm) {
+      int len = 0;
+      for (Group.Sequence seq : perm.sequences) {
+        len += seq.accept(this);
+      }
+      return len;
+    }
+
+    @Override
+    public Integer visit(Group.Literal lit) {
+      if (!(lit.size instanceof RangeExpr range)) {
+        return 1;
+      }
+      final var constant = constantEvaluator.eval(range.to);
+      return constant.value().intValueExact();
+    }
+
+  }
+}

--- a/vadl-frontend/main/vadl/ast/PseudoFormatType.java
+++ b/vadl-frontend/main/vadl/ast/PseudoFormatType.java
@@ -181,7 +181,7 @@ public class PseudoFormatType extends StructType {
 
   @Override
   public String toString() {
-    StringBuilder sb = new StringBuilder();
+    StringBuilder sb = new StringBuilder("PseudoFormat<");
     boolean first = true;
     for (Map.Entry<String, Type> field : fields().entrySet()) {
       if (!first) {
@@ -192,6 +192,7 @@ public class PseudoFormatType extends StructType {
       sb.append(": ");
       sb.append(field.getValue());
     }
+    sb.append(">");
     return sb.toString();
   }
 }

--- a/vadl-frontend/main/vadl/ast/TypeChecker.java
+++ b/vadl-frontend/main/vadl/ast/TypeChecker.java
@@ -4062,7 +4062,15 @@ public class TypeChecker
               .locationDescription(indexExpr, "Groups cannot be sliced.")
               .build());
         }
-        check(indexExpr);
+
+        final Type lenType = currGroupType.lengthType();
+        Type indexType = checkWith(indexExpr, lenType);
+
+        if (!indexType.equals(lenType) && canImplicitCast(indexType, lenType)) {
+          indexExpr = new CastExpr(indexExpr, lenType);
+          slice.values = List.of(indexExpr);
+          indexType = lenType;
+        }
 
         if (constantEvaluator.isConstant(indexExpr)
             && expr.path().target() instanceof GroupDefinition group) {

--- a/vadl-frontend/main/vadl/ast/TypeChecker.java
+++ b/vadl-frontend/main/vadl/ast/TypeChecker.java
@@ -17,6 +17,7 @@
 package vadl.ast;
 
 import static java.util.Objects.requireNonNull;
+import static vadl.ast.GroupDefUtils.GroupExprBitLengthCollector.maxBitLength;
 import static vadl.ast.GroupDefUtils.GroupExprLengthCollector.maxLength;
 import static vadl.error.Diagnostic.error;
 import static vadl.error.Diagnostic.warning;
@@ -3348,7 +3349,10 @@ public class TypeChecker
       final int maxLength = maxLength(constantEvaluator, group.expr());
       final var lengthType = UIntType.minimalTypeFor(maxLength);
 
-      expr.type = Type.array(elemType, lengthType);
+      final int maxBitLength = maxBitLength(constantEvaluator, group.expr());
+      final var bitLengthType = UIntType.minimalTypeFor(maxBitLength);
+
+      expr.type = Type.array(elemType, lengthType, bitLengthType);
       return;
     }
 
@@ -4203,10 +4207,10 @@ public class TypeChecker
 
         expr.type = output.get().type();
       } else if (type instanceof ArrayType arrayType) {
-        if (!fieldName.equals("length")) {
+        if (!fieldName.equals("length") && !fieldName.equals("bitLength")) {
           throw addErrorAndStopChecking(
               error("Unknown array access `%s`".formatted(fieldName), expr)
-                  .description("Arrays only have the field `length`").build());
+                  .description("Arrays only have the fields `length` or `bitLength`").build());
         }
         if (!subCall.argsIndices.isEmpty()) {
           throw addErrorAndStopChecking(
@@ -4215,7 +4219,13 @@ public class TypeChecker
                   .description("This subcall doesn't take any arguments.")
                   .build());
         }
-        expr.type = arrayType.lengthType();
+
+        expr.type = switch (fieldName) {
+          case "length" -> arrayType.lengthType();
+          case "bitLength" -> arrayType.bitLengthType();
+          default ->
+              throw new IllegalArgumentException("Unknown array field: `%s`".formatted(fieldName));
+        };
       } else {
         throw addErrorAndStopChecking(error("Cannot resolve `%s`".formatted(fieldName), expr)
             .description("No subcall `%s` exists for the type `%s`",

--- a/vadl-frontend/main/vadl/ast/TypeChecker.java
+++ b/vadl-frontend/main/vadl/ast/TypeChecker.java
@@ -3344,6 +3344,15 @@ public class TypeChecker
     if (origin instanceof GroupDefinition group) {
       check(group);
 
+      var def = getCurrentlyVisitingDefinition();
+      if (!(def instanceof AnnotationDefinition annotation)
+          || !(annotation.target instanceof GroupDefinition)) {
+        final var diagnostic = error("Invalid Reference", expr)
+            .description(
+                "Reference to a `group` definition is only allowed within its annotations.");
+        addErrorAndContinueChecking(diagnostic.build());
+      }
+
       final var elemType = PseudoFormatType.of(group.operations());
 
       final int maxLength = maxLength(constantEvaluator, group.expr());
@@ -4047,6 +4056,21 @@ public class TypeChecker
               .build());
         }
         check(indexExpr);
+
+        if (constantEvaluator.isConstant(indexExpr)
+            && expr.path().target() instanceof GroupDefinition group) {
+
+          final var idx = constantEvaluator.eval(indexExpr);
+          final var maxLen = maxLength(constantEvaluator, group.expr());
+
+          if (idx.value().intValueExact() > maxLen - 1) {
+            addErrorAndContinueChecking(error("Index Out Of Bounds", indexExpr)
+                .locationDescription(indexExpr,
+                    "Index is out of bounds for maximal length of `%d`.", maxLen)
+                .build());
+          }
+
+        }
 
         currType = currArrayType.elementType();
         expr.type = currType;

--- a/vadl-frontend/main/vadl/ast/TypeChecker.java
+++ b/vadl-frontend/main/vadl/ast/TypeChecker.java
@@ -17,6 +17,7 @@
 package vadl.ast;
 
 import static java.util.Objects.requireNonNull;
+import static vadl.ast.GroupDefUtils.GroupExprLengthCollector.maxLength;
 import static vadl.error.Diagnostic.error;
 import static vadl.error.Diagnostic.warning;
 
@@ -32,6 +33,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
@@ -166,6 +168,7 @@ import vadl.ast.nodes.WildcardLiteral;
 import vadl.error.DeferredDiagnosticStore;
 import vadl.error.Diagnostic;
 import vadl.error.DiagnosticList;
+import vadl.types.ArrayType;
 import vadl.types.BitsType;
 import vadl.types.BoolType;
 import vadl.types.BuiltInTable;
@@ -426,8 +429,8 @@ public class TypeChecker
       String message = "This %s is defined by itself.".formatted(def.nodeName());
       if (def instanceof IdentifiableNode identifiableNode) {
         message = "This %s `%s` is defined by itself.".formatted(
-                def.nodeName(),
-                identifiableNode.identifier().name);
+            def.nodeName(),
+            identifiableNode.identifier().name);
       }
 
       throw addErrorAndAbortChecking(error("Infinite Recursion", def)
@@ -974,7 +977,7 @@ public class TypeChecker
   }
 
   private BuiltInCheckResult unCachedCheckBuiltin(BuiltInTable.BuiltIn builtIn, List<Expr> args,
-                                          WithLocation location) {
+                                                  WithLocation location) {
     if (!(args.size() == builtIn.argTypeClasses().size() || (builtIn.signature().hasVarArgs()
         && args.size() >= builtIn.argTypeClasses().size()))) {
       throw addErrorAndStopChecking(
@@ -3337,6 +3340,18 @@ public class TypeChecker
       return;
     }
 
+    if (origin instanceof GroupDefinition group) {
+      check(group);
+
+      final var elemType = PseudoFormatType.of(group.operations());
+
+      final int maxLength = maxLength(constantEvaluator, group.expr());
+      final var lengthType = UIntType.minimalTypeFor(maxLength);
+
+      expr.type = Type.array(elemType, lengthType);
+      return;
+    }
+
     if (origin != null) {
       // It's not a builtin but we don't handle it yet.
       // We might be here from a call expr and it might be necessary to handle the call for another
@@ -3641,8 +3656,8 @@ public class TypeChecker
    *                              constructing them was expensive.
    */
   private ParsedTypeLiteralResult internalParseTypeLiteral(TypeLiteral expr,
-                                                            @Nullable Integer preferredBitWidth,
-                                                                      boolean skipErrorConstruction
+                                                           @Nullable Integer preferredBitWidth,
+                                                           boolean skipErrorConstruction
   ) {
     var base = expr.baseType.pathToString();
 
@@ -3661,9 +3676,9 @@ public class TypeChecker
 
       return ParsedTypeLiteralResult.error(skipErrorConstruction ? null :
           error("Unknown Type `%s`".formatted(base), expr)
-              .locationDescription(expr, "No type with that name exists.")
-              .suggestions(suggestions)
-              .build());
+          .locationDescription(expr, "No type with that name exists.")
+          .suggestions(suggestions)
+          .build());
     }
 
     // 2. Calculate the sizes
@@ -3703,9 +3718,9 @@ public class TypeChecker
       if (!sizes.isEmpty()) {
         return ParsedTypeLiteralResult.error(skipErrorConstruction ? null :
             error("Invalid Type Notation", expr.location())
-                .description("The `%s` type doesn't use the size notation.", base)
-                .help("Try removing the size parameter here.")
-                .build());
+            .description("The `%s` type doesn't use the size notation.", base)
+            .help("Try removing the size parameter here.")
+            .build());
       }
       return ParsedTypeLiteralResult.success(unSizedBuiltins.get(base).get());
     }
@@ -3720,12 +3735,12 @@ public class TypeChecker
       if (sizes.isEmpty()) {
         return ParsedTypeLiteralResult.error(skipErrorConstruction ? null :
             error("Invalid Type Notation", expr.location())
-                .description(
-                    "Unsized `%s` can only be used in special places when it's obvious what the bit"
-                        + " width should be.",
-                    base)
-                .help("Try adding a size parameter here.")
-                .build());
+            .description(
+                "Unsized `%s` can only be used in special places when it's obvious what the bit"
+                + " width should be.",
+                base)
+            .help("Try adding a size parameter here.")
+            .build());
       }
 
       if (sizes.size() == 1) {
@@ -3761,8 +3776,9 @@ public class TypeChecker
 
     return ParsedTypeLiteralResult.error(
         skipErrorConstruction ? null : error("Invalid Tensor Type", expr)
-            .locationDescription(expr, "You can only create tensors from data types.")
-            .build());
+                                       .locationDescription(expr,
+                                           "You can only create tensors from data types.")
+                                       .build());
   }
 
   @Override
@@ -3889,17 +3905,18 @@ public class TypeChecker
       return;
     }
 
-    var lastSlice = sliceGroups.getLast();
-
-    if (!(typeBeforeSlice instanceof BitsType) && !(typeBeforeSlice instanceof TensorType)) {
-      var loc = expr.target.location().join(lastSlice.location);
-      addErrorAndStopChecking(error("Type Mismatch", loc)
-          .description("Only bit types can be sliced but the target was a `%s`", typeBeforeSlice)
-          .build());
-    }
-
     Type currType = typeBeforeSlice;
+    SourceLocation targetLoc = expr.location();
     for (var slice : sliceGroups) {
+
+      if (!(currType instanceof BitsType) && !(currType instanceof TensorType)
+          && !(currType instanceof ArrayType)) {
+        var loc = expr.target.location().join(targetLoc.location());
+        throw addErrorAndStopChecking(error("Type Mismatch", loc)
+            .description("Type `%s` cannot be indexed or sliced", currType)
+            .build());
+      }
+
       if (currType instanceof BitsType currBitsType) {
         // construct BitSlice for each slice group
         var parts = new ArrayList<Constant.BitSlice.Part>();
@@ -3911,7 +3928,7 @@ public class TypeChecker
           parts.add(part);
         }
 
-        var hasDynamicSlice = parts.stream().anyMatch(p -> p == null);
+        var hasDynamicSlice = parts.stream().anyMatch(Objects::isNull);
         if (hasDynamicSlice) {
           // FIXME: Implement this
           // Dynamic slices cannot be stacked because of a VIAM constraint
@@ -4010,6 +4027,28 @@ public class TypeChecker
           slice.type = currType;
         }
       }
+      if (currType instanceof ArrayType currArrayType) {
+        if (slice.values.size() != 1) {
+          var loc = slice.values.getFirst().location()
+              .join(slice.values.getLast().location());
+          throw addErrorAndStopChecking(error("Invalid Array Indexing", loc)
+              .locationDescription(loc, "Indexing arrays only allows one argument.")
+              .build());
+        }
+
+        var indexExpr = slice.values.getFirst();
+        if (indexExpr instanceof RangeExpr) {
+          throw addErrorAndStopChecking(error("Invalid Array Indexing", indexExpr)
+              .locationDescription(indexExpr, "Arrays cannot be sliced.")
+              .build());
+        }
+        check(indexExpr);
+
+        currType = currArrayType.elementType();
+        expr.type = currType;
+      }
+
+      targetLoc = slice.location;
     }
   }
 
@@ -4163,8 +4202,22 @@ public class TypeChecker
         }
 
         expr.type = output.get().type();
+      } else if (type instanceof ArrayType arrayType) {
+        if (!fieldName.equals("length")) {
+          throw addErrorAndStopChecking(
+              error("Unknown array access `%s`".formatted(fieldName), expr)
+                  .description("Arrays only have the field `length`").build());
+        }
+        if (!subCall.argsIndices.isEmpty()) {
+          throw addErrorAndStopChecking(
+              error("Wrong Argument Number",
+                  SourceLocation.join(subCall.argsIndices.stream().map(a -> a.location).toList()))
+                  .description("This subcall doesn't take any arguments.")
+                  .build());
+        }
+        expr.type = arrayType.lengthType();
       } else {
-        addErrorAndStopChecking(error("Cannot resolve `%s`".formatted(fieldName), expr)
+        throw addErrorAndStopChecking(error("Cannot resolve `%s`".formatted(fieldName), expr)
             .description("No subcall `%s` exists for the type `%s`",
                 fieldName,
                 requireNonNull(type))

--- a/vadl-frontend/main/vadl/ast/TypeChecker.java
+++ b/vadl-frontend/main/vadl/ast/TypeChecker.java
@@ -169,13 +169,13 @@ import vadl.ast.nodes.WildcardLiteral;
 import vadl.error.DeferredDiagnosticStore;
 import vadl.error.Diagnostic;
 import vadl.error.DiagnosticList;
-import vadl.types.ArrayType;
 import vadl.types.BitsType;
 import vadl.types.BoolType;
 import vadl.types.BuiltInTable;
 import vadl.types.ConcreteRelationType;
 import vadl.types.DataType;
 import vadl.types.FetchResultType;
+import vadl.types.GroupType;
 import vadl.types.InstructionType;
 import vadl.types.MicroArchitectureType;
 import vadl.types.SIntType;
@@ -478,6 +478,13 @@ public class TypeChecker
     if (!checker.errors.isEmpty()) {
       throw new DiagnosticList(checker.errors);
     }
+  }
+
+  /**
+   * Return current state of recoverable errors.
+   */
+  public List<Diagnostic> getErrors() {
+    return errors;
   }
 
   /**
@@ -3361,7 +3368,7 @@ public class TypeChecker
       final int maxBitLength = maxBitLength(constantEvaluator, group.expr());
       final var bitLengthType = UIntType.minimalTypeFor(maxBitLength);
 
-      expr.type = Type.array(elemType, lengthType, bitLengthType);
+      expr.type = Type.group(elemType, lengthType, bitLengthType);
       return;
     }
 
@@ -3919,14 +3926,14 @@ public class TypeChecker
     }
 
     Type currType = typeBeforeSlice;
-    SourceLocation targetLoc = expr.location();
+    SourceLocation targetLoc = null;
     for (var slice : sliceGroups) {
 
       if (!(currType instanceof BitsType) && !(currType instanceof TensorType)
-          && !(currType instanceof ArrayType)) {
-        var loc = expr.target.location().join(targetLoc.location());
+          && !(currType instanceof GroupType)) {
+        var loc = expr.target.location().join(targetLoc != null ? targetLoc : expr.location());
         throw addErrorAndStopChecking(error("Type Mismatch", loc)
-            .description("Type `%s` cannot be indexed or sliced", currType)
+            .description("Type `%s` cannot be indexed or sliced", currType.name())
             .build());
       }
 
@@ -4040,19 +4047,19 @@ public class TypeChecker
           slice.type = currType;
         }
       }
-      if (currType instanceof ArrayType currArrayType) {
+      if (currType instanceof GroupType currGroupType) {
         if (slice.values.size() != 1) {
           var loc = slice.values.getFirst().location()
               .join(slice.values.getLast().location());
-          throw addErrorAndStopChecking(error("Invalid Array Indexing", loc)
-              .locationDescription(loc, "Indexing arrays only allows one argument.")
+          throw addErrorAndStopChecking(error("Invalid Group Indexing", loc)
+              .locationDescription(loc, "Indexing groups only allows one argument.")
               .build());
         }
 
         var indexExpr = slice.values.getFirst();
         if (indexExpr instanceof RangeExpr) {
-          throw addErrorAndStopChecking(error("Invalid Array Indexing", indexExpr)
-              .locationDescription(indexExpr, "Arrays cannot be sliced.")
+          throw addErrorAndStopChecking(error("Invalid Group Indexing", indexExpr)
+              .locationDescription(indexExpr, "Groups cannot be sliced.")
               .build());
         }
         check(indexExpr);
@@ -4072,7 +4079,8 @@ public class TypeChecker
 
         }
 
-        currType = currArrayType.elementType();
+        currType = currGroupType.elementType();
+        slice.type = currType;
         expr.type = currType;
       }
 
@@ -4230,11 +4238,11 @@ public class TypeChecker
         }
 
         expr.type = output.get().type();
-      } else if (type instanceof ArrayType arrayType) {
+      } else if (type instanceof GroupType groupType) {
         if (!fieldName.equals("length") && !fieldName.equals("bitLength")) {
           throw addErrorAndStopChecking(
-              error("Unknown array access `%s`".formatted(fieldName), expr)
-                  .description("Arrays only have the fields `length` or `bitLength`").build());
+              error("Unknown group access `%s`".formatted(fieldName), expr)
+                  .description("Groups only have the fields `length` or `bitLength`").build());
         }
         if (!subCall.argsIndices.isEmpty()) {
           throw addErrorAndStopChecking(
@@ -4245,10 +4253,10 @@ public class TypeChecker
         }
 
         expr.type = switch (fieldName) {
-          case "length" -> arrayType.lengthType();
-          case "bitLength" -> arrayType.bitLengthType();
+          case "length" -> groupType.lengthType();
+          case "bitLength" -> groupType.bitLengthType();
           default ->
-              throw new IllegalArgumentException("Unknown array field: `%s`".formatted(fieldName));
+              throw new IllegalArgumentException("Unknown group field: `%s`".formatted(fieldName));
         };
       } else {
         throw addErrorAndStopChecking(error("Cannot resolve `%s`".formatted(fieldName), expr)

--- a/vadl-frontend/main/vadl/ast/nodes/GroupDefinition.java
+++ b/vadl-frontend/main/vadl/ast/nodes/GroupDefinition.java
@@ -16,8 +16,10 @@
 
 package vadl.ast.nodes;
 
+import java.util.List;
 import java.util.Objects;
 import javax.annotation.Nullable;
+import vadl.ast.GroupDefUtils;
 import vadl.javaannotations.ast.Child;
 import vadl.utils.SourceLocation;
 
@@ -32,7 +34,7 @@ public class GroupDefinition extends Definition implements IdentifiableNode {
   public SourceLocation loc;
 
   public GroupDefinition(IdentifierOrPlaceholder name, @Nullable TypeLiteral type,
-                  Group.Sequence groupSequence, SourceLocation loc) {
+                         Group.Sequence groupSequence, SourceLocation loc) {
     this.name = name;
     this.type = type;
     this.groupSequence = groupSequence;
@@ -69,6 +71,14 @@ public class GroupDefinition extends Definition implements IdentifiableNode {
     builder.append("\n");
   }
 
+  public Group expr() {
+    return groupSequence;
+  }
+
+  public List<OperationDefinition> operations() {
+    return GroupDefUtils.OperationCollector.operations(groupSequence);
+  }
+  
   @Override
   public <R> R accept(DefinitionVisitor<R> visitor) {
     return visitor.visit(this);

--- a/vadl-frontend/test/resources/frontend-snapshots/lowering/groupDefinition.vadl
+++ b/vadl-frontend/test/resources/frontend-snapshots/lowering/groupDefinition.vadl
@@ -19,6 +19,7 @@ instruction set architecture ISA = {
   operation O2 = {A,B}
 
   [stop : exists i in {O1}, j in {O2} then i = j]
+  [assert : VLIW(0).opcode = 0b0]
   [assert : VLIW(VLIW.length - 1).opcode != 0b01]
   [assert : forall i in {O1, O2} then i.opcode(7..4,2) = 0b10101]
   group VLIW = ({O1,O2}|O1<2..5>)

--- a/vadl-frontend/test/resources/frontend-snapshots/lowering/groupDefinition.vadl
+++ b/vadl-frontend/test/resources/frontend-snapshots/lowering/groupDefinition.vadl
@@ -19,6 +19,7 @@ instruction set architecture ISA = {
   operation O2 = {A,B}
 
   [stop : exists i in {O1}, j in {O2} then i = j]
+  [assert : VLIW(VLIW.length - 1).opcode != 0b01]
   [assert : forall i in {O1, O2} then i.opcode(7..4,2) = 0b10101]
   group VLIW = ({O1,O2}|O1<2..5>)
 }

--- a/vadl-frontend/test/resources/frontend-snapshots/typechecker/invalidGroupArrayIndexOutOfBounds.vadl
+++ b/vadl-frontend/test/resources/frontend-snapshots/typechecker/invalidGroupArrayIndexOutOfBounds.vadl
@@ -1,0 +1,42 @@
+instruction set architecture ISA = {
+  program counter PC : Bits<32>
+
+  format AType : Bits<32> = {
+    a : Bits<20>,
+    b : Bits<5>,
+    c : Bits<7>
+  }
+
+  format BType : Bits<32> = {
+    a : Bits<20>,
+    b : Bits<5>,
+    d : Bits<7>
+  }
+
+  instruction A : AType = PC := 0
+  encoding A = {a = 0b00}
+  assembly A = (mnemonic, "")
+
+  instruction B : BType = PC := 0
+  encoding B = {a = 0b01}
+  assembly B = (mnemonic, "")
+
+  operation OpA = {A}
+  operation OpB = {B}
+
+  [assert : VLIW(2).a = 0b0]
+  group VLIW = OpA.OpB
+}
+
+
+//  Reported Diagnostics:
+//
+//  error: Index Out Of Bounds
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidGroupArrayIndexOutOfBounds.vadl:27:18
+//       │
+//    27 │   [assert : VLIW(2).a = 0b0]
+//       │                  ^ Index is out of bounds for maximal length of `2`.
+//       │
+//
+//
+// Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl-frontend/test/resources/frontend-snapshots/typechecker/invalidGroupArrayMultiArgs.vadl
+++ b/vadl-frontend/test/resources/frontend-snapshots/typechecker/invalidGroupArrayMultiArgs.vadl
@@ -31,20 +31,12 @@ instruction set architecture ISA = {
 
 //  Reported Diagnostics:
 //
-//  error: Invalid Array Indexing
+//  error: Invalid Group Indexing
 //       ╭── test/resources/frontend-snapshots/typechecker/invalidGroupArrayMultiArgs.vadl:27:18
 //       │
 //    27 │   [assert : VLIW(1,0).a = 0b0]
-//       │                  ^^^ Indexing arrays only allows one argument.
+//       │                  ^^^ Indexing groups only allows one argument.
 //       │
-//
-//  error: Invalid annotation expression
-//       ╭── test/resources/frontend-snapshots/typechecker/invalidGroupArrayMultiArgs.vadl:27:13
-//       │
-//    27 │   [assert : VLIW(1,0).a = 0b0]
-//       │             ^^^^^^^^^^^^^^^^^ Unable to determine type
-//       │
-//       help: Check additional errors which may have caused the type to be missing
 //
 //
 // Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl-frontend/test/resources/frontend-snapshots/typechecker/invalidGroupArrayMultiArgs.vadl
+++ b/vadl-frontend/test/resources/frontend-snapshots/typechecker/invalidGroupArrayMultiArgs.vadl
@@ -1,0 +1,50 @@
+instruction set architecture ISA = {
+  program counter PC : Bits<32>
+
+  format AType : Bits<32> = {
+    a : Bits<20>,
+    b : Bits<5>,
+    c : Bits<7>
+  }
+
+  format BType : Bits<32> = {
+    a : Bits<20>,
+    b : Bits<5>,
+    d : Bits<7>
+  }
+
+  instruction A : AType = PC := 0
+  encoding A = {a = 0b00}
+  assembly A = (mnemonic, "")
+
+  instruction B : BType = PC := 0
+  encoding B = {a = 0b01}
+  assembly B = (mnemonic, "")
+
+  operation OpA = {A}
+  operation OpB = {B}
+
+  [assert : VLIW(1,0).a = 0b0]
+  group VLIW = OpA.OpB
+}
+
+
+//  Reported Diagnostics:
+//
+//  error: Invalid Array Indexing
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidGroupArrayMultiArgs.vadl:27:18
+//       │
+//    27 │   [assert : VLIW(1,0).a = 0b0]
+//       │                  ^^^ Indexing arrays only allows one argument.
+//       │
+//
+//  error: Invalid annotation expression
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidGroupArrayMultiArgs.vadl:27:13
+//       │
+//    27 │   [assert : VLIW(1,0).a = 0b0]
+//       │             ^^^^^^^^^^^^^^^^^ Unable to determine type
+//       │
+//       help: Check additional errors which may have caused the type to be missing
+//
+//
+// Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl-frontend/test/resources/frontend-snapshots/typechecker/invalidGroupArrayMultiIndex.vadl
+++ b/vadl-frontend/test/resources/frontend-snapshots/typechecker/invalidGroupArrayMultiIndex.vadl
@@ -1,0 +1,51 @@
+instruction set architecture ISA = {
+  program counter PC : Bits<32>
+
+  format AType : Bits<32> = {
+    a : Bits<20>,
+    b : Bits<5>,
+    c : Bits<7>
+  }
+
+  format BType : Bits<32> = {
+    a : Bits<20>,
+    b : Bits<5>,
+    d : Bits<7>
+  }
+
+  instruction A : AType = PC := 0
+  encoding A = {a = 0b00}
+  assembly A = (mnemonic, "")
+
+  instruction B : BType = PC := 0
+  encoding B = {a = 0b01}
+  assembly B = (mnemonic, "")
+
+  operation OpA = {A}
+  operation OpB = {B}
+
+  [assert : VLIW(1)(2).a = 0b0]
+  group VLIW = OpA.OpB
+}
+
+
+//  Reported Diagnostics:
+//
+//  error: Type Mismatch
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidGroupArrayMultiIndex.vadl:27:13
+//       │
+//    27 │   [assert : VLIW(1)(2).a = 0b0]
+//       │             ^^^^^^^
+//       │
+//       Type `a: Bits<20>, b: Bits<5>` cannot be indexed or sliced
+//
+//  error: Invalid annotation expression
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidGroupArrayMultiIndex.vadl:27:13
+//       │
+//    27 │   [assert : VLIW(1)(2).a = 0b0]
+//       │             ^^^^^^^^^^^^^^^^^^ Unable to determine type
+//       │
+//       help: Check additional errors which may have caused the type to be missing
+//
+//
+// Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl-frontend/test/resources/frontend-snapshots/typechecker/invalidGroupArrayMultiIndex.vadl
+++ b/vadl-frontend/test/resources/frontend-snapshots/typechecker/invalidGroupArrayMultiIndex.vadl
@@ -37,15 +37,7 @@ instruction set architecture ISA = {
 //    27 │   [assert : VLIW(1)(2).a = 0b0]
 //       │             ^^^^^^^
 //       │
-//       Type `a: Bits<20>, b: Bits<5>` cannot be indexed or sliced
-//
-//  error: Invalid annotation expression
-//       ╭── test/resources/frontend-snapshots/typechecker/invalidGroupArrayMultiIndex.vadl:27:13
-//       │
-//    27 │   [assert : VLIW(1)(2).a = 0b0]
-//       │             ^^^^^^^^^^^^^^^^^^ Unable to determine type
-//       │
-//       help: Check additional errors which may have caused the type to be missing
+//       Type `(AType ∩ BType)` cannot be indexed or sliced
 //
 //
 // Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl-frontend/test/resources/frontend-snapshots/typechecker/invalidGroupArraySlicing.vadl
+++ b/vadl-frontend/test/resources/frontend-snapshots/typechecker/invalidGroupArraySlicing.vadl
@@ -1,0 +1,50 @@
+instruction set architecture ISA = {
+  program counter PC : Bits<32>
+
+  format AType : Bits<32> = {
+    a : Bits<20>,
+    b : Bits<5>,
+    c : Bits<7>
+  }
+
+  format BType : Bits<32> = {
+    a : Bits<20>,
+    b : Bits<5>,
+    d : Bits<7>
+  }
+
+  instruction A : AType = PC := 0
+  encoding A = {a = 0b00}
+  assembly A = (mnemonic, "")
+
+  instruction B : BType = PC := 0
+  encoding B = {a = 0b01}
+  assembly B = (mnemonic, "")
+
+  operation OpA = {A}
+  operation OpB = {B}
+
+  [assert : VLIW(2..1).a = 0b0]
+  group VLIW = OpA.OpB
+}
+
+
+//  Reported Diagnostics:
+//
+//  error: Invalid Array Indexing
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidGroupArraySlicing.vadl:27:18
+//       │
+//    27 │   [assert : VLIW(2..1).a = 0b0]
+//       │                  ^^^^ Arrays cannot be sliced.
+//       │
+//
+//  error: Invalid annotation expression
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidGroupArraySlicing.vadl:27:13
+//       │
+//    27 │   [assert : VLIW(2..1).a = 0b0]
+//       │             ^^^^^^^^^^^^^^^^^^ Unable to determine type
+//       │
+//       help: Check additional errors which may have caused the type to be missing
+//
+//
+// Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl-frontend/test/resources/frontend-snapshots/typechecker/invalidGroupArraySlicing.vadl
+++ b/vadl-frontend/test/resources/frontend-snapshots/typechecker/invalidGroupArraySlicing.vadl
@@ -31,20 +31,12 @@ instruction set architecture ISA = {
 
 //  Reported Diagnostics:
 //
-//  error: Invalid Array Indexing
+//  error: Invalid Group Indexing
 //       ╭── test/resources/frontend-snapshots/typechecker/invalidGroupArraySlicing.vadl:27:18
 //       │
 //    27 │   [assert : VLIW(2..1).a = 0b0]
-//       │                  ^^^^ Arrays cannot be sliced.
+//       │                  ^^^^ Groups cannot be sliced.
 //       │
-//
-//  error: Invalid annotation expression
-//       ╭── test/resources/frontend-snapshots/typechecker/invalidGroupArraySlicing.vadl:27:13
-//       │
-//    27 │   [assert : VLIW(2..1).a = 0b0]
-//       │             ^^^^^^^^^^^^^^^^^^ Unable to determine type
-//       │
-//       help: Check additional errors which may have caused the type to be missing
 //
 //
 // Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl-frontend/test/resources/frontend-snapshots/typechecker/invalidGroupElemField.vadl
+++ b/vadl-frontend/test/resources/frontend-snapshots/typechecker/invalidGroupElemField.vadl
@@ -40,13 +40,5 @@ instruction set architecture ISA = {
 //       Intersection format `(AType ∩ BType)` doesn't have any field with this name
 //       help: Did you maybe mean one of: a, b
 //
-//  error: Invalid annotation expression
-//       ╭── test/resources/frontend-snapshots/typechecker/invalidGroupElemField.vadl:27:13
-//       │
-//    27 │   [assert : VLIW(0).c = 0b0]
-//       │             ^^^^^^^^^^^^^^^ Unable to determine type
-//       │
-//       help: Check additional errors which may have caused the type to be missing
-//
 //
 // Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl-frontend/test/resources/frontend-snapshots/typechecker/invalidGroupElemField.vadl
+++ b/vadl-frontend/test/resources/frontend-snapshots/typechecker/invalidGroupElemField.vadl
@@ -1,0 +1,52 @@
+instruction set architecture ISA = {
+  program counter PC : Bits<32>
+
+  format AType : Bits<32> = {
+    a : Bits<20>,
+    b : Bits<5>,
+    c : Bits<7>
+  }
+
+  format BType : Bits<32> = {
+    a : Bits<20>,
+    b : Bits<5>,
+    d : Bits<7>
+  }
+
+  instruction A : AType = PC := 0
+  encoding A = {a = 0b00}
+  assembly A = (mnemonic, "")
+
+  instruction B : BType = PC := 0
+  encoding B = {a = 0b01}
+  assembly B = (mnemonic, "")
+
+  operation OpA = {A}
+  operation OpB = {B}
+
+  [assert : VLIW(0).c = 0b0]
+  group VLIW = OpA.OpB
+}
+
+
+//  Reported Diagnostics:
+//
+//  error: Unknown format field `c`
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidGroupElemField.vadl:27:13
+//       │
+//    27 │   [assert : VLIW(0).c = 0b0]
+//       │             ^^^^^^^^^
+//       │
+//       Intersection format `(AType ∩ BType)` doesn't have any field with this name
+//       help: Did you maybe mean one of: a, b
+//
+//  error: Invalid annotation expression
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidGroupElemField.vadl:27:13
+//       │
+//    27 │   [assert : VLIW(0).c = 0b0]
+//       │             ^^^^^^^^^^^^^^^ Unable to determine type
+//       │
+//       help: Check additional errors which may have caused the type to be missing
+//
+//
+// Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl-frontend/test/resources/frontend-snapshots/typechecker/invalidGroupReference.vadl
+++ b/vadl-frontend/test/resources/frontend-snapshots/typechecker/invalidGroupReference.vadl
@@ -33,21 +33,13 @@ instruction set architecture ISA = {
 
 //  Reported Diagnostics:
 //
-//  error: Unknown array access `a`
+//  error: Unknown group access `a`
 //       ╭── test/resources/frontend-snapshots/typechecker/invalidGroupReference.vadl:27:13
 //       │
 //    27 │   [assert : VLIW.a = 0b0]
 //       │             ^^^^^^
 //       │
-//       Arrays only have the fields `length` or `bitLength`
-//
-//  error: Invalid annotation expression
-//       ╭── test/resources/frontend-snapshots/typechecker/invalidGroupReference.vadl:27:13
-//       │
-//    27 │   [assert : VLIW.a = 0b0]
-//       │             ^^^^^^^^^^^^ Unable to determine type
-//       │
-//       help: Check additional errors which may have caused the type to be missing
+//       Groups only have the fields `length` or `bitLength`
 //
 //
 // Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl-frontend/test/resources/frontend-snapshots/typechecker/invalidGroupReference.vadl
+++ b/vadl-frontend/test/resources/frontend-snapshots/typechecker/invalidGroupReference.vadl
@@ -1,0 +1,53 @@
+instruction set architecture ISA = {
+  program counter PC : Bits<32>
+
+  format AType : Bits<32> = {
+    a : Bits<20>,
+    b : Bits<5>,
+    c : Bits<7>
+  }
+
+  format BType : Bits<32> = {
+    a : Bits<20>,
+    b : Bits<5>,
+    d : Bits<7>
+  }
+
+  instruction A : AType = PC := 0
+  encoding A = {a = 0b00}
+  assembly A = (mnemonic, "")
+
+  instruction B : BType = PC := 0
+  encoding B = {a = 0b01}
+  assembly B = (mnemonic, "")
+
+  operation OpA = {A}
+  operation OpB = {B}
+
+  [assert : VLIW.a = 0b0]
+  [assert : VLIW.length = 0b0]
+  [assert : VLIW.bitLength = 0b0]
+  group VLIW = OpA.OpB
+}
+
+
+//  Reported Diagnostics:
+//
+//  error: Unknown array access `a`
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidGroupReference.vadl:27:13
+//       │
+//    27 │   [assert : VLIW.a = 0b0]
+//       │             ^^^^^^
+//       │
+//       Arrays only have the fields `length` or `bitLength`
+//
+//  error: Invalid annotation expression
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidGroupReference.vadl:27:13
+//       │
+//    27 │   [assert : VLIW.a = 0b0]
+//       │             ^^^^^^^^^^^^ Unable to determine type
+//       │
+//       help: Check additional errors which may have caused the type to be missing
+//
+//
+// Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl-frontend/test/vadl/ast/ExceptionTest.java
+++ b/vadl-frontend/test/vadl/ast/ExceptionTest.java
@@ -88,7 +88,7 @@ public class ExceptionTest {
     var diagnostics = assertThrows(DiagnosticList.class, () -> TypeChecker.verify(ast));
     Assertions.assertEquals(1, diagnostics.items.size());
     org.assertj.core.api.Assertions.assertThat(diagnostics.items.getFirst().getMessage())
-        .contains("Only bit types can be sliced but the target was a `void`");
+        .contains("Type `void` cannot be indexed or sliced");
   }
 
   @Test

--- a/vadl/main/vadl/cppCodeGen/FunctionCodeGenerator.java
+++ b/vadl/main/vadl/cppCodeGen/FunctionCodeGenerator.java
@@ -33,6 +33,7 @@ import vadl.viam.graph.dependency.ExpressionNode;
 import vadl.viam.graph.dependency.FieldAccessRefNode;
 import vadl.viam.graph.dependency.FieldRefNode;
 import vadl.viam.graph.dependency.FoldNode;
+import vadl.viam.graph.dependency.GroupRef;
 import vadl.viam.graph.dependency.OperationExistsNode;
 import vadl.viam.graph.dependency.OperationForAllNode;
 import vadl.viam.graph.dependency.ReadArtificialResNode;
@@ -106,6 +107,11 @@ public abstract class FunctionCodeGenerator extends AbstractFunctionCodeGenerato
   @Handler
   protected void handle(CGenContext<Node> ctx, OperationExistsNode toHandle) {
     throwNotAllowed(toHandle, "exists then expressions");
+  }
+
+  @Handler
+  protected void handle(CGenContext<Node> ctx, GroupRef toHandle) {
+    throwNotAllowed(toHandle, "group reference expressions");
   }
 
   public String genReturnExpression() {

--- a/vadl/main/vadl/error/DeferredDiagnosticStore.java
+++ b/vadl/main/vadl/error/DeferredDiagnosticStore.java
@@ -54,6 +54,13 @@ public class DeferredDiagnosticStore {
     return diagnosticList.stream().toList();
   }
 
+  /**
+   * Check whether the diagnostic store already contains an error.
+   */
+  public static boolean hasError() {
+    return diagnosticList.stream().anyMatch(d -> d.level == Diagnostic.Level.ERROR);
+  }
+
   public static boolean isEmpty() {
     return diagnosticList.isEmpty();
   }

--- a/vadl/main/vadl/gcb/passes/operands/GenerateInstructionOperandsPass.java
+++ b/vadl/main/vadl/gcb/passes/operands/GenerateInstructionOperandsPass.java
@@ -67,6 +67,7 @@ import vadl.viam.graph.dependency.FoldNode;
 import vadl.viam.graph.dependency.ForIdxNode;
 import vadl.viam.graph.dependency.FuncCallNode;
 import vadl.viam.graph.dependency.FuncParamNode;
+import vadl.viam.graph.dependency.GroupRef;
 import vadl.viam.graph.dependency.InstructionWidthNode;
 import vadl.viam.graph.dependency.LabelNode;
 import vadl.viam.graph.dependency.LetNode;
@@ -699,6 +700,10 @@ class PseudoNodeOperandCollector {
     throw Diagnostic.error("not supported", node.location()).build();
   }
 
+  @Handler
+  protected void handle(GroupRef node) {
+    throw Diagnostic.error("not supported", node.location()).build();
+  }
 
   @Handler
   protected void handle(LetNode node) {

--- a/vadl/main/vadl/iss/codegen/IssProcGen.java
+++ b/vadl/main/vadl/iss/codegen/IssProcGen.java
@@ -41,6 +41,7 @@ import vadl.viam.graph.dependency.FieldAccessRefNode;
 import vadl.viam.graph.dependency.FieldRefNode;
 import vadl.viam.graph.dependency.FoldNode;
 import vadl.viam.graph.dependency.ForIdxNode;
+import vadl.viam.graph.dependency.GroupRef;
 import vadl.viam.graph.dependency.LetNode;
 import vadl.viam.graph.dependency.OperationExistsNode;
 import vadl.viam.graph.dependency.OperationForAllNode;
@@ -221,6 +222,11 @@ abstract class IssProcGen implements CDefaultMixins.All,
   @Handler
   void handle(CGenContext<Node> ctx, OperationExistsNode toHandle) {
     throwNotAllowed(toHandle, "exists then expressions");
+  }
+
+  @Handler
+  void handle(CGenContext<Node> ctx, GroupRef toHandle) {
+    throwNotAllowed(toHandle, "group reference expressions");
   }
 
   private boolean shouldInlineExprSave(ExprSaveNode save) {

--- a/vadl/main/vadl/iss/codegen/IssTbStaticExpressionCodeGen.java
+++ b/vadl/main/vadl/iss/codegen/IssTbStaticExpressionCodeGen.java
@@ -34,6 +34,7 @@ import vadl.viam.graph.dependency.ExpressionNode;
 import vadl.viam.graph.dependency.FieldAccessRefNode;
 import vadl.viam.graph.dependency.FieldRefNode;
 import vadl.viam.graph.dependency.FoldNode;
+import vadl.viam.graph.dependency.GroupRef;
 import vadl.viam.graph.dependency.OperationExistsNode;
 import vadl.viam.graph.dependency.OperationForAllNode;
 import vadl.viam.graph.dependency.TensorNode;
@@ -147,5 +148,10 @@ public class IssTbStaticExpressionCodeGen implements
   @Handler
   void handle(CGenContext<Node> ctx, TensorNode toHandle) {
     throw new UnsupportedOperationException("Type TensorNode not allowed");
+  }
+
+  @Handler
+  void handle(CGenContext<Node> ctx, GroupRef toHandle) {
+    throw new UnsupportedOperationException("Type GroupRef not yet implemented");
   }
 }

--- a/vadl/main/vadl/iss/codegen/TcgTranslateGenerator.java
+++ b/vadl/main/vadl/iss/codegen/TcgTranslateGenerator.java
@@ -38,6 +38,7 @@ import vadl.viam.graph.dependency.AsmBuiltInCall;
 import vadl.viam.graph.dependency.FieldAccessRefNode;
 import vadl.viam.graph.dependency.FieldRefNode;
 import vadl.viam.graph.dependency.FoldNode;
+import vadl.viam.graph.dependency.GroupRef;
 import vadl.viam.graph.dependency.OperationExistsNode;
 import vadl.viam.graph.dependency.OperationForAllNode;
 
@@ -155,5 +156,10 @@ class TcgTranslateGenerator implements InstructionTranslateGenerator,
   @Handler
   void handle(CGenContext<Node> ctx, OperationExistsNode toHandle) {
     throwNotAllowed(toHandle, "exists then expressions");
+  }
+
+  @Handler
+  void handle(CGenContext<Node> ctx, GroupRef toHandle) {
+    throwNotAllowed(toHandle, "group reference expressions");
   }
 }

--- a/vadl/main/vadl/iss/passes/common/IssNormalizationPass.java
+++ b/vadl/main/vadl/iss/passes/common/IssNormalizationPass.java
@@ -22,7 +22,6 @@ import static vadl.utils.GraphUtils.add;
 import static vadl.utils.GraphUtils.bits;
 import static vadl.utils.GraphUtils.intU;
 import static vadl.utils.GraphUtils.intUNode;
-import static vadl.utils.GraphUtils.or;
 import static vadl.utils.GraphUtils.sub;
 import static vadl.utils.StreamUtils.only;
 
@@ -54,6 +53,7 @@ import vadl.pass.PassName;
 import vadl.pass.PassResults;
 import vadl.types.BitsType;
 import vadl.types.BuiltInTable;
+import vadl.types.DataType;
 import vadl.types.Type;
 import vadl.utils.GraphUtils;
 import vadl.utils.VadlBuiltInNoStatusDispatcher;
@@ -74,6 +74,7 @@ import vadl.viam.graph.dependency.FoldNode;
 import vadl.viam.graph.dependency.ForIdxNode;
 import vadl.viam.graph.dependency.FuncCallNode;
 import vadl.viam.graph.dependency.FuncParamNode;
+import vadl.viam.graph.dependency.GroupRef;
 import vadl.viam.graph.dependency.InstructionWidthNode;
 import vadl.viam.graph.dependency.LabelNode;
 import vadl.viam.graph.dependency.LetNode;
@@ -384,6 +385,9 @@ class IssNormalizer implements VadlBuiltInNoStatusDispatcher<BuiltInCall> {
             "DynSliceNode msb or lsb depends on a ResourceReadNode. "
                 + "This isn't handled by the ISS."));
 
+    node.ensure(node.type() instanceof DataType, "Dynamic slice nodes with type %s not supported",
+        node.type());
+
     var offset = node.lsb();
     var one = intUNode(1, offset.type().asDataType().bitWidth());
     // length = msb - lsb + 1
@@ -393,7 +397,7 @@ class IssNormalizer implements VadlBuiltInNoStatusDispatcher<BuiltInCall> {
             node.value(),
             offset,
             len,
-            node.type().toBitsType()
+            ((DataType) node.type()).toBitsType()
         )
     );
   }
@@ -897,6 +901,11 @@ class IssNormalizer implements VadlBuiltInNoStatusDispatcher<BuiltInCall> {
 
   @Handler
   void handle(OperationExistsNode toHandle) {
+    // do nothing
+  }
+
+  @Handler
+  void handle(GroupRef toHandle) {
     // do nothing
   }
 }

--- a/vadl/main/vadl/iss/passes/common/opDecomposition/Decomposer.java
+++ b/vadl/main/vadl/iss/passes/common/opDecomposition/Decomposer.java
@@ -52,6 +52,7 @@ import vadl.viam.graph.dependency.FoldNode;
 import vadl.viam.graph.dependency.ForIdxNode;
 import vadl.viam.graph.dependency.FuncCallNode;
 import vadl.viam.graph.dependency.FuncParamNode;
+import vadl.viam.graph.dependency.GroupRef;
 import vadl.viam.graph.dependency.InstructionWidthNode;
 import vadl.viam.graph.dependency.LabelNode;
 import vadl.viam.graph.dependency.LetNode;
@@ -641,6 +642,11 @@ class Decomposer
   @Handler
   void handle(Request rq, LabelNode toHandle) {
     throw new UnsupportedOperationException("Type LabelNode not yet implemented");
+  }
+
+  @Handler
+  void handle(Request rq, GroupRef toHandle) {
+    throw new UnsupportedOperationException("Type GroupRef not yet implemented");
   }
 
   @Handler

--- a/vadl/main/vadl/iss/passes/common/planning/analysis/VectorAnalysisSupport.java
+++ b/vadl/main/vadl/iss/passes/common/planning/analysis/VectorAnalysisSupport.java
@@ -33,6 +33,7 @@ import vadl.iss.passes.common.planning.analysis.VectorInstructionFacts.StorageFa
 import vadl.iss.passes.nodes.IssReadRegNode;
 import vadl.iss.passes.nodes.IssWriteRegNode;
 import vadl.types.BuiltInTable;
+import vadl.types.DataType;
 import vadl.viam.ArtificialResource;
 import vadl.viam.graph.Node;
 import vadl.viam.graph.dependency.BuiltInCall;
@@ -72,7 +73,8 @@ public final class VectorAnalysisSupport {
     if (!(expression instanceof DynSliceNode slice)
         || !(slice.value() instanceof IssReadRegNode read)
         || read.windowKind() != IssReadRegNode.WindowKind.FULL
-        || slice.type().bitWidth() != elementBits
+        || !(slice.type() instanceof DataType dataType)
+        || dataType.bitWidth() != elementBits
         || !isLoopElementOffset(slice.lsb(), idx, elementBits)
         || !isLaneUpperBound(slice.msb(), slice.lsb(), elementBits)) {
       return null;

--- a/vadl/main/vadl/iss/passes/tcg/lowering/TcgOpLoweringPass.java
+++ b/vadl/main/vadl/iss/passes/tcg/lowering/TcgOpLoweringPass.java
@@ -112,6 +112,7 @@ import vadl.viam.graph.dependency.DynSliceNode;
 import vadl.viam.graph.dependency.FoldNode;
 import vadl.viam.graph.dependency.ForIdxNode;
 import vadl.viam.graph.dependency.FuncCallNode;
+import vadl.viam.graph.dependency.GroupRef;
 import vadl.viam.graph.dependency.InstructionWidthNode;
 import vadl.viam.graph.dependency.LabelNode;
 import vadl.viam.graph.dependency.LetNode;
@@ -744,6 +745,10 @@ class TcgOpLoweringExecutor implements CfgTraverser {
     throw new UnsupportedOperationException("Type ExistsNode not supported");
   }
 
+  @Handler
+  void handle(GroupRef node) {
+    throw new UnsupportedOperationException("Type GroupRef not supported");
+  }
 
   /// / Nodes that are already considered lowered ////
 

--- a/vadl/main/vadl/lcb/codegen/assembly/AssemblyInstructionPrinterImmediateHandler.java
+++ b/vadl/main/vadl/lcb/codegen/assembly/AssemblyInstructionPrinterImmediateHandler.java
@@ -76,6 +76,7 @@ import vadl.viam.graph.dependency.FieldRefNode;
 import vadl.viam.graph.dependency.FoldNode;
 import vadl.viam.graph.dependency.ForIdxNode;
 import vadl.viam.graph.dependency.FuncParamNode;
+import vadl.viam.graph.dependency.GroupRef;
 import vadl.viam.graph.dependency.OperationExistsNode;
 import vadl.viam.graph.dependency.OperationForAllNode;
 import vadl.viam.graph.dependency.ProcCallNode;
@@ -464,6 +465,12 @@ public class AssemblyInstructionPrinterImmediateHandler
   @Handler
   @SuppressWarnings("MissingJavadocMethod")
   public void handle(CGenContext<Node> ctx, ReadSignalNode node) {
+    throw Diagnostic.error("not supported", node.location()).build();
+  }
+
+  @Handler
+  @SuppressWarnings("MissingJavadocMethod")
+  public void handle(CGenContext<Node> ctx, GroupRef node) {
     throw Diagnostic.error("not supported", node.location()).build();
   }
 

--- a/vadl/main/vadl/lcb/codegen/expansion/CompilerInstructionExpansionCodeGenerator.java
+++ b/vadl/main/vadl/lcb/codegen/expansion/CompilerInstructionExpansionCodeGenerator.java
@@ -90,6 +90,7 @@ import vadl.viam.graph.dependency.FieldRefNode;
 import vadl.viam.graph.dependency.FoldNode;
 import vadl.viam.graph.dependency.FuncCallNode;
 import vadl.viam.graph.dependency.FuncParamNode;
+import vadl.viam.graph.dependency.GroupRef;
 import vadl.viam.graph.dependency.LabelNode;
 import vadl.viam.graph.dependency.OperationExistsNode;
 import vadl.viam.graph.dependency.OperationForAllNode;
@@ -1174,6 +1175,11 @@ class InstructionFieldExpansionCodeGenerator implements CDefaultMixins.AllExpres
   protected void handle(CGenContext<Node> ctx, ReadSignalNode toHandle) {
     throwNotAllowed(toHandle, "read  signal node");
   }
+
+  @Handler
+  protected void handle(CGenContext<Node> ctx, GroupRef toHandle) {
+    throwNotAllowed(toHandle, "group reference node");
+  }
 }
 
 /**
@@ -1313,6 +1319,11 @@ class InstructionFieldAccessExpansionCodeGeneratorForImmediateCase
   @Handler
   protected void handle(CGenContext<Node> ctx, ReadSignalNode toHandle) {
     throwNotAllowed(toHandle, "read signal node");
+  }
+
+  @Handler
+  protected void handle(CGenContext<Node> ctx, GroupRef toHandle) {
+    throwNotAllowed(toHandle, "group reference node");
   }
 }
 
@@ -1457,6 +1468,11 @@ class InstructionFieldAccessExpansionCodeGeneratorForLabelCase
   @Handler
   protected void handle(CGenContext<Node> ctx, ReadSignalNode toHandle) {
     throwNotAllowed(toHandle, "read signal node");
+  }
+
+  @Handler
+  protected void handle(CGenContext<Node> ctx, GroupRef toHandle) {
+    throwNotAllowed(toHandle, "group reference node");
   }
 }
 

--- a/vadl/main/vadl/lcb/codegen/relocation/RelocationCodeGenerator.java
+++ b/vadl/main/vadl/lcb/codegen/relocation/RelocationCodeGenerator.java
@@ -35,6 +35,7 @@ import vadl.viam.graph.dependency.FieldAccessRefNode;
 import vadl.viam.graph.dependency.FieldRefNode;
 import vadl.viam.graph.dependency.FoldNode;
 import vadl.viam.graph.dependency.FuncParamNode;
+import vadl.viam.graph.dependency.GroupRef;
 import vadl.viam.graph.dependency.OperationExistsNode;
 import vadl.viam.graph.dependency.OperationForAllNode;
 import vadl.viam.graph.dependency.ReadArtificialResNode;
@@ -179,6 +180,11 @@ public class RelocationCodeGenerator
   @Handler
   void handle(CGenContext<Node> ctx, OperationExistsNode toHandle) {
     throwNotAllowed(toHandle, "exists then expressions");
+  }
+
+  @Handler
+  void handle(CGenContext<Node> ctx, GroupRef toHandle) {
+    throwNotAllowed(toHandle, "group reference expressions");
   }
 
   @Override

--- a/vadl/main/vadl/lcb/passes/asm/AsmGrammarRuleGenerator.java
+++ b/vadl/main/vadl/lcb/passes/asm/AsmGrammarRuleGenerator.java
@@ -73,6 +73,7 @@ import vadl.viam.graph.dependency.FoldNode;
 import vadl.viam.graph.dependency.ForIdxNode;
 import vadl.viam.graph.dependency.FuncCallNode;
 import vadl.viam.graph.dependency.FuncParamNode;
+import vadl.viam.graph.dependency.GroupRef;
 import vadl.viam.graph.dependency.InstructionWidthNode;
 import vadl.viam.graph.dependency.LabelNode;
 import vadl.viam.graph.dependency.LetNode;
@@ -596,6 +597,12 @@ public class AsmGrammarRuleGenerator {
   @Handler
   @SuppressWarnings("MissingJavadocMethod")
   public void handle(AsmRuleContext ctx, SliceNode node) {
+    throw Diagnostic.error("not supported", node.location()).build();
+  }
+
+  @Handler
+  @SuppressWarnings("MissingJavadocMethod")
+  public void handle(AsmRuleContext ctx, GroupRef node) {
     throw Diagnostic.error("not supported", node.location()).build();
   }
 }

--- a/vadl/main/vadl/types/ArrayType.java
+++ b/vadl/main/vadl/types/ArrayType.java
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText : © 2026 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.types;
+
+/**
+ * An array type, as used in group annotations.
+ * E.g: <pre>
+ * [assert : VLIW.length <= 2]
+ * group VLIW = O1.O2
+ * </pre>
+ */
+public class ArrayType extends Type {
+
+  private final Type elementType;
+  private final UIntType lengthType;
+
+  /**
+   * Construct an array type.
+   *
+   * @param elementType the type of the elements of the array.
+   * @param lengthType  the type of the length of the array. Must be an unsigned integer type.
+   */
+  public ArrayType(Type elementType, UIntType lengthType) {
+    this.elementType = elementType;
+    this.lengthType = lengthType;
+  }
+
+  public Type elementType() {
+    return elementType;
+  }
+
+  public UIntType lengthType() {
+    return lengthType;
+  }
+
+  @Override
+  public String name() {
+    return "%s[%s]".formatted(elementType.name(), lengthType.name());
+  }
+}

--- a/vadl/main/vadl/types/ArrayType.java
+++ b/vadl/main/vadl/types/ArrayType.java
@@ -26,17 +26,21 @@ package vadl.types;
 public class ArrayType extends Type {
 
   private final Type elementType;
+
   private final UIntType lengthType;
+  private final UIntType bitLengthType;
 
   /**
    * Construct an array type.
    *
-   * @param elementType the type of the elements of the array.
-   * @param lengthType  the type of the length of the array. Must be an unsigned integer type.
+   * @param elementType   the type of the elements of the array.
+   * @param lengthType    the type of the length of the array. Must be an unsigned integer type.
+   * @param bitLengthType the type of the bitlength of the array.
    */
-  public ArrayType(Type elementType, UIntType lengthType) {
+  public ArrayType(Type elementType, UIntType lengthType, UIntType bitLengthType) {
     this.elementType = elementType;
     this.lengthType = lengthType;
+    this.bitLengthType = bitLengthType;
   }
 
   public Type elementType() {
@@ -45,6 +49,10 @@ public class ArrayType extends Type {
 
   public UIntType lengthType() {
     return lengthType;
+  }
+
+  public UIntType bitLengthType() {
+    return bitLengthType;
   }
 
   @Override

--- a/vadl/main/vadl/types/GroupType.java
+++ b/vadl/main/vadl/types/GroupType.java
@@ -23,7 +23,7 @@ package vadl.types;
  * group VLIW = O1.O2
  * </pre>
  */
-public class ArrayType extends Type {
+public class GroupType extends Type {
 
   private final Type elementType;
 
@@ -31,13 +31,13 @@ public class ArrayType extends Type {
   private final UIntType bitLengthType;
 
   /**
-   * Construct an array type.
+   * Construct a group expression type.
    *
-   * @param elementType   the type of the elements of the array.
-   * @param lengthType    the type of the length of the array. Must be an unsigned integer type.
-   * @param bitLengthType the type of the bitlength of the array.
+   * @param elementType   the type of the elements of the group.
+   * @param lengthType    the type of the length of the group. Must be an unsigned integer type.
+   * @param bitLengthType the type of the bitlength of the group.
    */
-  public ArrayType(Type elementType, UIntType lengthType, UIntType bitLengthType) {
+  public GroupType(Type elementType, UIntType lengthType, UIntType bitLengthType) {
     this.elementType = elementType;
     this.lengthType = lengthType;
     this.bitLengthType = bitLengthType;

--- a/vadl/main/vadl/types/Type.java
+++ b/vadl/main/vadl/types/Type.java
@@ -379,6 +379,21 @@ public abstract class Type {
     }
   }
 
+  private static final HashMap<Integer, ArrayType> arrayTypes = new HashMap<>();
+
+  /**
+   * Returns an array type with the given element type.
+   *
+   * @param elementType the type of the elements of the array.
+   * @param lengthType  the type of the length of the array. Must be an unsigned integer type.
+   * @return the array type.
+   */
+  public static ArrayType array(Type elementType, UIntType lengthType) {
+    var hash = Objects.hash(elementType, lengthType);
+    return arrayTypes
+        .computeIfAbsent(hash, k -> new ArrayType(elementType, lengthType));
+  }
+
   /// These are all the builtin types that exist in the language.
   /// Some of them cannot be initialized like them since they require a size, like `SInt<16>`
   /// which is why they are named bases.

--- a/vadl/main/vadl/types/Type.java
+++ b/vadl/main/vadl/types/Type.java
@@ -384,14 +384,15 @@ public abstract class Type {
   /**
    * Returns an array type with the given element type.
    *
-   * @param elementType the type of the elements of the array.
-   * @param lengthType  the type of the length of the array. Must be an unsigned integer type.
+   * @param elementType   the type of the elements of the array.
+   * @param lengthType    the type of the length of the array. Must be an unsigned integer type.
+   * @param bitLengthType the type of the bit length of the array. Must be an unsigned integer type.
    * @return the array type.
    */
-  public static ArrayType array(Type elementType, UIntType lengthType) {
-    var hash = Objects.hash(elementType, lengthType);
+  public static ArrayType array(Type elementType, UIntType lengthType, UIntType bitLengthType) {
+    var hash = Objects.hash(elementType, lengthType, bitLengthType);
     return arrayTypes
-        .computeIfAbsent(hash, k -> new ArrayType(elementType, lengthType));
+        .computeIfAbsent(hash, k -> new ArrayType(elementType, lengthType, bitLengthType));
   }
 
   /// These are all the builtin types that exist in the language.

--- a/vadl/main/vadl/types/Type.java
+++ b/vadl/main/vadl/types/Type.java
@@ -379,20 +379,25 @@ public abstract class Type {
     }
   }
 
-  private static final HashMap<Integer, ArrayType> arrayTypes = new HashMap<>();
+  private record GroupTypeKey(Type elementType, UIntType lengthType, UIntType bitLengthType) {
+  }
+
+  private static final HashMap<GroupTypeKey, GroupType> groupTypes = new HashMap<>();
 
   /**
-   * Returns an array type with the given element type.
+   * Returns a group type with the given element type. The element is the common pseudo format of
+   * the operations occurring in the group expression.
    *
-   * @param elementType   the type of the elements of the array.
+   * @param elementType   the type of the group elements.
    * @param lengthType    the type of the length of the array. Must be an unsigned integer type.
    * @param bitLengthType the type of the bit length of the array. Must be an unsigned integer type.
-   * @return the array type.
+   * @return the group type.
    */
-  public static ArrayType array(Type elementType, UIntType lengthType, UIntType bitLengthType) {
-    var hash = Objects.hash(elementType, lengthType, bitLengthType);
-    return arrayTypes
-        .computeIfAbsent(hash, k -> new ArrayType(elementType, lengthType, bitLengthType));
+  public static GroupType group(Type elementType, UIntType lengthType, UIntType bitLengthType) {
+    final var key = new GroupTypeKey(elementType, lengthType, bitLengthType);
+    return groupTypes
+        .computeIfAbsent(key,
+            k -> new GroupType(k.elementType(), k.lengthType(), k.bitLengthType()));
   }
 
   /// These are all the builtin types that exist in the language.

--- a/vadl/main/vadl/viam/graph/dependency/DynSliceNode.java
+++ b/vadl/main/vadl/viam/graph/dependency/DynSliceNode.java
@@ -19,6 +19,7 @@ package vadl.viam.graph.dependency;
 import java.util.List;
 import vadl.javaannotations.viam.Input;
 import vadl.types.DataType;
+import vadl.types.Type;
 import vadl.viam.Constant;
 import vadl.viam.graph.Canonicalizable;
 import vadl.viam.graph.GraphNodeVisitor;
@@ -60,7 +61,7 @@ public class DynSliceNode extends ExpressionNode implements Canonicalizable {
    * @param lsb   The lsb bit index expression to slice the value from.
    * @param type  The result type of the node.
    */
-  public DynSliceNode(ExpressionNode value, ExpressionNode msb, ExpressionNode lsb, DataType type) {
+  public DynSliceNode(ExpressionNode value, ExpressionNode msb, ExpressionNode lsb, Type type) {
     super(type);
 
     this.value = value;
@@ -78,11 +79,6 @@ public class DynSliceNode extends ExpressionNode implements Canonicalizable {
 
   public ExpressionNode lsb() {
     return lsb;
-  }
-
-  @Override
-  public DataType type() {
-    return (DataType) super.type();
   }
 
   @Override
@@ -118,6 +114,11 @@ public class DynSliceNode extends ExpressionNode implements Canonicalizable {
 
   @Override
   public Node canonical() {
+    if (!(type() instanceof DataType dataType)) {
+      // No canonical representation
+      return this;
+    }
+
     if (msb.isConstant() && lsb.isConstant()) {
       // if the slice range is constant we can convert it to a SliceNode
       var msbVal = ((ConstantNode) msb).constant().asVal().unsignedInteger().intValue();
@@ -129,7 +130,7 @@ public class DynSliceNode extends ExpressionNode implements Canonicalizable {
         lsbVal = tmp;
       }
 
-      var sliceNode = new SliceNode(value, Constant.BitSlice.of(msbVal, lsbVal), type());
+      var sliceNode = new SliceNode(value, Constant.BitSlice.of(msbVal, lsbVal), dataType);
       // if the value itself is constant, it can be constant folded.
       return sliceNode.canonical();
     }

--- a/vadl/main/vadl/viam/graph/dependency/GroupRef.java
+++ b/vadl/main/vadl/viam/graph/dependency/GroupRef.java
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText : © 2026 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.viam.graph.dependency;
+
+import vadl.types.Type;
+import vadl.viam.Group;
+import vadl.viam.graph.Node;
+
+/**
+ * Reference to a {@link Group} definition.
+ */
+public class GroupRef extends ExpressionNode {
+
+  public GroupRef(Type type) {
+    super(type);
+  }
+
+  @Override
+  public ExpressionNode copy() {
+    return new GroupRef(type());
+  }
+
+  @Override
+  public Node shallowCopy() {
+    return new GroupRef(type());
+  }
+
+}


### PR DESCRIPTION
The group definition's name can be used in expressions (within group annotations) to access the matched instructions / operations at runtime. In addition it exposes a `length` and `bitLength` field.

```vadl
VLIW.length // number of instructions in the group
VLIW.bitLength // number of bits in the group

VLIW(1) // the second instruction in the group
VLIW(VLIW.length - 1) // the last instruction in the group
```

I introduced a 'GroupType' for such group references. Since we're able to upper-bound the `length` and `bitLength`, we can also give these properties a `UIntType` type with some maximal width.