### PR TITLE
chore: Add memory big-/bi-endian tests

### DIFF
--- a/vadl/main/vadl/iss/passes/common/IssApplyMemoryEndiannessPass.java
+++ b/vadl/main/vadl/iss/passes/common/IssApplyMemoryEndiannessPass.java
@@ -21,6 +21,7 @@ import static vadl.error.Diagnostic.error;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -34,8 +35,9 @@ import vadl.pass.PassName;
 import vadl.pass.PassResults;
 import vadl.utils.GraphUtils;
 import vadl.utils.ViamUtils;
+import vadl.viam.Endianness;
 import vadl.viam.Memory;
-import vadl.viam.Procedure;
+import vadl.viam.MemoryRegion;
 import vadl.viam.Processor;
 import vadl.viam.RegisterTensor;
 import vadl.viam.Specification;
@@ -43,6 +45,8 @@ import vadl.viam.annotations.TbStateRegisterAnnotation;
 import vadl.viam.graph.Graph;
 import vadl.viam.graph.control.AbstractEndNode;
 import vadl.viam.graph.control.ProcEndNode;
+import vadl.viam.graph.control.ReturnNode;
+import vadl.viam.graph.dependency.ConstantNode;
 import vadl.viam.graph.dependency.ExpressionNode;
 import vadl.viam.graph.dependency.ReadMemNode;
 import vadl.viam.graph.dependency.ReadRegTensorNode;
@@ -51,6 +55,7 @@ import vadl.viam.graph.dependency.SelectNode;
 import vadl.viam.graph.dependency.SliceNode;
 import vadl.viam.graph.dependency.WriteMemNode;
 import vadl.viam.graph.dependency.WriteRegTensorNode;
