### PR TITLE
iss/aarch32: Fix HTIF and add embench setup

### DIFF
--- a/docker/iss/merged-toolchain/Dockerfile
+++ b/docker/iss/merged-toolchain/Dockerfile
@@ -1,3 +1,4 @@
+FROM ghcr.io/openvadl/aarch32-toolchain:latest AS aarch32
 FROM ghcr.io/openvadl/aarch64-toolchain@sha256:68f072ee959a07586a2a761d9ba354d0f218cf27c756277510c01579ea701c13 AS aarch64
 FROM ghcr.io/openvadl/ppc64-toolchain:latest AS ppc64
 FROM ghcr.io/openvadl/riscv-toolchain:medany-rv32i-rv32im-rv32impriv-rv64i-rv64im-rv64impriv AS riscv
@@ -5,7 +6,15 @@ FROM ghcr.io/openvadl/riscv-toolchain:medany-rv32i-rv32im-rv32impriv-rv64i-rv64i
 FROM ubuntu:22.04 AS build
 COPY --from=riscv /opt/riscv /opt/riscv
 COPY --from=ppc64 /opt/ppc64 /opt/ppc64
+COPY --from=aarch32 /opt/aarch32-linux /opt/aarch32-linux
+COPY --from=aarch32 /opt/aarch32-elf /opt/aarch32-elf
 COPY --from=aarch64 /opt/aarch64-linux /opt/aarch64-linux
 COPY --from=aarch64 /opt/aarch64-elf /opt/aarch64-elf
 
-ENV PATH=/opt/riscv/bin:/opt/aarch64-elf/bin:/opt/aarch64-linux/bin:$PATH
+ENV TOOLCHAIN_PATH=/opt/riscv/bin:\
+/opt/aarch32-elf/bin:\
+/opt/aarch32-linux/bin:\
+/opt/aarch64-elf/bin:\
+/opt/aarch64-linux/bin
+
+ENV PATH=${TOOLCHAIN_PATH}:$PATH

--- a/docker/iss/merged-toolchain/Dockerfile
+++ b/docker/iss/merged-toolchain/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/openvadl/aarch32-toolchain:latest AS aarch32
+FROM ghcr.io/openvadl/aarch32-toolchain@sha256:1cd5737436cf7b584bc7af4245e2c2932b6b00022b9c5cd598a7ff868531351c AS aarch32
 FROM ghcr.io/openvadl/aarch64-toolchain@sha256:68f072ee959a07586a2a761d9ba354d0f218cf27c756277510c01579ea701c13 AS aarch64
 FROM ghcr.io/openvadl/ppc64-toolchain:latest AS ppc64
 FROM ghcr.io/openvadl/riscv-toolchain:medany-rv32i-rv32im-rv32impriv-rv64i-rv64im-rv64impriv AS riscv

--- a/docker/iss/test-base/Dockerfile
+++ b/docker/iss/test-base/Dockerfile
@@ -1,6 +1,7 @@
 # The QEMU (ISS) test base image comes with the required architecture toolchains, QEMU source code and sccache
 
-FROM ghcr.io/openvadl/merged-toolchain@sha256:5577337b65538b01dfe5e4032c3e9dc1d66b943990c73e586b2b1e55e4bfd492 AS toolchains
+ARG MERGED_TOOLCHAIN_IMAGE=ghcr.io/openvadl/merged-toolchain:latest
+FROM ${MERGED_TOOLCHAIN_IMAGE} AS toolchains
 
 FROM ubuntu:22.04 AS base
 
@@ -72,8 +73,17 @@ RUN cargo chef cook --release --recipe-path recipe.json
 FROM cosim-chef-deps AS iss-test-base
 COPY --from=toolchains /opt/riscv /opt/riscv
 COPY --from=toolchains /opt/ppc64 /opt/ppc64
+COPY --from=toolchains /opt/aarch32-linux /opt/aarch32-linux
+COPY --from=toolchains /opt/aarch32-elf /opt/aarch32-elf
 COPY --from=toolchains /opt/aarch64-linux /opt/aarch64-linux
 COPY --from=toolchains /opt/aarch64-elf /opt/aarch64-elf
 
 # Add toolchains to PATH
-ENV PATH=/opt/riscv/bin:/opt/ppc64/bin:/opt/aarch64-elf/bin:/opt/aarch64-linux/bin:$PATH
+ENV TOOLCHAIN_PATH=/opt/riscv/bin:\
+/opt/ppc64/bin:\
+/opt/aarch32-elf/bin:\
+/opt/aarch32-linux/bin:\
+/opt/aarch64-elf/bin:\
+/opt/aarch64-linux/bin
+
+ENV PATH=${TOOLCHAIN_PATH}:$PATH

