### PR TITLE
iss: Implement VADL::rrx, add VADL::rrxs

### DIFF
--- a/docs/refman/refmanual.md
+++ b/docs/refman/refmanual.md
@@ -389,8 +389,8 @@ The carry flag is unchanged if the shift/rotate amount is `0`.
 Rotate left (right) provides the operand `a` rotated by a variable number of bits.
 The bits that are rotated off the left (right) end are inserted into the vacated bit positions on the right (left).
 Rotate right with extend ( `rrx`) moves the bits of a register to the right by one bit.
-It copies the carry flag into the highest bit position of the result and sets the carry flag to lowest bit position of
-operand `a`.
+It copies the carry flag into the highest bit position of the result and sets the carry flag to the lowest bit position
+of operand `a`.
 
 \listing{basic_math_shifting, VADL Shifting Operations}
 
@@ -414,7 +414,9 @@ function rolc( a : Bits<N>, b : UInt<M>, c : Bool ) -> ( Bits<N>, Status )
 function ror ( a : Bits<N>, b : UInt<M> ) -> Bits<N> // <=> a <>> b
 function rors( a : Bits<N>, b : UInt<M> ) -> ( Bits<N>, Status )
 function rorc( a : Bits<N>, b : UInt<M>, c : Bool ) -> ( Bits<N>, Status )
+
 function rrx ( a : Bits<N>, c : Bool ) -> Bits<N>
+function rrxs( a : Bits<N>, c : Bool ) -> ( Bits<N>, Status )
 ~~~
 
 \endlisting

