### PR TITLE
typechecker: Further performance improvements

### DIFF
--- a/vadl-frontend/main/vadl/ast/TypeChecker.java
+++ b/vadl-frontend/main/vadl/ast/TypeChecker.java
@@ -916,17 +916,42 @@ public class TypeChecker
     }
   }
 
-  private Map<Pair<BuiltInTable.BuiltIn, List<Type>>, BuiltInCheckResult> builtInCheckCache =
-      new HashMap<>();
+  /// A tiny custom cache for built-in function type checking.
+  private static class BuiltInCheckCache {
+    private Map<BuiltInTable.BuiltIn, Map<List<Type>, BuiltInCheckResult>> store =
+        new HashMap<>();
+
+    @Nullable
+    private BuiltInCheckResult get(BuiltInTable.BuiltIn builtIn, List<Type> argTypes) {
+      var inner = store.get(builtIn);
+      if (inner == null) {
+        return null;
+      }
+      return inner.get(argTypes);
+    }
+
+    @Nullable
+    private void put(BuiltInTable.BuiltIn builtIn, List<Type> argTypes, BuiltInCheckResult result) {
+      var inner = store.computeIfAbsent(builtIn, k -> new HashMap<>());
+      inner.put(argTypes, result);
+    }
+  }
+
+  private BuiltInCheckCache builtInCheckCache = new BuiltInCheckCache();
+
 
   /// Check if the built-in function call, but doesn't care which kind of expression it arises from
   /// binary expressions, unary expressions or direct calls.
   /// The passed arguments have to be already checked!
   private BuiltInCheckResult checkBuiltin(BuiltInTable.BuiltIn builtIn, List<Expr> args,
                                           WithLocation location) {
-    var key = Pair.of(builtIn, args.stream().map(Expr::type).toList());
-    if (builtInCheckCache.containsKey(key)) {
-      return builtInCheckCache.get(key);
+    List<Type> argTypes = new ArrayList<>(args.size());
+    for (var arg: args) {
+      argTypes.add(arg.type());
+    }
+    var cached = builtInCheckCache.get(builtIn, argTypes);
+    if (cached != null) {
+      return cached;
     }
 
     var result = unCachedCheckBuiltin(builtIn, args, location);
@@ -938,7 +963,7 @@ public class TypeChecker
       return result;
     }
 
-    builtInCheckCache.put(key, result);
+    builtInCheckCache.put(builtIn, argTypes, result);
     return result;
   }
 

--- a/vadl-frontend/main/vadl/ast/TypeChecker.java
+++ b/vadl-frontend/main/vadl/ast/TypeChecker.java
@@ -630,41 +630,40 @@ public class TypeChecker
       return true;
     }
 
