### PR TITLE
ci: Switch avoid artifact upload for frontend benchmarks

### DIFF
--- a/.github/workflows/benchmark-frontend.yml
+++ b/.github/workflows/benchmark-frontend.yml
@@ -14,7 +14,6 @@ on:
 
 permissions:
   contents: read
-  actions: write
   checks: write
 
 jobs:
@@ -29,22 +28,20 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build
         run: ./gradlew nativeBuild
-      - name: Verify native binary
-        run: test -x vadl-cli/build/native/nativeCompile/openvadl
-      - name: Cache native binary
-        uses: actions/cache/save@v5
-        with:
-          key: openvadl-native-${{ github.run_id }}-${{ github.run_attempt }}
-          path: vadl-cli/build/native/nativeCompile/openvadl
+      - name: Stage native binary on runner
+        run: |
+          set -euo pipefail
+          shared_dir="/tmp/openvadl-benchmark-frontend-${{ github.run_id }}-${{ github.run_attempt }}"
+          rm -rf "${shared_dir}"
+          mkdir -p "${shared_dir}"
+          install -m 0755 vadl-cli/build/native/nativeCompile/openvadl "${shared_dir}/openvadl"
 
   aarch64:
     needs: build
     uses: ./.github/workflows/reusable-benchmark-publish.yml
     with:
       runner: self-hosted-x64
-      cache-key: openvadl-native-${{ github.run_id }}-${{ github.run_attempt }}
-      cache-path: vadl-cli/build/native/nativeCompile/openvadl
-      benchmark-command: python3 scripts/benchmark/benchmark_frontend.py --openvadl-binary=vadl-cli/build/native/nativeCompile/openvadl sys/aarch64/aarch64.vadl
+      benchmark-command: python3 scripts/benchmark/benchmark_frontend.py --openvadl-binary=/tmp/openvadl-benchmark-frontend-${{ github.run_id }}-${{ github.run_attempt }}/openvadl sys/aarch64/aarch64.vadl
       artifact-source: output/timings-mean.csv
       destination-folder: data/frontend/aarch64/native/results
       commit-message: 'data: Pushed frontend aarch64 native data'
@@ -55,9 +52,7 @@ jobs:
     uses: ./.github/workflows/reusable-benchmark-publish.yml
     with:
       runner: self-hosted-x64
-      cache-key: openvadl-native-${{ github.run_id }}-${{ github.run_attempt }}
-      cache-path: vadl-cli/build/native/nativeCompile/openvadl
-      benchmark-command: python3 scripts/benchmark/benchmark_frontend.py --openvadl-binary=vadl-cli/build/native/nativeCompile/openvadl sys/aarch32/aarch32.vadl
+      benchmark-command: python3 scripts/benchmark/benchmark_frontend.py --openvadl-binary=/tmp/openvadl-benchmark-frontend-${{ github.run_id }}-${{ github.run_attempt }}/openvadl sys/aarch32/aarch32.vadl
       artifact-source: output/timings-mean.csv
       destination-folder: data/frontend/aarch32/native/results
       commit-message: 'data: Pushed frontend aarch32 native data'
@@ -68,9 +63,7 @@ jobs:
     uses: ./.github/workflows/reusable-benchmark-publish.yml
     with:
       runner: self-hosted-x64
-      cache-key: openvadl-native-${{ github.run_id }}-${{ github.run_attempt }}
-      cache-path: vadl-cli/build/native/nativeCompile/openvadl
-      benchmark-command: python3 scripts/benchmark/benchmark_frontend.py --openvadl-binary=vadl-cli/build/native/nativeCompile/openvadl sys/huge/huge.vadl
+      benchmark-command: python3 scripts/benchmark/benchmark_frontend.py --openvadl-binary=/tmp/openvadl-benchmark-frontend-${{ github.run_id }}-${{ github.run_attempt }}/openvadl sys/huge/huge.vadl
       artifact-source: output/timings-mean.csv
       destination-folder: data/frontend/huge/native/results
       commit-message: 'data: Pushed frontend huge native data'
@@ -81,9 +74,7 @@ jobs:
     uses: ./.github/workflows/reusable-benchmark-publish.yml
     with:
       runner: self-hosted-x64
