### PR TITLE
iss: Support gvec lowering for `forall tensor` assignments

### DIFF
--- a/vadl/main/vadl/iss/codegen/RegisterAccessEmitters.java
+++ b/vadl/main/vadl/iss/codegen/RegisterAccessEmitters.java
@@ -199,6 +199,7 @@ public final class RegisterAccessEmitters {
             .wr(node.regTensor().simpleName().toLowerCase())
             .wr("_chunk(env");
         emitChunkBaseIndices(ctx, readNode);
+        ctx.wr(", ").wr(Integer.toString(readNode.indices().size()));
         ctx.wr(", ").gen(readNode.bitOffset());
         ctx.wr(", ").gen(readNode.bitWidth());
         ctx.wr("))");
@@ -217,6 +218,7 @@ public final class RegisterAccessEmitters {
             .wr(node.regTensor().simpleName().toLowerCase())
             .wr("_chunk(env");
         emitChunkBaseIndices(ctx, writeNode);
+        ctx.wr(", ").wr(Integer.toString(writeNode.indices().size()));
         ctx.wr(", ").gen(writeNode.bitOffset());
         ctx.wr(", ").gen(writeNode.bitWidth());
         ctx.wr(", ((uint64_t) ").gen(node.value()).wr("))");

--- a/vadl/main/vadl/iss/passes/common/IssTensorAssignmentToForallPass.java
+++ b/vadl/main/vadl/iss/passes/common/IssTensorAssignmentToForallPass.java
@@ -84,11 +84,17 @@ public class IssTensorAssignmentToForallPass extends AbstractIssPass {
   @Nullable
   @Override
   public Object execute(PassResults passResults, Specification viam) throws IOException {
-    allInstrs(viam).forEach(instruction ->
-        instruction.behavior().getNodes(IssWriteRegNode.class)
+    allInstrs(viam).forEach(instruction -> {
+      while (true) {
+        var candidate = instruction.behavior().getNodes(IssWriteRegNode.class)
             .filter(this::canLower)
-            .toList()
-            .forEach(this::lower));
+            .findFirst();
+        if (candidate.isEmpty()) {
+          break;
+        }
+        lower(candidate.get());
+      }
+    });
     return null;
   }
 

--- a/vadl/main/vadl/iss/passes/nodes/IssReadRegNode.java
+++ b/vadl/main/vadl/iss/passes/nodes/IssReadRegNode.java
@@ -16,7 +16,9 @@
 
 package vadl.iss.passes.nodes;
 
+import com.google.common.collect.Streams;
 import java.util.List;
+import java.util.Objects;
 import javax.annotation.Nullable;
 import vadl.javaannotations.viam.DataValue;
 import vadl.javaannotations.viam.Input;
@@ -204,6 +206,53 @@ public class IssReadRegNode extends ReadRegTensorNode {
       return c.constant().asVal().intValue();
     }
     return type().bitWidth();
+  }
+
+  @Override
+  public void verifyState() {
+    ensure(regTensor().indexTypes().size() >= indices().size(),
+        "The resource takes %d indices but read provided %d",
+        regTensor().indexTypes().size(), indices().size());
+    Streams.forEachPair(indices().stream(), regTensor().indexTypes().stream(),
+        (index, expectedType) -> {
+          Objects.requireNonNull(index);
+          ensure(index.type() instanceof DataType,
+              "Address must be a DataValue, was %s", index.type());
+          ensure(index.type().isTrivialCastTo(expectedType),
+              "Address value type `%s` cannot be cast to resource's address type `%s`.",
+              index.type(), expectedType);
+        });
+
+    ensure(indices().size() <= regTensor().maxNumberOfAccessIndices(),
+        "Too many indices for tensor access. Read uses %d indices, tensor has %d indices",
+        indices().size(), regTensor().maxNumberOfAccessIndices());
+    regTensor().ensureMatchingIndexTypes(
+        indices().stream().map(e -> e.type().asDataType()).toList());
+
+    if (windowKind == WindowKind.FULL) {
+      ensure(type().bitWidth() >= regTensor().resultType(indices().size()).bitWidth(),
+          "Read result width is smaller than register tensor result width.");
+    } else {
+      ensure(type().bitWidth() == readBitWidth(),
+          "Chunk read result width (%d) does not match declared chunk width (%d).",
+          type().bitWidth(), readBitWidth());
+      ensure(bitOffset.type() instanceof DataType,
+          "Chunk read bit offset must be a data type, was %s", bitOffset.type());
+      ensure(bitWidth.type() instanceof DataType,
+          "Chunk read bit width must be a data type, was %s", bitWidth.type());
+
+      var containerWidth = regTensor().resultType(indices().size()).bitWidth();
+      if (bitOffset instanceof ConstantNode offsetConst
+          && bitWidth instanceof ConstantNode widthConst) {
+        var offset = offsetConst.constant().asVal().intValue();
+        var width = widthConst.constant().asVal().intValue();
+        ensure(offset >= 0, "Chunk read bit offset must be non-negative.");
+        ensure(width > 0, "Chunk read bit width must be positive.");
+        ensure(offset + width <= containerWidth,
+            "Chunk read window [%d, %d) exceeds container width %d.",
+            offset, offset + width, containerWidth);
+      }
+    }
   }
 
   @Override

--- a/vadl/main/vadl/iss/passes/nodes/IssWriteRegNode.java
+++ b/vadl/main/vadl/iss/passes/nodes/IssWriteRegNode.java
@@ -16,10 +16,13 @@
 
 package vadl.iss.passes.nodes;
 
+import com.google.common.collect.Streams;
 import java.util.List;
+import java.util.Objects;
 import javax.annotation.Nullable;
 import vadl.javaannotations.viam.DataValue;
 import vadl.javaannotations.viam.Input;
+import vadl.types.DataType;
 import vadl.types.Type;
 import vadl.viam.ArtificialResource;
 import vadl.viam.Constant;
@@ -204,6 +207,62 @@ public class IssWriteRegNode extends WriteRegTensorNode {
       return c.constant().asVal().intValue();
     }
     return value().type().asDataType().bitWidth();
+  }
+
+  @Override
+  public void verifyState() {
+    if (nullableCondition() != null) {
+      ensure(nullableCondition().type().isTrivialCastTo(Type.bool()),
+          "Condition must be a boolean but was %s",
+          nullableCondition());
+    }
+
+    ensure(value().type() instanceof DataType valueType && valueType.bitWidth() <= writeBitWidth(),
+        "Mismatching resource type. Value expression's type (%s) has not the expected "
+            + "width of %s.",
+        value().type(), writeBitWidth());
+
+    ensure(regTensor().indexTypes().size() >= indices().size(),
+        "The resource takes %d indices but write provided %d",
+        regTensor().indexTypes().size(), indices().size());
+    Streams.forEachPair(indices().stream(), regTensor().indexTypes().stream(),
+        (index, expectedType) -> {
+          Objects.requireNonNull(index);
+          ensure(index.type() instanceof DataType,
+              "Address must be a DataValue, was %s", index.type());
+          ensure(index.type().isTrivialCastTo(expectedType),
+              "Address value type `%s` cannot be cast to resource's address type `%s`.",
+              index.type(), expectedType);
+        });
+
+    ensure(indices().size() <= regTensor().maxNumberOfAccessIndices(),
+        "Too many indices for tensor access. Write uses %d indices, tensor has %d indices",
+        indices().size(), regTensor().maxNumberOfAccessIndices());
+    regTensor().ensureMatchingIndexTypes(
+        indices().stream().map(e -> e.type().asDataType()).toList());
+
+    if (windowKind == WindowKind.FULL) {
+      ensure(regTensor().resultType(indices().size()).isTrivialCastTo(value().type()),
+          "Try to write value of type %s to register tensor with write type %s",
+          value().type(), regTensor().resultType(indices().size()));
+    } else {
+      ensure(bitOffset.type() instanceof DataType,
+          "Chunk write bit offset must be a data type, was %s", bitOffset.type());
+      ensure(bitWidth.type() instanceof DataType,
+          "Chunk write bit width must be a data type, was %s", bitWidth.type());
+
+      var containerWidth = regTensor().resultType(indices().size()).bitWidth();
+      if (bitOffset instanceof ConstantNode offsetConst
+          && bitWidth instanceof ConstantNode widthConst) {
+        var offset = offsetConst.constant().asVal().intValue();
+        var width = widthConst.constant().asVal().intValue();
+        ensure(offset >= 0, "Chunk write bit offset must be non-negative.");
+        ensure(width > 0, "Chunk write bit width must be positive.");
+        ensure(offset + width <= containerWidth,
+            "Chunk write window [%d, %d) exceeds container width %d.",
+            offset, offset + width, containerWidth);
+      }
+    }
   }
 
   @Override

--- a/vadl/main/vadl/iss/template/target/BaseChunkCpuAccessors.java
+++ b/vadl/main/vadl/iss/template/target/BaseChunkCpuAccessors.java
@@ -62,11 +62,13 @@ final class BaseChunkCpuAccessors {
   private static Map<String, Object> renderReadAccessor(RegisterTensor reg,
                                                         IssConfiguration config) {
     var body = new StringBuilder();
-    var containerWidth = reg.resultType(reg.indexDimensions().size()).bitWidth();
     body.append("assert(bit_width > 0);\n");
     body.append("assert(bit_width <= 64);\n");
+    body.append("assert(provided_index_count <= ")
+        .append(reg.indexDimensions().size())
+        .append("u);\n");
     body.append("assert(bit_offset + bit_width <= ((uint64_t) ")
-        .append(containerWidth)
+        .append(aggregateContainerWidthExpr(reg))
         .append("));\n");
     for (int i = 0; i < reg.indexDimensions().size(); i++) {
       body.append("assert(i")
@@ -77,9 +79,9 @@ final class BaseChunkCpuAccessors {
     }
     body.append("size_t reg_off = ")
         .append(flatBaseIndexExpr(reg))
-        .append(" * ((size_t) ")
-        .append(containerWidth / 8)
-        .append(");\n");
+        .append(" * ((size_t) (")
+        .append(aggregateContainerWidthExpr(reg))
+        .append(" >> 3));\n");
     body.append("if ((bit_offset & UINT64_C(0x7)) == UINT64_C(0) && (bit_width & 7u) == 0) {\n");
     body.append("  size_t byte_off = reg_off + (size_t) (bit_offset >> 3);\n");
     body.append("  size_t byte_count = (size_t) (bit_width >> 3);\n");
@@ -104,7 +106,7 @@ final class BaseChunkCpuAccessors {
     var signature = "uint64_t cpu_get_" + reg.simpleName().toLowerCase() + "_chunk("
         + "CPU" + config.targetName().toUpperCase() + "State *env"
         + renderArgDecls(reg.indexDimensions().size())
-        + ", uint64_t bit_offset, uint32_t bit_width)";
+        + ", uint32_t provided_index_count, uint64_t bit_offset, uint32_t bit_width)";
     return Map.of(
         "signature", signature,
         "body", body.toString()
@@ -114,11 +116,13 @@ final class BaseChunkCpuAccessors {
   private static Map<String, Object> renderWriteAccessor(RegisterTensor reg,
                                                          IssConfiguration config) {
     var body = new StringBuilder();
-    var containerWidth = reg.resultType(reg.indexDimensions().size()).bitWidth();
     body.append("assert(bit_width > 0);\n");
     body.append("assert(bit_width <= 64);\n");
+    body.append("assert(provided_index_count <= ")
+        .append(reg.indexDimensions().size())
+        .append("u);\n");
     body.append("assert(bit_offset + bit_width <= ((uint64_t) ")
-        .append(containerWidth)
+        .append(aggregateContainerWidthExpr(reg))
         .append("));\n");
     for (int i = 0; i < reg.indexDimensions().size(); i++) {
       body.append("assert(i")
@@ -129,9 +133,9 @@ final class BaseChunkCpuAccessors {
     }
     body.append("size_t reg_off = ")
         .append(flatBaseIndexExpr(reg))
-        .append(" * ((size_t) ")
-        .append(containerWidth / 8)
-        .append(");\n");
+        .append(" * ((size_t) (")
+        .append(aggregateContainerWidthExpr(reg))
+        .append(" >> 3));\n");
     body.append("if ((bit_offset & UINT64_C(0x7)) == UINT64_C(0) && (bit_width & 7u) == 0) {\n");
     body.append("  size_t byte_off = reg_off + (size_t) (bit_offset >> 3);\n");
     body.append("  size_t byte_count = (size_t) (bit_width >> 3);\n");
@@ -155,7 +159,8 @@ final class BaseChunkCpuAccessors {
     var signature = "void cpu_set_" + reg.simpleName().toLowerCase() + "_chunk("
         + "CPU" + config.targetName().toUpperCase() + "State *env"
         + renderArgDecls(reg.indexDimensions().size())
-        + ", uint64_t bit_offset, uint32_t bit_width, uint64_t value)";
+        + ", uint32_t provided_index_count, uint64_t bit_offset, uint32_t bit_width, "
+        + "uint64_t value)";
     return Map.of(
         "signature", signature,
         "body", body.toString()
@@ -170,14 +175,32 @@ final class BaseChunkCpuAccessors {
     return sb.toString();
   }
 
+  private static String aggregateContainerWidthExpr(RegisterTensor reg) {
+    var dims = reg.indexDimensions().size();
+    var sb = new StringBuilder();
+    sb.append("(");
+    for (int provided = 0; provided <= dims; provided++) {
+      if (provided != 0) {
+        sb.append(" : ");
+      }
+      if (provided != dims) {
+        sb.append("(provided_index_count == ").append(provided).append("u) ? ");
+      }
+      sb.append("((uint32_t) ").append(reg.resultType(provided).bitWidth()).append(")");
+    }
+    sb.append(")");
+    return sb.toString();
+  }
+
   private static String flatBaseIndexExpr(RegisterTensor base) {
     var dims = base.indexDimensions();
     if (dims.isEmpty()) {
       return "((size_t) 0)";
     }
-    var expr = "((size_t) i0)";
-    for (int i = 1; i < dims.size(); i++) {
-      expr = "((" + expr + ") * ((size_t) " + dims.get(i).size() + ") + ((size_t) i" + i + "))";
+    var expr = "((size_t) 0)";
+    for (int i = 0; i < dims.size(); i++) {
+      expr = "((provided_index_count > " + i + "u) ? ((" + expr + ") * ((size_t) "
+          + dims.get(i).size() + ") + ((size_t) i" + i + ")) : (" + expr + "))";
     }
     return expr;
   }

--- a/vadl/main/vadl/iss/template/target/EmitIssCpuSourcePass.java
+++ b/vadl/main/vadl/iss/template/target/EmitIssCpuSourcePass.java
@@ -140,7 +140,7 @@ public class EmitIssCpuSourcePass extends IssTemplateRenderingPass {
       sb.callStmt("qemu_fprintf", "f", "\" " + reg.simpleName() + ":    \"");
       sb.forLoop("int j = " + (bytesPerReg - 1), "j >= 0", "j--", (byteLoop) -> {
         sb.callStmt("qemu_fprintf", "f", "\"%02x\"",
-            "(uint8_t) cpu_get_" + regLower + "_chunk(env, ((uint64_t) j) * 8, 8)");
+            "(uint8_t) cpu_get_" + regLower + "_chunk(env, 0, ((uint64_t) j) * 8, 8)");
       });
       sb.callStmt("qemu_fprintf", "f", "\"\\n\"");
       return;
@@ -151,7 +151,7 @@ public class EmitIssCpuSourcePass extends IssTemplateRenderingPass {
         sb.callStmt("qemu_fprintf", "f", "\" %-8s \"", names + "[i]");
         sb.forLoop("int j = " + (bytesPerReg - 1), "j >= 0", "j--", (byteLoop) -> {
           sb.callStmt("qemu_fprintf", "f", "\"%02x\"",
-              "(uint8_t) cpu_get_" + regLower + "_chunk(env, i, ((uint64_t) j) * 8, 8)");
+              "(uint8_t) cpu_get_" + regLower + "_chunk(env, i, 1, ((uint64_t) j) * 8, 8)");
         });
         sb.callStmt("qemu_fprintf", "f", "\"\\n\"");
       });

--- a/vadl/main/vadl/iss/template/target/EmitIssGdbStubPass.java
+++ b/vadl/main/vadl/iss/template/target/EmitIssGdbStubPass.java
@@ -419,7 +419,7 @@ public class EmitIssGdbStubPass extends IssTemplateRenderingPass {
     for (var i : indices) {
       args.append(", ").append(i);
     }
-    return "cpu_get_" + base + "_chunk(" + args + ", ";
+    return "cpu_get_" + base + "_chunk(" + args + ", " + indices.size() + ", ";
   }
 
   private static String chunkSetCallPrefix(RegisterTensor origin, List<String> indices) {
@@ -428,6 +428,6 @@ public class EmitIssGdbStubPass extends IssTemplateRenderingPass {
     for (var i : indices) {
       args.append(", ").append(i);
     }
-    return "cpu_set_" + base + "_chunk(" + args + ", ";
+    return "cpu_set_" + base + "_chunk(" + args + ", " + indices.size() + ", ";
   }
 }

--- a/vadl/main/vadl/pass/order/IssPassOrder.java
+++ b/vadl/main/vadl/pass/order/IssPassOrder.java
@@ -69,7 +69,9 @@ import vadl.iss.template.target.EmitIssMachinePass;
 import vadl.iss.template.target.EmitIssTranslateCPass;
 import vadl.lcb.passes.OverwriteInputOperandsPass;
 import vadl.pass.PassOrder;
+import vadl.viam.passes.ArtificialResPartialAccessExpansionPass;
 import vadl.viam.passes.NormalizeFieldsToFieldAccessFunctionsPass;
+import vadl.viam.passes.RegisterTensorPartialAccessExpansionPass;
 import vadl.viam.passes.canonicalization.CanonicalizationPass;
 import vadl.viam.passes.functionInliner.ArtificialResInlinerPass;
 import vadl.viam.passes.functionInliner.FieldAccessInlinerPass;
@@ -92,6 +94,11 @@ public final class IssPassOrder {
     order.skip(NormalizeFieldsToFieldAccessFunctionsPass.class);
     order.skip(RenamingConflictingRegistersPass.class);
     order.skip(OverwriteInputOperandsPass.class);
+
+    // Skip partial (alias) register extension passes as the ISS is able to handle them downstream
+    // in an optimized way.
+    order.skip(RegisterTensorPartialAccessExpansionPass.class);
+    order.skip(ArtificialResPartialAccessExpansionPass.class);
 
     addCommonPasses(order, config);
     addScalarTcgPasses(order, config);


### PR DESCRIPTION
This PR enables gvec lowering for forall tensor assignments by skipping the (partial) register access expansion passes.