-    return explicitTypeCache.computeIfAbsent(Pair.of(from, to),
-        k -> uncachedCanExplicitCast(k.left(), k.right()));
-  }
-
-  private boolean uncachedCanExplicitCast(Type from, Type to) {
-    if (from.equals(to)) {
-      return true;
-    }
+    // Note: This code already was fancy, functional but it is on the hot path, so now it is fast.
 
     // Tensors need special rules for casting
-    if (from instanceof TensorType fromTensor && to instanceof TensorType toTensor) {
-      return fromTensor.flattenBitsType().equals(toTensor.flattenBitsType());
-    }
-    if (from instanceof TensorType fromTensor && to instanceof BitsType toBits) {
-      return fromTensor.flattenBitsType().equals(toBits);
-    }
-    if (from instanceof BitsType fromBits && to instanceof TensorType toTensor) {
-      return toTensor.flattenBitsType().bitWidth() == fromBits.bitWidth();
+    if (from instanceof TensorType fromTensor ) {
+      if(to instanceof TensorType toTensor) {
+        return fromTensor.flattenBitsType().equals(toTensor.flattenBitsType());
+      }
+      if (to instanceof BitsType toBits) {
+        return fromTensor.flattenBitsType().equals(toBits);
+      }
     }
 
-    // Casting rules for basic types
-    var castTable = Map.of(
-        ConstantType.class, List.of(BitsType.class, BoolType.class),
-        BitsType.class, List.of(BitsType.class, BoolType.class),
-        BoolType.class, List.of(BoolType.class, BitsType.class),
-        StringType.class, List.of(StringType.class)
-    );
-
-    var key =
-        castTable.keySet().stream().filter(k -> k.isInstance(from)).findFirst().orElse(null);
-    if (key == null) {
-      return false;
+    // All the Basic types
+    if (from instanceof BitsType fromBits) {
+      if (to instanceof TensorType toTensor) {
+        return toTensor.flattenBitsType().bitWidth() == fromBits.bitWidth();
+      }
+      return to instanceof BitsType || to instanceof BoolType;
     }
-    var allowedTargets = requireNonNull(castTable.get(key));
-    return allowedTargets.stream().anyMatch(t -> t.isInstance(to));
+
+    if (from instanceof ConstantType) {
+      return to instanceof BitsType || to instanceof BoolType;
+    }
+
+    if (from instanceof BoolType) {
+      return to instanceof BoolType || to instanceof BitsType;
+    }
+
+
+    if (from instanceof StringType) {
+      return to instanceof StringType;
+    }
+
+    return false;
   }
 
   /**

--- a/vadl-frontend/main/vadl/ast/TypeChecker.java
+++ b/vadl-frontend/main/vadl/ast/TypeChecker.java
@@ -330,6 +330,16 @@ public class TypeChecker
     return expr.type();
   }
 
+  /// A tiny helper to check a list of expressions.
+  /// This is faster than the more intuitive way with streams.
+  private List<Type> checkExpressions(List<Expr> exprs) {
+    var types = new ArrayList<Type>(exprs.size());
+    for (var expr : exprs) {
+      types.add(check(expr));
+    }
+    return types;
+  }
+
   /**
    * Typecheck the statement, if not yet checked.
    *
@@ -616,8 +626,6 @@ public class TypeChecker
     }
   }
 
-  private Map<Pair<Type, Type>, Boolean> explicitTypeCache = new HashMap<>();
-
   /**
    * Tests whether a type can explicit be cast to another.
    *
@@ -633,8 +641,8 @@ public class TypeChecker
     // Note: This code already was fancy, functional but it is on the hot path, so now it is fast.
 
     // Tensors need special rules for casting
-    if (from instanceof TensorType fromTensor ) {
-      if(to instanceof TensorType toTensor) {
+    if (from instanceof TensorType fromTensor) {
+      if (to instanceof TensorType toTensor) {
         return fromTensor.flattenBitsType().equals(toTensor.flattenBitsType());
       }
       if (to instanceof BitsType toBits) {
@@ -930,7 +938,6 @@ public class TypeChecker
       return inner.get(argTypes);
     }
 
-    @Nullable
     private void put(BuiltInTable.BuiltIn builtIn, List<Type> argTypes, BuiltInCheckResult result) {
       var inner = store.computeIfAbsent(builtIn, k -> new HashMap<>());
       inner.put(argTypes, result);
@@ -946,7 +953,7 @@ public class TypeChecker
   private BuiltInCheckResult checkBuiltin(BuiltInTable.BuiltIn builtIn, List<Expr> args,
                                           WithLocation location) {
     List<Type> argTypes = new ArrayList<>(args.size());
-    for (var arg: args) {
+    for (var arg : args) {
       argTypes.add(arg.type());
     }
     var cached = builtInCheckCache.get(builtIn, argTypes);
@@ -3432,7 +3439,7 @@ public class TypeChecker
       return null;
     }
 
-    var types = expr.expressions.stream().map(this::check).toList();
+    var types = checkExpressions(expr.expressions);
 
     // String concatination
     if (types.stream().allMatch(x -> x instanceof StringType)) {
@@ -3466,7 +3473,7 @@ public class TypeChecker
       }
 
       expr.expressions.replaceAll(e -> wrapImplicitCast(e, concreteTypes.get(0)));
-      types = expr.expressions.stream().map(this::check).toList();
+      types = checkExpressions(expr.expressions);
     }
 
     if (types.stream().allMatch(x -> x instanceof DataType)) {
@@ -4205,7 +4212,7 @@ public class TypeChecker
     // Builtin function
     List<Expr> args =
         !expr.argsIndices.isEmpty() ? expr.argsIndices.getFirst().values : new ArrayList<>();
-    var argTypes = args.stream().map(this::check).toList();
+    var argTypes = checkExpressions(args);
     var builtin = AstUtils.getBuiltIn(expr.target.path().pathToString(), argTypes);
 
     if (builtin == null) {


### PR DESCRIPTION
This PR is somewhat related to #1032 

It reverts the caches introduced for `canExplicitCast` by simply rewriting the logic that implements it in a more imperative style, which makes it even faster than the caches. 
(original: 56ms, with cache: 8ms, with rewrite: 4ms)

The cache for `checkBuiltin` had especially slow lookup, because it looked the values up twice and by implementing a custom cache the time got down from 120ms to 48ms.

Lastly at some places we used streams to iterate over tiny lists where the overhead is especially large and by rewriting those parts we saved an additional 43ms on huge.

