### PR TITLE
chore: Add odd-sized tests for shift/rotate builtins

### DIFF
--- a/vadl/test/resources/testSource/passes/canonicalization/valid_builtin_constant_evaluation.vadl
+++ b/vadl/test/resources/testSource/passes/canonicalization/valid_builtin_constant_evaluation.vadl
@@ -20,12 +20,18 @@
 #set($s4 = "SInt<4>")
 #set($u4 = "UInt<4>")
 #set($b4 = "Bits<4>")
+#set($s7 = "SInt<7>")
+#set($u7 = "UInt<7>")
+#set($b7 = "Bits<7>")
 #set($s8 = "SInt<8>")
 #set($u8 = "UInt<8>")
 #set($b8 = "Bits<8>")
 #set($s16 = "SInt<16>")
 #set($u16 = "UInt<16>")
 #set($b16 = "Bits<16>")
+#set($s17 = "SInt<17>")
+#set($u17 = "UInt<17>")
+#set($b17 = "Bits<17>")
 #set($u32 = "UInt<32>")
 #set($s32 = "SInt<32>")
 #set($b32 = "Bits<32>")
@@ -216,6 +222,12 @@
 
 #rrx_(27075, $b16, 0, 13537, $b16)
 #rrx_(27075, $b16, 1, 46305, $b16)
+
+#rrx_(53, $b7, 0, 26, $b7)
+#rrx_(53, $b7, 1, 90, $b7)
+
+#rrx_(111785, $b17, 0, 55892, $b17)
+#rrx_(111785, $b17, 1, 121428, $b17)
 
 
 ///////// TEST MACROS Implementation ///////////

--- a/vadl/test/vadl/viam/passes/statusBuiltInInlinePass/ShiftRotateInlineTest.java
+++ b/vadl/test/vadl/viam/passes/statusBuiltInInlinePass/ShiftRotateInlineTest.java
@@ -65,7 +65,20 @@ public class ShiftRotateInlineTest extends StatusBuiltinInlineTest {
 
         // shift large amount
         lsls(0xFFFFFFFFL, 32, 0xFFFF, 32, 0x0, false, true, true),
-        lsls(0x0,         32, 0xFFFF, 32, 0x0, false, true, false)
+        lsls(0x0,         32, 0xFFFF, 32, 0x0, false, true, false),
+
+        // odd sizes
+        lsls(0b0101110, 7, 1, 1, 0b1011100, true, false, false),
+        lsls(0b0101110, 7, 3, 2, 0b1110000, true, false, false),
+        lsls(0b0101111, 7, 6, 3, 0b1000000, true, false, true),
+        lsls(0b0101111, 7, 7, 3, 0, false, true, true),
+        lsls(0b0101110, 7, 0xFFFF, 32, 0, false, true, false),
+
+        lsls(0b01011101011010110, 17, 1, 1, 0b10111010110101100, true, false, false),
+        lsls(0b01011101011010110, 17, 3, 2, 0b11101011010110000, true, false, false),
+        lsls(0b01011101011010111, 17, 16, 8, 0b10000000000000000, true, false, true),
+        lsls(0b01011101011010110, 17, 17, 8, 0, false, true, false),
+        lsls(0b01011101011010111, 17, 0xFFFF, 32, 0, false, true, true)
     );
   }
 
@@ -108,7 +121,20 @@ public class ShiftRotateInlineTest extends StatusBuiltinInlineTest {
 
         // rotate large amount
         rors(0xFFFFFFFFL, 32, 0xFFFF, 32, 0xFFFFFFFFL, true, false, true),
-        rors(0x0,         32, 0xFFFF, 32, 0x0,         false, true, false)
+        rors(0x0,         32, 0xFFFF, 32, 0x0,         false, true, false),
+
+        // odd sizes
+        rors(0b0101110, 7, 1, 1, 0b0010111, false, false, false),
+        rors(0b0101110, 7, 3, 2, 0b1100101, true, false, true),
+        rors(0b0101111, 7, 6, 3, 0b1011110, true, false, true),
+        rors(0b0101111, 7, 7, 3, 0b0101111, false, false, false),
+        rors(0b0101110, 7, 0xFFFF, 32, 0b0010111, false, false, false),
+
+        rors(0b01011101011010110, 17, 1, 1, 0b00101110101101011, false, false, false),
+        rors(0b01011101011010110, 17, 3, 2, 0b11001011101011010, true, false, true),
+        rors(0b01011101011010111, 17, 16, 8, 0b10111010110101110, true, false, true),
+        rors(0b01011101011010110, 17, 17, 8, 0b01011101011010110, false, false, false),
+        rors(0b01011101011010111, 17, 0xFFFF, 32, 0b01011101011010111, false, false, false)
     );
   }
 


### PR DESCRIPTION
Added tests for:
- `rrx` constant evaluation
- `lsls`/`rors` status bits and result inlining