### PR TITLE
dump: Improve performance of VIAM dumps

### DIFF
--- a/vadl/main/vadl/dump/CollectBehaviorDotGraphPass.java
+++ b/vadl/main/vadl/dump/CollectBehaviorDotGraphPass.java
@@ -19,6 +19,7 @@ package vadl.dump;
 import static vadl.utils.ViamUtils.findDefinitionsByFilter;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -66,17 +67,26 @@ public class CollectBehaviorDotGraphPass extends Pass {
      * the rendering. It returns a list where each entry is separate pass result which contains
      * the dot graph.
      */
-    public List<PassResults.DotGraphResult> map() {
-      return behaviors.entrySet().stream()
-          .flatMap(x -> x.getValue().stream()
-              .map(behaviorDotGraph -> new PassResults.DotGraphResult(
-                  prevPass.passKey(),
-                  prevPass().pass(),
-                  prevPass().durationNs(),
-                  behaviorDotGraph,
-                  prevPass().skipped(),
-                  x.getKey())))
-          .toList();
+    public List<PassResults.DotGraphResult> mapFor(Definition def) {
+      var results = new ArrayList<PassResults.DotGraphResult>();
+      var graphList = behaviors.get(def);
+
+      if (graphList == null) {
+        return results;
+      }
+
+      for (int i = 0; i < graphList.size(); i++) {
+        results.add(new PassResults.DotGraphResult(
+            prevPass.passKey(),
+            prevPass.pass(),
+            prevPass.durationNs(),
+            graphList.get(i),
+            prevPass.skipped(),
+            def));
+      }
+
+
+      return results;
     }
   }
 

--- a/vadl/main/vadl/dump/infoEnrichers/ViamEnricherCollection.java
+++ b/vadl/main/vadl/dump/infoEnrichers/ViamEnricherCollection.java
@@ -158,9 +158,8 @@ public class ViamEnricherCollection {
               CollectBehaviorDotGraphPass.class,
               CollectBehaviorDotGraphPass.Result.class
           )
-          .flatMap(r -> r.map().stream())
+          .flatMap(r -> r.mapFor(def).stream())
           // only filter for affected definitions
-          .filter(dotGraphResult -> dotGraphResult.definition() == def)
           // Downcast because Java doesn't support Higher Order Subtyping
           .map(x -> (BehaviorTimelineDisplay) x)
           .toList();

--- a/vadl/main/vadl/template/AbstractMultiTemplateRenderingPass.java
+++ b/vadl/main/vadl/template/AbstractMultiTemplateRenderingPass.java
@@ -18,6 +18,7 @@ package vadl.template;
 
 import static vadl.viam.ViamError.ensure;
 
+import java.io.BufferedWriter;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -246,7 +247,7 @@ public abstract class AbstractMultiTemplateRenderingPass extends Pass {
     return Path.of(configuration.outputPath().toString(), subDir, outputPath);
   }
 
-  private FileWriter createFileWriter(Path filePath)
+  private Writer createFileWriter(Path filePath)
       throws IOException {
     var file = filePath.toFile();
 
@@ -258,7 +259,7 @@ public abstract class AbstractMultiTemplateRenderingPass extends Pass {
       ensure(file.createNewFile(), "Cannot create new file %s", file);
     }
 
-    return new FileWriter(file, Charset.defaultCharset());
+    return new BufferedWriter(new FileWriter(file, Charset.defaultCharset()));
   }
 
   @SuppressWarnings("LineLength")
@@ -292,7 +293,7 @@ public abstract class AbstractMultiTemplateRenderingPass extends Pass {
     templateResolver.setTemplateMode(TemplateMode.TEXT);
     templateResolver.setCharacterEncoding("UTF8");
     templateResolver.setCheckExistence(true);
-    templateResolver.setCacheable(false);
+    templateResolver.setCacheable(true);
     return templateResolver;
   }
 


### PR DESCRIPTION
This PR implements two optimizations for emitting the VIAM dumps:

## Enabling thymeleaf caches

Reenabling the caches, improves generation performance by an order of magnitude.
@Jozott00  do you remember why this was disabled in the first place.

**Before:**
	- HTML Dump at phase VIAM Creation:         6380.560ms
	- HTML Dump at phase VDT Creation:          5967.223ms

**After:**
	- HTML Dump at phase VIAM Creation:          966.983ms
	- HTML Dump at phase VDT Creation:           435.627ms
	
## Optimizing CollectBehaviorDotGraphPass.Result.map
Which first mapped over a dict to later evict all entries except for a special key.
Instead we are now just using the dictionary to get the values for a key.

With that dumps are now almost instant and even for huge you only have to wait for ~12s per dump, which previously didn't finish in any reasonable time (after 20m I gave up).