--- a/vadl-test/resources/cosim_scripts/aarch32/compiler.py
+++ b/vadl-test/resources/cosim_scripts/aarch32/compiler.py
@@ -2,9 +2,9 @@ import os
 import subprocess
 from pathlib import Path
 
-AS = "arm-linux-gnueabihf-as"
-LD = "arm-linux-gnueabihf-ld"
-OBJDUMP = "arm-linux-gnueabihf-objdump"
+AS = "arm-none-linux-gnueabihf-as"
+LD = "arm-none-linux-gnueabihf-ld"
+OBJDUMP = "arm-none-linux-gnueabihf-objdump"
 
 def compile(id: str, asm: str, debug: bool = True) -> dict:
     asm_path = build_assembly(id, asm)

--- a/vadl/build.gradle.kts
+++ b/vadl/build.gradle.kts
@@ -140,6 +140,12 @@ val benchmarkIssAarch64 = registerBenchmarkTestTask(
     includePattern = "vadl.iss.aarch64.IssAarch64EmbenchBenchmarkTest"
 )
 
+val benchmarkIssAarch32 = registerBenchmarkTestTask(
+    name = "benchmark-iss-aarch32",
+    description = "Runs the ISS AArch32 benchmark tests",
+    includePattern = "vadl.iss.aarch32.IssAarch32EmbenchBenchmarkTest"
+)
+
 val benchmarkIssVectorBench64 = registerBenchmarkTestTask(
     name = "benchmark-iss-vectorbench64",
     description = "Runs the synthetic vector benchmark ISA tests",

--- a/vadl/test/resources/embench/benchmark-extras/run-benchmarks-a32-iss.sh
+++ b/vadl/test/resources/embench/benchmark-extras/run-benchmarks-a32-iss.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText : © 2026 TU Wien <vadl@tuwien.ac.at>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+set -e
+
+cd $(realpath $(dirname "$0"))
+
+CPU_MHZ="${EMBENCH_MHZ:-1000}"
+
+../build_virt-iss-a32.sh --cpu-mhz "$CPU_MHZ"
+echo "Benchmarking open-vadl..."
+./run-benchmark.sh "a32-open-vadl" ./benchmark_qemu.sh "qemu-system-a32" -nographic -bios
+echo "Benchmarking qemu..."
+./run-benchmark.sh "a32-qemu" ./benchmark_qemu.sh \
+  "qemu-system-arm" -M virt -cpu cortex-a15 -m 4G -net none -nographic -semihosting -kernel
+echo "Done."
+
+python3 data-relative.py results-a32-iss \
+        results/a32-qemu/a32-qemu.csv \
+        results/a32-open-vadl/a32-open-vadl.csv

--- a/vadl/test/resources/embench/build_virt-iss-a32.sh
+++ b/vadl/test/resources/embench/build_virt-iss-a32.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+cd $(realpath $(dirname "$0"))
+
+CFLAGS="-march=armv6 -marm -mfloat-abi=soft -g -mno-unaligned-access"
+# benchmarks that use floating point types must be excluded
+FLOATEXCL="cubic,nbody,minver,st,statemate,ud,wikisort"
+./build_all.py --cc arm-none-eabi-gcc --arch aarch32 --chip generic --board virt-iss --clean --cflags "$CFLAGS" --exclude "$FLOATEXCL" "$@"

--- a/vadl/test/resources/embench/config/aarch32/arch.cfg
+++ b/vadl/test/resources/embench/config/aarch32/arch.cfg
@@ -1,0 +1,9 @@
+# Architecture configuration for Arm
+#
+# Copyright (C) 2026 TU Wien
+#
+# This file is part of Embench.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+cc = 'arm-none-eabi-gcc'

--- a/vadl/test/resources/embench/config/aarch32/boards/virt-iss/board.cfg
+++ b/vadl/test/resources/embench/config/aarch32/boards/virt-iss/board.cfg
@@ -1,0 +1,35 @@
+# Board configuration for the OpenVADL AArch32 ISS virt machine
+#
+# Copyright (C) 2026 TU Wien
+#
+# This file is part of Embench.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+cflags = [
+    '-c',
+    '-O2',
+    '-ffreestanding',
+    '-ffunction-sections',
+    '-specs=nosys.specs',
+    '-marm',
+    '-march=armv6',
+    '-mfloat-abi=soft',
+    '-mno-unaligned-access',
+]
+ldflags = [
+    '-static',
+    '-O2',
+    '-nostartfiles',
+    '-nostdlib',
+    '-Wl,-gc-sections',
+    '-specs=nosys.specs',
+    '-T../../../config/aarch32/boards/virt-iss/link.ld',
+]
+user_libs = [
+    '-lm',
+    '-lgcc',
+]
+dummy_libs = ['memset', 'memcpy', 'memcmp', 'memmove', 'assert', 'str']
+
+cpu_mhz = 10