-      cache-key: openvadl-native-${{ github.run_id }}-${{ github.run_attempt }}
-      cache-path: vadl-cli/build/native/nativeCompile/openvadl
-      benchmark-command: python3 scripts/benchmark/benchmark_frontend.py --openvadl-binary=vadl-cli/build/native/nativeCompile/openvadl sys/risc-v/rv32i.vadl
+      benchmark-command: python3 scripts/benchmark/benchmark_frontend.py --openvadl-binary=/tmp/openvadl-benchmark-frontend-${{ github.run_id }}-${{ github.run_attempt }}/openvadl sys/risc-v/rv32i.vadl
       artifact-source: output/timings-mean.csv
       destination-folder: data/frontend/rv32i/native/results
       commit-message: 'data: Pushed frontend rv32i native data'
@@ -94,9 +85,7 @@ jobs:
     uses: ./.github/workflows/reusable-benchmark-publish.yml
     with:
       runner: self-hosted-x64
-      cache-key: openvadl-native-${{ github.run_id }}-${{ github.run_attempt }}
-      cache-path: vadl-cli/build/native/nativeCompile/openvadl
-      benchmark-command: python3 scripts/benchmark/benchmark_frontend.py --openvadl-binary=vadl-cli/build/native/nativeCompile/openvadl sys/ppc64/ppc64.vadl
+      benchmark-command: python3 scripts/benchmark/benchmark_frontend.py --openvadl-binary=/tmp/openvadl-benchmark-frontend-${{ github.run_id }}-${{ github.run_attempt }}/openvadl sys/ppc64/ppc64.vadl
       artifact-source: output/timings-mean.csv
       destination-folder: data/frontend/ppc64/native/results
       commit-message: 'data: Pushed frontend ppc64 native data'
@@ -107,10 +96,23 @@ jobs:
     uses: ./.github/workflows/reusable-benchmark-publish.yml
     with:
       runner: self-hosted-x64
-      cache-key: openvadl-native-${{ github.run_id }}-${{ github.run_attempt }}
-      cache-path: vadl-cli/build/native/nativeCompile/openvadl
-      benchmark-command: python3 scripts/benchmark/benchmark_frontend.py --openvadl-binary=vadl-cli/build/native/nativeCompile/openvadl sys/hexagon/hexagon.vadl
+      benchmark-command: python3 scripts/benchmark/benchmark_frontend.py --openvadl-binary=/tmp/openvadl-benchmark-frontend-${{ github.run_id }}-${{ github.run_attempt }}/openvadl sys/hexagon/hexagon.vadl
       artifact-source: output/timings-mean.csv
       destination-folder: data/frontend/hexagon/native/results
       commit-message: 'data: Pushed frontend hexagon native data'
     secrets: inherit
+
+  cleanup:
+    needs:
+      - build
+      - aarch64
+      - aarch32
+      - huge
+      - rv32i
+      - ppc64
+      - hexagon
+    if: ${{ always() }}
+    runs-on: self-hosted-x64
+    steps:
+      - name: Remove staged native binary
+        run: rm -rf "/tmp/openvadl-benchmark-frontend-${{ github.run_id }}-${{ github.run_attempt }}"

--- a/.github/workflows/benchmark-frontend.yml
+++ b/.github/workflows/benchmark-frontend.yml
@@ -29,22 +29,22 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build
         run: ./gradlew nativeBuild
-      - name: Upload native binary
-        uses: actions/upload-artifact@v7
+      - name: Verify native binary
+        run: test -x vadl-cli/build/native/nativeCompile/openvadl
+      - name: Cache native binary
+        uses: actions/cache/save@v5
         with:
-           name: openvadl
-           path: vadl-cli/build/native/nativeCompile/openvadl
-           retention-days: 1
-           compression-level: 0
-           if-no-files-found: error
+          key: openvadl-native-${{ github.run_id }}-${{ github.run_attempt }}
+          path: vadl-cli/build/native/nativeCompile/openvadl
 
   aarch64:
     needs: build
     uses: ./.github/workflows/reusable-benchmark-publish.yml
     with:
       runner: self-hosted-x64
-      download-artifact: openvadl
-      benchmark-command: python3 scripts/benchmark/benchmark_frontend.py --openvadl-binary=./openvadl sys/aarch64/aarch64.vadl
+      cache-key: openvadl-native-${{ github.run_id }}-${{ github.run_attempt }}
+      cache-path: vadl-cli/build/native/nativeCompile/openvadl
+      benchmark-command: python3 scripts/benchmark/benchmark_frontend.py --openvadl-binary=vadl-cli/build/native/nativeCompile/openvadl sys/aarch64/aarch64.vadl
       artifact-source: output/timings-mean.csv
       destination-folder: data/frontend/aarch64/native/results
       commit-message: 'data: Pushed frontend aarch64 native data'
