### PR TITLE
frontend/viam: Support partial (alias) register access

### DIFF
--- a/vadl/main/vadl/ast/BehaviorLowering.java
+++ b/vadl/main/vadl/ast/BehaviorLowering.java
@@ -68,7 +68,6 @@ import vadl.viam.Logic;
 import vadl.viam.Memory;
 import vadl.viam.Operation;
 import vadl.viam.Procedure;
-import vadl.viam.RegisterResource;
 import vadl.viam.RegisterTensor;
 import vadl.viam.Resource;
 import vadl.viam.StageOutput;
@@ -816,37 +815,23 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
   }
 
 
-  /// It is allowed to read from a TensorResource and not supply all indices. In that case all the
-  /// missing indices have to be filled, many reads are issued and
+  /// It is allowed to read from a register tensor and not supply all indices. In that case all the
+  /// missing indices have to be filled, many reads are issued and concatenated again.
   ///
   /// @return the expression to read from a register.
-  private ExpressionNode readTensorResourceConcatinated(RegisterResource resource,
+  private ExpressionNode readRegisterTensorConcatenated(RegisterTensor resource,
                                                         List<ExpressionNode> indices,
                                                         DataType type
   ) {
     // Matches exactly
     if (resource.indexTypes().size() == indices.size()) {
-      return switch (resource) {
-        case RegisterTensor register ->
-            new ReadRegTensorNode(register, new NodeList<>(indices), type, null);
-        case ArtificialResource register ->
-            new ReadArtificialResNode(register, new NodeList<>(indices), type);
-        default -> throw new IllegalStateException("Unsupported resource type: " + resource);
-      };
+      return new ReadRegTensorNode(resource, new NodeList<>(indices), type, null);
     }
 
-    // Concatination needed
+    // Concatenation needed.
     // Here we take all provided indices and for the missing dimensions we fill out all possible
     // values and concatenate them.
-
-    var requiredDimensions = switch (resource) {
-      case RegisterTensor register -> register.indexDimensions();
-      case ArtificialResource register -> register.dimensions();
-      default -> throw new IllegalStateException("Unsupported resource type: " + resource);
-    };
-
-
-    var missingDimensions = requiredDimensions.stream()
+    var missingDimensions = resource.indexDimensions().stream()
         .skip(indices.size()).toList();
 
     var missingTypes = missingDimensions.stream().map(d -> d.indexType()).toList();
@@ -872,13 +857,8 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
     ExpressionNode result = null;
     int currentBitWidth = 0;
     for (var indexList : fullIndices) {
-      var read = switch (resource) {
-        case RegisterTensor register ->
-            new ReadRegTensorNode(register, new NodeList<>(indexList), register.resultType(), null);
-        case ArtificialResource register ->
-            new ReadArtificialResNode(register, new NodeList<>(indexList), register.resultType());
-        default -> throw new IllegalStateException("Unsupported resource type: " + resource);
-      };
+      var read = new ReadRegTensorNode(resource, new NodeList<>(indexList), resource.resultType(),
+          null);
 
       currentBitWidth += read.type().asDataType().bitWidth();
       if (result == null) {
@@ -892,51 +872,28 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
     return requireNonNull(result);
   }
 
-  /// Write to a resource even if not all indices are supplied.
+  /// Write to a register tensor even if not all indices are supplied.
   ///
   /// @return A list of sideeffects which write to the provided resource
-  private List<WriteResourceNode> writeTensorResourceSliced(RegisterResource resource,
+  private List<WriteResourceNode> writeRegisterTensorSliced(RegisterTensor resource,
                                                             List<ExpressionNode> indices,
                                                             ExpressionNode value,
                                                             List<Constant.BitSlice> slices,
                                                             @Nullable ExpressionNode dynamicIndex) {
     // No multiple writes and slices needed
     if (resource.indexTypes().size() <= indices.size()) {
-      switch (resource) {
-        case RegisterTensor register -> {
-          var resourceRead =
-              new ReadRegTensorNode(register, new NodeList<>(indices), register.resultType(), null);
-          var slicedValue = dynamicIndexWriteValue(
-              staticSliceWriteValue(value, resourceRead, slices),
-              resourceRead,
-              dynamicIndex);
-          return List.of(
-              new WriteRegTensorNode(register, new NodeList<>(indices), slicedValue, null, null));
-        }
-        case ArtificialResource register -> {
-          var resourceRead =
-              new ReadArtificialResNode(register, new NodeList<>(indices), register.resultType());
-          var slicedValue =
-              dynamicIndexWriteValue(staticSliceWriteValue(value, resourceRead, slices),
-                  resourceRead,
-                  dynamicIndex);
-          return List.of(
-              new WriteArtificialResNode(register, new NodeList<>(indices), slicedValue));
-        }
-        default -> throw new IllegalStateException("Unsupported resource type: " + resource);
-      }
+      var resourceRead =
+          new ReadRegTensorNode(resource, new NodeList<>(indices), resource.resultType(), null);
+      var slicedValue = dynamicIndexWriteValue(
+          staticSliceWriteValue(value, resourceRead, slices),
+          resourceRead,
+          dynamicIndex);
+      return List.of(
+          new WriteRegTensorNode(resource, new NodeList<>(indices), slicedValue, null, null));
     }
 
     // Multiple writes needed and value must be sliced
-
-    var requiredDimensions = switch (resource) {
-      case RegisterTensor register -> register.indexDimensions();
-      case ArtificialResource register -> register.dimensions();
-      default -> throw new IllegalStateException("Unsupported resource type: " + resource);
-    };
-
-
-    var missingDimensions = requiredDimensions.stream()
+    var missingDimensions = resource.indexDimensions().stream()
         .skip(indices.size()).toList();
 
     var missingTypes = missingDimensions.stream().map(d -> d.indexType()).toList();
@@ -967,14 +924,7 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
       var slice = new SliceNode(value, Constant.BitSlice.of(msb, lsb), Type.bits(width));
 
       result.add(
-          switch (resource) {
-            case RegisterTensor register ->
-                new WriteRegTensorNode(register, new NodeList<>(fullIndices.get(i)), slice, null,
-                    null);
-            case ArtificialResource register ->
-                new WriteArtificialResNode(register, new NodeList<>(fullIndices.get(i)), slice);
-            default -> throw new IllegalStateException("Unsupported resource type: " + resource);
-          }
+          new WriteRegTensorNode(resource, new NodeList<>(fullIndices.get(i)), slice, null, null)
       );
     }
 
@@ -1033,24 +983,22 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
     // Register
     if (computedTarget instanceof RegisterDefinition registerDefinition) {
       var register = (RegisterTensor) viamLowering.fetch(registerDefinition).orElseThrow();
-      return readTensorResourceConcatinated(register, List.of(),
+      return readRegisterTensorConcatenated(register, List.of(),
           (DataType) getViamType(expr.type()));
     }
 
     // Register Alias
     if (computedTarget instanceof AliasDefinition aliasDefinition) {
       var lowered = viamLowering.fetch(aliasDefinition).orElseThrow();
-      var resource = switch (aliasDefinition.kind) {
-        case REGISTER -> (ArtificialResource) lowered;
-        case PROGRAM_COUNTER -> ((Counter) lowered).registerTensor();
-      };
-      List<ExpressionNode> indices = switch (aliasDefinition.kind) {
-        case REGISTER -> List.of();
-        case PROGRAM_COUNTER -> ((Counter) lowered).indices().stream()
-            .map(idx -> (ExpressionNode) new ConstantNode(idx)).toList();
-      };
-      return readTensorResourceConcatinated(resource, indices,
-          (DataType) getViamType(expr.type()));
+      if (aliasDefinition.kind == AliasDefinition.AliasKind.REGISTER) {
+        return new ReadArtificialResNode((ArtificialResource) lowered, new NodeList<>(),
+            (DataType) getViamType(expr.type()));
+      }
+
+      var resource = ((Counter) lowered).registerTensor();
+      List<ExpressionNode> indices = ((Counter) lowered).indices().stream()
+          .map(idx -> (ExpressionNode) new ConstantNode(idx)).toList();
+      return readRegisterTensorConcatenated(resource, indices, (DataType) getViamType(expr.type()));
     }
 
     // Counters
@@ -1487,25 +1435,24 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
             (Function) viamLowering.fetch(funcDef).orElseThrow(),
             args, typeBeforeSlice);
 
-        case RegisterDefinition regDef -> readTensorResourceConcatinated(
-            (RegisterResource) viamLowering.fetch(regDef).orElseThrow(), args,
+        case RegisterDefinition regDef -> readRegisterTensorConcatenated(
+            (RegisterTensor) viamLowering.fetch(regDef).orElseThrow(), args,
             (DataType) typeBeforeSlice
         );
 
         case AliasDefinition aliasDef -> {
           var lowered = viamLowering.fetch(aliasDef).orElseThrow();
-          var resource = switch (aliasDef.kind) {
-            case REGISTER -> (ArtificialResource) lowered;
-            case PROGRAM_COUNTER -> ((Counter) lowered).registerTensor();
-          };
-          var aliasArgs = (NodeList<ExpressionNode>) switch (aliasDef.kind) {
-            case REGISTER -> args;
-            case PROGRAM_COUNTER -> Stream.concat(
-                ((Counter) lowered).indices().stream().map(ConstantNode::new),
-                args.stream()
-            ).collect(Collectors.toCollection(NodeList::new));
-          };
-          yield readTensorResourceConcatinated(resource, aliasArgs, (DataType) typeBeforeSlice);
+          if (aliasDef.kind == AliasDefinition.AliasKind.REGISTER) {
+            yield new ReadArtificialResNode((ArtificialResource) lowered, args,
+                (DataType) typeBeforeSlice);
+          }
+
+          var aliasArgs = Stream.concat(
+              ((Counter) lowered).indices().stream().map(ConstantNode::new),
+              args.stream()
+          ).collect(Collectors.toCollection(NodeList::new));
+          yield readRegisterTensorConcatenated(((Counter) lowered).registerTensor(), aliasArgs,
+              (DataType) typeBeforeSlice);
         }
 
         case MemoryDefinition memDef -> {
@@ -1839,11 +1786,11 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
 
     // No need to call getViamType here as the viam definitions should already have that.
     var writeNodes = switch (viamTargetDef) {
-      case RegisterTensor regDef -> writeTensorResourceSliced(
+      case RegisterTensor regDef -> writeRegisterTensorSliced(
           regDef, argExprs, value, staticSlices, dynamicIndex
       );
 
-      case ArtificialResource aliasDef -> writeTensorResourceSliced(
+      case ArtificialResource aliasDef -> writeAliasResourceDirect(
           aliasDef, argExprs, value, staticSlices, dynamicIndex
       );
 
@@ -1971,6 +1918,24 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
     var mask = slice.mask().castTo(Type.bits(entireRead.type().bitWidth())).not().toNode();
     var clearedResource = BuiltInCall.of(BuiltInTable.AND, entireRead, mask);
     return BuiltInCall.of(BuiltInTable.OR, clearedResource, requireNonNull(injected));
+  }
+
+  private List<WriteResourceNode> writeAliasResourceDirect(ArtificialResource resource,
+                                                           NodeList<ExpressionNode> indices,
+                                                           ExpressionNode value,
+                                                           List<Constant.BitSlice> slices,
+                                                           @Nullable ExpressionNode dynamicIndex) {
+    // Preserve one aggregate alias write even when not all alias dimensions are supplied.
+    // A later VIAM pass expands this back to the old concrete per-element shape for backends
+    // that still require exhaustive alias indices.
+    var resourceRead = new ReadArtificialResNode(resource, indices.copy(),
+        resource.resultType(indices.size()));
+    var shapedValue = dynamicIndexWriteValue(
+        staticSliceWriteValue(value, resourceRead, slices),
+        resourceRead,
+        dynamicIndex
+    );
+    return List.of(new WriteArtificialResNode(resource, indices.copy(), shapedValue));
   }
 
 

--- a/vadl/main/vadl/ast/BehaviorLowering.java
+++ b/vadl/main/vadl/ast/BehaviorLowering.java
@@ -786,16 +786,6 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
     return result;
   }
 
-
-  /// This utility function can be used to fill in missing indexes of a tensor.
-  ///
-  /// It basically returns a permutation of all possible indices for the dimensions provided.
-  ///
-  /// Example:
-  /// ```
-  /// [2] -> [[0], [1]]
-  /// [2, 2] -> [[0, 0], [0, 1], [1, 0], [1, 1]]
-  /// ```
   private ExpressionNode readRegisterTensorDirect(RegisterTensor resource,
                                                   List<ExpressionNode> indices,
                                                   DataType type) {

--- a/vadl/main/vadl/ast/BehaviorLowering.java
+++ b/vadl/main/vadl/ast/BehaviorLowering.java
@@ -31,7 +31,6 @@ import static vadl.utils.GraphUtils.signExtend;
 import static vadl.utils.GraphUtils.zeroExtend;
 
 import com.google.common.collect.Lists;
-import com.google.common.collect.Streams;
 import com.google.errorprone.annotations.concurrent.LazyInit;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -797,138 +796,30 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
   /// [2] -> [[0], [1]]
   /// [2, 2] -> [[0, 0], [0, 1], [1, 0], [1, 1]]
   /// ```
-  private List<List<Integer>> permutationOfTensorIndicies(List<Integer> dimensions) {
-    if (dimensions.isEmpty()) {
-      return List.of(List.of());
-    }
-
-    var tailResult = permutationOfTensorIndicies(dimensions.subList(1, dimensions.size()));
-
-    var result = new ArrayList<List<Integer>>();
-    for (int i = 0; i < dimensions.getFirst(); i++) {
-      for (var tail : tailResult) {
-        result.add(Stream.concat(Stream.of(i), tail.stream()).toList());
-      }
-    }
-
-    return result;
+  private ExpressionNode readRegisterTensorDirect(RegisterTensor resource,
+                                                  List<ExpressionNode> indices,
+                                                  DataType type) {
+    // Preserve aggregate base-register accesses when fewer than all register-tensor indices are
+    // supplied. The VIAM and ISS node contracts already support these partial reads directly.
+    return new ReadRegTensorNode(resource, new NodeList<>(indices), type, null);
   }
 
-
-  /// It is allowed to read from a register tensor and not supply all indices. In that case all the
-  /// missing indices have to be filled, many reads are issued and concatenated again.
-  ///
-  /// @return the expression to read from a register.
-  private ExpressionNode readRegisterTensorConcatenated(RegisterTensor resource,
-                                                        List<ExpressionNode> indices,
-                                                        DataType type
-  ) {
-    // Matches exactly
-    if (resource.indexTypes().size() == indices.size()) {
-      return new ReadRegTensorNode(resource, new NodeList<>(indices), type, null);
-    }
-
-    // Concatenation needed.
-    // Here we take all provided indices and for the missing dimensions we fill out all possible
-    // values and concatenate them.
-    var missingDimensions = resource.indexDimensions().stream()
-        .skip(indices.size()).toList();
-
-    var missingTypes = missingDimensions.stream().map(d -> d.indexType()).toList();
-
-    var missingPermutations = permutationOfTensorIndicies(
-        missingDimensions.stream()
-            .map(d -> d.size()).toList());
-
-
-    var missingIndices =
-        missingPermutations.stream()
-            .map(
-                entry -> Streams.zip(entry.stream(), missingTypes.stream(),
-                        (a, b) -> (ExpressionNode) Constant.Value.of(a, b).toNode())
-                    .toList())
-            .toList();
-
-    var fullIndices = missingIndices.stream().map(item ->
-        Streams.concat(indices.stream(), item.stream()).toList()
-    ).toList();
-
-
-    ExpressionNode result = null;
-    int currentBitWidth = 0;
-    for (var indexList : fullIndices) {
-      var read = new ReadRegTensorNode(resource, new NodeList<>(indexList), resource.resultType(),
-          null);
-
-      currentBitWidth += read.type().asDataType().bitWidth();
-      if (result == null) {
-        result = read;
-      } else {
-        result = new BuiltInCall(BuiltInTable.CONCATENATE_BITS, new NodeList<>(read, result),
-            Type.bits(currentBitWidth));
-      }
-    }
-
-    return requireNonNull(result);
-  }
-
-  /// Write to a register tensor even if not all indices are supplied.
-  ///
-  /// @return A list of sideeffects which write to the provided resource
-  private List<WriteResourceNode> writeRegisterTensorSliced(RegisterTensor resource,
-                                                            List<ExpressionNode> indices,
+  private List<WriteResourceNode> writeRegisterTensorDirect(RegisterTensor resource,
+                                                            NodeList<ExpressionNode> indices,
                                                             ExpressionNode value,
                                                             List<Constant.BitSlice> slices,
                                                             @Nullable ExpressionNode dynamicIndex) {
-    // No multiple writes and slices needed
-    if (resource.indexTypes().size() <= indices.size()) {
-      var resourceRead =
-          new ReadRegTensorNode(resource, new NodeList<>(indices), resource.resultType(), null);
-      var slicedValue = dynamicIndexWriteValue(
-          staticSliceWriteValue(value, resourceRead, slices),
-          resourceRead,
-          dynamicIndex);
-      return List.of(
-          new WriteRegTensorNode(resource, new NodeList<>(indices), slicedValue, null, null));
-    }
-
-    // Multiple writes needed and value must be sliced
-    var missingDimensions = resource.indexDimensions().stream()
-        .skip(indices.size()).toList();
-
-    var missingTypes = missingDimensions.stream().map(d -> d.indexType()).toList();
-
-    var missingPermutations = permutationOfTensorIndicies(
-        missingDimensions.stream()
-            .map(d -> d.size()).toList());
-
-
-    var missingIndices =
-        missingPermutations.stream()
-            .map(
-                entry -> Streams.zip(entry.stream(), missingTypes.stream(),
-                        (a, b) -> (ExpressionNode) Constant.Value.of(a, b).toNode())
-                    .toList())
-            .toList();
-
-    var fullIndices = missingIndices.stream().map(item ->
-        Streams.concat(indices.stream(), item.stream()).toList()
-    ).toList();
-
-
-    var result = new ArrayList<WriteResourceNode>();
-    var width = resource.resultType().bitWidth();
-    for (int i = 0; i < fullIndices.size(); i++) {
-      var lsb = i * width;
-      var msb = i * width + width - 1;
-      var slice = new SliceNode(value, Constant.BitSlice.of(msb, lsb), Type.bits(width));
-
-      result.add(
-          new WriteRegTensorNode(resource, new NodeList<>(fullIndices.get(i)), slice, null, null)
-      );
-    }
-
-    return result;
+    // Preserve aggregate base-register writes as one side effect even when not all indices are
+    // supplied. Backends can lower the partial access directly instead of requiring frontend
+    // scalarization into per-element writes.
+    var resourceRead = new ReadRegTensorNode(resource, indices.copy(),
+        resource.resultType(indices.size()), null);
+    var shapedValue = dynamicIndexWriteValue(
+        staticSliceWriteValue(value, resourceRead, slices),
+        resourceRead,
+        dynamicIndex
+    );
+    return List.of(new WriteRegTensorNode(resource, indices.copy(), shapedValue, null, null));
   }
 
   /**
@@ -983,7 +874,7 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
     // Register
     if (computedTarget instanceof RegisterDefinition registerDefinition) {
       var register = (RegisterTensor) viamLowering.fetch(registerDefinition).orElseThrow();
-      return readRegisterTensorConcatenated(register, List.of(),
+      return readRegisterTensorDirect(register, List.of(),
           (DataType) getViamType(expr.type()));
     }
 
@@ -998,7 +889,7 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
       var resource = ((Counter) lowered).registerTensor();
       List<ExpressionNode> indices = ((Counter) lowered).indices().stream()
           .map(idx -> (ExpressionNode) new ConstantNode(idx)).toList();
-      return readRegisterTensorConcatenated(resource, indices, (DataType) getViamType(expr.type()));
+      return readRegisterTensorDirect(resource, indices, (DataType) getViamType(expr.type()));
     }
 
     // Counters
@@ -1435,7 +1326,7 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
             (Function) viamLowering.fetch(funcDef).orElseThrow(),
             args, typeBeforeSlice);
 
-        case RegisterDefinition regDef -> readRegisterTensorConcatenated(
+        case RegisterDefinition regDef -> readRegisterTensorDirect(
             (RegisterTensor) viamLowering.fetch(regDef).orElseThrow(), args,
             (DataType) typeBeforeSlice
         );
@@ -1451,7 +1342,7 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
               ((Counter) lowered).indices().stream().map(ConstantNode::new),
               args.stream()
           ).collect(Collectors.toCollection(NodeList::new));
-          yield readRegisterTensorConcatenated(((Counter) lowered).registerTensor(), aliasArgs,
+          yield readRegisterTensorDirect(((Counter) lowered).registerTensor(), aliasArgs,
               (DataType) typeBeforeSlice);
         }
 
@@ -1786,7 +1677,7 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
 
     // No need to call getViamType here as the viam definitions should already have that.
     var writeNodes = switch (viamTargetDef) {
-      case RegisterTensor regDef -> writeRegisterTensorSliced(
+      case RegisterTensor regDef -> writeRegisterTensorDirect(
           regDef, argExprs, value, staticSlices, dynamicIndex
       );
 

--- a/vadl/main/vadl/iss/codegen/IssCpuFunctionGenerator.java
+++ b/vadl/main/vadl/iss/codegen/IssCpuFunctionGenerator.java
@@ -359,13 +359,7 @@ public class IssCpuFunctionGenerator extends PureFunctionCodeGenerator
       int chunkWidthBits
   ) {
     var loweredRead = toChunkRead(read, chunkOffsetBits, chunkWidthBits);
-    var accessName = RegisterAccessEmitters.readAccessorName(loweredRead, accessorRegistry);
-    ctx.wr(accessName).wr("(env");
-    for (var index : RegisterAccessEmitters.readAccessorArgs(loweredRead)) {
-      ctx.wr(", ");
-      ctx.gen(index);
-    }
-    ctx.wr(")");
+    RegisterAccessEmitters.emitRead(ctx, loweredRead, accessorRegistry);
   }
 
   private ReadRegTensorNode toChunkRead(ReadRegTensorNode read,

--- a/vadl/main/vadl/iss/codegen/RegisterAccessEmitters.java
+++ b/vadl/main/vadl/iss/codegen/RegisterAccessEmitters.java
@@ -126,6 +126,29 @@ public final class RegisterAccessEmitters {
     ctx.wr(")");
   }
 
+  private static void emitChunkBaseIndices(CGenContext<Node> ctx,
+                                           ReadRegTensorNode node) {
+    emitChunkBaseIndices(ctx, node.indices(), node.regTensor().indexDimensions().size());
+  }
+
+  private static void emitChunkBaseIndices(CGenContext<Node> ctx,
+                                           WriteRegTensorNode node) {
+    emitChunkBaseIndices(ctx, node.indices(), node.regTensor().indexDimensions().size());
+  }
+
+  private static void emitChunkBaseIndices(CGenContext<Node> ctx,
+                                           NodeList<ExpressionNode> indices,
+                                           int expectedIndexCount) {
+    for (var index : indices) {
+      ctx.wr(", ").gen(index);
+    }
+    for (int i = indices.size(); i < expectedIndexCount; i++) {
+      // Chunk helpers operate on the flattened aggregate that starts at the first omitted
+      // sub-index, so omitted inner indices default to the zero offset within that aggregate.
+      ctx.wr(", ((uint32_t) 0)");
+    }
+  }
+
   private static RegisterAccessEmitter emitterFor(RegInfo regInfo) {
     return regInfo.execClass() == RegInfo.ExecClass.TCG_SCALAR
         ? TcgScalarRegisterAccessEmitter.INSTANCE
@@ -175,9 +198,7 @@ public final class RegisterAccessEmitters {
         ctx.wr("((").wr(valueType).wr(") cpu_get_")
             .wr(node.regTensor().simpleName().toLowerCase())
             .wr("_chunk(env");
-        for (var i : readNode.indices()) {
-          ctx.wr(", ").gen(i);
-        }
+        emitChunkBaseIndices(ctx, readNode);
         ctx.wr(", ").gen(readNode.bitOffset());
         ctx.wr(", ").gen(readNode.bitWidth());
         ctx.wr("))");
@@ -195,9 +216,7 @@ public final class RegisterAccessEmitters {
         ctx.wr("cpu_set_")
             .wr(node.regTensor().simpleName().toLowerCase())
             .wr("_chunk(env");
-        for (var i : writeNode.indices()) {
-          ctx.wr(", ").gen(i);
-        }
+        emitChunkBaseIndices(ctx, writeNode);
         ctx.wr(", ").gen(writeNode.bitOffset());
         ctx.wr(", ").gen(writeNode.bitWidth());
         ctx.wr(", ((uint64_t) ").gen(node.value()).wr("))");

--- a/vadl/main/vadl/iss/passes/common/IssTensorAssignmentToForallPass.java
+++ b/vadl/main/vadl/iss/passes/common/IssTensorAssignmentToForallPass.java
@@ -27,6 +27,7 @@ import vadl.iss.passes.AbstractIssPass;
 import vadl.iss.passes.nodes.IssWriteRegNode;
 import vadl.pass.PassName;
 import vadl.pass.PassResults;
+import vadl.types.BitsType;
 import vadl.types.BuiltInTable;
 import vadl.types.Type;
 import vadl.viam.Constant;
@@ -39,6 +40,8 @@ import vadl.viam.graph.control.ForallEndNode;
 import vadl.viam.graph.control.ForallNode;
 import vadl.viam.graph.dependency.ExpressionNode;
 import vadl.viam.graph.dependency.TensorNode;
+import vadl.viam.graph.dependency.TruncateNode;
+import vadl.viam.graph.dependency.ZeroExtendNode;
 
 /**
  * Lowers full tensor assignments to element-wise forall statements.
@@ -118,9 +121,10 @@ public class IssTensorAssignmentToForallPass extends AbstractIssPass {
     var loopIdx = tensor.idx().copy();
     var elementValue = copyWithIndexSubstitution(tensor.body(), tensor.idx(), loopIdx);
     var elementWidth = tensor.body().type().asDataType().bitWidth();
+    var bitOffsetType = Type.bits(BitsType.indexWidthFor(write.writeBitWidth()));
     var bitOffset = BuiltInTable.MUL.call(
-        loopIdx,
-        Constant.Value.of(elementWidth, loopIdx.type()).toNode()
+        castIndexTo(loopIdx, bitOffsetType),
+        Constant.Value.of(elementWidth, bitOffsetType).toNode()
     );
     var bitWidth = Constant.Value.of(elementWidth, Type.bits(32)).toNode();
 
@@ -156,5 +160,15 @@ public class IssTensorAssignmentToForallPass extends AbstractIssPass {
       write.safeDelete();
     }
     forall.setSourceLocationIfNotSet(write.location());
+  }
+
+  private ExpressionNode castIndexTo(ExpressionNode index, BitsType targetType) {
+    var sourceType = index.type().asDataType();
+    if (sourceType.isTrivialCastTo(targetType)) {
+      return index;
+    }
+    return sourceType.bitWidth() > targetType.bitWidth()
+        ? new TruncateNode(index, targetType)
+        : new ZeroExtendNode(index, targetType);
   }
 }

--- a/vadl/main/vadl/pass/order/ViamPassOrder.java
+++ b/vadl/main/vadl/pass/order/ViamPassOrder.java
@@ -22,6 +22,7 @@ import vadl.gcb.passes.RenamingConflictingRegistersPass;
 import vadl.lcb.passes.OverwriteInputOperandsPass;
 import vadl.pass.PassOrder;
 import vadl.pass.PassOrders;
+import vadl.viam.passes.ArtificialResPartialAccessExpansionPass;
 import vadl.viam.passes.ControlFlowOptimizationPass;
 import vadl.viam.passes.DetectRegisterIndicesPass;
 import vadl.viam.passes.DuplicateWriteDetectionPass;
@@ -72,6 +73,7 @@ public final class ViamPassOrder {
     order.add(new CounterAccessResolvingPass(configuration));
     order.add(new FunctionInlinerPass(configuration));
     order.add(new FieldAccessInlinerPass(configuration));
+    order.add(new ArtificialResPartialAccessExpansionPass(configuration));
     order.add(new ArtificialResInlinerPass(configuration));
     order.add(new ControlFlowOptimizationPass(configuration));
     order.add(new SideEffectConditionResolvingPass(configuration));

--- a/vadl/main/vadl/pass/order/ViamPassOrder.java
+++ b/vadl/main/vadl/pass/order/ViamPassOrder.java
@@ -29,6 +29,7 @@ import vadl.viam.passes.DuplicateWriteDetectionPass;
 import vadl.viam.passes.HardcodeLGALabelPass;
 import vadl.viam.passes.InstructionResourceAccessAnalysisPass;
 import vadl.viam.passes.NormalizeFieldsToFieldAccessFunctionsPass;
+import vadl.viam.passes.RegisterTensorPartialAccessExpansionPass;
 import vadl.viam.passes.SnapshotInstructionBehaviorPass;
 import vadl.viam.passes.algebraic_simplication.AlgebraicSimplificationPass;
 import vadl.viam.passes.behaviorRewrite.BehaviorRewritePass;
@@ -74,6 +75,7 @@ public final class ViamPassOrder {
     order.add(new FunctionInlinerPass(configuration));
     order.add(new FieldAccessInlinerPass(configuration));
     order.add(new ArtificialResPartialAccessExpansionPass(configuration));
+    order.add(new RegisterTensorPartialAccessExpansionPass(configuration));
     order.add(new ArtificialResInlinerPass(configuration));
     order.add(new ControlFlowOptimizationPass(configuration));
     order.add(new SideEffectConditionResolvingPass(configuration));

--- a/vadl/main/vadl/viam/ArtificialResource.java
+++ b/vadl/main/vadl/viam/ArtificialResource.java
@@ -231,7 +231,15 @@ public class ArtificialResource extends RegisterResource {
 
   @Override
   public DataType resultType(int providedDimensions) {
-    return resultType();
+    ensure(providedDimensions <= maxNumberOfAccessIndices(),
+        "Too many dimensions provided, max is %s, got %s.", maxNumberOfAccessIndices(),
+        providedDimensions);
+
+    var width = resultType().bitWidth();
+    for (var dimension : dimensions().stream().skip(providedDimensions).toList()) {
+      width = Math.multiplyExact(width, dimension.size());
+    }
+    return DataType.bits(width);
   }
 
   @Override

--- a/vadl/main/vadl/viam/graph/control/AbstractEndNode.java
+++ b/vadl/main/vadl/viam/graph/control/AbstractEndNode.java
@@ -80,4 +80,22 @@ public abstract class AbstractEndNode extends ControlNode {
     this.sideEffects.add(sideEffectNode);
     updateUsageOf(null, sideEffectNode);
   }
+
+  /**
+   * Replaces a side effect with zero or more side effects while preserving order.
+   */
+  public void replaceSideEffect(SideEffectNode original,
+                                List<? extends SideEffectNode> replacement) {
+    var index = sideEffects.indexOf(original);
+    ensure(index >= 0, "Side effect %s is not attached to %s.", original, this);
+
+    sideEffects.remove(index);
+    original.removeUsage(this);
+
+    for (int i = 0; i < replacement.size(); i++) {
+      var node = replacement.get(i);
+      sideEffects.add(index + i, node);
+      updateUsageOf(null, node);
+    }
+  }
 }

--- a/vadl/main/vadl/viam/passes/ArtificialResPartialAccessExpansionPass.java
+++ b/vadl/main/vadl/viam/passes/ArtificialResPartialAccessExpansionPass.java
@@ -1,0 +1,206 @@
+// SPDX-FileCopyrightText : © 2026 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.viam.passes;
+
+import static java.util.Objects.requireNonNull;
+
+import com.google.common.collect.Streams;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nullable;
+import vadl.configuration.GeneralConfiguration;
+import vadl.pass.Pass;
+import vadl.pass.PassName;
+import vadl.pass.PassResults;
+import vadl.types.BuiltInTable;
+import vadl.types.Type;
+import vadl.utils.ViamUtils;
+import vadl.viam.ArtificialResource;
+import vadl.viam.Constant;
+import vadl.viam.RegisterTensor;
+import vadl.viam.Specification;
+import vadl.viam.graph.Graph;
+import vadl.viam.graph.NodeList;
+import vadl.viam.graph.control.AbstractEndNode;
+import vadl.viam.graph.dependency.BuiltInCall;
+import vadl.viam.graph.dependency.ExpressionNode;
+import vadl.viam.graph.dependency.ReadArtificialResNode;
+import vadl.viam.graph.dependency.SideEffectNode;
+import vadl.viam.graph.dependency.SliceNode;
+import vadl.viam.graph.dependency.WriteArtificialResNode;
+
+/**
+ * Expands partial alias accesses into the concrete concatenated/sliced access shape.
+ *
+ * <p>The frontend now preserves partial alias accesses such as {@code V(vd)} as one
+ * {@link ReadArtificialResNode} / {@link WriteArtificialResNode}. This pass restores the old VIAM
+ * shape by enumerating the missing alias dimensions and lowering them to the exact read/write
+ * sequence that downstream passes already understand.</p>
+ */
+public class ArtificialResPartialAccessExpansionPass extends Pass {
+
+  public ArtificialResPartialAccessExpansionPass(GeneralConfiguration configuration) {
+    super(configuration);
+  }
+
+  @Override
+  public PassName getName() {
+    return new PassName("Artificial Resource Partial Access Expansion");
+  }
+
+  @Nullable
+  @Override
+  public Object execute(PassResults passResults, Specification viam) throws IOException {
+    ViamUtils.findAllBehaviors(viam).forEach(this::expandInBehavior);
+    return null;
+  }
+
+  private void expandInBehavior(Graph behavior) {
+    behavior.getNodes(ReadArtificialResNode.class)
+        .filter(this::isPartialAccess)
+        .toList()
+        .forEach(this::expandRead);
+    behavior.getNodes(WriteArtificialResNode.class)
+        .filter(this::isPartialAccess)
+        .toList()
+        .forEach(this::expandWrite);
+  }
+
+  private boolean isPartialAccess(ReadArtificialResNode read) {
+    return read.indices().size() < read.resourceDefinition().dimensions().size();
+  }
+
+  private boolean isPartialAccess(WriteArtificialResNode write) {
+    return write.indices().size() < write.resourceDefinition().dimensions().size();
+  }
+
+  private void expandRead(ReadArtificialResNode read) {
+    var replacement = expandReadValue(read.resourceDefinition(), read.indices());
+    replacement.setSourceLocationIfNotSet(read.location());
+    read.replaceAndDelete(replacement);
+  }
+
+  private void expandWrite(WriteArtificialResNode write) {
+    var ends = write.usages()
+        .filter(AbstractEndNode.class::isInstance)
+        .map(AbstractEndNode.class::cast)
+        .toList();
+    var replacementByEnd = ends.stream()
+        .map(end -> expandWriteEffects(write))
+        .toList();
+
+    for (int i = 0; i < ends.size(); i++) {
+      var end = ends.get(i);
+      var replacements = replacementByEnd.get(i);
+      replacements.forEach(effect -> write.ensureGraph().addWithInputs(effect));
+      end.replaceSideEffect(write, replacements);
+    }
+
+    if (write.usageCount() == 0) {
+      write.safeDelete();
+    }
+  }
+
+  private ExpressionNode expandReadValue(ArtificialResource resource,
+                                         List<ExpressionNode> indices) {
+    var fullIndices = fullIndices(resource, indices);
+    ExpressionNode result = null;
+    int currentBitWidth = 0;
+
+    for (var indexList : fullIndices) {
+      var read = new ReadArtificialResNode(resource, new NodeList<>(indexList),
+          resource.resultType(indexList.size()));
+      currentBitWidth += read.type().bitWidth();
+      if (result == null) {
+        result = read;
+      } else {
+        result = new BuiltInCall(BuiltInTable.CONCATENATE_BITS, new NodeList<>(read, result),
+            Type.bits(currentBitWidth));
+      }
+    }
+
+    return requireNonNull(result);
+  }
+
+  private List<SideEffectNode> expandWriteEffects(WriteArtificialResNode write) {
+    var resource = write.resourceDefinition();
+    var fullIndices = fullIndices(resource, write.indices());
+    var result = new ArrayList<SideEffectNode>(fullIndices.size());
+    var elementWidth = resource.resultType(resource.dimensions().size()).bitWidth();
+
+    for (int i = 0; i < fullIndices.size(); i++) {
+      var lsb = i * elementWidth;
+      var msb = lsb + elementWidth - 1;
+      var slice = new SliceNode(
+          write.value(),
+          Constant.BitSlice.of(msb, lsb),
+          Type.bits(elementWidth)
+      );
+      slice.setSourceLocationIfNotSet(write.value().location());
+
+      var elementWrite = new WriteArtificialResNode(
+          resource,
+          new NodeList<>(fullIndices.get(i)),
+          slice,
+          write.nullableCondition() == null ? null : write.nullableCondition().copy()
+      );
+      elementWrite.setSourceLocationIfNotSet(write.location());
+      result.add(elementWrite);
+    }
+
+    return result;
+  }
+
+  private List<List<ExpressionNode>> fullIndices(ArtificialResource resource,
+                                                 List<ExpressionNode> indices) {
+    var missingDimensions = resource.dimensions().stream().skip(indices.size()).toList();
+    var missingTypes = missingDimensions.stream().map(RegisterTensor.Dimension::indexType)
+        .toList();
+    var missingPermutations = permutationOfTensorIndices(
+        missingDimensions.stream().map(RegisterTensor.Dimension::size).toList());
+
+    var missingIndices = missingPermutations.stream()
+        .map(entry -> Streams.zip(entry.stream(), missingTypes.stream(),
+            (value, type) -> (ExpressionNode) Constant.Value.of(value, type).toNode()).toList())
+        .toList();
+
+    return missingIndices.stream().map(item ->
+        Streams.concat(indices.stream(), item.stream()).toList()
+    ).toList();
+  }
+
+  private static List<List<Long>> permutationOfTensorIndices(List<Integer> dimensionSizes) {
+    if (dimensionSizes.isEmpty()) {
+      return List.of(List.of());
+    }
+
+    var currentSize = dimensionSizes.getFirst();
+    var suffixPermutations = permutationOfTensorIndices(dimensionSizes.subList(1,
+        dimensionSizes.size()));
+    var result = new ArrayList<List<Long>>(currentSize * suffixPermutations.size());
+    for (long i = 0; i < currentSize; i++) {
+      for (var suffix : suffixPermutations) {
+        var entry = new ArrayList<Long>(1 + suffix.size());
+        entry.add(i);
+        entry.addAll(suffix);
+        result.add(entry);
+      }
+    }
+    return result;
+  }
+}

--- a/vadl/main/vadl/viam/passes/PartialAccessExpansionSupport.java
+++ b/vadl/main/vadl/viam/passes/PartialAccessExpansionSupport.java
@@ -1,0 +1,184 @@
+// SPDX-FileCopyrightText : © 2026 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.viam.passes;
+
+import static java.util.Objects.requireNonNull;
+
+import com.google.common.collect.Streams;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nullable;
+import vadl.types.BuiltInTable;
+import vadl.types.Type;
+import vadl.viam.ArtificialResource;
+import vadl.viam.Constant;
+import vadl.viam.RegisterTensor;
+import vadl.viam.graph.NodeList;
+import vadl.viam.graph.dependency.BuiltInCall;
+import vadl.viam.graph.dependency.ExpressionNode;
+import vadl.viam.graph.dependency.ReadArtificialResNode;
+import vadl.viam.graph.dependency.ReadRegTensorNode;
+import vadl.viam.graph.dependency.SideEffectNode;
+import vadl.viam.graph.dependency.SliceNode;
+import vadl.viam.graph.dependency.WriteArtificialResNode;
+import vadl.viam.graph.dependency.WriteRegTensorNode;
+
+final class PartialAccessExpansionSupport {
+
+  private PartialAccessExpansionSupport() {
+  }
+
+  static ExpressionNode expandReadValue(ArtificialResource resource,
+                                        List<ExpressionNode> indices) {
+    var fullIndices = fullIndices(resource.dimensions(), indices);
+    ExpressionNode result = null;
+    int currentBitWidth = 0;
+
+    for (var indexList : fullIndices) {
+      var read = new ReadArtificialResNode(resource, new NodeList<>(indexList),
+          resource.resultType(indexList.size()));
+      currentBitWidth += read.type().bitWidth();
+      if (result == null) {
+        result = read;
+      } else {
+        result = new BuiltInCall(BuiltInTable.CONCATENATE_BITS, new NodeList<>(read, result),
+            Type.bits(currentBitWidth));
+      }
+    }
+
+    return requireNonNull(result);
+  }
+
+  static ExpressionNode expandReadValue(RegisterTensor resource,
+                                        List<ExpressionNode> indices,
+                                        @Nullable vadl.viam.Counter staticCounterAccess) {
+    var fullIndices = fullIndices(resource.indexDimensions(), indices);
+    ExpressionNode result = null;
+    int currentBitWidth = 0;
+
+    for (var indexList : fullIndices) {
+      var read = new ReadRegTensorNode(resource, new NodeList<>(indexList),
+          resource.resultType(indexList.size()), staticCounterAccess);
+      currentBitWidth += read.type().bitWidth();
+      if (result == null) {
+        result = read;
+      } else {
+        result = new BuiltInCall(BuiltInTable.CONCATENATE_BITS, new NodeList<>(read, result),
+            Type.bits(currentBitWidth));
+      }
+    }
+
+    return requireNonNull(result);
+  }
+
+  static List<SideEffectNode> expandWriteEffects(WriteArtificialResNode write) {
+    var resource = write.resourceDefinition();
+    var fullIndices = fullIndices(resource.dimensions(), write.indices());
+    var result = new ArrayList<SideEffectNode>(fullIndices.size());
+    var elementWidth = resource.resultType(resource.dimensions().size()).bitWidth();
+
+    for (int i = 0; i < fullIndices.size(); i++) {
+      var lsb = i * elementWidth;
+      var msb = lsb + elementWidth - 1;
+      var slice = new SliceNode(
+          write.value(),
+          Constant.BitSlice.of(msb, lsb),
+          Type.bits(elementWidth)
+      );
+      slice.setSourceLocationIfNotSet(write.value().location());
+
+      var elementWrite = new WriteArtificialResNode(
+          resource,
+          new NodeList<>(fullIndices.get(i)),
+          slice,
+          write.nullableCondition() == null ? null : write.nullableCondition().copy()
+      );
+      elementWrite.setSourceLocationIfNotSet(write.location());
+      result.add(elementWrite);
+    }
+
+    return result;
+  }
+
+  static List<SideEffectNode> expandWriteEffects(WriteRegTensorNode write) {
+    var resource = write.resourceDefinition();
+    var fullIndices = fullIndices(resource.indexDimensions(), write.indices());
+    var result = new ArrayList<SideEffectNode>(fullIndices.size());
+    var elementWidth = resource.resultType(resource.indexDimensions().size()).bitWidth();
+
+    for (int i = 0; i < fullIndices.size(); i++) {
+      var lsb = i * elementWidth;
+      var msb = lsb + elementWidth - 1;
+      var slice = new SliceNode(
+          write.value(),
+          Constant.BitSlice.of(msb, lsb),
+          Type.bits(elementWidth)
+      );
+      slice.setSourceLocationIfNotSet(write.value().location());
+
+      var elementWrite = new WriteRegTensorNode(
+          resource,
+          new NodeList<>(fullIndices.get(i)),
+          slice,
+          write.staticCounterAccess(),
+          write.nullableCondition() == null ? null : write.nullableCondition().copy()
+      );
+      elementWrite.setSourceLocationIfNotSet(write.location());
+      result.add(elementWrite);
+    }
+
+    return result;
+  }
+
+  private static List<List<ExpressionNode>> fullIndices(List<RegisterTensor.Dimension> dimensions,
+                                                        List<ExpressionNode> indices) {
+    var missingDimensions = dimensions.stream().skip(indices.size()).toList();
+    var missingTypes = missingDimensions.stream().map(RegisterTensor.Dimension::indexType)
+        .toList();
+    var missingPermutations = permutationOfTensorIndices(
+        missingDimensions.stream().map(RegisterTensor.Dimension::size).toList());
+
+    var missingIndices = missingPermutations.stream()
+        .map(entry -> Streams.zip(entry.stream(), missingTypes.stream(),
+            (value, type) -> (ExpressionNode) Constant.Value.of(value, type).toNode()).toList())
+        .toList();
+
+    return missingIndices.stream().map(item ->
+        Streams.concat(indices.stream(), item.stream()).toList()
+    ).toList();
+  }
+
+  private static List<List<Long>> permutationOfTensorIndices(List<Integer> dimensionSizes) {
+    if (dimensionSizes.isEmpty()) {
+      return List.of(List.of());
+    }
+
+    var currentSize = dimensionSizes.getFirst();
+    var suffixPermutations = permutationOfTensorIndices(dimensionSizes.subList(1,
+        dimensionSizes.size()));
+    var result = new ArrayList<List<Long>>(currentSize * suffixPermutations.size());
+    for (long i = 0; i < currentSize; i++) {
+      for (var suffix : suffixPermutations) {
+        var entry = new ArrayList<Long>(1 + suffix.size());
+        entry.add(i);
+        entry.addAll(suffix);
+        result.add(entry);
+      }
+    }
+    return result;
+  }
+}

--- a/vadl/main/vadl/viam/passes/RegisterTensorPartialAccessExpansionPass.java
+++ b/vadl/main/vadl/viam/passes/RegisterTensorPartialAccessExpansionPass.java
@@ -26,26 +26,26 @@ import vadl.utils.ViamUtils;
 import vadl.viam.Specification;
 import vadl.viam.graph.Graph;
 import vadl.viam.graph.control.AbstractEndNode;
-import vadl.viam.graph.dependency.ReadArtificialResNode;
-import vadl.viam.graph.dependency.WriteArtificialResNode;
+import vadl.viam.graph.dependency.ReadRegTensorNode;
+import vadl.viam.graph.dependency.WriteRegTensorNode;
 
 /**
- * Expands partial alias-register accesses into the concrete concatenated/sliced access shape.
+ * Expands partial base-register accesses into the concrete concatenated/sliced access shape.
  *
- * <p>The frontend now preserves partial alias accesses such as {@code V(vd)} as one
- * {@link ReadArtificialResNode} / {@link WriteArtificialResNode}. This pass restores the old VIAM
- * shape by enumerating the missing alias dimensions and lowering them to the exact read/write
- * sequence that downstream passes already understand.</p>
+ * <p>The frontend now preserves partial register-tensor accesses such as {@code V(vd)} as one
+ * {@link ReadRegTensorNode} / {@link WriteRegTensorNode}. This pass restores the old VIAM shape by
+ * enumerating the missing register dimensions and lowering them to the exact read/write sequence
+ * that downstream passes already understand.</p>
  */
-public class ArtificialResPartialAccessExpansionPass extends Pass {
+public class RegisterTensorPartialAccessExpansionPass extends Pass {
 
-  public ArtificialResPartialAccessExpansionPass(GeneralConfiguration configuration) {
+  public RegisterTensorPartialAccessExpansionPass(GeneralConfiguration configuration) {
     super(configuration);
   }
 
   @Override
   public PassName getName() {
-    return new PassName("Artificial Resource Partial Access Expansion");
+    return new PassName("Register Tensor Partial Access Expansion");
   }
 
   @Nullable
@@ -56,32 +56,32 @@ public class ArtificialResPartialAccessExpansionPass extends Pass {
   }
 
   private void expandInBehavior(Graph behavior) {
-    behavior.getNodes(ReadArtificialResNode.class)
+    behavior.getNodes(ReadRegTensorNode.class)
         .filter(this::isPartialAccess)
         .toList()
         .forEach(this::expandRead);
-    behavior.getNodes(WriteArtificialResNode.class)
+    behavior.getNodes(WriteRegTensorNode.class)
         .filter(this::isPartialAccess)
         .toList()
         .forEach(this::expandWrite);
   }
 
-  private boolean isPartialAccess(ReadArtificialResNode read) {
-    return read.indices().size() < read.resourceDefinition().dimensions().size();
+  private boolean isPartialAccess(ReadRegTensorNode read) {
+    return read.indices().size() < read.resourceDefinition().indexDimensions().size();
   }
 
-  private boolean isPartialAccess(WriteArtificialResNode write) {
-    return write.indices().size() < write.resourceDefinition().dimensions().size();
+  private boolean isPartialAccess(WriteRegTensorNode write) {
+    return write.indices().size() < write.resourceDefinition().indexDimensions().size();
   }
 
-  private void expandRead(ReadArtificialResNode read) {
+  private void expandRead(ReadRegTensorNode read) {
     var replacement = PartialAccessExpansionSupport.expandReadValue(
-        read.resourceDefinition(), read.indices());
+        read.resourceDefinition(), read.indices(), read.staticCounterAccess());
     replacement.setSourceLocationIfNotSet(read.location());
     read.replaceAndDelete(replacement);
   }
 
-  private void expandWrite(WriteArtificialResNode write) {
+  private void expandWrite(WriteRegTensorNode write) {
     var ends = write.usages()
         .filter(AbstractEndNode.class::isInstance)
         .map(AbstractEndNode.class::cast)

--- a/vadl/test/resources/frontend-snapshots/lowering/dynamicTensorSlicingForAllTensor.vadl
+++ b/vadl/test/resources/frontend-snapshots/lowering/dynamicTensorSlicingForAllTensor.vadl
@@ -68,50 +68,27 @@ instruction set architecture Tensor = {
 //    . : ' Encoding: encoding
 //    . : ' Assembly: assembly
 //    . : ' Behavior Graph:
-//    . : ' | n0  FieldRef             in: ()                succ: ()      type: b4     field: rd    format: F
-//    . : ' | n1  Constant             in: ()                succ: ()      type: b2     const: 0x0: Bits<2>
-//    . : ' | n2  ForIdx               in: ()                succ: ()      type: b4     from: 0   to: 3
-//    . : ' | n3  FieldRef             in: ()                succ: ()      type: b4     field: rs1   format: F
-//    . : ' | n4  Constant             in: ()                succ: ()      type: b2     const: 0x3: Bits<2>
-//    . : ' | n5  ReadsRegisterTensor  in: (n3 n4)           succ: ()      type: b32    reg: Q
-//    . : ' | n6  Constant             in: ()                succ: ()      type: b2     const: 0x2: Bits<2>
-//    . : ' | n7  ReadsRegisterTensor  in: (n3 n6)           succ: ()      type: b32    reg: Q
-//    . : ' | n8  Constant             in: ()                succ: ()      type: b2     const: 0x1: Bits<2>
-//    . : ' | n9  ReadsRegisterTensor  in: (n3 n8)           succ: ()      type: b32    reg: Q
-//    . : ' | n10 ReadsRegisterTensor  in: (n3 n1)           succ: ()      type: b32    reg: Q
-//    . : ' | n11 BuiltInCall          in: (n9 n10)          succ: ()      type: b64    builtin: VADL::concat
-//    . : ' | n12 BuiltInCall          in: (n7 n11)          succ: ()      type: b96    builtin: VADL::concat
-//    . : ' | n13 BuiltInCall          in: (n5 n12)          succ: ()      type: b128   builtin: VADL::concat
-//    . : ' | n14 Let                  in: (n13)             succ: ()      type: b128   name: v
-//    . : ' | n15 Constant             in: ()                succ: ()      type: b7     const: 0x20: Bits<7>
-//    . : ' | n16 ZeroExtend           in: (n2)              succ: ()      type: b7     fromWidth: 4
-//    . : ' | n17 BuiltInCall          in: (n15 n16)         succ: ()      type: b7     builtin: VADL::mul      operator: *
-//    . : ' | n18 BuiltInCall          in: (n15 n17)         succ: ()      type: b7     builtin: VADL::add      operator: +
-//    . : ' | n19 DynSlice             in: (n14 n18 n17)     succ: ()      type: u32    slice: dynamic
-//    . : ' | n20 FieldRef             in: ()                succ: ()      type: b4     field: rs2   format: F
-//    . : ' | n21 ReadsRegisterTensor  in: (n20 n4)          succ: ()      type: b32    reg: Q
-//    . : ' | n22 ReadsRegisterTensor  in: (n20 n6)          succ: ()      type: b32    reg: Q
-//    . : ' | n23 ReadsRegisterTensor  in: (n20 n8)          succ: ()      type: b32    reg: Q
-//    . : ' | n24 ReadsRegisterTensor  in: (n20 n1)          succ: ()      type: b32    reg: Q
-//    . : ' | n25 BuiltInCall          in: (n23 n24)         succ: ()      type: b64    builtin: VADL::concat
-//    . : ' | n26 BuiltInCall          in: (n22 n25)         succ: ()      type: b96    builtin: VADL::concat
-//    . : ' | n27 BuiltInCall          in: (n21 n26)         succ: ()      type: b128   builtin: VADL::concat
-//    . : ' | n28 Let                  in: (n27)             succ: ()      type: b128   name: m
-//    . : ' | n29 DynSlice             in: (n28 n18 n17)     succ: ()      type: u32    slice: dynamic
-//    . : ' | n30 BuiltInCall          in: (n19 n29)         succ: ()      type: u32    builtin: VADL::add      operator: +
-//    . : ' | n31 Tensor               in: (n2 n30)          succ: ()      type: b128
-//    . : ' | n32 Let                  in: (n31)             succ: ()      type: u128   name: sum
-//    . : ' | n33 Let                  in: (n32)             succ: ()      type: u128   name: p
-//    . : ' | n34 Slice                in: (n33)             succ: ()      type: b32    slice: [31..0]
-//    . : ' | n35 WritesRegisterTensor in: (n0 n1 n34)       succ: ()      reg: Q
-//    . : ' | n36 Slice                in: (n33)             succ: ()      type: b32    slice: [63..32]
-//    . : ' | n37 WritesRegisterTensor in: (n0 n8 n36)       succ: ()      reg: Q
-//    . : ' | n38 Slice                in: (n33)             succ: ()      type: b32    slice: [95..64]
-//    . : ' | n39 WritesRegisterTensor in: (n0 n6 n38)       succ: ()      reg: Q
-//    . : ' | n40 Slice                in: (n33)             succ: ()      type: b32    slice: [127..96]
-//    . : ' | n41 WritesRegisterTensor in: (n0 n4 n40)       succ: ()      reg: Q
-//    . : ' | n42 InstrEnd             in: (n35 n37 n39 n41) succ: ()      effects: 4
-//    . : ' | n43 Start                in: ()                succ: (n42)   next: set
+//    . : ' | n0  FieldRef             in: ()          succ: ()      type: b4     field: rd    format: F
+//    . : ' | n1  ForIdx               in: ()          succ: ()      type: b4     from: 0   to: 3
+//    . : ' | n2  FieldRef             in: ()          succ: ()      type: b4     field: rs1   format: F
+//    . : ' | n3  ReadsRegisterTensor  in: (n2)        succ: ()      type: b128   reg: Q
+//    . : ' | n4  Let                  in: (n3)        succ: ()      type: b128   name: v
+//    . : ' | n5  Constant             in: ()          succ: ()      type: b7     const: 0x20: Bits<7>
+//    . : ' | n6  ZeroExtend           in: (n1)        succ: ()      type: b7     fromWidth: 4
+//    . : ' | n7  BuiltInCall          in: (n5 n6)     succ: ()      type: b7     builtin: VADL::mul   operator: *
+//    . : ' | n8  BuiltInCall          in: (n5 n7)     succ: ()      type: b7     builtin: VADL::add   operator: +
+//    . : ' | n9  DynSlice             in: (n4 n8 n7)  succ: ()      type: u32    slice: dynamic
+//    . : ' | n10 FieldRef             in: ()          succ: ()      type: b4     field: rs2   format: F
+//    . : ' | n11 ReadsRegisterTensor  in: (n10)       succ: ()      type: b128   reg: Q
+//    . : ' | n12 Let                  in: (n11)       succ: ()      type: b128   name: m
+//    . : ' | n13 DynSlice             in: (n12 n8 n7) succ: ()      type: u32    slice: dynamic
+//    . : ' | n14 BuiltInCall          in: (n9 n13)    succ: ()      type: u32    builtin: VADL::add   operator: +
+//    . : ' | n15 Tensor               in: (n1 n14)    succ: ()      type: b128
+//    . : ' | n16 Let                  in: (n15)       succ: ()      type: u128   name: sum
+//    . : ' | n17 Let                  in: (n16)       succ: ()      type: u128   name: p
+//    . : ' | n18 WritesRegisterTensor in: (n0 n17)    succ: ()      reg: Q
+//    . : ' | n19 InstrEnd             in: (n18)       succ: ()      effects: 1
+//    . : ' | n20 Start                in: ()          succ: (n19)   next: set
 //    . : ' Assembly name: "assembly"
 //    . : ' | Function: func
 //    . : ' | FieldAccesses: []

--- a/vadl/test/vadl/iss/passes/IssTensorAssignmentToForallPassTest.java
+++ b/vadl/test/vadl/iss/passes/IssTensorAssignmentToForallPassTest.java
@@ -34,6 +34,7 @@ import vadl.iss.passes.nodes.IssWriteRegNode;
 import vadl.pass.PassResults;
 import vadl.types.BitsType;
 import vadl.types.BuiltInTable;
+import vadl.types.DataType;
 import vadl.types.Type;
 import vadl.viam.Constant;
 import vadl.viam.InstructionSetArchitecture;
@@ -45,9 +46,12 @@ import vadl.viam.graph.control.ForallNode;
 import vadl.viam.graph.control.InstrEndNode;
 import vadl.viam.graph.control.StartNode;
 import vadl.viam.graph.dependency.BuiltInCall;
+import vadl.viam.graph.dependency.ConstantNode;
 import vadl.viam.graph.dependency.ForIdxNode;
 import vadl.viam.graph.dependency.SideEffectNode;
 import vadl.viam.graph.dependency.TensorNode;
+import vadl.viam.graph.dependency.TruncateNode;
+import vadl.viam.graph.dependency.ZeroExtendNode;
 
 public class IssTensorAssignmentToForallPassTest extends AbstractTest {
 
@@ -80,7 +84,13 @@ public class IssTensorAssignmentToForallPassTest extends AbstractTest {
     var value = assertInstanceOf(BuiltInCall.class, chunkWrite.value());
     var bitOffset = assertInstanceOf(BuiltInCall.class, chunkWrite.bitOffset());
     assertInstanceOf(ForIdxNode.class, value.arg(0));
-    assertSame(value.arg(0), bitOffset.arg(0));
+    if (bitOffset.arg(0) instanceof ZeroExtendNode widenedIdx) {
+      assertSame(value.arg(0), widenedIdx.value());
+    } else if (bitOffset.arg(0) instanceof TruncateNode truncatedIdx) {
+      assertSame(value.arg(0), truncatedIdx.value());
+    } else {
+      assertSame(value.arg(0), bitOffset.arg(0));
+    }
   }
 
   @Test
@@ -97,21 +107,52 @@ public class IssTensorAssignmentToForallPassTest extends AbstractTest {
     assertFalse(fixture.tensorWrite().isDeleted());
   }
 
+  @Test
+  public void widensTensorBitOffsetArithmeticForNarrowLoopIndices() throws IOException {
+    var fixture = createTensorWriteFixture("narrow_loop_idx", 256, 8, Type.bits(4), Type.bits(32));
+
+    runPass(fixture.specification());
+
+    var chunkWrite = fixture.instruction().behavior().getNodes(IssWriteRegNode.class)
+        .filter(write -> write.windowKind() == IssWriteRegNode.WindowKind.CHUNK)
+        .findFirst()
+        .orElseThrow();
+    var bitOffset = assertInstanceOf(BuiltInCall.class, chunkWrite.bitOffset());
+    assertInstanceOf(ZeroExtendNode.class, bitOffset.arg(0));
+    var elementWidth = assertInstanceOf(ConstantNode.class, bitOffset.arg(1));
+    assertEquals(32, elementWidth.constant().asVal().intValue());
+    var originalTensor = assertInstanceOf(TensorNode.class, fixture.tensorWrite().value());
+    assertTrue(elementWidth.type().asDataType().bitWidth()
+        > originalTensor.idx().type().bitWidth());
+  }
+
   private void runPass(Specification specification) throws IOException {
     var configuration = IssConfiguration.from(getConfiguration(false));
     new IssTensorAssignmentToForallPass(configuration).execute(new PassResults(), specification);
   }
 
   private static Fixture createTensorWriteFixture(String name, int regBitWidth, int lanes) {
+    return createTensorWriteFixture(name, regBitWidth, lanes, Type.bits(8), Type.bits(8));
+  }
+
+  private static Fixture createTensorWriteFixture(String name,
+                                                  int regBitWidth,
+                                                  int lanes,
+                                                  DataType loopIdxType,
+                                                  DataType tensorElementType) {
     var spec = TestUtils.createSpecification(name + ".specification");
     var format = TestUtils.createFormat(name + ".format", BitsType.bits(32));
     var instruction = TestUtils.createInstruction(name + ".instruction", format);
     var reg = RegisterTensor.of(TestUtils.createIdentifier(name + ".reg"), regBitWidth);
     var otherReg = RegisterTensor.of(TestUtils.createIdentifier(name + ".other_reg"), 64);
 
-    var idx = new ForIdxNode(Type.bits(8), 0, lanes - 1);
+    var idx = new ForIdxNode(loopIdxType, 0, lanes - 1);
+    var widenedIdx = idx.type().bitWidth() == tensorElementType.bitWidth()
+        ? idx
+        : new ZeroExtendNode(idx, tensorElementType);
     var tensor = new TensorNode(Type.bits(regBitWidth), idx,
-        BuiltInTable.ADD.call(idx, Constant.Value.of(1, Type.bits(8)).toNode()));
+        BuiltInTable.ADD.call(widenedIdx,
+            Constant.Value.of(1, tensorElementType.asDataType()).toNode()));
     var tensorWrite = new IssWriteRegNode(reg, new NodeList<>(), tensor, null);
     var otherWrite = new IssWriteRegNode(otherReg, new NodeList<>(),
         Constant.Value.zero(Type.bits(64).asDataType()).toNode(), null);

--- a/vadl/test/vadl/iss/riscv/IssRV64IInstrTest.java
+++ b/vadl/test/vadl/iss/riscv/IssRV64IInstrTest.java
@@ -41,6 +41,10 @@ public class IssRV64IInstrTest extends AbstractIssRiscv64InstrTest {
 
   private static final String VADL_SPEC = "sys/risc-v/rv64v.vadl";
   private static final int TESTS_PER_INSTRUCTION = 50;
+  // The test linker places .text.init at 0x80000000 and aligns .tohost to the next 4 KiB page.
+  // Keep randomized load/store scratch addresses above that reserved startup/HTIF region.
+  private static final BigInteger TEST_DATA_MIN_ADDR = BigInteger.valueOf(0x80002000L);
+  private static final BigInteger TEST_DATA_MAX_ADDR = BigInteger.valueOf(0x800F0000L);
 
   @Override
   public int getTestPerInstruction() {
@@ -189,7 +193,7 @@ public class IssRV64IInstrTest extends AbstractIssRiscv64InstrTest {
       var storeReg = b.anyTempReg().sample();
       b.fillRegSigned(storeReg, dataSize);
       var addrReg = b.anyTempReg().sample();
-      b.fillReg(addrReg, BigInteger.valueOf(0x80000100L), BigInteger.valueOf(0x800F0000L),
+      b.fillReg(addrReg, TEST_DATA_MIN_ADDR, TEST_DATA_MAX_ADDR,
           calculateAlignment(dataSize));
       b.add("%s %s, 0(%s)", storeInstruction, storeReg, addrReg);
       var loadReg = b.anyTempReg().sample();
@@ -207,7 +211,7 @@ public class IssRV64IInstrTest extends AbstractIssRiscv64InstrTest {
       var storeReg = b.anyTempReg().sample();
       b.fillRegSigned(storeReg, dataSize);
       var addrReg = b.anyTempReg().sample();
-      b.fillReg(addrReg, BigInteger.valueOf(0x80000100L), BigInteger.valueOf(0x800F0000L),
+      b.fillReg(addrReg, TEST_DATA_MIN_ADDR, TEST_DATA_MAX_ADDR,
           calculateAlignment(dataSize));
       b.add("%s %s, 0(%s)", instruction, storeReg, addrReg);
       var loadReg = b.anyTempReg()

--- a/vadl/test/vadl/viam/passes/ArtificialResPartialAccessExpansionPassTest.java
+++ b/vadl/test/vadl/viam/passes/ArtificialResPartialAccessExpansionPassTest.java
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText : © 2026 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.viam.passes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+import vadl.AbstractTest;
+import vadl.TestUtils;
+import vadl.pass.PassOrders;
+import vadl.pass.exception.DuplicatedPassKeyException;
+import vadl.viam.Instruction;
+import vadl.viam.graph.dependency.ReadArtificialResNode;
+import vadl.viam.graph.dependency.WriteArtificialResNode;
+
+public class ArtificialResPartialAccessExpansionPassTest extends AbstractTest {
+
+  @Test
+  void frontendKeepsVectorBenchTensorWriteAsPartialAliasWrite() throws IOException {
+    var spec = runAndGetViamSpecification("sys/vectorbench/vectorbench64.vadl");
+    var instr = TestUtils.findDefinitionByNameIn("VectorBench64::VADD_TENSOR_VV", spec,
+        Instruction.class);
+
+    var aliasWrites = instr.behavior().getNodes(WriteArtificialResNode.class)
+        .filter(write -> write.resourceDefinition().simpleName().equals("V"))
+        .toList();
+    assertEquals(1, aliasWrites.size());
+    assertEquals(1, aliasWrites.getFirst().indices().size());
+    assertEquals(1024, aliasWrites.getFirst().value().type().asDataType().bitWidth());
+  }
+
+  @Test
+  void frontendKeepsVectorBenchStoreAsPartialAliasRead() throws IOException {
+    var spec = runAndGetViamSpecification("sys/vectorbench/vectorbench64.vadl");
+    var instr = TestUtils.findDefinitionByNameIn("VectorBench64::VST", spec, Instruction.class);
+
+    var aliasReads = instr.behavior().getNodes(ReadArtificialResNode.class)
+        .filter(read -> read.resourceDefinition().simpleName().equals("V"))
+        .toList();
+    assertEquals(1, aliasReads.size());
+    assertEquals(1, aliasReads.getFirst().indices().size());
+    assertEquals(1024, aliasReads.getFirst().type().bitWidth());
+  }
+
+  @Test
+  void expansionPassRestoresConcreteVectorBenchAliasAccesses()
+      throws IOException, DuplicatedPassKeyException {
+    var setup = setupPassManagerAndRunSpec(
+        "sys/vectorbench/vectorbench64.vadl",
+        PassOrders.viam(getConfiguration(false))
+            .untilFirst(ArtificialResPartialAccessExpansionPass.class)
+    );
+    var spec = setup.specification();
+
+    var tensorInstr = TestUtils.findDefinitionByNameIn("VectorBench64::VADD_TENSOR_VV", spec,
+        Instruction.class);
+    assertEquals(32, tensorInstr.behavior().getNodes(WriteArtificialResNode.class)
+        .filter(write -> write.resourceDefinition().simpleName().equals("V"))
+        .count());
+    assertEquals(0, tensorInstr.behavior().getNodes(WriteArtificialResNode.class)
+        .filter(write -> write.resourceDefinition().simpleName().equals("V"))
+        .filter(write -> write.indices().size() < write.resourceDefinition().dimensions().size())
+        .count());
+
+    var storeInstr = TestUtils.findDefinitionByNameIn("VectorBench64::VST", spec,
+        Instruction.class);
+    assertEquals(32, storeInstr.behavior().getNodes(ReadArtificialResNode.class)
+        .filter(read -> read.resourceDefinition().simpleName().equals("V"))
+        .count());
+    assertEquals(0, storeInstr.behavior().getNodes(ReadArtificialResNode.class)
+        .filter(read -> read.resourceDefinition().simpleName().equals("V"))
+        .filter(read -> read.indices().size() < read.resourceDefinition().dimensions().size())
+        .count());
+  }
+}


### PR DESCRIPTION
This PR moves the partial (alias) register access expansion to the VIAM.
This means that the frontend generates normal (alias) register access nodes, even for accesses where not all indices are provided. 

In the common VIAM pipeline, two passes perform the expansion logic on the register accesses, so the VIAM stays the same for all backends.

This is crucial for the ISS, as it will later bypass the expansion passes and handle partial vector accesses independently, resulting in improved performance.