--- a/vadl/test/resources/embench/config/aarch32/boards/virt-iss/boardsupport.c
+++ b/vadl/test/resources/embench/config/aarch32/boards/virt-iss/boardsupport.c
@@ -1,0 +1,22 @@
+/* Copyright (C) 2026 TU Wien
+
+   This file is part of Embench.
+
+   SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include <support.h>
+
+void
+initialise_board ()
+{
+}
+
+void __attribute__ ((noinline)) __attribute__ ((externally_visible))
+start_trigger ()
+{
+}
+
+void __attribute__ ((noinline)) __attribute__ ((externally_visible))
+stop_trigger ()
+{
+}

--- a/vadl/test/resources/embench/config/aarch32/boards/virt-iss/boardsupport.h
+++ b/vadl/test/resources/embench/config/aarch32/boards/virt-iss/boardsupport.h
@@ -1,0 +1,7 @@
+/* Copyright (C) 2026 TU Wien
+
+   This file is part of Embench.
+
+   SPDX-License-Identifier: GPL-3.0-or-later */
+
+#define CPU_MHZ 1

--- a/vadl/test/resources/embench/config/aarch32/boards/virt-iss/init.S
+++ b/vadl/test/resources/embench/config/aarch32/boards/virt-iss/init.S
@@ -1,0 +1,63 @@
+.section .text.init
+.align  4
+
+.extern  main
+.type    main, %function
+
+.global _start
+.type   _start, %function
+
+.arm
+.syntax unified
+
+_start:
+    @ The AArch32 virt spec contains firmware at 0x0 that jumps into RAM at
+    @ 0x40000000, so the benchmark image only needs a plain freestanding entry.
+    ldr     sp, =__stack_top
+    bl      main
+    b       exit
+
+exit:
+    @ Preserve the C return value so both exit mechanisms report the same code.
+    mov     r2, r0
+
+    @ Semihosting SYS_EXIT_EXTENDED expects a two-word argument block where the
+    @ second word carries the application exit code.
+    ldr     r1, =args
+    str     r2, [r1, #4]
+
+    @ HTIF exit is used by the generated qemu-system-a32 target. The current
+    @ device model only commits the command after the high 32-bit word is
+    @ written, so emit the 64-bit value as two ordered 32-bit stores.
+    lsl     r0, r2, #1
+    orr     r0, r0, #1
+    ldr     r1, =tohost
+    str     r0, [r1]
+    mov     r3, #0
+    str     r3, [r1, #4]
+
+    @ Upstream qemu-system-arm exits through Arm semihosting instead of HTIF.
+    ldr     r1, =args
+    mov     r0, #0x20
+    svc     #0x123456
+
+1:  b       1b
+
+.section .data
+.align 3
+args:
+.word 0x20026
+.word 0x0
+
+@ Keep the HTIF mailboxes as standalone 8-byte objects so both the linker
+@ script and the guest-side stores use the same layout.
+.section .tohost, "aw", %progbits
+.align 6
+.global tohost
+tohost: .quad 0
+.size tohost, 8
+
+.align 6
+.global fromhost
+fromhost: .quad 0
+.size fromhost, 8

--- a/vadl/test/resources/embench/config/aarch32/boards/virt-iss/link.ld
+++ b/vadl/test/resources/embench/config/aarch32/boards/virt-iss/link.ld
@@ -1,0 +1,30 @@
+OUTPUT_ARCH("arm")
+ENTRY(_start)
+
+SECTIONS
+{
+  /* The AArch32 virt firmware jumps here, so place the image at the start of
+     RAM instead of trying to own the firmware region at 0x0. */
+  . = 0x40000000;
+  .text.init : { *(.text.init) }
+
+  /* Keep the HTIF mailbox on its own page so the device-facing symbol has a
+     stable address and stays visually separate from ordinary program text. */
+  . = ALIGN(0x1000);
+  .tohost : { *(.tohost) }
+
+  /* The remaining sections follow as a simple flat freestanding image. */
+  . = ALIGN(0x1000);
+  .text : { *(.text) }
+  . = ALIGN(0x1000);
+  .data : { *(.data) }
+  .bss : { *(.bss) }
+
+  /* Embench only needs a single process-style stack, so reserve one fixed
+     stack block above the image and export its top for init.S. */
+  . = ALIGN(16);
+  . = . + 8M;
+  . = ALIGN(16);
+  __stack_top = .;
+  _end = .;
+}

--- a/vadl/test/resources/embench/config/aarch32/chips/generic/chip.cfg
+++ b/vadl/test/resources/embench/config/aarch32/chips/generic/chip.cfg
@@ -1,0 +1,7 @@
+# Chip configuration for generic AArch32 ISS benchmarks
+#
+# Copyright (C) 2026 TU Wien
+#
+# This file is part of Embench.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later

--- a/vadl/test/resources/embench/config/aarch32/chips/generic/chipsupport.c
+++ b/vadl/test/resources/embench/config/aarch32/chips/generic/chipsupport.c
@@ -1,0 +1,9 @@
+/* Chip support for generic AArch32 ISS benchmarks
+
+   Copyright (C) 2026 TU Wien
+
+   This file is part of Embench.
+
+   SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "chipsupport.h"

--- a/vadl/test/resources/embench/config/aarch32/chips/generic/chipsupport.h
+++ b/vadl/test/resources/embench/config/aarch32/chips/generic/chipsupport.h
@@ -1,0 +1,17 @@
+/* Chip support for generic AArch32 ISS benchmarks
+
+   Copyright (C) 2026 TU Wien
+
+   This file is part of Embench.
+
+   SPDX-License-Identifier: GPL-3.0-or-later */
+
+#ifndef CHIPSUPPORT_H
+#define CHIPSUPPORT_H
+
+/* Nothing here.  */
+
+/* Dummy typedef: ISO C forbids an empty translation unit */
+typedef int ISO_C_COMPLIANCE;
+
+#endif

--- a/vadl/test/resources/scripts/iss_qemu/compilers/aarch32_compiler.py
+++ b/vadl/test/resources/scripts/iss_qemu/compilers/aarch32_compiler.py
@@ -2,8 +2,8 @@ import asyncio
 import os
 from pathlib import Path
 
-CC="arm-linux-gnueabihf-gcc"
-NM="arm-linux-gnueabihf-nm"
+CC="arm-none-linux-gnueabihf-gcc"
+NM="arm-none-linux-gnueabihf-nm"
 
 async def compile(id: str, asm: str, compargs: str) -> dict:
   asm_path = await build_assembly(id, asm)
@@ -120,4 +120,3 @@ def _tmp_file(id: str, name: str) -> Path:
   build_dir = f"/tmp/build-{id}/"
   os.makedirs(build_dir, exist_ok=True)
   return Path(f"{build_dir}/{name}")
-

--- a/vadl/test/resources/scripts/iss_qemu/compilers/aarch32_compiler.py
+++ b/vadl/test/resources/scripts/iss_qemu/compilers/aarch32_compiler.py
@@ -59,7 +59,9 @@ async def build_assembly(id: str, core: str) -> Path:
       @ exit VADL virt (HTIF)
       mov     r0, #1           @ cmd: exit 0
       ldr     r1, =tohost      @ load addr of 'tohost' into r1
-      str     r0, [r1]         @ store r0 to 'tohost'
+      str     r0, [r1]         @ write low 32 bits of 'tohost'
+      mov     r2, #0
+      str     r2, [r1, #4]     @ write high 32 bits of 'tohost'
       
       @ exit upstream (semihosting)
       ldr     r1, =args

--- a/vadl/test/vadl/iss/TestConstants.java
+++ b/vadl/test/vadl/iss/TestConstants.java
@@ -19,6 +19,6 @@ package vadl.iss;
 class TestConstants {
 
   static final String TEST_BASE_IMAGE =
-      "ghcr.io/openvadl/iss-test-base@sha256:cf494fecb128f4f9a3b6ea2521997b16fdecb99f1b70a3e4f1a0d9f86a5545ae";
+      "ghcr.io/openvadl/iss-test-base@sha256:b06d35aac32965ef48e1e6c8aced83af1bfc2253eccac44e079053f7021d5e3a";
 
 }

--- a/vadl/test/vadl/iss/aarch32/IssAarch32EmbenchBenchmarkTest.java
+++ b/vadl/test/vadl/iss/aarch32/IssAarch32EmbenchBenchmarkTest.java
@@ -19,7 +19,6 @@ package vadl.iss.aarch32;
 import java.io.IOException;
 import java.util.List;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
 import vadl.iss.IssEmbenchBenchmark;
 
 public class IssAarch32EmbenchBenchmarkTest extends IssEmbenchBenchmark {
@@ -29,8 +28,8 @@ public class IssAarch32EmbenchBenchmarkTest extends IssEmbenchBenchmark {
     return List.of("arm-softmmu");
   }
 
+  // @Test
   @Tag("BenchmarkTest")
-  @Test
   void a32BenchmarkTest() throws IOException {
     runBenchmark(benchmarkSpec(
         "a32",

--- a/vadl/test/vadl/iss/aarch32/IssAarch32EmbenchBenchmarkTest.java
+++ b/vadl/test/vadl/iss/aarch32/IssAarch32EmbenchBenchmarkTest.java
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText : © 2026 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.iss.aarch32;
+
+import java.io.IOException;
+import java.util.List;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import vadl.iss.IssEmbenchBenchmark;
+
+public class IssAarch32EmbenchBenchmarkTest extends IssEmbenchBenchmark {
+
+  @Override
+  protected List<String> withUpstreamTargets() {
+    return List.of("arm-softmmu");
+  }
+
+  @Tag("BenchmarkTest")
+  @Test
+  void a32BenchmarkTest() throws IOException {
+    runBenchmark(benchmarkSpec(
+        "a32",
+        "sys/aarch32/virt.vadl",
+        "benchmark-extras/run-benchmarks-a32-iss.sh",
+        "benchmark-extras/results-a32-iss"
+    ));
+  }
+}

--- a/vadl/test/vadl/iss/aarch32/IssAarch32EmbenchTest.java
+++ b/vadl/test/vadl/iss/aarch32/IssAarch32EmbenchTest.java
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText : © 2026 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.iss.aarch32;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.utility.MountableFile;
+import vadl.iss.QemuIssTest;
+import vadl.utils.VadlFileUtils;
+
+public class IssAarch32EmbenchTest extends QemuIssTest {
+
+  private static final Logger log = LoggerFactory.getLogger(IssAarch32EmbenchTest.class);
+
+  @Test
+  void a32EmbenchTest() throws IOException {
+    runEmbenchTest("sys/aarch32/virt.vadl", "build_virt-iss-a32.sh", "qemu-system-a32");
+  }
+
+  private void runEmbenchTest(String vadlPath, String buildScript, String qemuSystem)
+      throws IOException {
+    var image = generateIssSimulator(vadlPath);
+
+    var mhz = 50;
+    var envMhz = System.getenv("EMBENCH_MHZ");
+    if (envMhz != null) {
+      mhz = Integer.parseInt(envMhz);
+    }
+
+    log.info("Setting up embench with {} mhz", mhz);
+
+    var embenchPath = VadlFileUtils.copyResourceDirToTempDir("embench", "embench");
+
+    var runCommand = String.format(
+        "chmod -R +x /work/embench && cd /work/embench "
+            + "&& bash ./%s --cpu-mhz=" + mhz
+            + "&& bash ./benchmark_qemu.sh %s -nographic -bios",
+        buildScript, qemuSystem
+    );
+
+    runContainer(image,
+        container -> container
+            .withCopyFileToContainer(MountableFile.forHostPath(embenchPath), "/work/embench")
+            .withCommand("/bin/bash", "-c", runCommand),
+        null);
+  }
+}

--- a/vadl/test/vadl/iss/aarch32/IssAarch32EmbenchTest.java
+++ b/vadl/test/vadl/iss/aarch32/IssAarch32EmbenchTest.java
@@ -17,7 +17,6 @@
 package vadl.iss.aarch32;
 
 import java.io.IOException;
-import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.utility.MountableFile;
@@ -28,7 +27,7 @@ public class IssAarch32EmbenchTest extends QemuIssTest {
 
   private static final Logger log = LoggerFactory.getLogger(IssAarch32EmbenchTest.class);
 
-  @Test
+  // @Test
   void a32EmbenchTest() throws IOException {
     runEmbenchTest("sys/aarch32/virt.vadl", "build_virt-iss-a32.sh", "qemu-system-a32");
   }


### PR DESCRIPTION
This PR
- updates the ISS test docker images to include the aarch32 gnu toolchain
- fixes the HTIF exit in the compiler script
- adds the embench setup (although it is currently disabled because the aarch32 spec lacks instructions required by the embench executables).