--- a/sys/aarch32/aarch32.vadl
+++ b/sys/aarch32/aarch32.vadl
@@ -275,21 +275,21 @@ instruction set architecture AArch32v6 = {
     }
 
   model ShiftedImmOpInstr (m : IdCondInstrFlagsShiftModel, c : CondRec, i : InstrRec, f : FlagRec) : IsaDefs = {
-    $m (ArithShiftImmFormat ; $c ; $i ; $f ; (LSL0 ; type = ShiftType::LSLI, imm5 = 0 ; R(rm)                        ;  ''                     ))
-    $m (ArithShiftImmFormat ; $c ; $i ; $f ; (LSL  ; type = ShiftType::LSLI           ; R(rm) << imm5                ; (', lsl #', udec(imm5)) ))
-    $m (ArithShiftImmFormat ; $c ; $i ; $f ; (LSR0 ; type = ShiftType::LSRI, imm5 = 0 ; 0 as Word                    ; (', lsr #32'          ) ))
-    $m (ArithShiftImmFormat ; $c ; $i ; $f ; (LSR  ; type = ShiftType::LSRI           ; R(rm) >> imm5                ; (', lsr #', udec(imm5)) ))
-    $m (ArithShiftImmFormat ; $c ; $i ; $f ; (ASR0 ; type = ShiftType::ASRI, imm5 = 0 ; R(rm) as SInt >> 31          ; (', asr #32'          ) ))
-    $m (ArithShiftImmFormat ; $c ; $i ; $f ; (ASR  ; type = ShiftType::ASRI           ; R(rm) as SInt >> imm5        ; (', asr #', udec(imm5)) ))
-    $m (ArithShiftImmFormat ; $c ; $i ; $f ; (RRX  ; type = ShiftType::RORI, imm5 = 0 ; VADL::rrx (R(rm), 1, APSR_C) ; (', rrx #1')            ))
-    $m (ArithShiftImmFormat ; $c ; $i ; $f ; (ROR  ; type = ShiftType::RORI           ; R(rm) <>> imm5               ; (', ror #', udec(imm5)) ))
+    $m (ArithShiftImmFormat ; $c ; $i ; $f ; (LSL0 ; type = ShiftType::LSLI, imm5 = 0 ; R(rm)                     ;  ''                     ))
+    $m (ArithShiftImmFormat ; $c ; $i ; $f ; (LSL  ; type = ShiftType::LSLI           ; R(rm) << imm5             ; (', lsl #', udec(imm5)) ))
+    $m (ArithShiftImmFormat ; $c ; $i ; $f ; (LSR0 ; type = ShiftType::LSRI, imm5 = 0 ; 0 as Word                 ; (', lsr #32'          ) ))
+    $m (ArithShiftImmFormat ; $c ; $i ; $f ; (LSR  ; type = ShiftType::LSRI           ; R(rm) >> imm5             ; (', lsr #', udec(imm5)) ))
+    $m (ArithShiftImmFormat ; $c ; $i ; $f ; (ASR0 ; type = ShiftType::ASRI, imm5 = 0 ; R(rm) as SInt >> 31       ; (', asr #32'          ) ))
+    $m (ArithShiftImmFormat ; $c ; $i ; $f ; (ASR  ; type = ShiftType::ASRI           ; R(rm) as SInt >> imm5     ; (', asr #', udec(imm5)) ))
+    $m (ArithShiftImmFormat ; $c ; $i ; $f ; (RRX  ; type = ShiftType::RORI, imm5 = 0 ; VADL::rrx (R(rm), APSR_C) ; (', rrx'              ) ))
+    $m (ArithShiftImmFormat ; $c ; $i ; $f ; (ROR  ; type = ShiftType::RORI           ; R(rm) <>> imm5            ; (', ror #', udec(imm5)) ))
     }
 
   model ShiftedRegOpInstr (m : IdCondInstrFlagsShiftModel, c : CondRec, i : InstrRec, f : FlagRec) : IsaDefs = {
-    $m (ArithShiftRegFormat ; $c ; $i ; $f ; (LSLR ; type = ShiftType::LSLR, op1 = 0  ; lslW (R(rm), R(rs))          ; (', lsl ', register(rs))))
-    $m (ArithShiftRegFormat ; $c ; $i ; $f ; (LSRR ; type = ShiftType::LSRR, op1 = 0  ; lsrW (R(rm), R(rs))          ; (', lsr ', register(rs))))
-    $m (ArithShiftRegFormat ; $c ; $i ; $f ; (ASRR ; type = ShiftType::ASRR, op1 = 0  ; asrW (R(rm), R(rs))          ; (', asr ', register(rs))))
-    $m (ArithShiftRegFormat ; $c ; $i ; $f ; (RORR ; type = ShiftType::RORR, op1 = 0  ; R(rm) <>> R(rs)              ; (', ror ', register(rs))))
+    $m (ArithShiftRegFormat ; $c ; $i ; $f ; (LSLR ; type = ShiftType::LSLR, op1 = 0  ; lslW (R(rm), R(rs))       ; (', lsl ', register(rs))))
+    $m (ArithShiftRegFormat ; $c ; $i ; $f ; (LSRR ; type = ShiftType::LSRR, op1 = 0  ; lsrW (R(rm), R(rs))       ; (', lsr ', register(rs))))
+    $m (ArithShiftRegFormat ; $c ; $i ; $f ; (ASRR ; type = ShiftType::ASRR, op1 = 0  ; asrW (R(rm), R(rs))       ; (', asr ', register(rs))))
+    $m (ArithShiftRegFormat ; $c ; $i ; $f ; (RORR ; type = ShiftType::RORR, op1 = 0  ; R(rm) <>> R(rs)           ; (', ror ', register(rs))))
     }
 
   model ArithmeticSftInstr (c : CondRec, i : InstrRec, f : FlagRec) : IsaDefs = {
@@ -481,14 +481,14 @@ instruction set architecture AArch32v6 = {
     }
 
   model MemRegShiftInstr (c : CondRec, i : InstrRec, blId : Id, memStmt : Stats) : IsaDefs = {
-    $MemRegInstr ($c ; $i ; $blId ; $memStmt ; (LSL0 ; type = ShiftType::LSLI, imm5 = 0 ; R(rm)                        ;  ''                     ))
-    $MemRegInstr ($c ; $i ; $blId ; $memStmt ; (LSL  ; type = ShiftType::LSLI           ; R(rm) << imm5                ; (', lsl #', udec(imm5)) ))
-    $MemRegInstr ($c ; $i ; $blId ; $memStmt ; (LSR0 ; type = ShiftType::LSRI, imm5 = 0 ; 0 as Word                    ; (', lsr #32')           ))
-    $MemRegInstr ($c ; $i ; $blId ; $memStmt ; (LSR  ; type = ShiftType::LSRI           ; R(rm) >> imm5                ; (', lsr #', udec(imm5)) ))
-    $MemRegInstr ($c ; $i ; $blId ; $memStmt ; (ASR0 ; type = ShiftType::ASRI, imm5 = 0 ; R(rm) as SInt >> 31          ; (', asr #32')           ))
-    $MemRegInstr ($c ; $i ; $blId ; $memStmt ; (ASR  ; type = ShiftType::ASRI           ; R(rm) as SInt >> imm5        ; (', asr #', udec(imm5)) ))
-    $MemRegInstr ($c ; $i ; $blId ; $memStmt ; (RRX  ; type = ShiftType::RORI, imm5 = 0 ; VADL::rrx (R(rm), 1, APSR_C) ; (', rrx #1')            ))
-    $MemRegInstr ($c ; $i ; $blId ; $memStmt ; (ROR  ; type = ShiftType::RORI           ; R(rm) <>> imm5               ; (', ror #', udec(imm5)) ))
+    $MemRegInstr ($c ; $i ; $blId ; $memStmt ; (LSL0 ; type = ShiftType::LSLI, imm5 = 0 ; R(rm)                     ;  ''                     ))
+    $MemRegInstr ($c ; $i ; $blId ; $memStmt ; (LSL  ; type = ShiftType::LSLI           ; R(rm) << imm5             ; (', lsl #', udec(imm5)) ))
+    $MemRegInstr ($c ; $i ; $blId ; $memStmt ; (LSR0 ; type = ShiftType::LSRI, imm5 = 0 ; 0 as Word                 ; (', lsr #32'          ) ))
+    $MemRegInstr ($c ; $i ; $blId ; $memStmt ; (LSR  ; type = ShiftType::LSRI           ; R(rm) >> imm5             ; (', lsr #', udec(imm5)) ))
+    $MemRegInstr ($c ; $i ; $blId ; $memStmt ; (ASR0 ; type = ShiftType::ASRI, imm5 = 0 ; R(rm) as SInt >> 31       ; (', asr #32'          ) ))
+    $MemRegInstr ($c ; $i ; $blId ; $memStmt ; (ASR  ; type = ShiftType::ASRI           ; R(rm) as SInt >> imm5     ; (', asr #', udec(imm5)) ))
+    $MemRegInstr ($c ; $i ; $blId ; $memStmt ; (RRX  ; type = ShiftType::RORI, imm5 = 0 ; VADL::rrx (R(rm), APSR_C) ; (', rrx'              ) ))
+    $MemRegInstr ($c ; $i ; $blId ; $memStmt ; (ROR  ; type = ShiftType::RORI           ; R(rm) <>> imm5            ; (', ror #', udec(imm5)) ))
     }
 
   model MemoryInstr (c : CondRec, i : InstrRec,  blId : Id, memStmt : Stats) : IsaDefs = {

--- a/vadl/main/resources/templates/common/vadl-builtins.h
+++ b/vadl/main/resources/templates/common/vadl-builtins.h
@@ -537,27 +537,20 @@ static inline Bits VADL_ror(Bits a, Width aw, Bits b, Width bw) {
     return (right | left) & m;
 }
 
-// TODO: What is the exact semantic of rrx?
 /*-----------------------------------------------------------------------
- *    rrx(a : Bits<N>, b : UInt<M>, c : Bool) => Bits<N>
- *    Rotate-right-extend by b bits, each step inserting 'c' from the left.
+ *    rrx(a : Bits<N>, c : Bool) => Bits<N>
+ *    Rotate-right-extend: Rotate right by one bit, using 'c' as the 33rd bit.
  *---------------------------------------------------------------------*/
-static inline Bits VADL_rrx(Bits a, Width aw, Bits b, Width bw, Bits c, Width cw) {
+static inline Bits VADL_rrx(Bits a, Width aw, Bits c, Width cw) {
     Bits x = VADL_uextract(a, aw);
-    Bits s = VADL_uextract(b, bw);
     // normalize c to 0 or 1
     c = c != 0;
-    s %= aw;
 
     Bits m   = VADL_mask(aw);
     Bits reg = x & m;
 
-    while (s > 0ULL) {
-        /* Shift right by 1, insert 'c' at top (bit aw-1). */
-        Bits top = (c & 1ULL) << (aw - 1);
-        reg      = ((reg >> 1) | top) & m;
-        s--;
-    }
+    Bits top = (c & 1ULL) << (aw - 1);
+    reg = ((reg >> 1) | top) & m;
 
     return reg;
 }

--- a/vadl/main/vadl/iss/passes/common/IssNormalizationPass.java
+++ b/vadl/main/vadl/iss/passes/common/IssNormalizationPass.java
@@ -22,6 +22,7 @@ import static vadl.utils.GraphUtils.add;
 import static vadl.utils.GraphUtils.bits;
 import static vadl.utils.GraphUtils.intU;
 import static vadl.utils.GraphUtils.intUNode;
+import static vadl.utils.GraphUtils.or;
 import static vadl.utils.GraphUtils.sub;
 import static vadl.utils.StreamUtils.only;
 
@@ -694,7 +695,17 @@ class IssNormalizer implements VadlBuiltInNoStatusDispatcher<BuiltInCall> {
 
   @Override
   public void handleRRX(BuiltInCall input) {
-    throw graphError(input, "Normalization not yet implemented for this built-in");
+    // we replace RRX as there is no such TCG operation.
+    var opWidth = input.type().asDataType().bitWidth();
+    var val = input.arg(0);
+    var cr = input.arg(1);
+    // the input operand is shifted right by 1
+    var valShifted = BuiltInTable.LSR.call(val, intUNode(1, 32));
+    // the carry bit is shifted to the msb
+    var crShifted = BuiltInTable.LSL.call(cr, intUNode(opWidth - 1, 32));
+    ExpressionNode result = BuiltInTable.OR.call(valShifted, crShifted);
+    result = truncate(result, opWidth);
+    input.replaceAndDelete(result);
   }
 
   @Override

--- a/vadl/main/vadl/iss/passes/tcg/lowering/TcgOpLoweringPass.java
+++ b/vadl/main/vadl/iss/passes/tcg/lowering/TcgOpLoweringPass.java
@@ -61,6 +61,7 @@ import vadl.iss.passes.tcg.lowering.nodes.TcgDepositNode;
 import vadl.iss.passes.tcg.lowering.nodes.TcgDivNode;
 import vadl.iss.passes.tcg.lowering.nodes.TcgExtractNode;
 import vadl.iss.passes.tcg.lowering.nodes.TcgGenException;
+import vadl.iss.passes.tcg.lowering.nodes.TcgGetVar;
 import vadl.iss.passes.tcg.lowering.nodes.TcgGottoTb;
 import vadl.iss.passes.tcg.lowering.nodes.TcgLoadMemory;
 import vadl.iss.passes.tcg.lowering.nodes.TcgLookupAndGotoPtr;

--- a/vadl/main/vadl/types/BuiltInTable.java
+++ b/vadl/main/vadl/types/BuiltInTable.java
@@ -945,6 +945,8 @@ public class BuiltInTable {
   public static final BuiltIn RRX =
       func("VADL::rrx",
           Type.relation(List.of(BitsType.class, BoolType.class), BitsType.class))
+          .compute((Constant.Value a, Constant.Value c) -> a.rrx(c.bool())
+              .get(BUILTIN_RESULT, Constant.Value.class))
           .takesDefault()
           .returnsFirstBitWidth(BitsType.class)
           .build();
@@ -956,6 +958,7 @@ public class BuiltInTable {
   public static final BuiltIn RRXS =
       func("VADL::rrxs",
           Type.relation(List.of(BitsType.class, BoolType.class), BitsType.class))
+          .compute((Constant.Value a, Constant.Value c) -> a.rrx(c.bool()))
           .takesDefault()
           .returnsFirstBitWidthAndStatus(BitsType.class)
           .build();

--- a/vadl/main/vadl/types/BuiltInTable.java
+++ b/vadl/main/vadl/types/BuiltInTable.java
@@ -940,14 +940,24 @@ public class BuiltInTable {
 
 
   /**
-   * {@code function rrx ( a : Bits<N>, b : UInt<M>, c : Bool ) -> Bits<N> }
+   * {@code function rrx ( a : Bits<N>, c : Bool ) -> Bits<N> }
    */
   public static final BuiltIn RRX =
       func("VADL::rrx",
-          Type.relation(List.of(BitsType.class, UIntType.class, BoolType.class),
-              BitsType.class))
+          Type.relation(List.of(BitsType.class, BoolType.class), BitsType.class))
           .takesDefault()
           .returnsFirstBitWidth(BitsType.class)
+          .build();
+
+
+  /**
+   * {@code function rrxs( a : Bits<N>, c : Bool ) -> ( Bits<N>, Status ) }
+   */
+  public static final BuiltIn RRXS =
+      func("VADL::rrxs",
+          Type.relation(List.of(BitsType.class, BoolType.class), BitsType.class))
+          .takesDefault()
+          .returnsFirstBitWidthAndStatus(BitsType.class)
           .build();
 
 
@@ -1407,7 +1417,8 @@ public class BuiltInTable {
       ROR,
       RORS,
       RORC,
-      RRX
+      RRX,
+      RRXS
   );
 
   public static final List<BuiltIn> BITWISE_COUNTING_BUILT_INS = List.of(

--- a/vadl/main/vadl/utils/VadlBuiltInStatusOnlyDispatcher.java
+++ b/vadl/main/vadl/utils/VadlBuiltInStatusOnlyDispatcher.java
@@ -105,6 +105,8 @@ public interface VadlBuiltInStatusOnlyDispatcher<T> {
       handleRORS(input);
     } else if (builtIn == BuiltInTable.RORC) {
       handleRORC(input);
+    } else if (builtIn == BuiltInTable.RRXS) {
+      handleRRXS(input);
     } else {
       return false;
     }
@@ -184,6 +186,8 @@ public interface VadlBuiltInStatusOnlyDispatcher<T> {
   void handleRORS(T input);
 
   void handleRORC(T input);
+
+  void handleRRXS(T input);
 
 
 }

--- a/vadl/main/vadl/viam/Constant.java
+++ b/vadl/main/vadl/viam/Constant.java
@@ -731,6 +731,38 @@ public abstract class Constant {
     }
 
     /**
+     * Performs a rotate-right-extend of this constant value. The value is shifted
+     * right by 1. The vacated msb is set to the given carry and the carry in turn
+     * becomes the shifted out bit (which is the lsb of the original value).
+     * The resulting type is the same as this type.
+     *
+     * @return a struct constant of form {@code ( result, ( z, c, o, n ) )}
+     */
+    public Struct rrx(boolean carry) {
+      int width = type().bitWidth();
+
+      BigInteger mask = BigInteger.ONE.shiftLeft(width).subtract(BigInteger.ONE); // width-bit mask
+
+      BigInteger rotated = value.shiftRight(1);
+      if (carry) {
+        rotated = rotated.or(BigInteger.ONE.shiftLeft(width - 1));
+      }
+      rotated = rotated.and(mask);
+
+      var isZero = rotated.equals(BigInteger.ZERO);
+      var isNegative = rotated.testBit(width - 1);
+      // carry is set to the shifted out bit (the lsb)
+      var isCarry = value.testBit(0);
+      var isOverflow = false;
+
+      var fields = new LinkedHashMap<String, Constant>();
+      fields.put(BUILTIN_RESULT, Constant.Value.fromTwosComplement(rotated, type()));
+      fields.put(BUILTIN_STATUS, Struct.status(isNegative, isZero, isCarry, isOverflow));
+
+      return new Struct(fields);
+    }
+
+    /**
      * Truncates this value to the width of the newType argument.
      * The newType must have the same type class as this type and its with must be
      * less or equal to this constant's width.

--- a/vadl/main/vadl/viam/passes/statusBuiltInInlinePass/RemoveUnusedStatusFlagsFromBuiltinsPass.java
+++ b/vadl/main/vadl/viam/passes/statusBuiltInInlinePass/RemoveUnusedStatusFlagsFromBuiltinsPass.java
@@ -317,5 +317,10 @@ class ResultInliner implements VadlBuiltInStatusOnlyDispatcher<BuiltInCall> {
   public void handleRORC(BuiltInCall input) {
     throwNotImplemented(input);
   }
+
+  @Override
+  public void handleRRXS(BuiltInCall input) {
+    inlineDefault(input, BuiltInTable.RRX);
+  }
 }
 

--- a/vadl/main/vadl/viam/passes/statusBuiltInInlinePass/StatusBuiltInInlinePass.java
+++ b/vadl/main/vadl/viam/passes/statusBuiltInInlinePass/StatusBuiltInInlinePass.java
@@ -279,4 +279,9 @@ class StatusBuiltInInliner implements VadlBuiltInStatusOnlyDispatcher<BuiltInCal
   public void handleRORC(BuiltInCall input) {
     throwNotImplemented(input);
   }
+
+  @Override
+  public void handleRRXS(BuiltInCall input) {
+    throwNotImplemented(input);
+  }
 }

--- a/vadl/test/resources/testSource/passes/canonicalization/valid_builtin_constant_evaluation.vadl
+++ b/vadl/test/resources/testSource/passes/canonicalization/valid_builtin_constant_evaluation.vadl
@@ -167,7 +167,10 @@
 #not_(1, $b1, 0, $b1)
 
 
-/////////////// LOGICAL OPERATIONS /////////////////
+/////////////// SHIFT/ROTATE OPERATIONS /////////////////
+
+
+// VADL::ror
 
 #macro(ror_ $a, $at, $b, $bt, $result, $resultType)
 #ntest("ror", {$a: $at, $b: $bt}, "VADL::ror($a as $at, $b as $bt)", $result, $resultType )
@@ -182,6 +185,37 @@
 #ror_(0, $b1, 1, $b1, 0, $b1)
 #ror_(1, $b1, 1, $b1, 1, $b1)
 
+
+// VADL::rrx
+
+#macro(rrx_ $a, $at, $c, $result, $resultType)
+#ntest("rrx", {$a: $at, $c: $b1}, "VADL::rrx($a as $at, $c as $b1)", $result, $resultType )
+#end
+
+#rrx_(0, $b1, 0, 0, $b1)
+#rrx_(0, $b1, 1, 1, $b1)
+#rrx_(0, $b2, 0, 0, $b2)
+#rrx_(0, $b2, 1, 2, $b2)
+#rrx_(0, $b4, 0, 0, $b4)
+#rrx_(0, $b4, 1, 8, $b4)
+
+#rrx_(1, $b1, 0, 0, $b1)
+#rrx_(1, $b1, 1, 1, $b1)
+#rrx_(1, $b2, 0, 0, $b2)
+#rrx_(1, $b2, 1, 2, $b2)
+#rrx_(1, $b4, 0, 0, $b4)
+#rrx_(1, $b4, 1, 8, $b4)
+
+#rrx_(2, $b2, 0, 1, $b2)
+#rrx_(2, $b2, 1, 3, $b2)
+#rrx_(2, $b4, 0, 1, $b4)
+#rrx_(2, $b4, 1, 9, $b4)
+
+#rrx_(75, $b8, 0, 37, $b8)
+#rrx_(75, $b8, 1, 165, $b8)
+
+#rrx_(27075, $b16, 0, 13537, $b16)
+#rrx_(27075, $b16, 1, 46305, $b16)
 
 
 ///////// TEST MACROS Implementation ///////////

--- a/vadl/test/vadl/cppCodeGen/BuiltinCTest.java
+++ b/vadl/test/vadl/cppCodeGen/BuiltinCTest.java
@@ -1415,37 +1415,36 @@ public class BuiltinCTest extends DockerExecutionTest {
   Stream<DynamicTest> rrxTests() {
     return runTests(
         // 1-bit rotate right with carry: 1 >> 1 + carry(0) = 0
-        rrx(0x1, 0x1, false, 1, 0x1),
+        rrx(0x1, false, 1, 0x1),
         // 1-bit rotate right with carry: 1 >> 1 + carry(1) = 1
-        rrx(0x1, 0x1, true, 1, 0x1),
+        rrx(0x1, true, 1, 0x1),
         // 2-bit rotate right with carry: 2 >> 1 + carry(0) = 1
-        rrx(0x2, 0x1, false, 2, 0x1),
+        rrx(0x2, false, 2, 0x1),
         // 2-bit rotate right with carry: 2 >> 1 + carry(1) = 3
-        rrx(0x2, 0x1, true, 2, 0x3),
+        rrx(0x2, true, 2, 0x3),
         // 8-bit rotate right with carry: 0x80 >> 1 + carry(0) = 0x40
-        rrx(0x80, 0x1, false, 8, 0x40),
+        rrx(0x80, false, 8, 0x40),
         // 8-bit rotate right with carry: 0x80 >> 1 + carry(1) = 0xC0
-        rrx(0x80, 0x1, true, 8, 0xC0),
+        rrx(0x80, true, 8, 0xC0),
         // 8-bit rotate right with carry: 0x01 >> 1 + carry(1) = 0x80
-        rrx(0x01, 0x1, true, 8, 0x80),
+        rrx(0x01, true, 8, 0x80),
         // 16-bit rotate right with carry: 0x8000 >> 1 + carry(0) = 0x4000
-        rrx(0x8000, 0x1, false, 16, 0x4000),
+        rrx(0x8000, false, 16, 0x4000),
         // 16-bit rotate right with carry: 0x8000 >> 1 + carry(1) = 0xC000
-        rrx(0x8000, 0x1, true, 16, 0xC000),
+        rrx(0x8000, true, 16, 0xC000),
         // 32-bit rotate right with carry: 0x80000000 >> 1 + carry(0) = 0x40000000
-        rrx(0x80000000L, 0x1, false, 32, 0x40000000),
+        rrx(0x80000000L, false, 32, 0x40000000),
         // 32-bit rotate right with carry: 0x80000000 >> 1 + carry(1) = 0xC0000000
-        rrx(0x80000000L, 0x1, true, 32, 0xC0000000L),
+        rrx(0x80000000L, true, 32, 0xC0000000L),
         // 64-bit rotate right with carry: 0x8000000000000000 >> 1 + carry(0) = 0x4000000000000000
-        rrx(0x8000000000000000L, 0x1, false, 64, 0x4000000000000000L),
+        rrx(0x8000000000000000L, false, 64, 0x4000000000000000L),
         // 64-bit rotate right with carry: 0x8000000000000000 >> 1 + carry(1) = 0xC000000000000000
-        rrx(0x8000000000000000L, 0x1, true, 64, 0xC000000000000000L)
+        rrx(0x8000000000000000L, true, 64, 0xC000000000000000L)
     );
   }
 
-  private Function rrx(long a, long b, boolean carry, int size, long expected) {
+  private Function rrx(long a, boolean carry, int size, long expected) {
     a = norm(a, size);
-    b = norm(b, size);
     expected = norm(expected, size);
     var builtIn = BuiltInTable.RRX;
     var name = builtIn.name().toLowerCase() + "_" + counter++;
@@ -1455,7 +1454,6 @@ public class BuiltinCTest extends DockerExecutionTest {
         new BuiltInCall(builtIn,
             new NodeList<>(
                 GraphUtils.bitsNode(a, size),
-                GraphUtils.bitsNode(b, size),
                 GraphUtils.bitsNode(carry ? 1 : 0, 1)
             ),
             Type.bits(size)

--- a/vadl/test/vadl/cppCodeGen/BuiltinCTest.java
+++ b/vadl/test/vadl/cppCodeGen/BuiltinCTest.java
@@ -1415,7 +1415,7 @@ public class BuiltinCTest extends DockerExecutionTest {
   Stream<DynamicTest> rrxTests() {
     return runTests(
         // 1-bit rotate right with carry: 1 >> 1 + carry(0) = 0
-        rrx(0x1, false, 1, 0x1),
+        rrx(0x1, false, 1, 0x0),
         // 1-bit rotate right with carry: 1 >> 1 + carry(1) = 1
         rrx(0x1, true, 1, 0x1),
         // 2-bit rotate right with carry: 2 >> 1 + carry(0) = 1

--- a/vadl/test/vadl/viam/canonicalization/BuiltInConstantEvaluationTest.java
+++ b/vadl/test/vadl/viam/canonicalization/BuiltInConstantEvaluationTest.java
@@ -41,7 +41,7 @@ import vadl.viam.passes.canonicalization.Canonicalizer;
 import vadl.viam.passes.verification.ViamVerificationPass;
 
 /**
- * This class executes all tests in the `valid_builtin_constant_eval.vadl` test source.
+ * This class executes all tests in the `valid_builtin_constant_evaluation.vadl` test source.
  * This is done by searching for all function definitions starting with `exercise_`.
  * For each of these exercise functions there exists a `solution_...` function that contains
  * the expected outcome of the exercise_function.


### PR DESCRIPTION
- Changed VADL::rrx spec
  - Removed second operand, it always rotates by 1
  - Added VADL::rrxs
- Implemented VADL::rrx for ISS
  - Since there is no tcg equivalent, it is converted in IssNormalizationPass (similar to how upstream does it)
- Changed aarch32 assembly to print `rrx` instead of `rrx #1` for rotating input operands