### PR TITLE
asm: Strengthen immediate checking in assembly parser

### DIFF
--- a/sys/risc-v/rv3264im.vadl
+++ b/sys/risc-v/rv3264im.vadl
@@ -443,10 +443,10 @@ $Arch3264 ( // ((((((((((((((((((((((((((((((((((((((((
   }
   assembly LLA = (mnemonic, " ", register(rd), ",", hex( symbol ))
 
-  pseudo instruction LI( rd : Index, symbol : Bits<32> ) =
+  pseudo instruction LI( rd : Index, symbol : SIntW ) =
   {
-      LUI{ rd = rd, imm = hi( symbol ) }
-      ADDI{ rd = rd, rs1 = rd, imm = lo( symbol ) }
+      LUI{ rd = rd, imm = hi( symbol as Bits<32> ) }
+      ADDI{ rd = rd, rs1 = rd, imm = lo( symbol as Bits<32> ) }
   }
   assembly LI = (mnemonic, " ", register( rd ), ",", decimal( symbol ))
 

--- a/sys/v-risc/ABI.vadl
+++ b/sys/v-risc/ABI.vadl
@@ -196,6 +196,12 @@ assembly description AD for ABI = {
             imm = ImmediateOperand
         ;
 
+        BalLInstruction @instruction:
+            mnemonic = "BAL_L" @operand
+            rd = Register @operand ","
+            imm = ImmediateOperand
+        ;
+
         CondIds: "SEQ" | "SNE" | "SLT" | "SLE" | "ULT" | "UGE";
 
         CondInstruction @instruction:

--- a/vadl/main/resources/templates/common/vadl-builtins.hpp
+++ b/vadl/main/resources/templates/common/vadl-builtins.hpp
@@ -26,4 +26,26 @@ static inline std::string VADL_concat_str(std::string a, std::string b) {
     return a + b;
 }
 
+/*-----------------------------------------------------------------------
+ *    fits_in_bit_width(value: int64_t, width: unsigned) -> bool
+ *---------------------------------------------------------------------*/
+static inline bool VADL_fits_in_bit_width(int64_t value, unsigned width) {
+    if (width >= 64) return true;
+
+    // build mask for where bits above width are 1, e.g.:
+    // 00000001
+    // 00010000 after shift
+    // 00001111 after -1
+    // 11110000 after ~
+    int64_t mask = ~((INT64_C(1) << width) - 1);
+
+    // only bits above width remain in upper
+    int64_t upper = value & mask;
+
+    // then the value fits if all remaining bits are either:
+    // 0 (value is positive)
+    // 1 (equal to the mask)
+    return upper == 0 || upper == mask;
+}
+
 #endif //VADL_BUILTINS_HPP

--- a/vadl/main/resources/templates/lcb/llvm/lib/Target/AsmParser/AsmParser.cpp
+++ b/vadl/main/resources/templates/lcb/llvm/lib/Target/AsmParser/AsmParser.cpp
@@ -9,6 +9,7 @@
 #include "llvm/MC/TargetRegistry.h"
 #include "Utils/ImmediateUtils.h"
 #include "llvm/MC/MCRegister.h"
+#include "vadl-builtins.hpp"
 
 
 using namespace llvm;
@@ -92,7 +93,20 @@ bool [(${namespace})]AsmParser::parse_[(${instruction.name})](MCInst &Inst, Oper
             int64_t opImm64 = dyn_cast<MCConstantExpr>(Op.getImm())->getValue();
 
             [# th:if="${operand.isFieldOperand}"]
+            if (!VADL_fits_in_bit_width([(${operand.params})], [(${operand.fieldBitWidth})])) {
+              std::string error = "Invalid immediate operand for [(${operand.name})]. Value is larger than [(${operand.fieldBitWidth})] bits.";
+              Parser.Error(Op.getStartLoc(), error);
+              return true;
+            }
             opImm64 = [(${operand.decodeMethod})]([(${operand.params})]);
+            [/]
+
+            [# th:if="${operand.lowest} != ${operand.highest}"]
+            if (opImm64 < [(${operand.lowest})] || opImm64 > [(${operand.highest})]) {
+              std::string error = "Invalid immediate operand for [(${operand.name})]. Value is out of range ([(${operand.lowest})],[(${operand.highest})]).";
+              Parser.Error(Op.getStartLoc(), error);
+              return true;
+            }
             [/]
 
             [# th:if="${operand.requiresPredicate}" ]

--- a/vadl/main/resources/templates/lcb/llvm/lib/Target/AsmParser/AsmRecursiveDescentParser.cpp
+++ b/vadl/main/resources/templates/lcb/llvm/lib/Target/AsmParser/AsmRecursiveDescentParser.cpp
@@ -53,10 +53,12 @@ namespace llvm {
 
   RuleParsingResult<const MCExpr*> [(${namespace})]AsmRecursiveDescentParser::BuiltinExpression() {
     const MCExpr* expr;
+    SMLoc start = Lexer.getTok().getLoc();
     if (Parser.parseExpression(expr)) {
       return RuleParsingResult<const MCExpr*>(Lexer.getTok().getLoc(), "Invalid expression.");
     } else {
-      return RuleParsingResult<const MCExpr*>(ParsedValue<const MCExpr*>(expr, expr->getLoc(), expr->getLoc()));
+      SMLoc end = Lexer.getTok().getLoc();
+      return RuleParsingResult<const MCExpr*>(ParsedValue<const MCExpr*>(expr, start, end));
     }
   }
 

--- a/vadl/main/vadl/lcb/template/lib/Target/AsmParser/EmitAsmParserCppFilePass.java
+++ b/vadl/main/vadl/lcb/template/lib/Target/AsmParser/EmitAsmParserCppFilePass.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -28,10 +28,12 @@ import vadl.error.DeferredDiagnosticStore;
 import vadl.error.Diagnostic;
 import vadl.gcb.passes.RenamedFieldRefNode;
 import vadl.gcb.passes.operands.model.GcbDefaultInstructionOperand;
+import vadl.gcb.passes.operands.model.GcbInstructionBareSymbolOperand;
 import vadl.gcb.passes.operands.model.GcbInstructionOperand;
 import vadl.gcb.passes.operands.model.GcbInstructionRegisterFileOperand;
 import vadl.lcb.passes.llvmLowering.GenerateTableGenMachineInstructionRecordPass;
 import vadl.lcb.passes.llvmLowering.GenerateTableGenPseudoInstructionRecordPass;
+import vadl.lcb.passes.llvmLowering.tablegen.model.TableGenImmediateRecord;
 import vadl.lcb.passes.llvmLowering.tablegen.model.TableGenInstruction;
 import vadl.lcb.passes.llvmLowering.tablegen.model.TableGenMachineInstruction;
 import vadl.lcb.passes.llvmLowering.tablegen.model.TableGenPseudoInstruction;
@@ -41,8 +43,12 @@ import vadl.lcb.template.CommonVarNames;
 import vadl.lcb.template.LcbTemplateRenderingPass;
 import vadl.pass.PassResults;
 import vadl.template.Renderable;
+import vadl.utils.Pair;
+import vadl.utils.SourceLocation;
 import vadl.viam.AssemblyDescription;
+import vadl.viam.Format;
 import vadl.viam.Specification;
+import vadl.viam.graph.dependency.FuncParamNode;
 
 /**
  * This file contains the implementation for parsing assembly files.
@@ -82,7 +88,24 @@ public class EmitAsmParserCppFilePass extends LcbTemplateRenderingPass {
                          boolean isFieldOperand,
                          String targetName,
                          String decodeMethod,
-                         String params) implements Renderable {
+                         String params,
+                         int fieldBitWidth,
+                         long lowest,
+                         long highest) implements Renderable {
+
+    public TableGenOperand(String name, String targetName) {
+      this(name, false, "", false, targetName, "", "", 0, 0, 0);
+    }
+
+    public TableGenOperand(String name, String targetName, long lowest, long highest) {
+      this(name, false, "", false, targetName, "", "", 0, lowest,
+          highest);
+    }
+
+    public TableGenOperand(String name, String targetName, boolean requiresPredicate,
+                           String predicateMethod) {
+      this(name, requiresPredicate, predicateMethod, false, targetName, "", "", 0, 0, 0);
+    }
 
     @Override
     public Map<String, Object> renderObj() {
@@ -92,7 +115,11 @@ public class EmitAsmParserCppFilePass extends LcbTemplateRenderingPass {
           "isFieldOperand", isFieldOperand,
           "targetName", targetName,
           "decodeMethod", decodeMethod,
-          "params", params);
+          "params", params,
+          "fieldBitWidth", fieldBitWidth,
+          "lowest", lowest,
+          "highest", highest
+      );
     }
   }
 
@@ -218,13 +245,12 @@ public class EmitAsmParserCppFilePass extends LcbTemplateRenderingPass {
    * takes multiple fields as input.
    * </p>
    */
-  private List<TableGenOperand> createOperands(TableGenInstruction instruction) {
+  private List<TableGenOperand> createOperands(TableGenMachineInstruction instruction) {
     var result = new ArrayList<TableGenOperand>();
     // Output
     for (var output : instruction.getOutOperands()) {
       var casted = (GcbDefaultInstructionOperand) output;
-      var operand = new TableGenOperand(casted.name(), false, "", false, casted.name(), "", "");
-      result.add(operand);
+      result.add(new TableGenOperand(casted.name(), casted.name()));
 
       // field access register operands
       if (output instanceof GcbInstructionRegisterFileOperand regOperand) {
@@ -236,87 +262,25 @@ public class EmitAsmParserCppFilePass extends LcbTemplateRenderingPass {
     for (var input : instruction.getInOperands()) {
       var casted = (GcbDefaultInstructionOperand) input;
       if (input instanceof TableGenInstructionImmediateOperand immediateOperand) {
-
-        var formatFields = immediateOperand.formatFields();
-        if (formatFields.size() != 1) {
-          DeferredDiagnosticStore.add(Diagnostic.warning(
-              "The AsmParser cannot deal with access functions with multiple fields.",
-              input.origin().location()).build());
-        }
-
-        var fieldAccessOperand = new TableGenOperand(immediateOperand.name(),
-            true,
-            immediateOperand.immediateOperand().predicateMethod().lower(),
-            false,
-            immediateOperand.name(),
-            "",
-            ""
-        );
-        result.add(fieldAccessOperand);
-
-        var fieldOperand = new TableGenOperand(
-            formatFields.get(0).simpleName(),
-            true,
-            immediateOperand.immediateOperand().predicateMethod().lower(),
-            true,
-            immediateOperand.name(),
-            immediateOperand.immediateOperand().rawDecoderMethod().lower(),
-            formatFields.stream().map(x -> "opImm64").collect(Collectors.joining(", "))
-        );
-        result.add(fieldOperand);
+        addMachineInstImmediateOperand(immediateOperand.name(), input.origin().location(),
+            immediateOperand.formatFields(), immediateOperand.immediateOperand(), result);
       } else if (input instanceof TableGenInstructionLabelOperand immediateOperand) {
-
-        var formatFields = immediateOperand.formatFields();
-        if (formatFields.size() != 1) {
-          DeferredDiagnosticStore.add(Diagnostic.warning(
-              "The AsmParser cannot deal with access functions with multiple fields.",
-              input.origin().location()).build());
-        }
-
-        var operand = new TableGenOperand(immediateOperand.name(),
-            true,
-            immediateOperand.immediateOperand().predicateMethod().lower(),
-            false,
-            immediateOperand.name(),
-            "",
-            ""
-        );
-        result.add(operand);
-
-        var fieldOperand = new TableGenOperand(
-            formatFields.get(0).simpleName(),
-            true,
-            immediateOperand.immediateOperand().predicateMethod().lower(),
-            true,
-            immediateOperand.name(),
-            immediateOperand.immediateOperand().rawDecoderMethod().lower(),
-            formatFields.stream().map(x -> "opImm64").collect(Collectors.joining(", "))
-        );
-        result.add(fieldOperand);
+        addMachineInstImmediateOperand(immediateOperand.name(), input.origin().location(),
+            immediateOperand.formatFields(), immediateOperand.immediateOperand(), result);
       } else if (input instanceof GcbInstructionRegisterFileOperand regOperand) {
         if (regOperand.formatField() instanceof RenamedFieldRefNode.RenamedField renamedField) {
-          var operand = new TableGenOperand(
-              renamedField.inner().simpleName(),
-              false,
-              "",
-              false,
-              casted.name(),
-              "",
-              ""
-          );
+          var operand = new TableGenOperand(renamedField.inner().simpleName(), casted.name());
           result.add(operand);
         } else {
           // normal register operand
-          var operand = new TableGenOperand(casted.name(), false, "", false, casted.name(), "", "");
-          result.add(operand);
+          result.add(new TableGenOperand(casted.name(), casted.name()));
 
           // field access register operands
           createRegisterFieldAccessOperands(regOperand, casted, result);
         }
 
       } else {
-        var operand = new TableGenOperand(casted.name(), false, "", false, casted.name(), "", "");
-        result.add(operand);
+        result.add(new TableGenOperand(casted.name(), casted.name()));
       }
 
     }
@@ -331,31 +295,68 @@ public class EmitAsmParserCppFilePass extends LcbTemplateRenderingPass {
     // Output
     for (var output : instruction.getOutOperands()) {
       var casted = (GcbDefaultInstructionOperand) output;
-      var operand = new TableGenOperand(casted.name(), false, "", false, casted.name(), "", "");
-      result.add(operand);
+      result.add(new TableGenOperand(casted.name(), casted.name()));
     }
 
     // Inputs
     for (var input : instruction.getInOperands()) {
       var casted = (GcbDefaultInstructionOperand) input;
-      if (input instanceof TableGenInstructionImmediateOperand immediateOperand) {
-        var operand =
-            new TableGenOperand(immediateOperand.name(), false, "", false, immediateOperand.name(),
-                "", "");
-        result.add(operand);
-      } else if (input instanceof TableGenInstructionLabelOperand immediateOperand) {
-        var operand =
-            new TableGenOperand(immediateOperand.name(), false, "", false, immediateOperand.name(),
-                "", "");
-        result.add(operand);
+      if (input instanceof GcbInstructionBareSymbolOperand operand) {
+        var type = ((FuncParamNode) operand.origin()).type().asDataType();
+        var valueRange = computeValueRange(type.bitWidth(), type.isSigned());
+
+        result.add(new TableGenOperand(casted.name(), casted.name(), valueRange.left(),
+            valueRange.right()));
       } else {
-        var operand = new TableGenOperand(casted.name(), false, "", false, casted.name(), "", "");
-        result.add(operand);
+        result.add(new TableGenOperand(casted.name(), casted.name()));
       }
     }
 
     return result;
+  }
 
+  private void addMachineInstImmediateOperand(String operandName,
+                                              SourceLocation originLocation,
+                                              List<Format.Field> formatFields,
+                                              TableGenImmediateRecord tableGenImmediate,
+                                              List<TableGenOperand> result) {
+    if (formatFields.size() != 1) {
+      DeferredDiagnosticStore.add(Diagnostic.warning(
+          "The AsmParser cannot deal with access functions with multiple fields.",
+          originLocation).build());
+    }
+
+    var field = formatFields.get(0);
+    var fieldOperand = new TableGenOperand(
+        field.simpleName(),
+        true,
+        tableGenImmediate.predicateMethod().lower(),
+        true,
+        operandName,
+        tableGenImmediate.rawDecoderMethod().lower(),
+        formatFields.stream().map(x -> "opImm64").collect(Collectors.joining(", ")),
+        field.type().bitWidth(),
+        0,
+        0
+    );
+    result.add(fieldOperand);
+
+    // only add field access operand if field access is actually used in behavior
+    if (!field.simpleName().equals(operandName)) {
+      var fieldAccessOperand = new TableGenOperand(operandName,
+          operandName,
+          true,
+          tableGenImmediate.predicateMethod().lower()
+      );
+      result.add(fieldAccessOperand);
+    }
+  }
+
+  private Pair<Long, Long> computeValueRange(int bitWidth, boolean signed) {
+    var highest = (long) (signed ? Math.pow(2, bitWidth - 1) - 1 :
+        Math.pow(2, bitWidth) - 1);
+    var lowest = signed ? -highest - 1 : 0;
+    return new Pair<>(lowest, highest);
   }
 
   private void createRegisterFieldAccessOperands(
@@ -366,7 +367,7 @@ public class EmitAsmParserCppFilePass extends LcbTemplateRenderingPass {
         fa -> fa.fieldRefs().getFirst().simpleName().equals(casted.name())).toList();
     fieldAccesses.forEach(
         fa -> result.add(
-            new TableGenOperand(fa.simpleName(), false, "", false, casted.name(), "", ""))
+            new TableGenOperand(fa.simpleName(), casted.name()))
     );
   }
 

--- a/vadl/test/resources/llvm/varrisc/asm/InvalidImmediates.s
+++ b/vadl/test/resources/llvm/varrisc/asm/InvalidImmediates.s
@@ -1,0 +1,33 @@
+# error cases have to be listed first because stderr is prepended to stdout
+
+# RUN: /src/llvm-final/build/bin/llvm-mc -arch=varrisc -show-inst < $INPUT 2>&1 | /src/llvm-final/build/bin/FileCheck $INPUT
+
+addi r1, r2, 0x7ffffffff
+# CHECK: error: Invalid immediate operand for imm. Value is larger than 11 bits.
+
+addi r1, r2, 2048
+# CHECK: error: Invalid immediate operand for imm. Value is larger than 11 bits.
+
+addi r1, r2, 0x800
+# CHECK: error: Invalid immediate operand for imm. Value is larger than 11 bits.
+
+LBU r1, 0x7ff (r2)
+# CHECK: error: Invalid immediate operand for imm. The predicate does not hold.
+
+LBU r1, 0xfff (r2)
+# CHECK: error: Invalid immediate operand for imm. Value is larger than 11 bits.
+
+bal r1, 0x10000
+# CHECK: error: Invalid immediate operand for imm. Value is larger than 16 bits.
+
+BEQZ r1, 0xffffffffffff
+# CHECK: error: Invalid immediate operand for offset. Value is out of range (-1024,1023).
+
+BEQZ r1, 1024
+# CHECK: error: Invalid immediate operand for offset. Value is out of range (-1024,1023).
+
+BEQZ r1, -1025
+# CHECK: error: Invalid immediate operand for offset. Value is out of range (-1024,1023).
+
+bal_l r1, 0x1ffffffff
+# CHECK: error: Invalid immediate operand for imm. Value is larger than 32 bits.

--- a/vadl/test/resources/llvm/varrisc/asm/MachineInstructions.s
+++ b/vadl/test/resources/llvm/varrisc/asm/MachineInstructions.s
@@ -78,6 +78,11 @@ BAL r22, 0x12
 # CHECK-NEXT: <MCOperand Reg:24>
 # CHECK-NEXT: <MCOperand Imm:36>>
 
+BAL_L r22, 0xffff
+# CHECK: <MCInst #{{[0-9]+}} BAL_L
+# CHECK-NEXT: <MCOperand Reg:24>
+# CHECK-NEXT: <MCOperand Imm:65535>>
+
 SEQ r23, r24, r25
 # CHECK: <MCInst #{{[0-9]+}} SEQ
 # CHECK-NEXT: <MCOperand Reg:25>


### PR DESCRIPTION
This PR fixes #982 by adding a check for the bitwidth of field operands, before `decode` functions are called. This ensures that passed values meet `decode` functions expectation regarding bit width.

Further included in this PR:
- Checks for value ranges of immediate operands of pseudo instructions
- Fixed location reporting regarding immediate errors in the parser
- Slightly refactored the `EmitAsmParserCppFilePass`