### PR TITLE
frontend: Improve symbol error performance

### DIFF
--- a/vadl-cli/main/vadl/cli/BaseCommand.java
+++ b/vadl-cli/main/vadl/cli/BaseCommand.java
@@ -422,7 +422,7 @@ public abstract class BaseCommand implements Callable<Integer> {
       returnVal = 1;
     } catch (DiagnosticList d) {
       System.out.println(
-          new DiagnosticPrinter(new DiskVirtualFileSystem()).toString(d.deflateSimilar()));
+          new DiagnosticPrinter(new DiskVirtualFileSystem()).toString(d.collapseSimilar()));
       if (showStacktrace) {
         System.out.println(getStackTrace(d));
       }

--- a/vadl-lsp/main/vadl/lsp/VadlTextDocumentService.java
+++ b/vadl-lsp/main/vadl/lsp/VadlTextDocumentService.java
@@ -313,7 +313,7 @@ public class VadlTextDocumentService implements TextDocumentService {
       } catch (DiagnosticList dl) {
         log.debug("Raw diagnostics ({}): {}", document.uri, dl.getMessage());
         List<String> importedFileErrors = new ArrayList<>();
-        for (vadl.error.Diagnostic item : dl.deflateSimilar().items) {
+        for (vadl.error.Diagnostic item : dl.collapseSimilar().items) {
           Path itemPath = item.multiLocation.primaryLocation().location().path();
           if (!Objects.equals(itemPath, path)) {
             if (itemPath == null) {

--- a/vadl/main/vadl/ast/SymbolTable.java
+++ b/vadl/main/vadl/ast/SymbolTable.java
@@ -598,16 +598,15 @@ class SymbolTable {
   private void reportUnkownError(String type, String actual, WithLocation locatable,
                                  @Nullable List<String> suggestions) {
 
-    var diagnostic = error("Unknown %s: \"%s\"".formatted(type, actual), locatable)
+    errors.add(error("Unknown %s: \"%s\"".formatted(type, actual), locatable)
         .locationDescription(locatable,
             "No %s with this name exists.", type
-        );
-
-    if (suggestions != null && !suggestions.isEmpty()) {
-      diagnostic = diagnostic.suggestions(suggestions);
-    }
-
-    errors.add(diagnostic.build());
+        )
+        .applyIf(errors.size() < MAX_DIAGNOSTICS_WITH_NAME_SUGGESTIONS
+            && suggestions != null
+            && !suggestions.isEmpty(), (builder) -> builder.suggestions(requireNonNull(suggestions)))
+        .build()
+    );
   }
 
   private void reportAlreadyDefined(String error, SourceLocation location,

--- a/vadl/main/vadl/ast/SymbolTable.java
+++ b/vadl/main/vadl/ast/SymbolTable.java
@@ -603,8 +603,9 @@ class SymbolTable {
             "No %s with this name exists.", type
         )
         .applyIf(errors.size() < MAX_DIAGNOSTICS_WITH_NAME_SUGGESTIONS
-            && suggestions != null
-            && !suggestions.isEmpty(), (builder) -> builder.suggestions(requireNonNull(suggestions)))
+                && suggestions != null
+                && !suggestions.isEmpty(),
+            (builder) -> builder.suggestions(requireNonNull(suggestions)))
         .build()
     );
   }

--- a/vadl/main/vadl/error/Diagnostic.java
+++ b/vadl/main/vadl/error/Diagnostic.java
@@ -18,6 +18,7 @@ package vadl.error;
 
 import com.google.common.collect.Streams;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.function.Supplier;
 import org.jetbrains.annotations.Contract;
@@ -202,18 +203,25 @@ public class Diagnostic extends RuntimeException {
    * @return the deflated diagnostics.
    */
   public static List<Diagnostic> collapseSimilar(List<Diagnostic> diagnostics) {
-    var deflated = new ArrayList<Diagnostic>();
+    var structure = new LinkedHashMap<SourceLocation.DirectLocation, List<Diagnostic>>();
+
     for (var diagnostic : diagnostics) {
-      var similar = deflated.stream()
+
+      final var locationDiagnostics = structure.computeIfAbsent(diagnostic.multiLocation.primaryLocation.location().asDirectLocation(), k -> new ArrayList<>());
+
+      var similar = locationDiagnostics.stream()
           .filter(d -> d.equalsIgnoringMacroTraces(diagnostic))
           .findFirst();
 
       similar.ifPresentOrElse(
           d -> d.macroTraces.addAll(diagnostic.macroTraces),
-          () -> deflated.add(diagnostic)
+          () -> locationDiagnostics.add(diagnostic)
       );
     }
-    return deflated;
+
+
+    return structure.values().stream().flatMap(locationDiagnostics -> locationDiagnostics.stream())
+        .toList();
   }
 
   @Override

--- a/vadl/main/vadl/error/Diagnostic.java
+++ b/vadl/main/vadl/error/Diagnostic.java
@@ -207,7 +207,9 @@ public class Diagnostic extends RuntimeException {
 
     for (var diagnostic : diagnostics) {
 
-      final var locationDiagnostics = structure.computeIfAbsent(diagnostic.multiLocation.primaryLocation.location().asDirectLocation(), k -> new ArrayList<>());
+      final var locationDiagnostics = structure.computeIfAbsent(
+          diagnostic.multiLocation.primaryLocation.location().asDirectLocation(),
+          k -> new ArrayList<>());
 
       var similar = locationDiagnostics.stream()
           .filter(d -> d.equalsIgnoringMacroTraces(diagnostic))

--- a/vadl/main/vadl/error/DiagnosticList.java
+++ b/vadl/main/vadl/error/DiagnosticList.java
@@ -39,7 +39,7 @@ public class DiagnosticList extends RuntimeException {
    *
    * @return the deflated diagnostic list.
    */
-  public DiagnosticList deflateSimilar() {
+  public DiagnosticList collapseSimilar() {
     return new DiagnosticList(Diagnostic.collapseSimilar(items));
   }
 }

--- a/vadl/main/vadl/error/DiagnosticPrinter.java
+++ b/vadl/main/vadl/error/DiagnosticPrinter.java
@@ -39,7 +39,18 @@ public class DiagnosticPrinter {
   private final Map<Path, List<String>> fileLineCache = new HashMap<>();
   VirtualFileSystem fileSystem;
 
+  /**
+   * Printing thousands of backtraces just clutters the output and reduces readability.
+   */
   private static final int MAX_PRINTED_BACKTRACES = 10;
+
+
+  /**
+   * Printing too many diagnostics can take significant time and means that compiler is no longer
+   * responsive.
+   * This field only describes compressed diagnostics.
+   */
+  private static final int MAX_PRINTED_DIAGNOSTICS = 10_000;
 
   public DiagnosticPrinter(VirtualFileSystem fileSystem) {
     this(fileSystem, true);
@@ -57,7 +68,15 @@ public class DiagnosticPrinter {
    */
   public String toString(List<Diagnostic> diagnosticList) {
     StringBuilder builder = new StringBuilder();
-    diagnosticList.forEach(d -> toString(d, builder));
+    if (diagnosticList.size() <= MAX_PRINTED_DIAGNOSTICS) {
+      diagnosticList.forEach(d -> toString(d, builder));
+    } else {
+      for (int i = 0; i < MAX_PRINTED_DIAGNOSTICS; i++) {
+        toString(diagnosticList.get(i), builder);
+      }
+      builder.append("\n    Additional %d diagnostics omited for readability.".formatted(
+          diagnosticList.size() - MAX_PRINTED_DIAGNOSTICS));
+    }
     return builder.toString();
   }
 

--- a/vadl/main/vadl/utils/Levenshtein.java
+++ b/vadl/main/vadl/utils/Levenshtein.java
@@ -86,12 +86,20 @@ public class Levenshtein {
         currentRow = tmp;
 
         // Calculate the necessary band (Ukkonen's algorithm)
-        int start = Math.max(1, j - upperBound);
-        int end = Math.min(target.length(), j + upperBound);
+        int start = upperBound == Integer.MAX_VALUE ? 1 : Math.max(1, j - upperBound);
+        int end = upperBound == Integer.MAX_VALUE
+            ? target.length()
+            : Math.min(target.length(), j + upperBound);
 
         // Avoid skipped cells to influence the next row
+        var skippedCellCost = upperBound == Integer.MAX_VALUE
+            ? Integer.MAX_VALUE
+            : upperBound + 1;
         if (start > 1) {
-          currentRow[start - 1] = Integer.MAX_VALUE;
+          currentRow[start - 1] = skippedCellCost;
+        }
+        if (end < target.length()) {
+          currentRow[end + 1] = skippedCellCost;
         }
 
         currentRow[0] = j;

--- a/vadl/main/vadl/utils/Levenshtein.java
+++ b/vadl/main/vadl/utils/Levenshtein.java
@@ -85,11 +85,19 @@ public class Levenshtein {
         lastRow = currentRow;
         currentRow = tmp;
 
-        // Init the current row
+        // Calculate the necessary band (Ukkonen's algorithm)
+        int start = Math.max(1, j - upperBound);
+        int end = Math.min(target.length(), j + upperBound);
+
+        // Avoid skipped cells to influence the next row
+        if (start > 1) {
+          currentRow[start - 1] = Integer.MAX_VALUE;
+        }
+
         currentRow[0] = j;
         var minCost = currentRow[0];
 
-        for (int i = 1; i <= target.length(); i++) {
+        for (int i = start; i <= end; i++) {
           var substituteCost = word.charAt(j - 1) == target.charAt(i - 1) ? 0 : 1;
           currentRow[i] = Math.min(
               Math.min(

--- a/vadl/main/vadl/utils/SourceLocation.java
+++ b/vadl/main/vadl/utils/SourceLocation.java
@@ -204,6 +204,13 @@ public sealed interface SourceLocation extends WithLocation, Comparable<SourceLo
     return SourceLocation.of(firstLocation.path(), begin, end, expanedFrom);
   }
 
+  default DirectLocation asDirectLocation() {
+    return switch (this) {
+      case DirectLocation direct -> direct;
+      case ExpandedLocation expanded -> expanded.primaryLocation;
+    };
+  }
+
   /**
    * Create a new source location that is a copy of the current one with the provided expanded stack
    * appended to the existing stack.

--- a/vadl/main/vadl/utils/SourceLocation.java
+++ b/vadl/main/vadl/utils/SourceLocation.java
@@ -204,6 +204,11 @@ public sealed interface SourceLocation extends WithLocation, Comparable<SourceLo
     return SourceLocation.of(firstLocation.path(), begin, end, expanedFrom);
   }
 
+  /**
+   * Strips a location of all expandedFrom information and returns it as a direct location.
+   *
+   * @return the direct location.
+   */
   default DirectLocation asDirectLocation() {
     return switch (this) {
       case DirectLocation direct -> direct;

--- a/vadl/test/vadl/ast/FrontendSnapshotTests.java
+++ b/vadl/test/vadl/ast/FrontendSnapshotTests.java
@@ -103,7 +103,7 @@ public class FrontendSnapshotTests {
         diagnostics = Diagnostic.collapseSimilar(DeferredDiagnosticStore.getAll());
       }
     } catch (DiagnosticList d) {
-      diagnostics = d.deflateSimilar().items;
+      diagnostics = d.collapseSimilar().items;
     } catch (Diagnostic d) {
       diagnostics = List.of(d);
     } finally {


### PR DESCRIPTION
This commit fixes the hours of compile time with deleting the format in the expanded huge spec.

It does this by:
- Improving the levenshtein algorithm (found after profiling)
- Optimizing the diagnostic compression from O(n^2) to O(n).
- Limiting the amount of printed diagnostics to 10k

This means that the huge spec without the error now takes 6sec (unchanged) and with the errors it also only takes 6sec.

Related: #989 