### PR TITLE
viam: Add InstructionWidthNode

### DIFF
--- a/vadl-frontend/main/vadl/ast/BehaviorLowering.java
+++ b/vadl-frontend/main/vadl/ast/BehaviorLowering.java
@@ -22,7 +22,7 @@ import static vadl.error.Diagnostic.ensure;
 import static vadl.error.Diagnostic.error;
 import static vadl.error.Diagnostic.warning;
 import static vadl.utils.GraphUtils.ifElseSideEffect;
-import static vadl.utils.GraphUtils.intS;
+import static vadl.utils.GraphUtils.intSNode;
 import static vadl.utils.GraphUtils.intU;
 import static vadl.utils.GraphUtils.neq;
 import static vadl.utils.GraphUtils.or;
@@ -166,6 +166,7 @@ import vadl.viam.graph.dependency.FoldNode;
 import vadl.viam.graph.dependency.ForIdxNode;
 import vadl.viam.graph.dependency.FuncCallNode;
 import vadl.viam.graph.dependency.FuncParamNode;
+import vadl.viam.graph.dependency.InstructionWidthNode;
 import vadl.viam.graph.dependency.LetNode;
 import vadl.viam.graph.dependency.MiaBuiltInCall;
 import vadl.viam.graph.dependency.OperationExistsNode;
