### PR TITLE
lcb: Add any-extension patterns for register-subregister relations

### DIFF
--- a/sys/aarch64/aarch64.vadl
+++ b/sys/aarch64/aarch64.vadl
@@ -1319,8 +1319,8 @@ model MovNZInstr (i: InstrWithFunct, size: Id): IsaDefs = {
     }
 
   model LoadInstr (memmodel: MemoryModel, i: InstrNoFunct): IsaDefs = {
-    $MemoryInstr ($memmodel; $i; "B"  ; (WSize; Byte ;  "b"; 0b01; X(rt) := MEM<1> (addr) as UIntX))
-    $MemoryInstr ($memmodel; $i; "H"  ; (WSize; Half ;  "h"; 0b01; X(rt) := MEM<2> (addr) as UIntX))
+    $MemoryInstr ($memmodel; $i; "B"  ; (WSize; Byte ;  "b"; 0b01; W(rt) := MEM<1> (addr) as UIntW))
+    $MemoryInstr ($memmodel; $i; "H"  ; (WSize; Half ;  "h"; 0b01; W(rt) := MEM<2> (addr) as UIntW))
     $MemoryInstr ($memmodel; $i; "W"  ; (WSize; Word ;   ""; 0b01; W(rt) := MEM<4> (addr) as UIntW))
     $MemoryInstr ($memmodel; $i; "X"  ; (XSize; XWord;   ""; 0b01; X(rt) := MEM<8> (addr)         ))
     $MemoryInstr ($memmodel; $i; "SBX"; (XSize; Byte ; "sb"; 0b10; X(rt) := MEM<1> (addr) as SIntX))

--- a/vadl/main/resources/templates/lcb/llvm/lib/Target/InstrInfo.td
+++ b/vadl/main/resources/templates/lcb/llvm/lib/Target/InstrInfo.td
@@ -227,6 +227,10 @@ def : Pat<([(${stackPointerType})] AddrFI:$rs1),
 def : Pat<([(${trunc.resultType})] (trunc [(${trunc.register})]:$rd)), (EXTRACT_SUBREG [(${trunc.register})]:$rd, [(${trunc.subIdx})])>;
 [/]
 
+[# th:each="ext : ${registerExtensions}"]
+def : Pat<([(${ext.resultType})] (anyext [(${ext.register})]:$rd)), (INSERT_SUBREG ([(${ext.resultType})] (IMPLICIT_DEF)), [(${ext.register})]:$rd, [(${ext.subIdx})])>;
+[/]
+
 [# th:each="pseudo : ${pseudos}" ]
 [(${pseudo})]
 [/]

--- a/vadl/main/vadl/lcb/template/lib/Target/EmitInstrInfoTableGenFilePass.java
+++ b/vadl/main/vadl/lcb/template/lib/Target/EmitInstrInfoTableGenFilePass.java
@@ -201,7 +201,14 @@ public class EmitInstrInfoTableGenFilePass extends LcbTemplateRenderingPass {
                 generateTableGenRegistersPassOutput.aliasRegisterClasses().stream())
             .toList();
 
-    var registerTruncations = generateRegisterTruncationPatterns(registerFiles)
+    var registerSubregisterPatterns = generateRegisterSubregisterPatterns(registerFiles);
+    var registerTruncations = registerSubregisterPatterns
+        .truncations()
+        .stream()
+        .map(this::map)
+        .toList();
+    var registerExtensions = registerSubregisterPatterns
+        .extensions()
         .stream()
         .map(this::map)
         .toList();
@@ -212,6 +219,7 @@ public class EmitInstrInfoTableGenFilePass extends LcbTemplateRenderingPass {
     map.put(CommonVarNames.NAMESPACE,
         lcbConfiguration().targetName().value().toLowerCase());
     map.put("registerTruncations", registerTruncations);
+    map.put("registerExtensions", registerExtensions);
     map.put("returnAddress", renderRegister(abi.returnAddress()));
     map.put("addi", addi.simpleName());
     map.put("stackPointerRegister", renderRegister(abi.stackPointer()));
@@ -233,29 +241,36 @@ public class EmitInstrInfoTableGenFilePass extends LcbTemplateRenderingPass {
     return map;
   }
 
-  private List<RegisterTruncation> generateRegisterTruncationPatterns(
+  private RegisterSubRegisterPatterns generateRegisterSubregisterPatterns(
       List<TableGenRegisterClass> registerClasses) {
-    return registerClasses
-      .stream()
-      .flatMap(regClass -> {
-        var regs = regClass.registers().getFirst();
-        return this.generateTruncationPatternsForAllSubregisters(
-            regClass, 
-            regs.subRegs(), 
-            regs.subRegIndices()).stream();
-      }).toList();
+    RegisterSubRegisterPatterns patterns = new RegisterSubRegisterPatterns(
+        new HashSet<>(), 
+        new HashSet<>());
+
+    registerClasses
+        .forEach(regClass -> {
+          var regs = regClass.registers().getFirst();
+          this.generateMovePatternsForAllSubregisters(
+              regClass,
+              regs.subRegs(),
+              regs.subRegIndices(),
+              patterns);
+        });
+
+    return patterns;
   }
 
-  private Set<RegisterTruncation> generateTruncationPatternsForAllSubregisters(
+  private void generateMovePatternsForAllSubregisters(
       TableGenRegisterClass current,
       List<CompilerRegister> subRegs,
-      List<SubRegIndex> subRegsIndices) {
+      List<SubRegIndex> subRegsIndices,
+      RegisterSubRegisterPatterns patterns) {
     if (subRegs.isEmpty()) {
-      return Set.of();
+      return;
     }
 
-    var truncations = new HashSet<RegisterTruncation>();
-    var currentWidth = current.registerFileRef().type().asDataType().bitWidth();
+    var currentType = current.registerFileRef().type().asDataType();
+    var currentWidth = currentType.bitWidth();
 
     for (int i = 0; i < subRegs.size(); i++) {
       var subReg = subRegs.get(i);
@@ -269,19 +284,23 @@ public class EmitInstrInfoTableGenFilePass extends LcbTemplateRenderingPass {
       }
 
       if (subWidth < currentWidth) {
-        truncations.add(new RegisterTruncation(
+        patterns.truncations().add(new RegisterSubregisterMove(
               current.name(), 
               ValueType.from(subType).get().getLlvmType(),
               subRegsIndices.get(i).name()));
+
+        patterns.extensions().add(new RegisterSubregisterMove(
+              subRegResource.simpleName(),
+              ValueType.from(currentType).get().getLlvmType(),
+              subRegsIndices.get(i).name()));
       }
 
-      truncations.addAll(this.generateTruncationPatternsForAllSubregisters(
+      this.generateMovePatternsForAllSubregisters(
             current, 
             subReg.subRegs(), 
-            subReg.subRegIndices()));
+            subReg.subRegIndices(),
+            patterns);
     }
-
-    return truncations;
   }
 
   private Constant.BitSlice.Part getRegisterSliceRange(RegisterResource r) {
@@ -294,7 +313,7 @@ public class EmitInstrInfoTableGenFilePass extends LcbTemplateRenderingPass {
     return new Constant.BitSlice.Part(r.type().asDataType().bitWidth(), 0);
   }
 
-  private Map<String, Object> map(RegisterTruncation obj) {
+  private Map<String, Object> map(RegisterSubregisterMove obj) {
     return Map.of(
       "register", obj.register(),
       "resultType", obj.resultType(),
@@ -310,7 +329,13 @@ public class EmitInstrInfoTableGenFilePass extends LcbTemplateRenderingPass {
   }
 }
 
-record RegisterTruncation(
+record RegisterSubRegisterPatterns(
+    Set<RegisterSubregisterMove> truncations,
+    Set<RegisterSubregisterMove> extensions) {
+}
+
+record RegisterSubregisterMove(
     String register,
     String resultType, 
-    String subIdx) {}
+    String subIdx) {
+}

--- a/vadl/test/resources/snapshots/aarch64/InstrInfoTableGen.td
+++ b/vadl/test/resources/snapshots/aarch64/InstrInfoTableGen.td
@@ -51544,6 +51544,11 @@ def : Pat<(i32 (trunc X:$rd)), (EXTRACT_SUBREG X:$rd, SUB_32)>;
 
 
 
+def : Pat<(i64 (anyext R:$rd)), (INSERT_SUBREG (i64 (IMPLICIT_DEF)), R:$rd, SUB_32)>;
+def : Pat<(i64 (anyext W:$rd)), (INSERT_SUBREG (i64 (IMPLICIT_DEF)), W:$rd, SUB_32)>;
+
+
+
 def ASRIW : Instruction
 {
 let Namespace = "processorNameValue";
@@ -55211,4 +55216,5 @@ def : Pat<(int_processorNameValue_UMSUBL X:$ra, W:$rn, W:$rm),
 
 def : Pat<(int_processorNameValue_UMULH X:$rn, X:$rm),
         (UMULH X:$rn, X:$rm)>;
+
 

--- a/vadl/test/resources/snapshots/aarch64/InstrInfoTableGen.td
+++ b/vadl/test/resources/snapshots/aarch64/InstrInfoTableGen.td
@@ -32197,7 +32197,7 @@ let Namespace = "processorNameValue";
 let Size = 4;
 let CodeSize = 4;
 
-let OutOperandList = ( outs X:$rt );
+let OutOperandList = ( outs W:$rt );
 let InOperandList = ( ins S:$rn, AArch64Base_LDRB_offsetAsInt64:$offset );
 
 field bits<32> Inst;
@@ -32251,7 +32251,7 @@ let Namespace = "processorNameValue";
 let Size = 4;
 let CodeSize = 4;
 
-let OutOperandList = ( outs X:$rt );
+let OutOperandList = ( outs W:$rt );
 let InOperandList = ( ins S:$rn, AArch64Base_LDRH_offsetAsInt64:$offset );
 
 field bits<32> Inst;
@@ -32455,7 +32455,7 @@ let Namespace = "processorNameValue";
 let Size = 4;
 let CodeSize = 4;
 
-let OutOperandList = ( outs S:$rn, X:$rt );
+let OutOperandList = ( outs S:$rn, W:$rt );
 let InOperandList = ( ins S:$rn_8, AArch64Base_LDRPreB_offsetAsInt64:$offset );
 
 field bits<32> Inst;
@@ -32511,7 +32511,7 @@ let Namespace = "processorNameValue";
 let Size = 4;
 let CodeSize = 4;
 
-let OutOperandList = ( outs S:$rn, X:$rt );
+let OutOperandList = ( outs S:$rn, W:$rt );
 let InOperandList = ( ins S:$rn_9, AArch64Base_LDRPreH_offsetAsInt64:$offset );
 
 field bits<32> Inst;
@@ -32959,7 +32959,7 @@ let Namespace = "processorNameValue";
 let Size = 4;
 let CodeSize = 4;
 
-let OutOperandList = ( outs S:$rn, X:$rt );
+let OutOperandList = ( outs S:$rn, W:$rt );
 let InOperandList = ( ins S:$rn_21, AArch64Base_LDRPstB_offsetAsInt64:$offset );
 
 field bits<32> Inst;
@@ -33015,7 +33015,7 @@ let Namespace = "processorNameValue";
 let Size = 4;
 let CodeSize = 4;
 
-let OutOperandList = ( outs S:$rn, X:$rt );
+let OutOperandList = ( outs S:$rn, W:$rt );
 let InOperandList = ( ins S:$rn_22, AArch64Base_LDRPstH_offsetAsInt64:$offset );
 
 field bits<32> Inst;
@@ -33463,7 +33463,7 @@ let Namespace = "processorNameValue";
 let Size = 4;
 let CodeSize = 4;
 
-let OutOperandList = ( outs X:$rt );
+let OutOperandList = ( outs W:$rt );
 let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
@@ -33523,7 +33523,7 @@ let Namespace = "processorNameValue";
 let Size = 4;
 let CodeSize = 4;
 
-let OutOperandList = ( outs X:$rt );
+let OutOperandList = ( outs W:$rt );
 let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
@@ -33583,7 +33583,7 @@ let Namespace = "processorNameValue";
 let Size = 4;
 let CodeSize = 4;
 
-let OutOperandList = ( outs X:$rt );
+let OutOperandList = ( outs W:$rt );
 let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
@@ -33643,7 +33643,7 @@ let Namespace = "processorNameValue";
 let Size = 4;
 let CodeSize = 4;
 
-let OutOperandList = ( outs X:$rt );
+let OutOperandList = ( outs W:$rt );
 let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
@@ -33703,7 +33703,7 @@ let Namespace = "processorNameValue";
 let Size = 4;
 let CodeSize = 4;
 
-let OutOperandList = ( outs X:$rt );
+let OutOperandList = ( outs W:$rt );
 let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
@@ -33763,7 +33763,7 @@ let Namespace = "processorNameValue";
 let Size = 4;
 let CodeSize = 4;
 
-let OutOperandList = ( outs X:$rt );
+let OutOperandList = ( outs W:$rt );
 let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
@@ -33823,7 +33823,7 @@ let Namespace = "processorNameValue";
 let Size = 4;
 let CodeSize = 4;
 
-let OutOperandList = ( outs X:$rt );
+let OutOperandList = ( outs W:$rt );
 let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
@@ -33883,7 +33883,7 @@ let Namespace = "processorNameValue";
 let Size = 4;
 let CodeSize = 4;
 
-let OutOperandList = ( outs X:$rt );
+let OutOperandList = ( outs W:$rt );
 let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
@@ -33943,7 +33943,7 @@ let Namespace = "processorNameValue";
 let Size = 4;
 let CodeSize = 4;
 
-let OutOperandList = ( outs X:$rt );
+let OutOperandList = ( outs W:$rt );
 let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
@@ -34003,7 +34003,7 @@ let Namespace = "processorNameValue";
 let Size = 4;
 let CodeSize = 4;
 
-let OutOperandList = ( outs X:$rt );
+let OutOperandList = ( outs W:$rt );
 let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
@@ -34063,7 +34063,7 @@ let Namespace = "processorNameValue";
 let Size = 4;
 let CodeSize = 4;
 
-let OutOperandList = ( outs X:$rt );
+let OutOperandList = ( outs W:$rt );
 let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
@@ -34123,7 +34123,7 @@ let Namespace = "processorNameValue";
 let Size = 4;
 let CodeSize = 4;
 
-let OutOperandList = ( outs X:$rt );
+let OutOperandList = ( outs W:$rt );
 let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
@@ -34183,7 +34183,7 @@ let Namespace = "processorNameValue";
 let Size = 4;
 let CodeSize = 4;
 
-let OutOperandList = ( outs X:$rt );
+let OutOperandList = ( outs W:$rt );
 let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
@@ -34243,7 +34243,7 @@ let Namespace = "processorNameValue";
 let Size = 4;
 let CodeSize = 4;
 
-let OutOperandList = ( outs X:$rt );
+let OutOperandList = ( outs W:$rt );
 let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
@@ -34303,7 +34303,7 @@ let Namespace = "processorNameValue";
 let Size = 4;
 let CodeSize = 4;
 
-let OutOperandList = ( outs X:$rt );
+let OutOperandList = ( outs W:$rt );
 let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
@@ -34363,7 +34363,7 @@ let Namespace = "processorNameValue";
 let Size = 4;
 let CodeSize = 4;
 
-let OutOperandList = ( outs X:$rt );
+let OutOperandList = ( outs W:$rt );
 let InOperandList = ( ins S:$rn, X:$rm );
 
 field bits<32> Inst;
@@ -38161,7 +38161,7 @@ let Namespace = "processorNameValue";
 let Size = 4;
 let CodeSize = 4;
 
-let OutOperandList = ( outs X:$rt );
+let OutOperandList = ( outs W:$rt );
 let InOperandList = ( ins S:$rn, AArch64Base_LDURB_offsetAsInt64:$offset );
 
 field bits<32> Inst;
@@ -38217,7 +38217,7 @@ let Namespace = "processorNameValue";
 let Size = 4;
 let CodeSize = 4;
 
-let OutOperandList = ( outs X:$rt );
+let OutOperandList = ( outs W:$rt );
 let InOperandList = ( ins S:$rn, AArch64Base_LDURH_offsetAsInt64:$offset );
 
 field bits<32> Inst;

--- a/vadl/test/resources/snapshots/rv64im/InstrInfoTableGen.td
+++ b/vadl/test/resources/snapshots/rv64im/InstrInfoTableGen.td
@@ -4106,6 +4106,8 @@ def : Pat<(i64 AddrFI:$rs1),
 
 
 
+
+
 def BEQZ : Instruction
 {
 let Namespace = "processorNameValue";


### PR DESCRIPTION
This PR adds "anyext" (any-extension) patterns for register-subregister relations, which enables the extension of a given subregister to its parent register.

Furthermore, byte and halfword load operations were adapted in the aarch64 vadl spec to store the resulting value in a 32-bit register (W) instead of 64-bit registers (X) as this matches the actual aarch64-instruction-spec.