@@ -55,8 +55,9 @@ jobs:
     uses: ./.github/workflows/reusable-benchmark-publish.yml
     with:
       runner: self-hosted-x64
-      download-artifact: openvadl
-      benchmark-command: python3 scripts/benchmark/benchmark_frontend.py --openvadl-binary=./openvadl sys/aarch32/aarch32.vadl
+      cache-key: openvadl-native-${{ github.run_id }}-${{ github.run_attempt }}
+      cache-path: vadl-cli/build/native/nativeCompile/openvadl
+      benchmark-command: python3 scripts/benchmark/benchmark_frontend.py --openvadl-binary=vadl-cli/build/native/nativeCompile/openvadl sys/aarch32/aarch32.vadl
       artifact-source: output/timings-mean.csv
       destination-folder: data/frontend/aarch32/native/results
       commit-message: 'data: Pushed frontend aarch32 native data'
@@ -67,8 +68,9 @@ jobs:
     uses: ./.github/workflows/reusable-benchmark-publish.yml
     with:
       runner: self-hosted-x64
-      download-artifact: openvadl
-      benchmark-command: python3 scripts/benchmark/benchmark_frontend.py --openvadl-binary=./openvadl sys/huge/huge.vadl
+      cache-key: openvadl-native-${{ github.run_id }}-${{ github.run_attempt }}
+      cache-path: vadl-cli/build/native/nativeCompile/openvadl
+      benchmark-command: python3 scripts/benchmark/benchmark_frontend.py --openvadl-binary=vadl-cli/build/native/nativeCompile/openvadl sys/huge/huge.vadl
       artifact-source: output/timings-mean.csv
       destination-folder: data/frontend/huge/native/results
       commit-message: 'data: Pushed frontend huge native data'
@@ -79,8 +81,9 @@ jobs:
     uses: ./.github/workflows/reusable-benchmark-publish.yml
     with:
       runner: self-hosted-x64
-      download-artifact: openvadl
-      benchmark-command: python3 scripts/benchmark/benchmark_frontend.py --openvadl-binary=./openvadl sys/risc-v/rv32i.vadl
+      cache-key: openvadl-native-${{ github.run_id }}-${{ github.run_attempt }}
+      cache-path: vadl-cli/build/native/nativeCompile/openvadl
+      benchmark-command: python3 scripts/benchmark/benchmark_frontend.py --openvadl-binary=vadl-cli/build/native/nativeCompile/openvadl sys/risc-v/rv32i.vadl
       artifact-source: output/timings-mean.csv
       destination-folder: data/frontend/rv32i/native/results
       commit-message: 'data: Pushed frontend rv32i native data'
@@ -91,8 +94,9 @@ jobs:
     uses: ./.github/workflows/reusable-benchmark-publish.yml
     with:
       runner: self-hosted-x64
-      download-artifact: openvadl
-      benchmark-command: python3 scripts/benchmark/benchmark_frontend.py --openvadl-binary=./openvadl sys/ppc64/ppc64.vadl
+      cache-key: openvadl-native-${{ github.run_id }}-${{ github.run_attempt }}
+      cache-path: vadl-cli/build/native/nativeCompile/openvadl
+      benchmark-command: python3 scripts/benchmark/benchmark_frontend.py --openvadl-binary=vadl-cli/build/native/nativeCompile/openvadl sys/ppc64/ppc64.vadl
       artifact-source: output/timings-mean.csv
       destination-folder: data/frontend/ppc64/native/results
       commit-message: 'data: Pushed frontend ppc64 native data'
@@ -103,8 +107,9 @@ jobs:
     uses: ./.github/workflows/reusable-benchmark-publish.yml
     with:
       runner: self-hosted-x64
-      download-artifact: openvadl
-      benchmark-command: python3 scripts/benchmark/benchmark_frontend.py --openvadl-binary=./openvadl sys/hexagon/hexagon.vadl
+      cache-key: openvadl-native-${{ github.run_id }}-${{ github.run_attempt }}
+      cache-path: vadl-cli/build/native/nativeCompile/openvadl
+      benchmark-command: python3 scripts/benchmark/benchmark_frontend.py --openvadl-binary=vadl-cli/build/native/nativeCompile/openvadl sys/hexagon/hexagon.vadl
       artifact-source: output/timings-mean.csv
       destination-folder: data/frontend/hexagon/native/results
       commit-message: 'data: Pushed frontend hexagon native data'