@@ -1278,17 +1279,12 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
           long annOffset = offsetAnn == null ? 0 : offsetAnn.offset();
           if (!expr.subCalls.isEmpty() && subcallOffset != annOffset) {
             long offsetAdjustment = subcallOffset - annOffset;
-            // FIXME: Get instructions size from surrounding instruction once that's possible
-            long instructionSize = 32;
-            // FIXME: Get byte size from memory definition
-            long byteSize = 8;
-            resultExpr = BuiltInCall.of(BuiltInTable.ADD,
-                resRead,
-                intS(
-                    offsetAdjustment * instructionSize / byteSize,
-                    resRead.type().bitWidth()
-                ).toNode()
+            var pcType = resRead.type();
+            var offsetNode = BuiltInTable.MUL.call(
+                intSNode(offsetAdjustment, pcType.bitWidth()), new InstructionWidthNode(pcType)
             );
+            offsetNode.setSourceLocationRecursively(resRead.location());
+            resultExpr = BuiltInTable.ADD.call(resRead, offsetNode);
           }
         }
       } else {

--- a/vadl-frontend/test/resources/frontend-snapshots/lowering/readProgramCounterStates.vadl
+++ b/vadl-frontend/test/resources/frontend-snapshots/lowering/readProgramCounterStates.vadl
@@ -99,11 +99,13 @@ instruction set architecture TEST = {
 //    . : ' Behavior Graph:
 //    . : ' | n0 Constant             in: ()      succ: ()     type: b3   const: 0x0: Bits<3>
 //    . : ' | n1 ReadsRegisterTensor  in: ()      succ: ()     type: b8   reg: PC
-//    . : ' | n2 Constant             in: ()      succ: ()     type: i8   const: 0x4: SInt<8>
-//    . : ' | n3 BuiltInCall          in: (n1 n2) succ: ()     type: b8   builtin: VADL::add   operator: +
-//    . : ' | n4 WritesRegisterTensor in: (n0 n3) succ: ()     reg: X
-//    . : ' | n5 InstrEnd             in: (n4)    succ: ()     effects: 1
-//    . : ' | n6 Start                in: ()      succ: (n5)   next: set
+//    . : ' | n2 Constant             in: ()      succ: ()     type: i8   const: 0x1: SInt<8>
+//    . : ' | n3 InstructionWidth     in: ()      succ: ()     type: b8
+//    . : ' | n4 BuiltInCall          in: (n2 n3) succ: ()     type: b8   builtin: VADL::mul   operator: *
+//    . : ' | n5 BuiltInCall          in: (n1 n4) succ: ()     type: b8   builtin: VADL::add   operator: +
+//    . : ' | n6 WritesRegisterTensor in: (n0 n5) succ: ()     reg: X
+//    . : ' | n7 InstrEnd             in: (n6)    succ: ()     effects: 1
+//    . : ' | n8 Start                in: ()      succ: (n7)   next: set
 //    . : ' Assembly name: "assembly"
 //    . : ' | Function: func
 //    . : ' | FieldAccesses: []
@@ -133,11 +135,13 @@ instruction set architecture TEST = {
 //    . : ' Behavior Graph:
 //    . : ' | n0 Constant             in: ()      succ: ()     type: b3   const: 0x0: Bits<3>
 //    . : ' | n1 ReadsRegisterTensor  in: ()      succ: ()     type: b8   reg: PC
-//    . : ' | n2 Constant             in: ()      succ: ()     type: i8   const: 0x8: SInt<8>
-//    . : ' | n3 BuiltInCall          in: (n1 n2) succ: ()     type: b8   builtin: VADL::add   operator: +
-//    . : ' | n4 WritesRegisterTensor in: (n0 n3) succ: ()     reg: X
-//    . : ' | n5 InstrEnd             in: (n4)    succ: ()     effects: 1
-//    . : ' | n6 Start                in: ()      succ: (n5)   next: set
+//    . : ' | n2 Constant             in: ()      succ: ()     type: i8   const: 0x2: SInt<8>
+//    . : ' | n3 InstructionWidth     in: ()      succ: ()     type: b8
+//    . : ' | n4 BuiltInCall          in: (n2 n3) succ: ()     type: b8   builtin: VADL::mul   operator: *
+//    . : ' | n5 BuiltInCall          in: (n1 n4) succ: ()     type: b8   builtin: VADL::add   operator: +
+//    . : ' | n6 WritesRegisterTensor in: (n0 n5) succ: ()     reg: X
+//    . : ' | n7 InstrEnd             in: (n6)    succ: ()     effects: 1
+//    . : ' | n8 Start                in: ()      succ: (n7)   next: set
 //    . : ' Assembly name: "assembly"
 //    . : ' | Function: func
 //    . : ' | FieldAccesses: []

--- a/vadl/main/vadl/cppCodeGen/mixins/CDefaultMixins.java
+++ b/vadl/main/vadl/cppCodeGen/mixins/CDefaultMixins.java
@@ -52,6 +52,7 @@ import vadl.viam.graph.dependency.DynSliceNode;
 import vadl.viam.graph.dependency.ForIdxNode;
 import vadl.viam.graph.dependency.FuncCallNode;
 import vadl.viam.graph.dependency.FuncParamNode;
+import vadl.viam.graph.dependency.InstructionWidthNode;
 import vadl.viam.graph.dependency.LabelNode;
 import vadl.viam.graph.dependency.OperationForAllNode;
 import vadl.viam.graph.dependency.SelectNode;
@@ -403,6 +404,11 @@ public interface CDefaultMixins {
       }
 
       ctx.wr(" )");
+    }
+
+    @Handler
+    default void handle(CGenContext<Node> ctx, InstructionWidthNode toHandle) {
+      throw new UnsupportedOperationException("Type InstructionWidthNode not yet implemented");
     }
   }
 

--- a/vadl/main/vadl/gcb/passes/operands/GenerateInstructionOperandsPass.java
+++ b/vadl/main/vadl/gcb/passes/operands/GenerateInstructionOperandsPass.java
@@ -67,6 +67,7 @@ import vadl.viam.graph.dependency.FoldNode;
 import vadl.viam.graph.dependency.ForIdxNode;
 import vadl.viam.graph.dependency.FuncCallNode;
 import vadl.viam.graph.dependency.FuncParamNode;
+import vadl.viam.graph.dependency.InstructionWidthNode;
 import vadl.viam.graph.dependency.LabelNode;
 import vadl.viam.graph.dependency.LetNode;
 import vadl.viam.graph.dependency.MiaBuiltInCall;
@@ -654,6 +655,11 @@ class PseudoNodeOperandCollector {
 
   @Handler
   protected void handle(ConstantNode node) {
+
+  }
+
+  @Handler
+  protected void handle(InstructionWidthNode node) {
 
   }
 

--- a/vadl/main/vadl/iss/passes/common/IssNormalizationPass.java
+++ b/vadl/main/vadl/iss/passes/common/IssNormalizationPass.java
@@ -74,6 +74,7 @@ import vadl.viam.graph.dependency.FoldNode;
 import vadl.viam.graph.dependency.ForIdxNode;
 import vadl.viam.graph.dependency.FuncCallNode;
 import vadl.viam.graph.dependency.FuncParamNode;
+import vadl.viam.graph.dependency.InstructionWidthNode;
 import vadl.viam.graph.dependency.LabelNode;
 import vadl.viam.graph.dependency.LetNode;
 import vadl.viam.graph.dependency.OperationExistsNode;
@@ -232,6 +233,11 @@ class IssNormalizer implements VadlBuiltInNoStatusDispatcher<BuiltInCall> {
 
   @Handler
   void handle(ConstantNode toHandle) {
+    // do nothing
+  }
+
+  @Handler
+  void handle(InstructionWidthNode toHandle) {
     // do nothing
   }
 

--- a/vadl/main/vadl/iss/passes/common/opDecomposition/Decomposer.java
+++ b/vadl/main/vadl/iss/passes/common/opDecomposition/Decomposer.java
@@ -52,6 +52,7 @@ import vadl.viam.graph.dependency.FoldNode;
 import vadl.viam.graph.dependency.ForIdxNode;
 import vadl.viam.graph.dependency.FuncCallNode;
 import vadl.viam.graph.dependency.FuncParamNode;
+import vadl.viam.graph.dependency.InstructionWidthNode;
 import vadl.viam.graph.dependency.LabelNode;
 import vadl.viam.graph.dependency.LetNode;
 import vadl.viam.graph.dependency.MiaBuiltInCall;
@@ -655,6 +656,11 @@ class Decomposer
     var val = toHandle.constant().asVal();
     var sliced = val.slice(Constant.BitSlice.of(rq.slice.hi(), rq.slice.lo()));
     rq.result = sliced.toNode();
+  }
+
+  @Handler
+  void handle(Request rq, InstructionWidthNode toHandle) {
+    throw new UnsupportedOperationException("Type InstructionWidthNode not yet implemented");
   }
 
   @Handler

--- a/vadl/main/vadl/iss/passes/tcg/lowering/TcgOpLoweringPass.java
+++ b/vadl/main/vadl/iss/passes/tcg/lowering/TcgOpLoweringPass.java
@@ -112,6 +112,7 @@ import vadl.viam.graph.dependency.DynSliceNode;
 import vadl.viam.graph.dependency.FoldNode;
 import vadl.viam.graph.dependency.ForIdxNode;
 import vadl.viam.graph.dependency.FuncCallNode;
+import vadl.viam.graph.dependency.InstructionWidthNode;
 import vadl.viam.graph.dependency.LabelNode;
 import vadl.viam.graph.dependency.LetNode;
 import vadl.viam.graph.dependency.OperationExistsNode;
@@ -928,6 +929,16 @@ class TcgOpLoweringExecutor implements CfgTraverser {
    */
   @Handler
   void handle(ConstantNode toHandle) {
+    throw failShouldNotHappen(toHandle);
+  }
+
+  /**
+   * Handles the {@link InstructionWidthNode}. Should never happen.
+   *
+   * @throws ViamGraphError Always thrown.
+   */
+  @Handler
+  void handle(InstructionWidthNode toHandle) {
     throw failShouldNotHappen(toHandle);
   }
 

--- a/vadl/main/vadl/lcb/passes/asm/AsmGrammarRuleGenerator.java
+++ b/vadl/main/vadl/lcb/passes/asm/AsmGrammarRuleGenerator.java
@@ -73,6 +73,7 @@ import vadl.viam.graph.dependency.FoldNode;
 import vadl.viam.graph.dependency.ForIdxNode;
 import vadl.viam.graph.dependency.FuncCallNode;
 import vadl.viam.graph.dependency.FuncParamNode;
+import vadl.viam.graph.dependency.InstructionWidthNode;
 import vadl.viam.graph.dependency.LabelNode;
 import vadl.viam.graph.dependency.LetNode;
 import vadl.viam.graph.dependency.OperationExistsNode;
@@ -256,6 +257,12 @@ public class AsmGrammarRuleGenerator {
     return rule.getAlternatives().alternatives().stream()
         .flatMap(alterative -> alterative.firstTokens().stream())
         .collect(java.util.stream.Collectors.toSet());
+  }
+
+  @Handler
+  @SuppressWarnings("MissingJavadocMethod")
+  public void handle(AsmRuleContext ctx, InstructionWidthNode node) {
+
   }
 
   @Handler

--- a/vadl/main/vadl/viam/graph/dependency/InstructionWidthNode.java
+++ b/vadl/main/vadl/viam/graph/dependency/InstructionWidthNode.java
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText : © 2026 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.viam.graph.dependency;
+
+import vadl.types.DataType;
+import vadl.viam.graph.Node;
+
+/**
+ * Represents the width of an instruction in bytes.
+ * Has the same type as the PC.
+ */
+public class InstructionWidthNode extends ExpressionNode {
+
+  public InstructionWidthNode(DataType type) {
+    super(type);
+  }
+
+  @Override
+  public ExpressionNode copy() {
+    return new InstructionWidthNode(type().asDataType());
+  }
+
+  @Override
+  public Node shallowCopy() {
+    return copy();
+  }
+}

--- a/vadl/main/vadl/viam/passes/pcOffset/PcOffsetPass.java
+++ b/vadl/main/vadl/viam/passes/pcOffset/PcOffsetPass.java
@@ -17,8 +17,8 @@
 package vadl.viam.passes.pcOffset;
 
 import static vadl.error.Diagnostic.error;
+import static vadl.utils.GraphUtils.intUNode;
 import static vadl.viam.ViamError.ensure;
-import static vadl.viam.ViamError.ensureNonNull;
 
 import java.io.IOException;
 import javax.annotation.Nullable;
@@ -27,18 +27,21 @@ import vadl.pass.Pass;
 import vadl.pass.PassName;
 import vadl.pass.PassResults;
 import vadl.types.BuiltInTable;
-import vadl.utils.GraphUtils;
 import vadl.utils.ViamUtils;
 import vadl.viam.Instruction;
 import vadl.viam.InstructionSetArchitecture;
+import vadl.viam.Memory;
 import vadl.viam.Specification;
 import vadl.viam.annotations.PcOffsetAnnotation;
-import vadl.viam.graph.dependency.BuiltInCall;
+import vadl.viam.graph.Graph;
+import vadl.viam.graph.dependency.ExpressionNode;
+import vadl.viam.graph.dependency.InstructionWidthNode;
 import vadl.viam.graph.dependency.ReadRegTensorNode;
 import vadl.viam.passes.staticCounterAccess.CounterAccessResolvingPass;
 
 /**
- * Applies program counter offsets to program counter reads.
+ * Applies program counter offsets to program counter reads and resolves
+ * {@link InstructionWidthNode}s.
  *
  * <p>When reading a program counter that has been annotated with
  * {@code [current]}, {@code [next]} or {@code [next next]}, the
@@ -48,6 +51,13 @@ import vadl.viam.passes.staticCounterAccess.CounterAccessResolvingPass;
  *
  * <p>This pass looks for {@link PcOffsetAnnotation}s and applies them to
  * {@link ReadRegTensorNode}s, which have access the program counter.
+ *
+ * <p>Inside {@link Instruction} behaviors, we can replace {@link InstructionWidthNode}s with the
+ * constant value of the width of the instruction they are in. In other behaviors, such as
+ * exceptions, this is not as trivial. The artifacts will have to implement special treatment in
+ * these cases. Currently, {@link InstructionWidthNode}s outside instruction behaviors are replaced
+ * with the width of the first found instruction in the ISA. This a temporary solution and only
+ * works for ISAs with only one instruction length.
  *
  * <p><strong>Note</strong>: This pass must run after {@link CounterAccessResolvingPass}.
  */
@@ -64,17 +74,14 @@ public class PcOffsetPass extends Pass {
 
   @Override
   public @Nullable Object execute(PassResults passResults, Specification viam) throws IOException {
-    var isa = viam.isa().get();
-    ViamUtils.findAllBehaviors(viam).forEach(behavior -> {
-      var instruction = behavior.parentDefinition() instanceof Instruction instr ? instr : null;
-      behavior.getNodes(ReadRegTensorNode.class)
-          .forEach(n -> handleRead(n, instruction, isa));
-    });
+    ViamUtils.findAllBehaviors(viam).forEach(
+        behavior -> behavior.getNodes(ReadRegTensorNode.class).toList().forEach(this::handleRead)
+    );
+    new InstructionWidthNodeConverter(viam).run();
     return null;
   }
 
-  private void handleRead(ReadRegTensorNode read, @Nullable Instruction instruction,
-                          InstructionSetArchitecture isa) {
+  private void handleRead(ReadRegTensorNode read) {
     if (read.staticCounterAccess() == null) {
       // this is not a pc access
       return;
@@ -85,24 +92,66 @@ public class PcOffsetPass extends Pass {
     }
     var offset = offsetAnn.offset();
     if (offset != 0) {
-      instruction = ensureNonNull(instruction, () -> error(
-          "Program counter read with offset can only happen in instruction behavior", read)
-          .locationHelp(offsetAnn, "The program counter offset")
+      var pcType = read.type();
+      ExpressionNode offsetNode = BuiltInTable.MUL.call(
+          intUNode(offset, pcType.bitWidth()), new InstructionWidthNode(pcType)
       );
-
-      var memories = isa.ownMemories();
-      ensure(memories.size() == 1, () -> error(
-          "Exactly one memory definition required for reading program counter with offset", isa)
-          .locationHelp(read, "The program counter read")
-          .locationHelp(offsetAnn, "The program counter offset")
-      );
-      var memory = memories.getFirst();
-
-      var instrBytes = instruction.format().type().bitWidth() / memory.resultType().bitWidth();
-      read.replace(BuiltInCall.of(
-          BuiltInTable.ADD, read,
-          GraphUtils.intUNode((long) offset * instrBytes, read.type().bitWidth())
-      ));
+      offsetNode.setSourceLocationRecursively(read.location());
+      read.replace(BuiltInTable.ADD.call(read.shallowCopy(), offsetNode));
     }
   }
+}
+
+class InstructionWidthNodeConverter {
+
+  Specification viam;
+  InstructionSetArchitecture isa;
+
+  @Nullable
+  Memory memory;
+
+  @Nullable
+  Instruction anyInstruction;
+
+  public InstructionWidthNodeConverter(Specification viam) {
+    this.viam = viam;
+    this.isa = viam.isa().get();
+  }
+
+  void run() {
+    anyInstruction = isa.ownInstructions().stream().findAny().orElse(null);
+
+    // FIXME: If the InstructionWidthNode is not in an instruction, we cannot resolve it here.
+    //        For now, we use the width of the first instruction found in the ISA. If not
+    //        instruction is present, we have to leave the InstructionWidthNode
+    var firstInstr = isa.ownInstructions().stream().findFirst().orElse(null);
+
+    ViamUtils.findAllBehaviors(viam).forEach(b -> {
+      var instruction = b.parentDefinition() instanceof Instruction instr ? instr : firstInstr;
+      if (instruction == null) {
+        return;
+      }
+      var nodes = b.getNodes(InstructionWidthNode.class).toList();
+      if (nodes.isEmpty()) {
+        return;
+      }
+      var instrBytes = instruction.format().type().bitWidth()
+          / memory(nodes.getFirst()).resultType().bitWidth();
+      nodes.forEach(
+          n -> n.replaceAndDelete(intUNode(instrBytes, n.type().asDataType().bitWidth())));
+    });
+  }
+
+  private Memory memory(InstructionWidthNode node) {
+    if (memory == null) {
+      var memories = isa.ownMemories();
+      ensure(memories.size() == 1, () ->
+          error("Exactly one memory definition required to infer how many bits are in a byte", isa)
+              .locationDescription(node, "Byte size required here")
+      );
+      memory = memories.getFirst();
+    }
+    return memory;
+  }
+
 }

--- a/vadl/test/vadl/viam/passes/PcOffsetTest.java
+++ b/vadl/test/vadl/viam/passes/PcOffsetTest.java
@@ -29,6 +29,7 @@ import vadl.pass.PassOrders;
 import vadl.types.BuiltInTable;
 import vadl.viam.Instruction;
 import vadl.viam.Specification;
+import vadl.viam.graph.Canonicalizable;
 import vadl.viam.graph.Node;
 import vadl.viam.graph.dependency.BuiltInCall;
 import vadl.viam.graph.dependency.ConstantNode;
@@ -122,8 +123,13 @@ public class PcOffsetTest extends AbstractTest {
   private void testOffset(Node usage, int offset) {
     var add = Assertions.assertInstanceOf(BuiltInCall.class, usage);
     Assertions.assertEquals(BuiltInTable.ADD, add.builtIn());
-    var offsetNode = Assertions.assertInstanceOf(ConstantNode.class, add.arg(1));
+    var offsetNode = switch (add.arg(1)) {
+      case ConstantNode constantNode -> constantNode;
+      case Canonicalizable canonicalizable -> canonicalizable.canonical();
+      default -> null;
+    };
+    var constOffsetNode = Assertions.assertInstanceOf(ConstantNode.class, offsetNode);
     Assertions.assertEquals(offset * TEST_INSTR_BYTE_LENGTH,
-        offsetNode.constant().asVal().intValue());
+        constOffsetNode.constant().asVal().intValue());
   }
 }


### PR DESCRIPTION
Add `InstructionWidthNode`, which is a new VIAM `ExpressionNode`, which represents the width of the current instruction in bytes. The necessity of this new node was discussed in #1003. It simplifies the frontend.

The node is replaced with a `ConstantNode` by the `PcOffsetPass`. Outside instruction behaviours, the instruction width is not known (e.g. in exceptions), so we will have to find custom solutions for some artefacts. For now, the pass replaces such occurrences with the width of the first instruction found in the ISA.

Closes #1003