+import vadl.viam.passes.canonicalization.Canonicalizer;
 
 /**
  * Verifies that the memory endianness condition expression(s) only contain reads from
@@ -82,8 +87,9 @@ public class IssApplyMemoryEndiannessPass extends Pass {
   @Override
   public Object execute(PassResults passResults, Specification viam) throws IOException {
     checkMemoryEndiannessConditions(viam);
-    ViamUtils.findAllBehaviors(viam).forEach(behaviour ->
-        new ApplyMemoryEndianness(behaviour).run());
+    ViamUtils.findAllBehaviors(viam)
+        .filter(behaviour -> !(behaviour.parentDefinition() instanceof MemoryRegion))
+        .forEach(behaviour -> new ApplyMemoryEndianness(behaviour).run());
     viam.processor().ifPresent(processor ->
         new ApplyMemoryEndiannessInMemoryRegionInit(processor).run());
     return null;
@@ -127,15 +133,13 @@ public class IssApplyMemoryEndiannessPass extends Pass {
 class ApplyMemoryEndiannessInMemoryRegionInit {
 
   private final Processor processor;
+  private final Map<Memory, Boolean> evaluatedConditions = new HashMap<>();
+  private final Map<RegisterTensor, ExpressionNode> resetVector;
 
   ApplyMemoryEndiannessInMemoryRegionInit(Processor processor) {
     this.processor = processor;
-  }
-
-  void run() {
-    var reset = processor.reset();
-    var end = reset.behavior().getNodes(ProcEndNode.class).findFirst().orElseThrow();
-    var resetVector = end.sideEffects().stream()
+    var end = processor.reset().behavior().getNodes(ProcEndNode.class).findFirst().orElseThrow();
+    resetVector = end.sideEffects().stream()
         .filter(se -> se instanceof WriteRegTensorNode)
         .map(se -> (WriteRegTensorNode) se)
         .filter(write -> write.regTensor().isSingleRegister())
@@ -144,44 +148,67 @@ class ApplyMemoryEndiannessInMemoryRegionInit {
             WriteRegTensorNode::regTensor,
             WriteRegTensorNode::value
         ));
-
-    // FIXME: this does not account for changes to the register values during the procedure
-    processor.memoryRegions().forEach(mr ->
-        mr.behavior().getNodes(ReadRegTensorNode.class).forEach(read ->
-            handleRead(read, resetVector, reset, mr.memoryRef())
-        )
-    );
   }
 
-  private void handleRead(ReadRegTensorNode read,
-                          Map<RegisterTensor, ExpressionNode> resetVector,
-                          Procedure reset,
-                          Memory memory) {
-    var reg = read.regTensor();
-    var resetValue = resetVector.get(reg);
-    if (resetValue == null) {
-      throw error(String.format("""
-              Value of register %s is unknown
-              """, reg.simpleName()),
-          read
-      ).description("""
-          The memory written here is bi-endian. What endianness is used depends on the \
-          value of register %s, which is not known at this point. Only registers initialized \
-          to a constant value in the default branch of the processor reset procedure can be \
-          statically inferred.
-          """, reg.simpleName()
-      ).locationHelp(
-          reset,
-          "Processor reset procedure"
-      ).locationHelp(
-          // we know that the memory is bi-endian, because there are reg reads, which
-          // can only stem from the bi-endian condition
-          requireNonNull(memory.biEndianCondition()).sourceLocation(),
-          "Bi-endian condition"
-      ).build();
+  void run() {
+    // FIXME: this does not account for changes to the register values during the procedure
+    processor.memoryRegions().stream().filter(mr -> mr.memoryRef().isBiEndian()).forEach(mr -> {
+      var endianness = endiannessOf(mr.memoryRef());
+      mr.behavior().getNodes(ReadMemNode.class).forEach(r -> r.setEndiannessOverwrite(endianness));
+      mr.behavior().getNodes(WriteMemNode.class).forEach(w -> w.setEndiannessOverwrite(endianness));
+    });
+  }
+
+  private Endianness endiannessOf(Memory mem) {
+    return evaluatedConditions.computeIfAbsent(mem, this::computeCondition)
+        ? mem.endianness()
+        : mem.endianness().other();
+  }
+
+  private boolean computeCondition(Memory memory) {
+    var errors = new ArrayList<Diagnostic>();
+    var condition = requireNonNull(memory.biEndianCondition()).copy();
+    for (var read : condition.getNodes(ReadRegTensorNode.class).toList()) {
+      var reg = read.regTensor();
+      var resetValue = resetVector.get(reg);
+      if (resetValue == null) {
+        errors.add(error(String.format("""
+                  Value of register %s is unknown
+                  """, reg.simpleName()),
+                read
+            ).description("""
+              The memory written here is bi-endian. What endianness is used depends on the \
+              value of register %s, which is not known at this point. Only registers initialized \
+              to a constant value in the default branch of the processor reset procedure can be \
+              statically inferred.
+              """, reg.simpleName()
+            ).locationHelp(
+                processor.reset(),
+                "Processor reset procedure"
+            ).locationHelp(
+                // we know that the memory is bi-endian, because there are reg reads, which
+                // can only stem from the bi-endian condition
+                requireNonNull(memory.biEndianCondition()).sourceLocation(),
+                "Bi-endian condition"
+            ).build()
+        );
+      } else {
+        read.replace(resetValue.copy());
+        read.safeDelete();
+      }
     }
-    read.replace(resetValue.copy());
-    read.safeDelete();
+
+    if (!errors.isEmpty()) {
+      throw new DiagnosticList(errors);
+    }
+
+    Canonicalizer.canonicalize(condition);
+    var value = condition.getNodes(ReturnNode.class).findFirst().get().value();
+    if (value instanceof ConstantNode constant) {
+      return constant.constant().asVal().bool();
+    } else {
+      throw new IllegalStateException("Failed to constant evaluate memory endian condition");
+    }
   }
 }
 

--- a/vadl/main/vadl/viam/graph/dependency/ReadMemNode.java
+++ b/vadl/main/vadl/viam/graph/dependency/ReadMemNode.java
@@ -145,6 +145,10 @@ public class ReadMemNode extends ReadResourceNode {
     return new ReadMemNode(memory, words, endianness, address().copy(), type());
   }
 
+  public void setEndiannessOverwrite(Endianness endianness) {
+    endiannessOverwrite = endianness;
+  }
+
   @Override
   public void accept(GraphNodeVisitor visitor) {
     visitor.visit(this);

--- a/vadl/main/vadl/viam/graph/dependency/WriteMemNode.java
+++ b/vadl/main/vadl/viam/graph/dependency/WriteMemNode.java
@@ -176,6 +176,10 @@ public class WriteMemNode extends WriteResourceNode {
     return node;
   }
 
+  public void setEndiannessOverwrite(Endianness endianness) {
+    endiannessOverwrite = endianness;
+  }
+
   @Override
   public void accept(GraphNodeVisitor visitor) {
     visitor.visit(this);

--- a/vadl/test/resources/frontend-snapshots/annotation/bigEndianAnnotation.vadl
+++ b/vadl/test/resources/frontend-snapshots/annotation/bigEndianAnnotation.vadl
@@ -1,0 +1,30 @@
+// INCLUDE-AST-DUMP
+
+instruction set architecture TEST =
+{
+  [ big endian ]
+  memory MEM : Bits<32> -> Bits<32>
+}
+
+
+//  Reported Diagnostics:
+//
+//  No diagnostics were reported, the input was correctly parsed, typechecked and lowered.
+//
+//
+//  Dumped AST:
+//
+//    InstructionSetDefinition name: "TEST"
+//    . MemoryDefinition name: "MEM"
+//    . : AnnotationDefinition
+//    . : ' Identifier name: "big" type: null
+//    . : ' Identifier name: "endian" type: null
+//    . : TypeLiteral type: Bits<32>
+//    . : ' Identifier name: "Bits" type: null
+//    . : ' IntegerLiteral literal: 32 (32) type: Const<32>
+//    . : TypeLiteral type: Bits<32>
+//    . : ' Identifier name: "Bits" type: null
+//    . : ' IntegerLiteral literal: 32 (32) type: Const<32>
+//
+//
+// Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl/test/resources/frontend-snapshots/annotation/condBigEndianAnnotation.vadl
+++ b/vadl/test/resources/frontend-snapshots/annotation/condBigEndianAnnotation.vadl
@@ -1,0 +1,44 @@
+// INCLUDE-AST-DUMP
+
+instruction set architecture TEST =
+{
+  [ execution state ]
+  register R : Bits<32>
+
+  [ big endian : R = 0 ]
+  memory MEM : Bits<32> -> Bits<32>
+}
+
+
+//  Reported Diagnostics:
+//
+//  No diagnostics were reported, the input was correctly parsed, typechecked and lowered.
+//
+//
+//  Dumped AST:
+//
+//    InstructionSetDefinition name: "TEST"
+//    . RegisterDefinition name: "R"
+//    . : AnnotationDefinition
+//    . : ' Identifier name: "execution" type: null
+//    . : ' Identifier name: "state" type: null
+//    . : TypeLiteral type: Bits<32>
+//    . : ' Identifier name: "Bits" type: null
+//    . : ' IntegerLiteral literal: 32 (32) type: Const<32>
+//    . MemoryDefinition name: "MEM"
+//    . : AnnotationDefinition
+//    . : ' Identifier name: "big" type: null
+//    . : ' Identifier name: "endian" type: null
+//    . : ' BinaryExpr operator: = type: Bool
+//    . : ' | Identifier name: "R" type: Bits<32>
+//    . : ' | CastExpr type: Bits<32>
+//    . : ' | . IntegerLiteral literal: 0 (0) type: Const<0>
+//    . : TypeLiteral type: Bits<32>
+//    . : ' Identifier name: "Bits" type: null
+//    . : ' IntegerLiteral literal: 32 (32) type: Const<32>
+//    . : TypeLiteral type: Bits<32>
+//    . : ' Identifier name: "Bits" type: null
+//    . : ' IntegerLiteral literal: 32 (32) type: Const<32>
+//
+//
+// Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl/test/resources/frontend-snapshots/annotation/condLittleEndianAnnotation.vadl
+++ b/vadl/test/resources/frontend-snapshots/annotation/condLittleEndianAnnotation.vadl
@@ -1,0 +1,44 @@
+// INCLUDE-AST-DUMP
+
+instruction set architecture TEST =
+{
+  [ execution state ]
+  register R : Bits<32>
+
+  [ little endian : R = 0 ]
+  memory MEM : Bits<32> -> Bits<32>
+}
+
+
+//  Reported Diagnostics:
+//
+//  No diagnostics were reported, the input was correctly parsed, typechecked and lowered.
+//
+//
+//  Dumped AST:
+//
+//    InstructionSetDefinition name: "TEST"
+//    . RegisterDefinition name: "R"
+//    . : AnnotationDefinition
+//    . : ' Identifier name: "execution" type: null
+//    . : ' Identifier name: "state" type: null
+//    . : TypeLiteral type: Bits<32>
+//    . : ' Identifier name: "Bits" type: null
+//    . : ' IntegerLiteral literal: 32 (32) type: Const<32>
+//    . MemoryDefinition name: "MEM"
+//    . : AnnotationDefinition
+//    . : ' Identifier name: "little" type: null
+//    . : ' Identifier name: "endian" type: null
+//    . : ' BinaryExpr operator: = type: Bool
+//    . : ' | Identifier name: "R" type: Bits<32>
+//    . : ' | CastExpr type: Bits<32>
+//    . : ' | . IntegerLiteral literal: 0 (0) type: Const<0>
+//    . : TypeLiteral type: Bits<32>
+//    . : ' Identifier name: "Bits" type: null
+//    . : ' IntegerLiteral literal: 32 (32) type: Const<32>
+//    . : TypeLiteral type: Bits<32>
+//    . : ' Identifier name: "Bits" type: null
+//    . : ' IntegerLiteral literal: 32 (32) type: Const<32>
+//
+//
+// Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl/test/resources/frontend-snapshots/annotation/invalidEndianAnnotationInvalidCondType.vadl
+++ b/vadl/test/resources/frontend-snapshots/annotation/invalidEndianAnnotationInvalidCondType.vadl
@@ -1,0 +1,46 @@
+// INCLUDE-AST-DUMP
+
+instruction set architecture TEST =
+{
+  [ execution state ]
+  register R : Bits<32>
+
+  [ big endian : R ]
+  memory MEM : Bits<32> -> Bits<32>
+}
+
+
+//  Reported Diagnostics:
+//
+//  error: Invalid annotation presentExpression
+//       ╭── test/resources/frontend-snapshots/annotation/invalidEndianAnnotationInvalidCondType.vadl:8:18
+//       │
+//     8 │   [ big endian : R ]
+//       │                  ^ Expression must be a Bool
+//       │
+//
+//
+//  Dumped AST:
+//
+//    InstructionSetDefinition name: "TEST"
+//    . RegisterDefinition name: "R"
+//    . : AnnotationDefinition
+//    . : ' Identifier name: "execution" type: null
+//    . : ' Identifier name: "state" type: null
+//    . : TypeLiteral type: Bits<32>
+//    . : ' Identifier name: "Bits" type: null
+//    . : ' IntegerLiteral literal: 32 (32) type: Const<32>
+//    . MemoryDefinition name: "MEM"
+//    . : AnnotationDefinition
+//    . : ' Identifier name: "big" type: null
+//    . : ' Identifier name: "endian" type: null
+//    . : ' Identifier name: "R" type: Bits<32>
+//    . : TypeLiteral type: Bits<32>
+//    . : ' Identifier name: "Bits" type: null
+//    . : ' IntegerLiteral literal: 32 (32) type: Const<32>
+//    . : TypeLiteral type: Bits<32>
+//    . : ' Identifier name: "Bits" type: null
+//    . : ' IntegerLiteral literal: 32 (32) type: Const<32>
+//
+//
+// Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl/test/resources/frontend-snapshots/annotation/invalidEndianAnnotationLittleAndBig.vadl
+++ b/vadl/test/resources/frontend-snapshots/annotation/invalidEndianAnnotationLittleAndBig.vadl
@@ -1,0 +1,44 @@
+// INCLUDE-AST-DUMP
+
+instruction set architecture TEST =
+{
+  [ big endian ]
+  [ little endian ]
+  memory MEM : Bits<32> -> Bits<32>
+}
+
+
+//  Reported Diagnostics:
+//
+//  error: Annotation clash
+//       ╭── test/resources/frontend-snapshots/annotation/invalidEndianAnnotationLittleAndBig.vadl:5:3
+//       │
+//     5 │   [ big endian ]
+//       │   ^^^^^^^^^^^^^^ First defined here
+//       │                  Conflicting defined here
+//       │
+//     6 │   [ little endian ]
+//       │   ----------------- Conflicting defined here
+//       │
+//       Only one of these annotations can be defined.
+//
+//
+//  Dumped AST:
+//
+//    InstructionSetDefinition name: "TEST"
+//    . MemoryDefinition name: "MEM"
+//    . : AnnotationDefinition
+//    . : ' Identifier name: "big" type: null
+//    . : ' Identifier name: "endian" type: null
+//    . : AnnotationDefinition
+//    . : ' Identifier name: "little" type: null
+//    . : ' Identifier name: "endian" type: null
+//    . : TypeLiteral type: Bits<32>
+//    . : ' Identifier name: "Bits" type: null
+//    . : ' IntegerLiteral literal: 32 (32) type: Const<32>
+//    . : TypeLiteral type: Bits<32>
+//    . : ' Identifier name: "Bits" type: null
+//    . : ' IntegerLiteral literal: 32 (32) type: Const<32>
+//
+//
+// Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl/test/resources/frontend-snapshots/annotation/littleEndianAnnotation.vadl
+++ b/vadl/test/resources/frontend-snapshots/annotation/littleEndianAnnotation.vadl
@@ -1,0 +1,30 @@
+// INCLUDE-AST-DUMP
+
+instruction set architecture TEST =
+{
+  [ little endian ]
+  memory MEM : Bits<32> -> Bits<32>
+}
+
+
+//  Reported Diagnostics:
+//
+//  No diagnostics were reported, the input was correctly parsed, typechecked and lowered.
+//
+//
+//  Dumped AST:
+//
+//    InstructionSetDefinition name: "TEST"
+//    . MemoryDefinition name: "MEM"
+//    . : AnnotationDefinition
+//    . : ' Identifier name: "little" type: null
+//    . : ' Identifier name: "endian" type: null
+//    . : TypeLiteral type: Bits<32>
+//    . : ' Identifier name: "Bits" type: null
+//    . : ' IntegerLiteral literal: 32 (32) type: Const<32>
+//    . : TypeLiteral type: Bits<32>
+//    . : ' Identifier name: "Bits" type: null
+//    . : ' IntegerLiteral literal: 32 (32) type: Const<32>
+//
+//
+// Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl/test/resources/testSource/passes/applyMemoryEndianness/bi_endian_mem_region_write_big.vadl
+++ b/vadl/test/resources/testSource/passes/applyMemoryEndianness/bi_endian_mem_region_write_big.vadl
@@ -1,0 +1,21 @@
+
+instruction set architecture EndianTest = {
+  using B32 = Bits<32>
+
+  [ execution state ]
+  register R : B32
+
+  [ big endian : R = 0 ]
+  memory MEM : B32 -> Bits<8>
+
+  program counter PC : B32
+}
+
+processor Test implements EndianTest = {
+
+  reset = R := 0
+
+  memory region [ROM] MR in MEM = {
+    MEM<4>(0) := 123 // should be big-endian
+  }
+}

--- a/vadl/test/resources/testSource/passes/applyMemoryEndianness/bi_endian_mem_region_write_little.vadl
+++ b/vadl/test/resources/testSource/passes/applyMemoryEndianness/bi_endian_mem_region_write_little.vadl
@@ -1,0 +1,21 @@
+
+instruction set architecture EndianTest = {
+  using B32 = Bits<32>
+
+  [ execution state ]
+  register R : B32
+
+  [ big endian : R = 0 ]
+  memory MEM : B32 -> Bits<8>
+
+  program counter PC : B32
+}
+
+processor Test implements EndianTest = {
+
+  reset = R := 1
+
+  memory region [ROM] MR in MEM = {
+    MEM<4>(0) := 123 // should be little-endian
+  }
+}

--- a/vadl/test/resources/testSource/passes/applyMemoryEndianness/bi_endian_read_with_cond.vadl
+++ b/vadl/test/resources/testSource/passes/applyMemoryEndianness/bi_endian_read_with_cond.vadl
@@ -1,0 +1,20 @@
+
+instruction set architecture EndianTest = {
+  using B32 = Bits<32>
+
+  [ execution state ]
+  register R : B32
+
+  [ big endian : R = 0 ]
+  memory MEM : B32 -> Bits<8>
+
+  instruction INSTR: F = R := MEM<4>(0)
+  encoding INSTR = { a = 0 }
+  assembly INSTR = "Test"
+
+  format F: B32 = { a: B32 }
+
+  program counter PC : B32
+}
+
+processor Test implements EndianTest = { }

--- a/vadl/test/resources/testSource/passes/applyMemoryEndianness/bi_endian_write_with_cond.vadl
+++ b/vadl/test/resources/testSource/passes/applyMemoryEndianness/bi_endian_write_with_cond.vadl
@@ -1,0 +1,20 @@
+
+instruction set architecture EndianTest = {
+  using B32 = Bits<32>
+
+  [ execution state ]
+  register R : B32
+
+  [ big endian : R = 0 ]
+  memory MEM : B32 -> Bits<8>
+
+  instruction INSTR: F = MEM<4>(0) := R
+  encoding INSTR = { a = 0 }
+  assembly INSTR = "Test"
+
+  format F: B32 = { a: B32 }
+
+  program counter PC : B32
+}
+
+processor Test implements EndianTest = { }

--- a/vadl/test/resources/testSource/passes/applyMemoryEndianness/big_endian_read_with_overwrite.vadl
+++ b/vadl/test/resources/testSource/passes/applyMemoryEndianness/big_endian_read_with_overwrite.vadl
@@ -1,0 +1,19 @@
+
+instruction set architecture EndianTest = {
+  using B32 = Bits<32>
+
+  register R : B32
+
+  [ big endian ]
+  memory MEM : B32 -> Bits<8>
+
+  instruction INSTR: F = R := MEM<4>(0)
+  encoding INSTR = { a = 0 }
+  assembly INSTR = "Test"
+
+  format F: B32 = { a: B32 }
+
+  program counter PC : B32
+}
+
+processor Test implements EndianTest = { }

--- a/vadl/test/resources/testSource/passes/applyMemoryEndianness/big_endian_write_with_overwrite.vadl
+++ b/vadl/test/resources/testSource/passes/applyMemoryEndianness/big_endian_write_with_overwrite.vadl
@@ -1,0 +1,19 @@
+
+instruction set architecture EndianTest = {
+  using B32 = Bits<32>
+
+  register R : B32
+
+  [ big endian ]
+  memory MEM : B32 -> Bits<8>
+
+  instruction INSTR: F = MEM<4>(0) := R
+  encoding INSTR = { a = 0 }
+  assembly INSTR = "Test"
+
+  format F: B32 = { a: B32 }
+
+  program counter PC : B32
+}
+
+processor Test implements EndianTest = { }

--- a/vadl/test/resources/testSource/passes/applyMemoryEndianness/invalid_bi_endian_condition_non_exec_state.vadl
+++ b/vadl/test/resources/testSource/passes/applyMemoryEndianness/invalid_bi_endian_condition_non_exec_state.vadl
@@ -1,0 +1,13 @@
+
+instruction set architecture EndianTest = {
+  using B32 = Bits<32>
+
+  register R : B32
+
+  [ big endian : R = 0 ]
+  memory MEM : B32 -> Bits<8>
+
+  program counter PC : B32
+}
+
+processor Test implements EndianTest = { }

--- a/vadl/test/resources/testSource/passes/applyMemoryEndianness/invalid_bi_endian_condition_non_exec_state_partial.vadl
+++ b/vadl/test/resources/testSource/passes/applyMemoryEndianness/invalid_bi_endian_condition_non_exec_state_partial.vadl
@@ -1,0 +1,16 @@
+
+instruction set architecture EndianTest = {
+  using B32 = Bits<32>
+
+  [ execution state : b ]
+  register R : F
+
+  [ big endian : R.a = 0 ]
+  memory MEM : B32 -> Bits<8>
+
+  format F : B32 = { a : Bits<1>, b : Bits<31> }
+
+  program counter PC : B32
+}
+
+processor Test implements EndianTest = { }

--- a/vadl/test/resources/testSource/passes/applyMemoryEndianness/invalid_bi_endian_mem_region_read.vadl
+++ b/vadl/test/resources/testSource/passes/applyMemoryEndianness/invalid_bi_endian_mem_region_read.vadl
@@ -1,0 +1,21 @@
+
+instruction set architecture EndianTest = {
+  using B32 = Bits<32>
+
+  [ execution state ]
+  register R : B32
+
+  [ big endian : R = 0 ]
+  memory MEM : B32 -> Bits<8>
+
+  program counter PC : B32
+}
+
+processor Test implements EndianTest = {
+
+  reset = { } // R not set here, so cond is undefined
+
+  memory region [ROM] MR in MEM = {
+    MEM<4>(0) := 123 // cannot determine endianness
+  }
+}

--- a/vadl/test/resources/testSource/passes/applyMemoryEndianness/little_endian_read_with_overwrite.vadl
+++ b/vadl/test/resources/testSource/passes/applyMemoryEndianness/little_endian_read_with_overwrite.vadl
@@ -1,0 +1,19 @@
+
+instruction set architecture EndianTest = {
+  using B32 = Bits<32>
+
+  register R : B32
+
+  [ little endian ]
+  memory MEM : B32 -> Bits<8>
+
+  instruction INSTR: F = R := MEM<4>(0)
+  encoding INSTR = { a = 0 }
+  assembly INSTR = "Test"
+
+  format F: B32 = { a: B32 }
+
+  program counter PC : B32
+}
+
+processor Test implements EndianTest = { }

--- a/vadl/test/resources/testSource/passes/applyMemoryEndianness/little_endian_write_with_overwrite.vadl
+++ b/vadl/test/resources/testSource/passes/applyMemoryEndianness/little_endian_write_with_overwrite.vadl
@@ -1,0 +1,19 @@
+
+instruction set architecture EndianTest = {
+  using B32 = Bits<32>
+
+  register R : B32
+
+  [ little endian ]
+  memory MEM : B32 -> Bits<8>
+
+  instruction INSTR: F = MEM<4>(0) := R
+  encoding INSTR = { a = 0 }
+  assembly INSTR = "Test"
+
+  format F: B32 = { a: B32 }
+
+  program counter PC : B32
+}
+
+processor Test implements EndianTest = { }

--- a/vadl/test/vadl/iss/passes/IssApplyMemoryEndiannessPassTest.java
+++ b/vadl/test/vadl/iss/passes/IssApplyMemoryEndiannessPassTest.java
@@ -1,0 +1,160 @@
+// SPDX-FileCopyrightText : © 2026 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.iss.passes;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.DynamicTest.dynamicTest;
+import static vadl.TestUtils.findDefinitionByNameIn;
+import static vadl.utils.GraphUtils.branchEnd;
+import static vadl.utils.GraphUtils.getNodes;
+import static vadl.utils.GraphUtils.getSingleNode;
+
+import java.io.IOException;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+import vadl.AbstractTest;
+import vadl.configuration.IssConfiguration;
+import vadl.error.DiagnosticList;
+import vadl.iss.passes.common.IssApplyMemoryEndiannessPass;
+import vadl.iss.passes.nodes.IssStaticEndianConditionNode;
+import vadl.pass.PassOrders;
+import vadl.pass.exception.DuplicatedPassKeyException;
+import vadl.viam.Endianness;
+import vadl.viam.Instruction;
+import vadl.viam.Specification;
+import vadl.viam.graph.Graph;
+import vadl.viam.graph.Node;
+import vadl.viam.graph.control.BranchBeginNode;
+import vadl.viam.graph.control.IfNode;
+import vadl.viam.graph.dependency.ReadMemNode;
+import vadl.viam.graph.dependency.SelectNode;
+import vadl.viam.graph.dependency.WriteMemNode;
+
+public class IssApplyMemoryEndiannessPassTest extends AbstractTest {
+
+  @TestFactory
+  Stream<DynamicTest> testEndian() {
+    return Stream.of(
+        invalid("invalid_bi_endian_condition_non_exec_state.vadl",
+            "Endianness condition may only read bits from"),
+        invalid("invalid_bi_endian_condition_non_exec_state_partial.vadl",
+            "Endianness condition may only read bits from"),
+        invalid("invalid_bi_endian_mem_region_read.vadl",
+            "Value of register R is unknown"),
+
+        readWithoutCond("big_endian_read_with_overwrite.vadl", Endianness.BIG),
+        readWithoutCond("little_endian_read_with_overwrite.vadl", Endianness.LITTLE),
+
+        writeWithoutCond("big_endian_write_with_overwrite.vadl", Endianness.BIG),
+        writeWithoutCond("little_endian_write_with_overwrite.vadl", Endianness.LITTLE),
+
+        readWithCond("bi_endian_read_with_cond.vadl"),
+        writeWithCond("bi_endian_write_with_cond.vadl"),
+
+        writeInMemRegion("bi_endian_mem_region_write_big.vadl", Endianness.BIG),
+        writeInMemRegion("bi_endian_mem_region_write_little.vadl", Endianness.LITTLE)
+    );
+  }
+
+  private DynamicTest invalid(String fileName, String diagSubstr) {
+    return dynamicTest(fileName, () -> {
+      var config = new IssConfiguration(getConfiguration(false));
+      var diag = assertThrows(DiagnosticList.class, () -> setupPassManagerAndRunSpec(
+          "passes/applyMemoryEndianness/" + fileName,
+          PassOrders.iss(config).untilFirst(IssApplyMemoryEndiannessPass.class)
+      ));
+      assertEquals(1, diag.items.size());
+      assertThat(diag.items.getFirst().getMessage(), containsString(diagSubstr));
+    });
+  }
+
+  private DynamicTest writeInMemRegion(String fileName, Endianness endianness) {
+    return dynamicTest(fileName, () -> {
+      var processor = spec(fileName).processor().orElseGet(Assertions::fail);
+      var regions = processor.memoryRegions();
+      assertEquals(1, regions.size());
+      var graph = regions.getFirst().behavior();
+      // assert that the condition was not inserted and that only one write exists
+      assertEquals(0, getNodes(graph, IfNode.class).size());
+      checkEndianness(getSingleNode(graph, WriteMemNode.class), endianness);
+    });
+  }
+
+  private DynamicTest readWithCond(String fileName) {
+    return dynamicTest(fileName, () -> {
+      var select = getSingleNode(getInstrGraph(fileName), SelectNode.class);
+      assertInstanceOf(IssStaticEndianConditionNode.class, select.condition());
+      checkEndianness(select.trueCase(), Endianness.BIG);
+      checkEndianness(select.falseCase(), Endianness.LITTLE);
+    });
+  }
+
+  private DynamicTest writeWithCond(String fileName) {
+    return dynamicTest(fileName, () -> {
+      var ifElse = getSingleNode(getInstrGraph(fileName), IfNode.class);
+      assertInstanceOf(IssStaticEndianConditionNode.class, ifElse.condition());
+      checkBranchEndianness(ifElse.trueBranch(), Endianness.BIG);
+      checkBranchEndianness(ifElse.falseBranch(), Endianness.LITTLE);
+    });
+  }
+
+  private void checkBranchEndianness(BranchBeginNode branch, Endianness endianness) {
+    var sideEffects = branchEnd(branch).sideEffects();
+    assertEquals(1, sideEffects.size());
+    checkEndianness(sideEffects.getFirst(), endianness);
+  }
+
+  private void checkEndianness(Node memNode, Endianness endianness) {
+    if (memNode instanceof ReadMemNode read) {
+      assertEquals(endianness, read.endianness());
+    } else if (memNode instanceof WriteMemNode write) {
+      assertEquals(endianness, write.endianness());
+    } else {
+      fail();
+    }
+  }
+
+  private DynamicTest readWithoutCond(String fileName, Endianness endianness) {
+    return dynamicTest(fileName, () ->
+        checkEndianness(getSingleNode(getInstrGraph(fileName), ReadMemNode.class), endianness));
+  }
+
+  private DynamicTest writeWithoutCond(String fileName, Endianness endianness) {
+    return dynamicTest(fileName, () ->
+        checkEndianness(getSingleNode(getInstrGraph(fileName), WriteMemNode.class), endianness));
+  }
+
+  private Graph getInstrGraph(String fileName) throws IOException, DuplicatedPassKeyException {
+    return findDefinitionByNameIn("EndianTest::INSTR", spec(fileName), Instruction.class).behavior();
+  }
+
+  private Specification spec(String fileName) throws IOException, DuplicatedPassKeyException {
+    var config = new IssConfiguration(getConfiguration(false));
+    return setupPassManagerAndRunSpec(
+        "passes/applyMemoryEndianness/" + fileName,
+        PassOrders.iss(config).untilFirst(IssApplyMemoryEndiannessPass.class)
+    ).specification();
+  }
+
+}


### PR DESCRIPTION
- Adds frontend snapshot tests and tests for `IssApplyMemoryEndiannessPassTest`
- Bugfix in `IssApplyMemoryEndiannessPass` concerning endianness of memory writes in memory region init procedure
  - before: writes were lowered to `IssStaticEndianConditionNode`
  - now: endian condition is constant-evaluated