--- a/.github/workflows/benchmark-frontend.yml
+++ b/.github/workflows/benchmark-frontend.yml
@@ -35,6 +35,8 @@ jobs:
            name: openvadl
            path: vadl-cli/build/native/nativeCompile/openvadl
            retention-days: 1
+           compression-level: 0
+           if-no-files-found: error
 
   aarch64:
     needs: build

--- a/.github/workflows/benchmark-frontend.yml
+++ b/.github/workflows/benchmark-frontend.yml
@@ -21,7 +21,7 @@ jobs:
   build:
     runs-on: self-hosted-x64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: graalvm/setup-graalvm@v1
         with:
           java-version: '25'
@@ -30,7 +30,7 @@ jobs:
       - name: Build
         run: ./gradlew nativeBuild
       - name: Upload native binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
            name: openvadl
            path: vadl-cli/build/native/nativeCompile/openvadl

--- a/.github/workflows/reusable-benchmark-publish.yml
+++ b/.github/workflows/reusable-benchmark-publish.yml
@@ -34,32 +34,12 @@ on:
         required: false
         default: ''
         type: string
-      cache-key:
-        description: 'Cache key for a pre-built artifact to restore before benchmarking (optional)'
-        required: false
-        default: ''
-        type: string
-      cache-path:
-        description: 'Path restored from the cache before benchmarking (required when cache-key is set)'
-        required: false
-        default: ''
-        type: string
 
 jobs:
   benchmark:
     runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v6
-      - name: Restore pre-built cache
-        if: ${{ inputs.cache-key != '' }}
-        uses: actions/cache/restore@v5
-        with:
-          key: ${{ inputs.cache-key }}
-          path: ${{ inputs.cache-path }}
-          fail-on-cache-miss: true
-      - name: Make cached artifact executable
-        if: ${{ inputs.cache-key != '' }}
-        run: chmod +x "${{ inputs.cache-path }}"
       - name: Download pre-built artifact
         if: ${{ inputs.download-artifact != '' }}
         uses: actions/download-artifact@v8

--- a/.github/workflows/reusable-benchmark-publish.yml
+++ b/.github/workflows/reusable-benchmark-publish.yml
@@ -39,10 +39,10 @@ jobs:
   benchmark:
     runs-on: ${{ inputs.runner }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download pre-built artifact
         if: ${{ inputs.download-artifact != '' }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ inputs.download-artifact }}
       - name: Make downloaded artifact executable
@@ -64,7 +64,7 @@ jobs:
       - name: Prepare artifact
         run: cp "${{ inputs.artifact-source }}" "${{ github.workspace }}/${ARTIFACT_NAME}"
       - name: Checkout target repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: openVADL/resselpark
           token: ${{ secrets.ACCESS_TOKEN_RESSELPARK }}

--- a/.github/workflows/reusable-benchmark-publish.yml
+++ b/.github/workflows/reusable-benchmark-publish.yml
@@ -34,12 +34,32 @@ on:
         required: false
         default: ''
         type: string
+      cache-key:
+        description: 'Cache key for a pre-built artifact to restore before benchmarking (optional)'
+        required: false
+        default: ''
+        type: string
+      cache-path:
+        description: 'Path restored from the cache before benchmarking (required when cache-key is set)'
+        required: false
+        default: ''
+        type: string
 
 jobs:
   benchmark:
     runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v6
+      - name: Restore pre-built cache
+        if: ${{ inputs.cache-key != '' }}
+        uses: actions/cache/restore@v5
+        with:
+          key: ${{ inputs.cache-key }}
+          path: ${{ inputs.cache-path }}
+          fail-on-cache-miss: true
+      - name: Make cached artifact executable
+        if: ${{ inputs.cache-key != '' }}
+        run: chmod +x "${{ inputs.cache-path }}"
       - name: Download pre-built artifact
         if: ${{ inputs.download-artifact != '' }}
         uses: actions/download-artifact@v8


### PR DESCRIPTION
This PR also bumps some versions in the benchmark ci setup