### PR TITLE
frontend: Reduce memory footprint

### DIFF
--- a/vadl-frontend/main/vadl/ast/MacroExpander.java
+++ b/vadl-frontend/main/vadl/ast/MacroExpander.java
@@ -549,7 +549,7 @@ class MacroExpander
 
   @Nullable
   private String concatStringifyExpressions(Expr origin, List<Expr> expressions) {
-    var nameBuilder = new StringBuilder();
+    var nameBuilder = new StringBuilder(expressions.size());
     for (var inner : expressions) {
       if (inner instanceof Identifier id) {
         nameBuilder.append(id.name);

--- a/vadl-frontend/main/vadl/ast/MacroExpander.java
+++ b/vadl-frontend/main/vadl/ast/MacroExpander.java
@@ -222,8 +222,8 @@ class MacroExpander
 
   private <T> List<T> expandExprs(List<T> expressions) {
     var result = new ArrayList<T>(expressions.size());
-    for (var expr : expressions) {
-      result.add(expandExpr(expr));
+    for (var i = 0; i < expressions.size(); i++) {
+      result.add(expandExpr(expressions.get(i)));
     }
     return result;
   }
@@ -285,7 +285,8 @@ class MacroExpander
 
   private CallIndexExpr.Arguments expandArgs(CallIndexExpr.Arguments args) {
     var values = new ArrayList<Expr>(args.values.size());
-    for (var value : args.values) {
+    for (var i = 0; i < args.values.size(); i++) {
+      var value = args.values.get(i);
       values.add(expandExpr(value));
     }
     return new CallIndexExpr.Arguments(values, copyLoc(args.location));
@@ -473,11 +474,13 @@ class MacroExpander
   @Override
   public Expr visit(CallIndexExpr expr) {
     var argsIndices = new ArrayList<CallIndexExpr.Arguments>(expr.argsIndices.size());
-    for (var argsIndex : expr.argsIndices) {
+    for (var i = 0; i < expr.argsIndices.size(); i++) {
+      var argsIndex = expr.argsIndices.get(i);
       argsIndices.add(expandArgs(argsIndex));
     }
     var subCalls = new ArrayList<CallIndexExpr.SubCall>(expr.subCalls.size());
-    for (var subCall : expr.subCalls) {
+    for (var i = 0; i < expr.subCalls.size(); i++) {
+      var subCall = expr.subCalls.get(i);
       var subCallArgsIndices = new ArrayList<CallIndexExpr.Arguments>(subCall.argsIndices.size());
       for (var argsIndex : subCall.argsIndices) {
         subCallArgsIndices.add(expandArgs(argsIndex));

--- a/vadl-frontend/main/vadl/ast/TypeChecker.java
+++ b/vadl-frontend/main/vadl/ast/TypeChecker.java
@@ -184,7 +184,6 @@ import vadl.types.asmTypes.AsmType;
 import vadl.types.asmTypes.GroupAsmType;
 import vadl.types.asmTypes.InstructionAsmType;
 import vadl.types.asmTypes.StringAsmType;
-import vadl.utils.Either;
 import vadl.utils.IdentityDeque;
 import vadl.utils.Levenshtein;
 import vadl.utils.Pair;
@@ -953,8 +952,8 @@ public class TypeChecker
   private BuiltInCheckResult checkBuiltin(BuiltInTable.BuiltIn builtIn, List<Expr> args,
                                           WithLocation location) {
     List<Type> argTypes = new ArrayList<>(args.size());
-    for (var arg : args) {
-      argTypes.add(arg.type());
+    for (int i = 0; i < args.size(); i++) {
+      argTypes.add(args.get(i).type());
     }
     var cached = builtInCheckCache.get(builtIn, argTypes);
     if (cached != null) {
@@ -3668,30 +3667,21 @@ public class TypeChecker
     }
 
     // 2. Calculate the sizes
-    var sizesOrErrors = expr.sizeIndices.stream().map(sizeExpr -> {
+    List<Integer> sizes = new ArrayList<>(expr.sizeIndices.size());
+    for (var sizeExpr : expr.sizeIndices) {
       check(sizeExpr);
       var size = constantEvaluator.eval(sizeExpr).value().intValueExact();
 
       if (size < 1) {
-        return new Either<Integer, Diagnostic>(null,
+        return ParsedTypeLiteralResult.error(
             error("Invalid Type Notation", sizeExpr.location())
                 .locationDescription(sizeExpr.location(),
                     "Width must of a %s must be greater or equal 1 but was %d", base, size)
                 .build());
       }
 
-      return new Either<Integer, Diagnostic>(size, null);
-    }).toList();
-
-    // Check for errors and return early if found
-    for (var sizeOrError : sizesOrErrors) {
-      if (sizeOrError.isRight()) {
-        return ParsedTypeLiteralResult.error(sizeOrError.right());
-      }
+      sizes.add(size);
     }
-
-    var sizes = sizesOrErrors.stream().map(Either::left).toList();
-
 
     // For the builtin bits types we can infer the size (sometimes)
     if (List.of("Bits", "SInt", "UInt").contains(base)

--- a/vadl-frontend/main/vadl/ast/Ungrouper.java
+++ b/vadl-frontend/main/vadl/ast/Ungrouper.java
@@ -246,11 +246,13 @@ public class Ungrouper
   @Override
   public Expr visit(CallIndexExpr expr) {
     expr.target = (IsSymExpr) ((Expr) expr.target).accept(this);
-    for (var entry : expr.argsIndices) {
+    for (int i = 0; i < expr.argsIndices.size(); i++) {
+      var entry = expr.argsIndices.get(i);
       entry.values.replaceAll(e -> e.accept(this));
     }
 
-    for (var subCall : expr.subCalls) {
+    for (int i = 0; i < expr.subCalls.size(); i++) {
+      var subCall = expr.subCalls.get(i);
       for (var entry : subCall.argsIndices) {
         entry.values.replaceAll(e -> e.accept(this));
       }
@@ -889,7 +891,8 @@ public class Ungrouper
   }
 
   private void ungroupAnnotations(Definition definition) {
-    for (var annotation : definition.annotations) {
+    for (var i = 0; i < definition.annotations.size(); i++) {
+      var annotation = definition.annotations.get(i);
       visit(annotation);
     }
   }

--- a/vadl-frontend/main/vadl/ast/ViamLowering.java
+++ b/vadl-frontend/main/vadl/ast/ViamLowering.java
@@ -424,7 +424,8 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
   }
 
   static <T> List<T> append(List<T> list, T... elements) {
-    var newList = new ArrayList<T>(list);
+    var newList = new ArrayList<T>(list.size() + elements.length);
+    newList.addAll(list);
     for (T element : elements) {
       newList.add(element);
     }

--- a/vadl-frontend/main/vadl/ast/nodes/CallIndexExpr.java
+++ b/vadl-frontend/main/vadl/ast/nodes/CallIndexExpr.java
@@ -156,14 +156,17 @@ public final class CallIndexExpr extends Expr implements IsCallExpr {
     if (target != null) {
       action.accept((Node) target);
     }
-    for (var a : argsIndices) {
-      for (var v : a.values) {
-        if (v != null) {
-          action.accept(v);
+    for (var i = 0; i < argsIndices.size(); i++) {
+      var args = argsIndices.get(i);
+      for (var j = 0; j < args.values.size(); j++) {
+        var value = args.values.get(j);
+        if (value != null) {
+          action.accept(value);
         }
       }
     }
-    for (var subCall : subCalls) {
+    for (var i = 0; i < subCalls.size(); i++) {
+      var subCall = subCalls.get(i);
       for (var a : subCall.argsIndices) {
         for (var v : a.values) {
           if (v != null) {

--- a/vadl-frontend/main/vadl/ast/nodes/IdentifierPath.java
+++ b/vadl-frontend/main/vadl/ast/nodes/IdentifierPath.java
@@ -80,7 +80,7 @@ public final class IdentifierPath extends Expr implements IsId {
 
   //  @Override
   public List<String> pathToSegments() {
-    var result = new ArrayList<String>();
+    var result = new ArrayList<String>(segments.size());
     for (var segment : segments) {
       result.add(((Identifier) segment).name);
     }


### PR DESCRIPTION
This PR is an odd collection resulting from lots of profiling and eliminating memory heavy sections wherever possible.

This includes stuff like:
- Sizing ArrayLists and StringBuilder
- Avoiding Iterators for tiny lists on hot paths

As a result in my benchmarks huge.vadl now runs in **601ms down from 713ms**.