### PR TITLE
iss: Fast-path aligned CPU-vector chunk accesses

### DIFF
--- a/vadl/main/vadl/iss/template/target/BaseChunkCpuAccessors.java
+++ b/vadl/main/vadl/iss/template/target/BaseChunkCpuAccessors.java
@@ -80,6 +80,15 @@ final class BaseChunkCpuAccessors {
         .append(" * ((size_t) ")
         .append(containerWidth / 8)
         .append(");\n");
+    body.append("if ((bit_offset & UINT64_C(0x7)) == UINT64_C(0) && (bit_width & 7u) == 0) {\n");
+    body.append("  size_t byte_off = reg_off + (size_t) (bit_offset >> 3);\n");
+    body.append("  size_t byte_count = (size_t) (bit_width >> 3);\n");
+    body.append("  uint64_t out = 0;\n");
+    body.append("  memcpy(&out, ((uint8_t*) env->")
+        .append(reg.simpleName().toLowerCase())
+        .append(") + byte_off, byte_count);\n");
+    body.append("  return out;\n");
+    body.append("}\n");
     body.append("uint64_t out = 0;\n");
     body.append("for (uint32_t b = 0; b < bit_width; b++) {\n");
     body.append("  uint64_t src_bit = bit_offset + ((uint64_t) b);\n");
@@ -123,6 +132,15 @@ final class BaseChunkCpuAccessors {
         .append(" * ((size_t) ")
         .append(containerWidth / 8)
         .append(");\n");
+    body.append("if ((bit_offset & UINT64_C(0x7)) == UINT64_C(0) && (bit_width & 7u) == 0) {\n");
+    body.append("  size_t byte_off = reg_off + (size_t) (bit_offset >> 3);\n");
+    body.append("  size_t byte_count = (size_t) (bit_width >> 3);\n");
+    body.append("  uint64_t tmp = value;\n");
+    body.append("  memcpy(((uint8_t*) env->")
+        .append(reg.simpleName().toLowerCase())
+        .append(") + byte_off, &tmp, byte_count);\n");
+    body.append("  return;\n");
+    body.append("}\n");
     body.append("for (uint32_t b = 0; b < bit_width; b++) {\n");
     body.append("  uint64_t dst_bit = bit_offset + ((uint64_t) b);\n");
     body.append("  size_t dst_byte = reg_off + (size_t) (dst_bit >> 3);\n");


### PR DESCRIPTION
It turned out that https://github.com/OpenVADL/openvadl/pull/977 introduced a lot of runtime overhead in vector helper instructions. This is because it replaces alias register access nodes, by chunk access on base register nodes. While this allowed us to enable gvec operations on simple `forall do` statements, it caused a big performance hit on the helper path, as the register chunk access helper implementation uses a loop to construct the access based on chunk params.

This PR makes accessing byte aligned vector regions faster to access, as it is a direct memory access instead a loop over certain lanes. Hopefully this will fix the performance decrease from PR #977.

