### PR TITLE
frontend: Add float support

### DIFF
--- a/vadl-frontend/main/vadl/ast/AnnotationTable.java
+++ b/vadl-frontend/main/vadl/ast/AnnotationTable.java
@@ -24,6 +24,7 @@ import static vadl.viam.ViamError.ensurePresent;
 import com.google.errorprone.annotations.concurrent.LazyInit;
 import java.math.BigInteger;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -47,6 +48,7 @@ import vadl.ast.nodes.Definition;
 import vadl.ast.nodes.DerivedFormatField;
 import vadl.ast.nodes.EncodingDefinition;
 import vadl.ast.nodes.Expr;
+import vadl.ast.nodes.FloatTypeDefinition;
 import vadl.ast.nodes.FormatField;
 import vadl.ast.nodes.GroupDefinition;
 import vadl.ast.nodes.Identifier;
@@ -69,6 +71,7 @@ import vadl.gcb.annotations.StatusRegisterAnnotation;
 import vadl.types.BitsType;
 import vadl.types.Type;
 import vadl.utils.Pair;
+import vadl.utils.functionInterfaces.QuadConsumer;
 import vadl.utils.functionInterfaces.TriConsumer;
 import vadl.viam.Abi;
 import vadl.viam.ArtificialResource;
@@ -77,6 +80,8 @@ import vadl.viam.Constant;
 import vadl.viam.Counter;
 import vadl.viam.Encoding;
 import vadl.viam.Endianness;
+import vadl.viam.FloatExceptionFlag;
+import vadl.viam.FloatFormat;
 import vadl.viam.Format;
 import vadl.viam.Group;
 import vadl.viam.Instruction;
@@ -204,7 +209,7 @@ public class AnnotationTable {
         // this handled in the VIAM lowering when constructing the ArtificialResource
         .build();
 
-    annotationOn(RegisterDefinition.class, "execution state", FormatFieldAnnotation::new)
+    annotationOn(RegisterDefinition.class, "execution state", ExecutionStateAnnotation::new)
         .check((def, annotation, lowering) -> annotation.typeCheckTarget(def))
         .applyAst((def, annotation) -> annotation.calcBitSlice(def))
         .applyViam((def, annotation, lowering) -> {
@@ -329,6 +334,56 @@ public class AnnotationTable {
           group.addAnnotation(new StopAnnotation(graph));
         })
         .build();
+
+    /// FLOAT RELATED ///
+
+    annotationOn(FloatTypeDefinition.class, "IEEE", ConstantAnnotation::new)
+        .applyAst((def, annotation) -> def.size = annotation.constant.value().intValue())
+        .applyViam((def, annotation, lowering) -> {
+          var encoding = FloatFormat.Encoding.ieee(annotation.constant.value().intValue());
+          ensure(encoding != null,
+              () -> error("Invalid IEEE encoding size", annotation)
+                  .description("The following sizes are supported: %s",
+                      Arrays.stream(FloatFormat.Encoding.values())
+                          .map(e -> Integer.toString(e.size)).collect(Collectors.joining(", ")))
+          );
+          ((FloatFormat) def).setEncoding(encoding);
+        }).build();
+
+    QuadConsumer<RegisterTensor, FloatFlagAnnotation, Boolean, FloatExceptionFlag>
+        applyViamFloatFlag;
+    applyViamFloatFlag = (reg, annotation, sticky, flag) -> {
+      var idx = annotation.index;
+      if (reg.hasAnnotation(vadl.viam.annotations.FloatFlagAnnotation.class)) {
+        var ann = reg.expectAnnotation(vadl.viam.annotations.FloatFlagAnnotation.class);
+        var setFlag = ann.get(idx);
+        ensure(setFlag == null, () -> error(
+            "Bit already mapped as " + (ann.isSticky(idx) ? "" : "non ")
+                + "sticky " + requireNonNull(setFlag).name + " flag",
+            annotation
+        ));
+        ann.set(idx, sticky, flag);
+      } else {
+        var ann = new vadl.viam.annotations.FloatFlagAnnotation();
+        ann.set(idx, sticky, flag);
+        reg.addAnnotation(ann);
+      }
+    };
+
+    for (var flag : FloatExceptionFlag.values()) {
+      annotationOn(RegisterDefinition.class, "fe flag " + flag.name, FloatFlagAnnotation::new)
+          .check((def, annotation, lowering) -> annotation.typeCheckTarget(def))
+          .applyViam((def, annotation, lowering) ->
+              applyViamFloatFlag.accept((RegisterTensor) def, annotation, false, flag))
+          .build();
+
+      annotationOn(RegisterDefinition.class, "sticky fe flag " + flag.name,
+          FloatFlagAnnotation::new)
+          .check((def, annotation, lowering) -> annotation.typeCheckTarget(def))
+          .applyViam((def, annotation, lowering) ->
+              applyViamFloatFlag.accept((RegisterTensor) def, annotation, true, flag))
+          .build();
+    }
 
     /// PROCESSOR RELATED ///
 
@@ -1104,6 +1159,95 @@ class EnableAnnotation extends Annotation {
 }
 
 /**
+ * An annotation that can be applied to registers of type {@link FormatType}. It can be used
+ * to reference one format field of the type. The bit-size of the format field must be 1.
+ *
+ * <p>Usage examples:
+ * <pre>
+ * [ sticky fe flag overflow : ov ]
+ * register reg : Format
+ * format Format : Bits<8> { ov [7], ... }
+ * </pre>
+ */
+class FloatFlagAnnotation extends FormatFieldAnnotation {
+
+  @LazyInit
+  Identifier field;
+
+  @LazyInit
+  int index;
+
+  @Override
+  void typeCheck(AnnotationDefinition definition, TypeChecker typeChecker) {
+    super.typeCheck(definition, typeChecker);
+    verifyValuesCnt(definition, 1);
+    field = (Identifier) definition.values.getFirst();
+  }
+
+  @Override
+  void typeCheckTarget(TypedNode target) {
+    super.typeCheckTarget(target);
+    var format = ((FormatType) target.type()).format;
+    var range = requireNonNull(format.getFieldRange(field.name));
+    Diagnostic.ensure(range.from() == range.to(), () ->
+        error("Float flag can only be one bit", field));
+    index = range.from();
+  }
+
+  @Override
+  String annotationName() {
+    return "Float exception flag annotation";
+  }
+
+  @Override
+  public String usageString() {
+    return "[ " + name + " : <format-field> ]";
+  }
+}
+
+/**
+ * An annotation that can be applied to registers of type {@link BitsType}. If the register's
+ * type is a {@link FormatType}, then this annotation can be used to reference its format fields.
+ *
+ * <p>Usage examples:
+ * <pre>
+ * [ execution state ]
+ * register reg : Bits<8>
+ *
+ * [ execution state : f0, f1 ]
+ * register reg : Format
+ * format Format : Bits<8> { f0 [7], f1 [6], ... }
+ * </pre>
+ */
+class ExecutionStateAnnotation extends FormatFieldAnnotation {
+
+  void calcBitSlice(TypedNode target) {
+    if (fields.isEmpty()) {
+      var width = ((BitsType) target.type()).bitWidth();
+      slice = Constant.BitSlice.of(width - 1, 0);
+      return;
+    }
+    var format = requireNonNull((FormatType) target.type()).format;
+    slice = new Constant.BitSlice(
+        fields.stream()
+            .map(field -> requireNonNull(format.getFieldRange(field.name)))
+            .map(range -> new Constant.BitSlice.Part(range.from(), range.to()))
+            .toArray(Constant.BitSlice.Part[]::new)
+    );
+  }
+
+  @Override
+  String annotationName() {
+    return "Execution state annotation";
+  }
+
+  @Override
+  public String usageString() {
+    return "[ " + name + " : <ident>, ... ]";
+  }
+}
+
+/**
  * An annotation that can be applied to anything that has a type which is a {@link BitsType}.
  * If the target's type is a {@link FormatType}, then this annotation can be used to reference
  * its format fields.
@@ -1118,7 +1262,7 @@ class EnableAnnotation extends Annotation {
  * format Format : Bits<8> { f0 [7], f1 [6], ... }
  * </pre>
  */
-class FormatFieldAnnotation extends Annotation {
+abstract class FormatFieldAnnotation extends Annotation {
 
   @LazyInit
   List<Identifier> fields;
@@ -1145,14 +1289,14 @@ class FormatFieldAnnotation extends Annotation {
     if (fields.isEmpty()) {
       Diagnostic.ensure(target.type() instanceof BitsType,
           () -> error("Annotation target has invalid type", this).description("""
-              Execution state annotation can only be applied to simple \
-              register definitions (no register files or tensors)"""));
+              %s can only be applied to simple register \
+              definitions (no register files or tensors)""", annotationName()));
       return;
     }
     Diagnostic.ensure(target.type() instanceof FormatType,
         () -> error("Annotation target has invalid type", this).description("""
-            Execution state annotation with format fields can only \
-            be applied to register definitions with a format type"""));
+            %s with format fields can only be applied \
+            to register definitions with a format type""", annotationName()));
 
     var format = ((FormatType) target.type()).format;
     fields.forEach(field -> {
@@ -1170,25 +1314,7 @@ class FormatFieldAnnotation extends Annotation {
     });
   }
 
-  void calcBitSlice(TypedNode target) {
-    if (fields.isEmpty()) {
-      var width = ((BitsType) target.type()).bitWidth();
-      slice = Constant.BitSlice.of(width - 1, 0);
-      return;
-    }
-    var format = requireNonNull((FormatType) target.type()).format;
-    slice = new Constant.BitSlice(
-        fields.stream()
-            .map(field -> requireNonNull(format.getFieldRange(field.name)))
-            .map(range -> new Constant.BitSlice.Part(range.from(), range.to()))
-            .toArray(Constant.BitSlice.Part[]::new)
-    );
-  }
-
-  @Override
-  public String usageString() {
-    return "[ " + name + " : <ident>, ... ]";
-  }
+  abstract String annotationName();
 }
 
 /**

--- a/vadl-frontend/main/vadl/ast/AnnotationTable.java
+++ b/vadl-frontend/main/vadl/ast/AnnotationTable.java
@@ -337,7 +337,7 @@ public class AnnotationTable {
 
     /// FLOAT RELATED ///
 
-    annotationOn(FloatTypeDefinition.class, "IEEE", ConstantAnnotation::new)
+    annotationOn(FloatTypeDefinition.class, "IEEE", IEEEFloatFormatAnnotation::new)
         .applyAst((def, annotation) -> def.size = annotation.constant.value().intValue())
         .applyViam((def, annotation, lowering) -> {
           var encoding = FloatFormat.Encoding.ieee(annotation.constant.value().intValue());
@@ -1315,6 +1315,19 @@ abstract class FormatFieldAnnotation extends Annotation {
   }
 
   abstract String annotationName();
+}
+
+/**
+ * Marker interface for all annotations that set the {@link FloatTypeDefinition#size} field.
+ */
+interface FloatEncodingSizeAnnotation {
+}
+
+/**
+ * An annotation which makes a {@link FloatTypeDefinition} use IEEE-754 encoding with a given
+ * size (32 or 64 bit).
+ */
+class IEEEFloatFormatAnnotation extends ConstantAnnotation implements FloatEncodingSizeAnnotation {
 }
 
 /**

--- a/vadl-frontend/main/vadl/ast/AstUtils.java
+++ b/vadl-frontend/main/vadl/ast/AstUtils.java
@@ -73,9 +73,7 @@ class AstUtils {
       name = "sdec";
     }
 
-    String finalBuiltinName = name;
-    var matchingBuiltin = nameLookupTable.get(finalBuiltinName);
-    return matchingBuiltin;
+    return nameLookupTable.get(name);
   }
 
   static BuiltInTable.BuiltIn getOperatorBuiltIn(Operator operator, List<Type> argTypes) {

--- a/vadl-frontend/main/vadl/ast/BehaviorLowering.java
+++ b/vadl-frontend/main/vadl/ast/BehaviorLowering.java
@@ -63,6 +63,7 @@ import vadl.ast.nodes.ExpandedAliasDefSequenceCallExpr;
 import vadl.ast.nodes.ExpandedSequenceCallExpr;
 import vadl.ast.nodes.Expr;
 import vadl.ast.nodes.ExprVisitor;
+import vadl.ast.nodes.FloatTypeDefinition;
 import vadl.ast.nodes.ForallExpr;
 import vadl.ast.nodes.ForallStatement;
 import vadl.ast.nodes.ForallThenExpr;
@@ -125,13 +126,13 @@ import vadl.types.UIntType;
 import vadl.utils.BigIntUtils;
 import vadl.utils.Either;
 import vadl.utils.Pair;
-import vadl.utils.SourceLocation;
 import vadl.utils.WithLocation;
 import vadl.viam.ArtificialResource;
 import vadl.viam.Constant;
 import vadl.viam.Counter;
 import vadl.viam.Definition;
 import vadl.viam.ExceptionDef;
+import vadl.viam.FloatFormat;
 import vadl.viam.Format;
 import vadl.viam.Function;
 import vadl.viam.Instruction;
@@ -912,6 +913,11 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
       return new ConstantNode(value);
     }
 
+    if (computedTarget instanceof FloatTypeDefinition floatType) {
+      var format = (FloatFormat) viamLowering.fetch(floatType).orElseThrow();
+      return new ConstantNode(new Constant.FloatType(format));
+    }
+
     // Enum field
     if (computedTarget instanceof EnumerationDefinition.Entry enumField) {
       // Inline the value of the enum
@@ -1376,6 +1382,26 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
     return new ReadStageOutputNode(output);
   }
 
+  private Constant visitConstArg(Expr expr) {
+    Node origin = null;
+    if (expr instanceof Identifier identifier) {
+      origin = requireNonNull(identifier.target());
+    } else if (expr instanceof IdentifierPath path) {
+      origin = requireNonNull(path.target());
+    }
+
+    // TODO: the constant evaluator can only evaluate integers currently. Once other stuff like
+    //       strings and float-types are supported, we do not need this function anymore and can
+    //       directly call the constant evaluator.
+    //       !!! There is a similar method in TypeChecker
+    if (origin instanceof FloatTypeDefinition floatType) {
+      var format = (FloatFormat) viamLowering.fetch(floatType).orElseThrow();
+      return new Constant.FloatType(format);
+    }
+
+    return constantEvaluator.eval(expr).toViamConstant();
+  }
+
   @Override
   public ExpressionNode visit(CallIndexExpr expr) {
 
@@ -1384,6 +1410,12 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
         && expr.computedTarget() instanceof StageDefinition stageDefinition) {
       return visitStageCall(expr, stageDefinition);
     }
+
+    var symbolArgs = expr.symbolArgs();
+
+    var constArgs = symbolArgs != null
+        ? symbolArgs.stream().map(this::visitConstArg).toList()
+        : List.<Constant>of();
 
     var argGroups = expr.args();
     final var args = new NodeList<ExpressionNode>(AstUtils.argumentCount(argGroups));
@@ -1395,11 +1427,9 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
     // Builtin Call
     if (expr.computedBuiltIn != null) {
       if (BuiltInTable.ASM_PARSER_BUILT_INS.contains(expr.computedBuiltIn)) {
-        exprBeforeSlice = new AsmBuiltInCall(expr.computedBuiltIn, args,
-            typeBeforeSlice);
+        exprBeforeSlice = new AsmBuiltInCall(expr.computedBuiltIn, args, typeBeforeSlice);
       } else {
-        exprBeforeSlice = new BuiltInCall(expr.computedBuiltIn, args,
-            typeBeforeSlice);
+        exprBeforeSlice = new BuiltInCall(expr.computedBuiltIn, constArgs, args, typeBeforeSlice);
       }
     } else {
       exprBeforeSlice = switch (expr.computedTarget()) {
@@ -1432,9 +1462,8 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
         }
 
         case MemoryDefinition memDef -> {
-          var sizeExpr = expr.target.size();
-          var words = sizeExpr != null
-              ? constantEvaluator.eval(sizeExpr).value().intValueExact()
+          var words = symbolArgs != null
+              ? constantEvaluator.eval(symbolArgs.getFirst()).value().intValueExact()
               : 1;
           yield new ReadMemNode((Memory) viamLowering.fetch(memDef).orElseThrow(),
               words, args.getFirst(), typeBeforeSlice.asDataType());
@@ -1745,9 +1774,9 @@ class BehaviorLowering implements StatementVisitor<SubgraphContext>, ExprVisitor
         }
       });
 
-      var sizeExpr = callTarget.target.size();
-      callSize = sizeExpr != null
-          ? constantEvaluator.eval(sizeExpr).value().intValueExact()
+      var symbolArgs = callTarget.target.symbolArgs();
+      callSize = symbolArgs != null
+          ? constantEvaluator.eval(symbolArgs.getFirst()).value().intValueExact()
           : null;
     } else if (statement.target instanceof Identifier identTarget) {
       targetDef = (vadl.ast.nodes.Definition) requireNonNull(identTarget.target());

--- a/vadl-frontend/main/vadl/ast/ConstantEvaluator.java
+++ b/vadl-frontend/main/vadl/ast/ConstantEvaluator.java
@@ -164,10 +164,18 @@ class ConstantEvaluator implements ExprVisitor<ConstantValue> {
         }
       }
 
+      if (!builtin.signature().constArgTypeClass().isEmpty()) {
+        throw new EvaluationError(
+            "Built-in function `%s` cannot be constant evaluated (yet)."
+                .formatted(builtin.name()),
+            loc
+        );
+      }
+
       // NOTE: If you are seeing this issue, someone forgot to add the `compute` method for a
       // built-in function. Look to into BuiltInTable.
       var val = builtin
-          .compute(args.stream().map(c -> (Constant) c.toViamConstant()).toList())
+          .compute(List.of(), args.stream().map(c -> (Constant) c.toViamConstant()).toList())
           .orElseThrow(() -> new EvaluationError(
               "Built-in function `%s` cannot be constant evaluated (yet).".formatted(
                   builtin.name()),

--- a/vadl-frontend/main/vadl/ast/ConstantEvaluator.java
+++ b/vadl-frontend/main/vadl/ast/ConstantEvaluator.java
@@ -164,6 +164,9 @@ class ConstantEvaluator implements ExprVisitor<ConstantValue> {
         }
       }
 
+      // NOTE: The semantics of a builtin function may depend on constant parameters. The built-in
+      // compute function does not account for these yet. Thus, constant-evaluating built-ins with
+      // constant parameters can not yet be done.
       if (!builtin.signature().constArgTypeClass().isEmpty()) {
         throw new EvaluationError(
             "Built-in function `%s` cannot be constant evaluated (yet)."

--- a/vadl-frontend/main/vadl/ast/MacroExpander.java
+++ b/vadl-frontend/main/vadl/ast/MacroExpander.java
@@ -73,6 +73,7 @@ import vadl.ast.nodes.ExpandedAliasDefSequenceCallExpr;
 import vadl.ast.nodes.ExpandedSequenceCallExpr;
 import vadl.ast.nodes.Expr;
 import vadl.ast.nodes.ExprVisitor;
+import vadl.ast.nodes.FloatTypeDefinition;
 import vadl.ast.nodes.ForallExpr;
 import vadl.ast.nodes.ForallIndex;
 import vadl.ast.nodes.ForallStatement;
@@ -522,7 +523,12 @@ class MacroExpander
 
   @Override
   public Expr visit(SymbolExpr expr) {
-    return new SymbolExpr(expandExpr(expr.path), expandExpr(expr.size), copyLoc(expr.location));
+    var symbolArgs = new ArrayList<Expr>(expr.symbolArgs.size());
+    for (var i = 0; i < expr.symbolArgs.size(); i++) {
+      var symbolArg = expr.symbolArgs.get(i);
+      symbolArgs.add(expandExpr(symbolArg));
+    }
+    return new SymbolExpr(expandExpr(expr.path), symbolArgs, copyLoc(expr.location));
   }
 
   @Override
@@ -703,6 +709,14 @@ class MacroExpander
         expandExpr(definition.identifier),
         definition.typeLiteral != null ? expandExpr(definition.typeLiteral) : null,
         expandExpr(definition.value),
+        copyLoc(definition.loc)
+    );
+  }
+
+  @Override
+  public Definition visit(FloatTypeDefinition definition) {
+    return new FloatTypeDefinition(
+        expandExpr(definition.identifier),
         copyLoc(definition.loc)
     );
   }

--- a/vadl-frontend/main/vadl/ast/ModelRemover.java
+++ b/vadl-frontend/main/vadl/ast/ModelRemover.java
@@ -47,6 +47,7 @@ import vadl.ast.nodes.EncodingDefinition;
 import vadl.ast.nodes.EncodingFormatField;
 import vadl.ast.nodes.EnumerationDefinition;
 import vadl.ast.nodes.ExceptionDefinition;
+import vadl.ast.nodes.FloatTypeDefinition;
 import vadl.ast.nodes.FormatDefinition;
 import vadl.ast.nodes.FunctionDefinition;
 import vadl.ast.nodes.GroupDefinition;
@@ -109,6 +110,11 @@ public class ModelRemover implements DefinitionVisitor<Definition> {
 
   @Override
   public Definition visit(ConstantDefinition definition) {
+    return definition;
+  }
+
+  @Override
+  public Definition visit(FloatTypeDefinition definition) {
     return definition;
   }
 

--- a/vadl-frontend/main/vadl/ast/SymbolTable.java
+++ b/vadl-frontend/main/vadl/ast/SymbolTable.java
@@ -52,6 +52,7 @@ import vadl.ast.nodes.EnumerationDefinition;
 import vadl.ast.nodes.ExistsInExpr;
 import vadl.ast.nodes.ExistsInThenExpr;
 import vadl.ast.nodes.Expr;
+import vadl.ast.nodes.FloatTypeDefinition;
 import vadl.ast.nodes.ForallExpr;
 import vadl.ast.nodes.ForallStatement;
 import vadl.ast.nodes.ForallThenExpr;
@@ -1174,6 +1175,16 @@ public class SymbolTable {
       }
 
       definition.forEachChild(this::travel);
+      afterTravel(definition);
+      return null;
+    }
+
+    @Override
+    public Void visit(FloatTypeDefinition definition) {
+      beforeTravel(definition);
+      // FloatTypeDefinition has no @Child fields, so it's not in NodeChildrenRegistry,
+      // and we need to manually visit annotations
+      definition.annotations.forEach(this::travel);
       afterTravel(definition);
       return null;
     }

--- a/vadl-frontend/main/vadl/ast/TypeChecker.java
+++ b/vadl-frontend/main/vadl/ast/TypeChecker.java
@@ -35,6 +35,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
@@ -196,6 +197,7 @@ import vadl.utils.Pair;
 import vadl.utils.SourceLocation;
 import vadl.utils.WithLocation;
 import vadl.viam.Constant;
+import vadl.viam.InstructionSetArchitecture;
 
 /**
  * A experimental, temporary type-checker to verify expressions and attach types to the AST.
@@ -944,15 +946,11 @@ public class TypeChecker
     @Nullable
     private BuiltInCheckResult get(BuiltInTable.BuiltIn builtIn, List<Constant> constArgs,
                                    List<Type> argTypes) {
-      var inner = store.get(builtIn);
-      if (inner == null) {
-        return null;
-      }
-      var innerInner = inner.get(constArgs);
-      if (innerInner == null) {
-        return null;
-      }
-      return innerInner.get(argTypes);
+      // unwrap the maps and propagate `null`
+      return Optional.ofNullable(store.get(builtIn))
+          .map(inner -> inner.get(constArgs))
+          .map(inner -> inner.get(argTypes))
+          .orElse(null);
     }
 
     private void put(BuiltInTable.BuiltIn builtIn, List<Constant> constArgs, List<Type> argTypes,
@@ -1268,19 +1266,15 @@ public class TypeChecker
 
     if (!builtIn.takes(constArgs, argTypes)) {
       // FIXME: Further improve these error messages.
+      var calledParamsAndTypes = String.join(", ", Stream.concat(
+          constArgs.stream().map(Constant::toString),
+          argTypes.stream().map(Type::toString)
+      ).toList());
       var areSomeConst = originalArgTypes.stream().anyMatch(ConstantType.class::isInstance);
-      var calledTypes = "(%s)".formatted(
-          String.join(", ", argTypes.stream().map(Type::toString).toList()));
-      if (!constArgs.isEmpty()) {
-        calledTypes = "<%s>%s".formatted(
-          String.join(", ", constArgs.stream().map(Constant::toString).toList()),
-            calledTypes
-        );
-      }
       addErrorAndStopChecking(
           error("Type Mismatch", location)
               .locationDescription(location, "The builtin has the signature `%s` but got `%s`.",
-                  builtIn.signature(), calledTypes)
+                  builtIn.signature(), calledParamsAndTypes)
               .applyIf(areSomeConst, b -> b.locationHelp(location,
                   "Try casting some of the constant arguments to explicit types."))
               .build());
@@ -1306,13 +1300,6 @@ public class TypeChecker
     //       !!! There is a similar method in BehaviorLowering
     if (origin instanceof FloatTypeDefinition floatType) {
       check(floatType);
-      if (floatType.size == null) {
-        addErrorAndStopChecking(
-            error("Missing float-type encoding size", floatType)
-                .help("Annotate with e.g. `[ IEEE : <size> ]`")
-                .build()
-        );
-      }
       return new Constant.FloatType(requireNonNull(floatType.size), requireNonNull(name));
     }
 
@@ -1321,6 +1308,12 @@ public class TypeChecker
 
   @Override
   public Void visit(FloatTypeDefinition definition) {
+    if (definition.annotations.stream().map(a -> a.annotation)
+        .noneMatch(FloatEncodingSizeAnnotation.class::isInstance)) {
+      addErrorAndStopChecking(error("Missing float-type encoding size", definition)
+          .help("Annotate with e.g. `[ IEEE : <size> ]`")
+          .build());
+    }
     return null;
   }
 

--- a/vadl-frontend/main/vadl/ast/TypeChecker.java
+++ b/vadl-frontend/main/vadl/ast/TypeChecker.java
@@ -90,6 +90,7 @@ import vadl.ast.nodes.ExpandedAliasDefSequenceCallExpr;
 import vadl.ast.nodes.ExpandedSequenceCallExpr;
 import vadl.ast.nodes.Expr;
 import vadl.ast.nodes.ExprVisitor;
+import vadl.ast.nodes.FloatTypeDefinition;
 import vadl.ast.nodes.ForallExpr;
 import vadl.ast.nodes.ForallStatement;
 import vadl.ast.nodes.ForallThenExpr;
@@ -175,6 +176,7 @@ import vadl.types.BuiltInTable;
 import vadl.types.ConcreteRelationType;
 import vadl.types.DataType;
 import vadl.types.FetchResultType;
+import vadl.types.FloatStatusType;
 import vadl.types.GroupType;
 import vadl.types.InstructionType;
 import vadl.types.MicroArchitectureType;
@@ -936,21 +938,28 @@ public class TypeChecker
 
   /// A tiny custom cache for built-in function type checking.
   private static class BuiltInCheckCache {
-    private Map<BuiltInTable.BuiltIn, Map<List<Type>, BuiltInCheckResult>> store =
-        new HashMap<>();
+    private Map<BuiltInTable.BuiltIn, Map<List<Constant>, Map<List<Type>, BuiltInCheckResult>>>
+        store = new HashMap<>();
 
     @Nullable
-    private BuiltInCheckResult get(BuiltInTable.BuiltIn builtIn, List<Type> argTypes) {
+    private BuiltInCheckResult get(BuiltInTable.BuiltIn builtIn, List<Constant> constArgs,
+                                   List<Type> argTypes) {
       var inner = store.get(builtIn);
       if (inner == null) {
         return null;
       }
-      return inner.get(argTypes);
+      var innerInner = inner.get(constArgs);
+      if (innerInner == null) {
+        return null;
+      }
+      return innerInner.get(argTypes);
     }
 
-    private void put(BuiltInTable.BuiltIn builtIn, List<Type> argTypes, BuiltInCheckResult result) {
+    private void put(BuiltInTable.BuiltIn builtIn, List<Constant> constArgs, List<Type> argTypes,
+                     BuiltInCheckResult result) {
       var inner = store.computeIfAbsent(builtIn, k -> new HashMap<>());
-      inner.put(argTypes, result);
+      var innerInner = inner.computeIfAbsent(constArgs, k -> new HashMap<>());
+      innerInner.put(argTypes, result);
     }
   }
 
@@ -960,18 +969,19 @@ public class TypeChecker
   /// Check if the built-in function call, but doesn't care which kind of expression it arises from
   /// binary expressions, unary expressions or direct calls.
   /// The passed arguments have to be already checked!
-  private BuiltInCheckResult checkBuiltin(BuiltInTable.BuiltIn builtIn, List<Expr> args,
-                                          WithLocation location) {
+  private BuiltInCheckResult checkBuiltin(BuiltInTable.BuiltIn builtIn, List<Expr> constArgs,
+                                          List<Expr> args, WithLocation location) {
     List<Type> argTypes = new ArrayList<>(args.size());
     for (int i = 0; i < args.size(); i++) {
       argTypes.add(args.get(i).type());
     }
-    var cached = builtInCheckCache.get(builtIn, argTypes);
+    var constArgValues = constArgs.stream().map(this::evalConstArg).toList();
+    var cached = builtInCheckCache.get(builtIn, constArgValues, argTypes);
     if (cached != null) {
       return cached;
     }
 
-    var result = unCachedCheckBuiltin(builtIn, args, location);
+    var result = unCachedCheckBuiltin(builtIn, constArgValues, args, location);
 
     // We cannot cache if the result is a constant but not all input types were also constant.
     // This is quite rare but here we simply cannot determine the result type simply based on the
@@ -980,18 +990,20 @@ public class TypeChecker
       return result;
     }
 
-    builtInCheckCache.put(builtIn, argTypes, result);
+    builtInCheckCache.put(builtIn, constArgValues, argTypes, result);
     return result;
   }
 
-  private BuiltInCheckResult unCachedCheckBuiltin(BuiltInTable.BuiltIn builtIn, List<Expr> args,
+  private BuiltInCheckResult unCachedCheckBuiltin(BuiltInTable.BuiltIn builtIn,
+                                                  List<Constant> constArgs, List<Expr> args,
                                                   WithLocation location) {
-    if (!(args.size() == builtIn.argTypeClasses().size() || (builtIn.signature().hasVarArgs()
-        && args.size() >= builtIn.argTypeClasses().size()))) {
+    int minArgCount = builtIn.argTypeClasses().size();
+    if (!(args.size() == minArgCount
+        || (builtIn.signature().hasVarArgs() && args.size() >= minArgCount))) {
       throw addErrorAndStopChecking(
           error("Type Mismatch", location)
               .locationDescription(location,
-                  "Expected %d arguments but got %d.", builtIn.argTypeClasses().size(), args.size())
+                  "Expected %d arguments but got %d.", minArgCount, args.size())
               .build());
     }
 
@@ -1254,11 +1266,17 @@ public class TypeChecker
     var originalArgTypes = argTypes;
     argTypes = args.stream().map(Expr::type).toList();
 
-
-    if (!builtIn.takes(argTypes)) {
+    if (!builtIn.takes(constArgs, argTypes)) {
       // FIXME: Further improve these error messages.
       var areSomeConst = originalArgTypes.stream().anyMatch(ConstantType.class::isInstance);
-      var calledTypes = String.join(", ", argTypes.stream().map(Type::toString).toList());
+      var calledTypes = "(%s)".formatted(
+          String.join(", ", argTypes.stream().map(Type::toString).toList()));
+      if (!constArgs.isEmpty()) {
+        calledTypes = "<%s>%s".formatted(
+          String.join(", ", constArgs.stream().map(Constant::toString).toList()),
+            calledTypes
+        );
+      }
       addErrorAndStopChecking(
           error("Type Mismatch", location)
               .locationDescription(location, "The builtin has the signature `%s` but got `%s`.",
@@ -1268,7 +1286,42 @@ public class TypeChecker
               .build());
     }
 
-    return new BuiltInCheckResult(argTypes, builtIn.returns(argTypes));
+    return new BuiltInCheckResult(argTypes, builtIn.returns(constArgs, argTypes));
+  }
+
+  private Constant evalConstArg(Expr expr) {
+    Node origin = null;
+    String name = null;
+    if (expr instanceof Identifier identifier) {
+      origin = requireNonNull(identifier.target());
+      name = identifier.name;
+    } else if (expr instanceof IdentifierPath path) {
+      origin = requireNonNull(path.target());
+      name = path.toString();
+    }
+
+    // TODO: the constant evaluator can only evaluate integers currently. Once other stuff like
+    //       strings and float-types are supported, we do not need this function anymore and can
+    //       directly call the constant evaluator.
+    //       !!! There is a similar method in BehaviorLowering
+    if (origin instanceof FloatTypeDefinition floatType) {
+      check(floatType);
+      if (floatType.size == null) {
+        addErrorAndStopChecking(
+            error("Missing float-type encoding size", floatType)
+                .help("Annotate with e.g. `[ IEEE : <size> ]`")
+                .build()
+        );
+      }
+      return new Constant.FloatType(requireNonNull(floatType.size), requireNonNull(name));
+    }
+
+    return constantEvaluator.eval(expr).toViamConstant();
+  }
+
+  @Override
+  public Void visit(FloatTypeDefinition definition) {
+    return null;
   }
 
   @Override
@@ -3216,6 +3269,12 @@ public class TypeChecker
       return;
     }
 
+    if (origin instanceof FloatTypeDefinition floatTypeDef) {
+      check(floatTypeDef);
+      expr.type = floatTypeDef.type();
+      return;
+    }
+
     if (origin instanceof RangeFormatField field) {
       // FIXME: Unfortonatley the format fields need to be specified in declare-after-use for now
       expr.type = field.type;
@@ -3452,7 +3511,7 @@ public class TypeChecker
       // operator and not in the builtin function we want to call.
       checkResult = checkLogicalBuiltIn(expr.left, expr.right, expr);
     } else {
-      checkResult = checkBuiltin(builtin, List.of(expr.left, expr.right), expr);
+      checkResult = checkBuiltin(builtin, List.of(), List.of(expr.left, expr.right), expr);
     }
 
     if (checkResult.castedArgTypes != null) {
@@ -3839,7 +3898,7 @@ public class TypeChecker
     };
     expr.computedTarget = builtin;
 
-    var result = checkBuiltin(builtin, List.of(expr.operand), expr);
+    var result = checkBuiltin(builtin, List.of(), List.of(expr.operand), expr);
     if (result.castedArgTypes != null) {
       expr.operand = result.applyCastToArgs(List.of(expr.operand)).get(0);
     }
@@ -4198,6 +4257,18 @@ public class TypeChecker
         var fieldType = Type.bool();
         visitSliceIndexCall(expr, fieldType, subCall.argsIndices);
         type = expr.type;
+      } else if (type instanceof FloatStatusType) {
+        var allowedStatusfields = List.of("nv", "dz", "of", "uf", "nx");
+        if (!allowedStatusfields.contains(fieldName)) {
+          var suggestions = Levenshtein.sortAll(fieldName, allowedStatusfields);
+          addErrorAndStopChecking(
+              error("Unknown float status field `%s`".formatted(fieldName), expr)
+                  .suggestions(suggestions)
+                  .build());
+        }
+        var fieldType = Type.bool();
+        visitSliceIndexCall(expr, fieldType, subCall.argsIndices);
+        type = expr.type;
       } else if (type instanceof InstructionType) {
         var allowedStatusfields =
             List.of("address", "read", "unknown", "compute", "verify", "write", "readOrForward",
@@ -4305,6 +4376,9 @@ public class TypeChecker
     // Builtin function
     List<Expr> args =
         !expr.argsIndices.isEmpty() ? expr.argsIndices.getFirst().values : new ArrayList<>();
+    var symbolArgs = expr.symbolArgs();
+    var constArgs = symbolArgs == null ? List.<Expr>of() : symbolArgs;
+    checkExpressions(constArgs);
     var argTypes = checkExpressions(args);
     var builtin = AstUtils.getBuiltIn(expr.target.path().pathToString(), argTypes);
 
@@ -4317,7 +4391,7 @@ public class TypeChecker
 
     expr.computedBuiltIn = builtin;
 
-    var checkResult = checkBuiltin(builtin, args, expr);
+    var checkResult = checkBuiltin(builtin, constArgs, args, expr);
     if (checkResult.castedArgTypes != null) {
       expr.replaceArgsFor(0, checkResult.applyCastToArgs(args));
     }
@@ -4451,8 +4525,18 @@ public class TypeChecker
       expr.typeBeforeSlice = typedNode.type();
     }
 
-    var targetSizeExpr = expr.target.size();
-    if (targetSizeExpr != null) {
+    var targetSymbolArgs = expr.target.symbolArgs();
+    if (targetSymbolArgs != null) {
+      if (targetSymbolArgs.size() != 1) {
+        var err = error("Invalid scaling arguments", expr);
+        if (!targetSymbolArgs.isEmpty()) {
+          var loc = targetSymbolArgs.stream().map(WithLocation::location)
+              .reduce(SourceLocation::join).get();
+          err = err.locationDescription(loc, "Expected exactly one scaling argument.");
+        }
+        throw addErrorAndStopChecking(err.build());
+      }
+      var targetSizeExpr = targetSymbolArgs.getFirst();
       if (!(expr.typeBeforeSlice() instanceof BitsType exprType)) {
         throw addErrorAndStopChecking(error("Invalid scaling type", targetSizeExpr)
             .locationDescription(targetSizeExpr, "Result type `%s` cannot be scaled.",

--- a/vadl-frontend/main/vadl/ast/Ungrouper.java
+++ b/vadl-frontend/main/vadl/ast/Ungrouper.java
@@ -63,6 +63,7 @@ import vadl.ast.nodes.ExpandedAliasDefSequenceCallExpr;
 import vadl.ast.nodes.ExpandedSequenceCallExpr;
 import vadl.ast.nodes.Expr;
 import vadl.ast.nodes.ExprVisitor;
+import vadl.ast.nodes.FloatTypeDefinition;
 import vadl.ast.nodes.ForallExpr;
 import vadl.ast.nodes.ForallStatement;
 import vadl.ast.nodes.ForallThenExpr;
@@ -284,7 +285,7 @@ public class Ungrouper
 
   @Override
   public Expr visit(SymbolExpr expr) {
-    expr.size = expr.size.accept(this);
+    expr.symbolArgs.replaceAll(e -> e.accept(this));
     return expr;
   }
 
@@ -358,6 +359,12 @@ public class Ungrouper
   @Override
   public Expr visit(ResourceReferenceExression expr) {
     return expr;
+  }
+
+  @Override
+  public Void visit(FloatTypeDefinition definition) {
+    ungroupAnnotations(definition);
+    return null;
   }
 
   @Override

--- a/vadl-frontend/main/vadl/ast/ViamLowering.java
+++ b/vadl-frontend/main/vadl/ast/ViamLowering.java
@@ -78,6 +78,7 @@ import vadl.ast.nodes.ExceptionDefinition;
 import vadl.ast.nodes.ExpandedAliasDefSequenceCallExpr;
 import vadl.ast.nodes.ExpandedSequenceCallExpr;
 import vadl.ast.nodes.Expr;
+import vadl.ast.nodes.FloatTypeDefinition;
 import vadl.ast.nodes.FormatDefinition;
 import vadl.ast.nodes.FormatField;
 import vadl.ast.nodes.FunctionDefinition;
@@ -141,6 +142,7 @@ import vadl.viam.Constant;
 import vadl.viam.Counter;
 import vadl.viam.Encoding;
 import vadl.viam.ExceptionDef;
+import vadl.viam.FloatFormat;
 import vadl.viam.Format;
 import vadl.viam.Function;
 import vadl.viam.Group;
@@ -1096,6 +1098,13 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
   }
 
   @Override
+  public Optional<vadl.viam.Definition> visit(FloatTypeDefinition definition) {
+    var identifier =
+        new vadl.viam.Identifier(definition.viamId, definition.identifier().location());
+    return Optional.of(new FloatFormat(identifier));
+  }
+
+  @Override
   public Optional<vadl.viam.Definition> visit(ConstantDefinition definition) {
     // Do nothing on purpose.
     // Constants are folded in the lowering and are not translated to VIAM.
@@ -1391,7 +1400,7 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
   }
 
   /**
-   * Get the field encoding for the {@link vadl.ast.EncodingFormatField}
+   * Get the field encoding for the {@link EncodingFormatField}
    * with the kind {@code ENCODING}.
    */
   @SuppressWarnings("LineLength")
@@ -1656,6 +1665,7 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
         mergedDef.definitions.stream().map(this::fetch).flatMap(Optional::stream)
             .toList();
     var formats = filterAndCastToInstance(allDefinitions, Format.class);
+    var floatFormats = filterAndCastToInstance(allDefinitions, FloatFormat.class);
     var functions = filterAndCastToInstance(allDefinitions, Function.class);
     var operations = filterAndCastToInstance(allDefinitions, Operation.class);
     var relocations = filterAndCastToInstance(allDefinitions, Relocation.class);
@@ -1700,6 +1710,7 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
         programCounter,
         memories,
         artificialResources,
+        floatFormats,
         group
     );
 

--- a/vadl-frontend/main/vadl/ast/nodes/CallIndexExpr.java
+++ b/vadl-frontend/main/vadl/ast/nodes/CallIndexExpr.java
@@ -21,6 +21,7 @@ import static java.util.Objects.requireNonNull;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
+import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 import vadl.ast.TensorType;
 import vadl.types.BuiltInTable;
@@ -193,8 +194,9 @@ public final class CallIndexExpr extends Expr implements IsCallExpr {
   }
 
   @Override
-  public @Nullable Expr size() {
-    return target.size();
+  @Nullable
+  public List<Expr> symbolArgs() {
+    return target.symbolArgs();
   }
 
   @Override

--- a/vadl-frontend/main/vadl/ast/nodes/DefinitionVisitor.java
+++ b/vadl-frontend/main/vadl/ast/nodes/DefinitionVisitor.java
@@ -68,6 +68,8 @@ public interface DefinitionVisitor<R> {
 
   public R visit(ExceptionDefinition definition);
 
+  public R visit(FloatTypeDefinition definition);
+
   public R visit(FormatDefinition definition);
 
   public R visit(DerivedFormatField definition);

--- a/vadl-frontend/main/vadl/ast/nodes/FloatTypeDefinition.java
+++ b/vadl-frontend/main/vadl/ast/nodes/FloatTypeDefinition.java
@@ -28,7 +28,6 @@ import vadl.utils.SourceLocation;
  * float-type binary32
  * }</pre>
  */
-@SuppressWarnings({"MissingJavadocType", "MissingJavadocMethod"})
 public class FloatTypeDefinition extends Definition implements IdentifiableNode, TypedNode {
   public IdentifierOrPlaceholder identifier;
 

--- a/vadl-frontend/main/vadl/ast/nodes/FloatTypeDefinition.java
+++ b/vadl-frontend/main/vadl/ast/nodes/FloatTypeDefinition.java
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText : © 2026 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.ast.nodes;
+
+import java.util.Objects;
+import javax.annotation.Nullable;
+import vadl.types.Type;
+import vadl.utils.SourceLocation;
+
+/**
+ * Represents a float-type definition, which is used to specify float formats.
+ * <pre>{@code
+ * [ IEEE : 32 ]
+ * float-type binary32
+ * }</pre>
+ */
+@SuppressWarnings({"MissingJavadocType", "MissingJavadocMethod"})
+public class FloatTypeDefinition extends Definition implements IdentifiableNode, TypedNode {
+  public IdentifierOrPlaceholder identifier;
+
+  /**
+   * Represents the bit-size of the represented float format. This is used by the type-checker
+   * to infer types when the float-type is used as a constant parameter in built-ins. This is not
+   * set during parsing, and must be set by an annotation such as {@code [ IEEE : 32 ]}.
+   */
+  @Nullable
+  public Integer size;
+
+  public SourceLocation loc;
+
+  public FloatTypeDefinition(IdentifierOrPlaceholder identifier, SourceLocation loc) {
+    this.identifier = identifier;
+    this.loc = loc;
+  }
+
+  @Override
+  public Identifier identifier() {
+    return (Identifier) identifier;
+  }
+
+  @Override
+  public SourceLocation location() {
+    return loc;
+  }
+
+  @Override
+  public SyntaxType syntaxType() {
+    return BasicSyntaxType.COMMON_DEFS;
+  }
+
+  @Override
+  public void prettyPrint(int indent, StringBuilder builder) {
+    prettyPrintAnnotations(indent, builder);
+    builder.append(prettyIndentString(indent));
+    builder.append("float-type %s".formatted(identifier().name));
+    builder.append("\n");
+  }
+
+  @Override
+  public <R> R accept(DefinitionVisitor<R> visitor) {
+    return visitor.visit(this);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    FloatTypeDefinition that = (FloatTypeDefinition) o;
+    return Objects.equals(identifier, that.identifier);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(identifier);
+  }
+
+  @Override
+  public Type type() {
+    return Type.floatType();
+  }
+}

--- a/vadl-frontend/main/vadl/ast/nodes/IsId.java
+++ b/vadl-frontend/main/vadl/ast/nodes/IsId.java
@@ -16,6 +16,7 @@
 
 package vadl.ast.nodes;
 
+import java.util.List;
 import javax.annotation.Nullable;
 
 @SuppressWarnings({"MissingJavadocType", "MissingJavadocMethod"})
@@ -28,7 +29,8 @@ public sealed interface IsId extends IsSymExpr
   }
 
   @Override
-  public default @Nullable Expr size() {
+  @Nullable
+  public default List<Expr> symbolArgs() {
     return null;
   }
 

--- a/vadl-frontend/main/vadl/ast/nodes/IsSymExpr.java
+++ b/vadl-frontend/main/vadl/ast/nodes/IsSymExpr.java
@@ -16,6 +16,7 @@
 
 package vadl.ast.nodes;
 
+import java.util.List;
 import javax.annotation.Nullable;
 
 @SuppressWarnings({"MissingJavadocType", "MissingJavadocMethod"})
@@ -25,5 +26,5 @@ public sealed interface IsSymExpr extends IsCallExpr permits SymbolExpr, IsId {
 
   @Override
   @Nullable
-  public Expr size();
+  public List<Expr> symbolArgs();
 }

--- a/vadl-frontend/main/vadl/ast/nodes/RecursiveAstVisitor.java
+++ b/vadl-frontend/main/vadl/ast/nodes/RecursiveAstVisitor.java
@@ -248,6 +248,14 @@ public class RecursiveAstVisitor implements AstVisitor<Void> {
   }
 
   @Override
+  public Void visit(FloatTypeDefinition definition) {
+    beforeTravel(definition);
+    definition.forEachChild(this::travel);
+    afterTravel(definition);
+    return null;
+  }
+
+  @Override
   public Void visit(FormatDefinition definition) {
     beforeTravel(definition);
     definition.forEachChild(this::travel);

--- a/vadl-frontend/main/vadl/ast/nodes/RecursiveAstVisitor.java
+++ b/vadl-frontend/main/vadl/ast/nodes/RecursiveAstVisitor.java
@@ -250,7 +250,11 @@ public class RecursiveAstVisitor implements AstVisitor<Void> {
   @Override
   public Void visit(FloatTypeDefinition definition) {
     beforeTravel(definition);
-    definition.forEachChild(this::travel);
+    // FIXME: FloatTypeDefinition has no fields annotated with @Child, therefore the
+    //        ChildNodeRegistry does not account for it. The children of the super type are
+    //        not checked (this seems wrong). So we manually visit the annotations.
+    definition.annotations.forEach(this::travel);
+    //definition.forEachChild(this::travel);
     afterTravel(definition);
     return null;
   }

--- a/vadl-frontend/main/vadl/ast/nodes/SymbolExpr.java
+++ b/vadl-frontend/main/vadl/ast/nodes/SymbolExpr.java
@@ -16,24 +16,29 @@
 
 package vadl.ast.nodes;
 
+import java.util.List;
 import java.util.Objects;
 import vadl.javaannotations.ast.Child;
 import vadl.utils.SourceLocation;
 
 /**
- * A representation of terms of form {@code "MEM<9>"}.
+ * A representation of terms of form {@code MEM<9>} or {@code VADL::fcvts::<IEEE32, 64>}.
+ * These terms always have at least one argument in the pointy brackets.
  */
 @SuppressWarnings("MissingJavadocMethod")
 public final class SymbolExpr extends Expr implements IsSymExpr {
   @Child
   public IsId path;
+  /**
+   * The list of arguments in the pointy brackets. Always contains at least one element.
+   */
   @Child
-  public Expr size;
+  public List<Expr> symbolArgs;
   public SourceLocation location;
 
-  public SymbolExpr(IsId path, Expr size, SourceLocation location) {
+  public SymbolExpr(IsId path, List<Expr> symbolArgs, SourceLocation location) {
     this.path = path;
-    this.size = size;
+    this.symbolArgs = symbolArgs;
     this.location = location;
   }
 
@@ -43,8 +48,8 @@ public final class SymbolExpr extends Expr implements IsSymExpr {
   }
 
   @Override
-  public Expr size() {
-    return size;
+  public List<Expr> symbolArgs() {
+    return symbolArgs;
   }
 
   @Override
@@ -60,11 +65,25 @@ public final class SymbolExpr extends Expr implements IsSymExpr {
   @Override
   public void prettyPrintExpr(int indent, StringBuilder builder, Precedence parentPrec) {
     path.prettyPrint(indent, builder);
-    var prefix = size instanceof BinaryExpr ? "<( " : "< ";
-    var suffix = size instanceof BinaryExpr ? " )>" : " >";
-    builder.append(prefix);
-    size.prettyPrintExpr(indent, builder, Precedence.NoPrecedence);
-    builder.append(suffix);
+    if (symbolArgs.size() > 1) {
+      builder.append("::");
+    }
+    builder.append("< ");
+    boolean first = true;
+    for (var arg : symbolArgs) {
+      if (!first) {
+        builder.append(", ");
+      }
+      if (arg instanceof BinaryExpr) {
+        builder.append("(");
+      }
+      arg.prettyPrintExpr(0, builder, Precedence.NoPrecedence);
+      if (arg instanceof BinaryExpr) {
+        builder.append(")");
+      }
+      first = false;
+    }
+    builder.append(" >");
   }
 
   @Override
@@ -83,13 +102,13 @@ public final class SymbolExpr extends Expr implements IsSymExpr {
     }
 
     SymbolExpr that = (SymbolExpr) o;
-    return path.equals(that.path) && Objects.equals(size, that.size);
+    return path.equals(that.path) && symbolArgs.equals(that.symbolArgs);
   }
 
   @Override
   public int hashCode() {
     int result = path.hashCode();
-    result = 31 * result + Objects.hashCode(size);
+    result = 31 * result + Objects.hashCode(symbolArgs);
     return result;
   }
 }

--- a/vadl-frontend/main/vadl/ast/nodes/TypeLiteral.java
+++ b/vadl-frontend/main/vadl/ast/nodes/TypeLiteral.java
@@ -49,8 +49,8 @@ public final class TypeLiteral extends Expr {
 
   public TypeLiteral(IsSymExpr symExpr) {
     this.baseType = symExpr.path();
-    var size = symExpr.size();
-    this.sizeIndices = size == null ? List.of() : List.of(size);
+    var symbolArgs = symExpr.symbolArgs();
+    this.sizeIndices = symbolArgs == null ? List.of() : List.of(symbolArgs.getFirst());
     this.loc = symExpr.location();
   }
 

--- a/vadl-frontend/main/vadl/ast/vadl.ATG
+++ b/vadl-frontend/main/vadl/ast/vadl.ATG
@@ -181,6 +181,7 @@ TOKENS
   FALSE        = "false".
   FETCH        = "fetch".
   FILE         = "file".
+  FLOAT_TYPE   = "float-type".
   FOLD         = "fold".
   FOR          = "for".
   FORALL       = "forall".
@@ -417,6 +418,7 @@ The #commonDefinitionList production rule lists (beside macro definitions) all c
 
   commonDefinition<out Definition def>    (. def = DUMMY_DEF; .)
   = constantDefinition<out def>
+  | floatTypeDefinition<out def>
   | formatDefinition<out def>
   | enumerationDefinition<out def>
   | usingDefinition<out def>
@@ -514,6 +516,11 @@ elements. A single annotation is described in the #annotation production rule.
     [ SYM_COLON typeLiteral<out type> ]
     SYM_EQ
     expression<out Expr expr, BIN_OPS>           (. def = new ConstantDefinition(id, type, expr, startLocation.join(lastTokenLoc())); .)
+  .
+
+  floatTypeDefinition<out FloatTypeDefinition def>          (. var startLocation = nextTokenLoc(); .)
+  = FLOAT_TYPE
+    identifierOrPlaceholder<out IdentifierOrPlaceholder id> (. def = new FloatTypeDefinition(id, startLocation.join(lastTokenLoc())); .)
   .
 
   formatDefinition<out FormatDefinition def>                                      (. var startLoc = nextTokenLoc(); var fields = new ArrayList<FormatField>(); .)
@@ -1797,15 +1804,30 @@ A micro architecture definition (#microArchitectureDefinition) is shown in line 
   = IF (isIdentifierToken(la) || isMacroReplacementOfType(this, BasicSyntaxType.ID))
     identifierPath<out IsId path>
     [
-      IF (la.kind == _SYM_LT)
-      SYM_LT                                                 (. var lessLoc = lastTokenLoc(); .)
-      term<out Expr term, BIN_OPS>
-      [
-        IF (!allowLtOp || la.kind == _SYM_GT)
-        SYM_GT                                               (. expr = new SymbolExpr(path, term, path.location().join(lastTokenLoc())); .)
-      ]                                                      (. if (expr.equals(DUMMY_EXPR)) expr = new BinaryExpr((Expr) path, new BinOp(Operator.Less, lessLoc), term); .)
-    ]                                                        (. if (expr.equals(DUMMY_EXPR)) expr = (Expr) path; .)
-  | macroReplacement<out Node node>                          (. expr = castExpr(this, node); .)
+      // TODO: decide if the ::<...> syntax should have its own rule
+      //       see Discussion #578, especially the comment
+      //       https://github.com/OpenVADL/openvadl/discussions/578#discussioncomment-17872831
+      IF (la.kind == _SYM_NAMESPACE || la.kind == _SYM_LT)  (. var values = new ArrayList<Expr>(); .)
+      (
+        IF (la.kind == _SYM_NAMESPACE)
+        SYM_NAMESPACE
+        SYM_LT
+        term<out Expr firstTerm, BIN_OPS>                   (. values.add(firstTerm); .)
+        {
+          SYM_COMMA
+          term<out Expr term, BIN_OPS>                      (. values.add(term); .)
+        }
+        SYM_GT                                              (. expr = new SymbolExpr(path, values, path.location().join(lastTokenLoc())); .)
+      |
+        SYM_LT                                              (. var lessLoc = lastTokenLoc(); .)
+        term<out Expr term, BIN_OPS>                        (. values.add(term); .)
+        [
+          IF (!allowLtOp || la.kind == _SYM_GT)
+          SYM_GT                                            (. expr = new SymbolExpr(path, values, path.location().join(lastTokenLoc())); .)
+        ]                                                   (. if (expr.equals(DUMMY_EXPR)) expr = new BinaryExpr((Expr) path, new BinOp(Operator.Less, lessLoc), term); .)
+      )
+    ]                                                       (. if (expr.equals(DUMMY_EXPR)) expr = (Expr) path; .)
+  | macroReplacement<out Node node>                         (. expr = castExpr(this, node); .)
   .
 
   binaryOperator<out Operator op> (. op = null; .)
@@ -1917,6 +1939,7 @@ A micro architecture definition (#microArchitectureDefinition) is shown in line 
   identifierPath<out IsId path>                                 (. List<IdentifierOrPlaceholder> segments = new ArrayList<>(); .)
   = identifierOrPlaceholder<out IdentifierOrPlaceholder id>     (. segments.add(id); .)
     {
+      IF (la.kind == _SYM_NAMESPACE && scanner.Peek().kind != _SYM_LT) // symbol expression can look like id::path::<>()
       SYM_NAMESPACE
       identifierOrPlaceholder<out IdentifierOrPlaceholder next> (. segments.add(next); .)
     }                                                           (. if (segments.size() == 1) path = id;

--- a/vadl-frontend/test/resources/frontend-snapshots/annotation/ieeeAnnotation.vadl
+++ b/vadl-frontend/test/resources/frontend-snapshots/annotation/ieeeAnnotation.vadl
@@ -1,0 +1,24 @@
+// INCLUDE-AST-DUMP
+
+instruction set architecture TEST =
+{
+  [ IEEE : 32 ]
+  float-type binary32
+}
+
+
+//  Reported Diagnostics:
+//
+//  No diagnostics were reported, the input was correctly parsed, typechecked and lowered.
+//
+//
+//  Dumped AST:
+//
+//    InstructionSetDefinition name: "TEST"
+//    . FloatTypeDefinition name: "binary32"
+//    . : AnnotationDefinition
+//    . : ' Identifier name: "IEEE" type: null
+//    . : ' IntegerLiteral literal: 32 (32) type: Const<32>
+//
+//
+// Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl-frontend/test/resources/frontend-snapshots/annotation/invalidIeeeAnnotationInvalidSize.vadl
+++ b/vadl-frontend/test/resources/frontend-snapshots/annotation/invalidIeeeAnnotationInvalidSize.vadl
@@ -1,0 +1,30 @@
+// INCLUDE-AST-DUMP
+
+instruction set architecture TEST =
+{
+  [ IEEE : 7 ]
+  float-type invalid
+}
+
+
+//  Reported Diagnostics:
+//
+//  error: Invalid IEEE encoding size
+//       ╭── test/resources/frontend-snapshots/annotation/invalidIeeeAnnotationInvalidSize.vadl:5:3
+//       │
+//     5 │   [ IEEE : 7 ]
+//       │   ^^^^^^^^^^^^
+//       │
+//       The following sizes are supported: 32, 64
+//
+//
+//  Dumped AST:
+//
+//    InstructionSetDefinition name: "TEST"
+//    . FloatTypeDefinition name: "invalid"
+//    . : AnnotationDefinition
+//    . : ' Identifier name: "IEEE" type: null
+//    . : ' IntegerLiteral literal: 7 (7) type: Const<7>
+//
+//
+// Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl-frontend/test/resources/frontend-snapshots/lowering/floatType.vadl
+++ b/vadl-frontend/test/resources/frontend-snapshots/lowering/floatType.vadl
@@ -1,0 +1,37 @@
+// INCLUDE-VIAM-DUMP
+
+instruction set architecture ISA = {
+
+  [ IEEE : 32 ]
+  float-type binary32
+
+}
+
+
+//  Reported Diagnostics:
+//
+//  No diagnostics were reported, the input was correctly parsed, typechecked and lowered.
+//
+//
+//  VIAM Dump:
+//
+//    Specification name: "floatType"
+//    . Definitions: 1
+//    . InstructionSetArchitecture name: "ISA"
+//    . : PC: -
+//    . : InstructionCount: 0
+//    . : PseudoInstructionCount: 0
+//    . : FormatCount: 0
+//    . : FunctionCount: 0
+//    . : OperationCount: 0
+//    . : ExceptionCount: 0
+//    . : RelocationCount: 0
+//    . : RegisterCount: 0
+//    . : MemoryCount: 0
+//    . : ArtificialResourceCount: 0
+//    . : FloatFormat name: "binary32"
+//    . : ' Type: FloatType
+//    . : ' Encoding: IEEE32(32)
+//
+//
+// Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl-frontend/test/resources/frontend-snapshots/lowering/invalidFloatTypeMissingSize.vadl
+++ b/vadl-frontend/test/resources/frontend-snapshots/lowering/invalidFloatTypeMissingSize.vadl
@@ -1,0 +1,26 @@
+// INCLUDE-VIAM-DUMP
+
+instruction set architecture ISA = {
+
+  float-type binary32
+
+}
+
+
+//  Reported Diagnostics:
+//
+//  error: Missing float-type encoding size
+//       ╭── test/resources/frontend-snapshots/lowering/invalidFloatTypeMissingSize.vadl:5:3
+//       │
+//     5 │   float-type binary32
+//       │   ^^^^^^^^^^^^^^^^^^^
+//       │
+//       help: Annotate with e.g. `[ IEEE : <size> ]`
+//
+//
+//  VIAM Dump:
+//
+//  Unable to dump VIAM
+//
+//
+// Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl-frontend/test/resources/frontend-snapshots/lowering/invalidUsedFloatTypeMissingSize.vadl
+++ b/vadl-frontend/test/resources/frontend-snapshots/lowering/invalidUsedFloatTypeMissingSize.vadl
@@ -1,0 +1,30 @@
+// INCLUDE-VIAM-DUMP
+
+instruction set architecture ISA = {
+
+  float-type binary32
+
+  // VADL::add does not actually take a float-type constant parameter,
+  // but the size is checked beforehand anyway
+  function F() -> Bits<32> = VADL::add::<binary32>(0, 0, 0)
+
+}
+
+
+//  Reported Diagnostics:
+//
+//  error: Missing float-type encoding size
+//       ╭── test/resources/frontend-snapshots/lowering/invalidUsedFloatTypeMissingSize.vadl:5:3
+//       │
+//     5 │   float-type binary32
+//       │   ^^^^^^^^^^^^^^^^^^^
+//       │
+//       help: Annotate with e.g. `[ IEEE : <size> ]`
+//
+//
+//  VIAM Dump:
+//
+//  Unable to dump VIAM
+//
+//
+// Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl-frontend/test/resources/frontend-snapshots/macro/floatTypeTest.vadl
+++ b/vadl-frontend/test/resources/frontend-snapshots/macro/floatTypeTest.vadl
@@ -1,0 +1,24 @@
+// INCLUDE-PRETTY-PRINT
+model FloatType(id : Id): Defs = { [ IEEE : 32 ] float-type $id }
+$FloatType(IEEE32)
+
+model FloatTypeId(): Id = { IEEE64 }
+[ IEEE : 64 ]
+float-type $FloatTypeId()
+
+
+//  Reported Diagnostics:
+//
+//  No diagnostics were reported, the input was correctly parsed, typechecked and lowered.
+//
+//
+//  Pretty Print:
+//
+//  [ IEEE : 32 ]
+//  float-type IEEE32
+//
+//  [ IEEE : 64 ]
+//  float-type IEEE64
+//
+//
+// Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl-frontend/test/resources/frontend-snapshots/parser/invalidSymbolExprMultipleParam.vadl
+++ b/vadl-frontend/test/resources/frontend-snapshots/parser/invalidSymbolExprMultipleParam.vadl
@@ -1,0 +1,24 @@
+// INCLUDE-AST-DUMP
+
+instruction set architecture TEST = {
+  function a() -> Bits<32> = VADL::add<0, 1>(0, 1)
+  //                                  ^^ missing `::` operator
+}
+
+
+//  Reported Diagnostics:
+//
+//  error: Parsing Error
+//       ╭── test/resources/frontend-snapshots/parser/invalidSymbolExprMultipleParam.vadl:4:41
+//       │
+//     4 │   function a() -> Bits<32> = VADL::add<0, 1>(0, 1)
+//       │                                         ^ The parser expected `}` here.
+//       │
+//
+//
+//  Dumped AST:
+//
+//  Unable to dump AST
+//
+//
+// Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl-frontend/test/resources/frontend-snapshots/parser/symbolExprMultipleParam.vadl
+++ b/vadl-frontend/test/resources/frontend-snapshots/parser/symbolExprMultipleParam.vadl
@@ -1,0 +1,31 @@
+// INCLUDE-AST-DUMP
+
+instruction set architecture TEST = {
+  function a() -> Bits<32> = VADL::add::<0, 1>(0, 1)
+}
+
+
+//  Reported Diagnostics:
+//
+//  No diagnostics were reported, the input was correctly parsed, typechecked and lowered.
+//
+//
+//  Dumped AST:
+//
+//    InstructionSetDefinition name: "TEST"
+//    . FunctionDefinition name: "a"
+//    . : TypeLiteral type: Bits<32>
+//    . : ' Identifier name: "Bits" type: null
+//    . : ' IntegerLiteral literal: 32 (32) type: Const<32>
+//    . : CastExpr type: Bits<32>
+//    . : ' CallIndexExpr type: Const<1>
+//    . : ' | SymbolExpr type: null
+//    . : ' | . IdentifierPath name: "VADL::add" type: null
+//    . : ' | . IntegerLiteral literal: 0 (0) type: Const<0>
+//    . : ' | . IntegerLiteral literal: 1 (1) type: Const<1>
+//    . : ' | ArgsIndices
+//    . : ' | . IntegerLiteral literal: 0 (0) type: Const<0>
+//    . : ' | . IntegerLiteral literal: 1 (1) type: Const<1>
+//
+//
+// Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl-frontend/test/resources/frontend-snapshots/parser/symbolExprSingleParam.vadl
+++ b/vadl-frontend/test/resources/frontend-snapshots/parser/symbolExprSingleParam.vadl
@@ -1,0 +1,49 @@
+// INCLUDE-AST-DUMP
+
+instruction set architecture TEST = {
+  memory MEM: Bits<8> -> Bits<32>
+  function a() -> Bits<32> = MEM<1>(0)
+  function b() -> Bits<32> = MEM::<1>(0)
+}
+
+
+//  Reported Diagnostics:
+//
+//  No diagnostics were reported, the input was correctly parsed, typechecked and lowered.
+//
+//
+//  Dumped AST:
+//
+//    InstructionSetDefinition name: "TEST"
+//    . MemoryDefinition name: "MEM"
+//    . : TypeLiteral type: Bits<8>
+//    . : ' Identifier name: "Bits" type: null
+//    . : ' IntegerLiteral literal: 8 (8) type: Const<8>
+//    . : TypeLiteral type: Bits<32>
+//    . : ' Identifier name: "Bits" type: null
+//    . : ' IntegerLiteral literal: 32 (32) type: Const<32>
+//    . FunctionDefinition name: "a"
+//    . : TypeLiteral type: Bits<32>
+//    . : ' Identifier name: "Bits" type: null
+//    . : ' IntegerLiteral literal: 32 (32) type: Const<32>
+//    . : CallIndexExpr type: Bits<32>
+//    . : ' SymbolExpr type: null
+//    . : ' | Identifier name: "MEM" type: null
+//    . : ' | IntegerLiteral literal: 1 (1) type: Const<1>
+//    . : ' ArgsIndices
+//    . : ' | CastExpr type: Bits<8>
+//    . : ' | . IntegerLiteral literal: 0 (0) type: Const<0>
+//    . FunctionDefinition name: "b"
+//    . : TypeLiteral type: Bits<32>
+//    . : ' Identifier name: "Bits" type: null
+//    . : ' IntegerLiteral literal: 32 (32) type: Const<32>
+//    . : CallIndexExpr type: Bits<32>
+//    . : ' SymbolExpr type: null
+//    . : ' | Identifier name: "MEM" type: null
+//    . : ' | IntegerLiteral literal: 1 (1) type: Const<1>
+//    . : ' ArgsIndices
+//    . : ' | CastExpr type: Bits<8>
+//    . : ' | . IntegerLiteral literal: 0 (0) type: Const<0>
+//
+//
+// Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl-frontend/test/resources/frontend-snapshots/typechecker/invalidBuiltitinCalls.vadl
+++ b/vadl-frontend/test/resources/frontend-snapshots/typechecker/invalidBuiltitinCalls.vadl
@@ -28,7 +28,7 @@ function abc(x: Bits<8>) -> Bits<8> = VADL::adds(1, x)
 //       ╭── test/resources/frontend-snapshots/typechecker/invalidBuiltitinCalls.vadl:8:39
 //       │
 //     8 │ function abc(x: Bits<8>) -> Bits<8> = VADL::adds(1, x)
-//       │                                       ^^^^^^^^^^^^^^^^ The builtin has the signature `(BitsType, BitsType) -> StructType` but got `Bits<1>, Bits<8>`.
+//       │                                       ^^^^^^^^^^^^^^^^ The builtin has the signature `(BitsType, BitsType) -> StructType` but got `(Bits<1>, Bits<8>)`.
 //       │                                                        help: Try casting some of the constant arguments to explicit types.
 //       │
 //

--- a/vadl-frontend/test/resources/frontend-snapshots/typechecker/invalidBuiltitinCalls.vadl
+++ b/vadl-frontend/test/resources/frontend-snapshots/typechecker/invalidBuiltitinCalls.vadl
@@ -28,7 +28,7 @@ function abc(x: Bits<8>) -> Bits<8> = VADL::adds(1, x)
 //       ╭── test/resources/frontend-snapshots/typechecker/invalidBuiltitinCalls.vadl:8:39
 //       │
 //     8 │ function abc(x: Bits<8>) -> Bits<8> = VADL::adds(1, x)
-//       │                                       ^^^^^^^^^^^^^^^^ The builtin has the signature `(BitsType, BitsType) -> StructType` but got `(Bits<1>, Bits<8>)`.
+//       │                                       ^^^^^^^^^^^^^^^^ The builtin has the signature `(BitsType, BitsType) -> StructType` but got `Bits<1>, Bits<8>`.
 //       │                                                        help: Try casting some of the constant arguments to explicit types.
 //       │
 //

--- a/vadl-frontend/test/vadl/viam/ViamSnapshotDumper.java
+++ b/vadl-frontend/test/vadl/viam/ViamSnapshotDumper.java
@@ -189,6 +189,17 @@ public class ViamSnapshotDumper extends DefinitionVisitor.Empty {
     }
 
     @Override
+    public void visit(FloatFormat floatFormat) {
+      lineAt(atIndent, "Type: %s".formatted(compactType(floatFormat.type())));
+      var encoding = floatFormat.encoding();
+      lineAt(atIndent, "Encoding: %s".formatted(
+          encoding == null
+              ? "-"
+              : "%s(%s)".formatted(encoding.name(), encoding.size)
+      ));
+    }
+
+    @Override
     public void visit(Format.Field field) {
       lineAt(atIndent, "Type: %s".formatted(compactType(field.type())));
       lineAt(atIndent, "BitSlice: %s".formatted(field.bitSlice()));

--- a/vadl/main/vadl/dump/InfoUtils.java
+++ b/vadl/main/vadl/dump/InfoUtils.java
@@ -16,6 +16,7 @@
 
 package vadl.dump;
 
+import com.google.common.html.HtmlEscapers;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -230,7 +231,7 @@ public class InfoUtils {
         """
             <pre><code class="text-sm text-gray-500 whitespace-pre">%s
             </code></pre>
-            """.formatted(code)
+            """.formatted(HtmlEscapers.htmlEscaper().escape(code))
     );
   }
 

--- a/vadl/main/vadl/types/BuiltInTable.java
+++ b/vadl/main/vadl/types/BuiltInTable.java
@@ -16,6 +16,7 @@
 
 package vadl.types;
 
+import static java.util.Objects.requireNonNull;
 import static org.slf4j.LoggerFactory.getLogger;
 import static vadl.types.Type.constructDataType;
 
@@ -1582,7 +1583,7 @@ public class BuiltInTable {
       return hasSameBitWidth;
     }
 
-    public Optional<Constant> compute(List<Constant> args) {
+    public Optional<Constant> compute(List<Constant> constArgs, List<Constant> args) {
       logger.atWarn().log("Computation of constants for built-in {} is not implemented", this);
       return Optional.empty();
     }
@@ -1600,10 +1601,11 @@ public class BuiltInTable {
      * in the built-in definition, and if not, if it is possible to produce a type of the
      * parameter type class that can be trivially cast from the argument type.
      *
-     * @param argTypes of the concrete arguments
+     * @param constArgs the concrete constant arguments
+     * @param argTypes  of the concrete arguments
      * @return true if argument types are correct, false otherwise
      */
-    public boolean takes(List<Type> argTypes) {
+    public boolean takes(List<Constant> constArgs, List<Type> argTypes) {
 
       if (this.signature().hasVarArgs()) {
         if (argTypes.size() < argTypeClasses().size()) {
@@ -1629,7 +1631,13 @@ public class BuiltInTable {
         return false;
       }
 
-      return argsCompatible(argTypes, argTypeClasses());
+      if (constArgTypeClasses().size() != constArgs.size()) {
+        // if the number of constant arguments is not correct, this can't be true
+        return false;
+      }
+
+      return argsCompatible(argTypes, argTypeClasses())
+          && argsCompatible(constArgs.stream().map(Constant::type).toList(), constArgTypeClasses());
     }
 
     private boolean argsCompatible(List<Type> argTypes,
@@ -1667,14 +1675,28 @@ public class BuiltInTable {
     }
 
     /**
+     * Returns the result type of the built-in when called with the given argument types and
+     * constant arguments.
+     * It assumes that the argument types are valid, such as a call to
+     * {@link #takes(List, List)} would return true.
+     *
+     * @param constArgs concrete constant arguments.
+     * @param argTypes  concrete types of argument for call.
+     * @return the concrete type that is return by this built-in
+     */
+    public abstract Type returns(List<Constant> constArgs, List<Type> argTypes);
+
+    /**
      * Returns the result type of the built-in when called with the given argument types.
      * It assumes that the argument types are valid, such as a call to
-     * {@link #takes(List)} would return true.
+     * {@link #takes(List, List)} would return true.
      *
      * @param argTypes concrete types of argument for call.
      * @return the concrete type that is return by this built-in
      */
-    public abstract Type returns(List<Type> argTypes);
+    public Type returns(List<Type> argTypes) {
+      return returns(List.of(), argTypes);
+    }
 
 
     public final boolean matches(RelationType type) {
@@ -1684,6 +1706,10 @@ public class BuiltInTable {
     @Override
     public String toString() {
       return name + signature;
+    }
+
+    public List<Class<? extends Type>> constArgTypeClasses() {
+      return signature.constArgTypeClass();
     }
 
     public List<Class<? extends Type>> argTypeClasses() {
@@ -1746,11 +1772,11 @@ public class BuiltInTable {
     private RelationType signature;
     private BuiltIn.Kind kind;
     @Nullable
-    private Function<List<Constant>, Optional<Constant>> computeFunction;
+    private BiFunction<List<Constant>, List<Constant>, Optional<Constant>> computeFunction;
     @Nullable
-    private Function<List<Type>, Boolean> takesFunction;
+    private BiFunction<List<Constant>, List<Type>, Boolean> takesFunction;
     @Nullable
-    private Function<List<Type>, Type> returnsFunction;
+    private BiFunction<List<Constant>, List<Type>, Type> returnsFunction;
     private boolean hasSameBitWidth = false;
 
     BuiltInBuilder(String name, @Nullable String operator, RelationType signature,
@@ -1763,52 +1789,74 @@ public class BuiltInTable {
 
     public <T extends Constant, R extends Constant> BuiltInBuilder computeUnary(
         Function<T, R> computeFunction) {
-      this.computeFunction =
-          (args) -> Optional.of(computeFunction.apply((T) args.get(0)));
+      this.computeFunction = (constArgs, args) ->
+          Optional.of(computeFunction.apply((T) args.get(0)));
       return this;
     }
 
     public <T extends Constant, R extends Constant> BuiltInBuilder compute(
         Function<List<T>, R> computeFunction) {
-      this.computeFunction =
-          (args) -> Optional.of(computeFunction.apply(args.stream().map(a -> (T) a).toList()));
+      this.computeFunction = (constArgs, args) ->
+          Optional.of(computeFunction.apply(args.stream().map(a -> (T) a).toList()));
       return this;
     }
 
     public <A extends Constant, B extends Constant, R extends Constant> BuiltInBuilder compute(
         BiFunction<A, B, R> computeFunction) {
-      this.computeFunction =
-          (args) -> Optional.of(computeFunction.apply((A) args.get(0), (B) args.get(1)));
+      this.computeFunction = (constArgs, args) ->
+          Optional.of(computeFunction.apply((A) args.get(0), (B) args.get(1)));
       return this;
     }
 
     @SuppressWarnings("LineLength")
     public <A extends Constant, B extends Constant, C extends Constant, R extends Constant> BuiltInBuilder compute(
         TriFunction<A, B, C, R> computeFunction) {
-      this.computeFunction =
-          (args) -> Optional.of(
-              computeFunction.apply((A) args.get(0), (B) args.get(1), (C) args.get(2)));
+      this.computeFunction = (constArgs, args) ->
+          Optional.of(computeFunction.apply((A) args.get(0), (B) args.get(1), (C) args.get(2)));
       return this;
     }
 
     public BuiltInBuilder noCompute() {
-      this.computeFunction = (args) -> Optional.empty();
+      this.computeFunction = (constArgs, args) -> Optional.empty();
+      return this;
+    }
+
+    public BuiltInBuilder takesData(
+        BiFunction<List<Constant>, List<DataType>, Boolean> takesFunction) {
+      this.takesFunction = (constArgs, args) -> args.stream().allMatch(DataType.class::isInstance)
+          && takesFunction.apply(constArgs, args.stream().map(DataType.class::cast).toList());
       return this;
     }
 
     public BuiltInBuilder takesData(Function<List<DataType>, Boolean> takesFunction) {
-      this.takesFunction = (args) -> args.stream().allMatch(DataType.class::isInstance)
-          && takesFunction.apply(args.stream().map(DataType.class::cast).toList());
-      return this;
+      return takesData((constArgs, args) -> takesFunction.apply(args));
+    }
+
+    public BuiltInBuilder takesDataFromFirstFloatSize(
+        BiFunction<Integer, List<DataType>, Boolean> takesFunction) {
+      return takesData((constArgs, args) -> {
+        ensure(!constArgs.isEmpty(), "Expected at least one constant argument, but found none.");
+        return takesFunction.apply(floatTypeSize(constArgs.get(0)), args);
+      });
+    }
+
+    public BuiltInBuilder takesDataFromFirstTwoFloatSizes(
+        TriFunction<Integer, Integer, List<DataType>, Boolean> takesFunction) {
+      return takesData((constArgs, args) -> {
+        ensure(constArgs.size() >= 2, "Expected at least two constant argument, but found %d.",
+            constArgs.size());
+        return takesFunction.apply(
+            floatTypeSize(constArgs.get(0)), floatTypeSize(constArgs.get(1)), args);
+      });
     }
 
     /**
-     * This will use the default implementation of {@link BuiltIn#takes(List)}.
+     * This will use the default implementation of {@link BuiltIn#takes(List, List)}.
      * So it will compare type classes and checks if an argument is trivially cast
      * to a parameter's type class.
      */
     public BuiltInBuilder takesDefault() {
-      this.takesFunction = (args) -> true;
+      this.takesFunction = (constArgs, args) -> true;
       return this;
     }
 
@@ -1826,12 +1874,32 @@ public class BuiltInTable {
       return this;
     }
 
+    public BuiltInBuilder takesFloatArgs(int floatArgCount) {
+      return takesDataFromFirstFloatSize((size, args) -> args.size() == floatArgCount
+          && args.stream().limit(floatArgCount).allMatch(a -> a.bitWidth() == size));
+    }
+
+    public BuiltInBuilder takesFloatArgsAndFrm(int floatArgCount) {
+      return takesDataFromFirstFloatSize((size, args) -> args.size() == floatArgCount + 1
+          && args.stream().limit(floatArgCount).allMatch(a -> a.bitWidth() == size)
+          && args.get(floatArgCount).bitWidth() == 3);
+    }
+
+    public BuiltInBuilder takesFrm(int frmArgIdx) {
+      return takesData(args -> args.size() == frmArgIdx + 1 && args.get(frmArgIdx).bitWidth() == 3);
+    }
+
     public BuiltInBuilder returns(Type returnType) {
       returns((args) -> returnType);
       return this;
     }
 
     public BuiltInBuilder returns(Function<List<Type>, Type> returnsFunction) {
+      returns((constArgs, args) -> returnsFunction.apply(args));
+      return this;
+    }
+
+    public BuiltInBuilder returns(BiFunction<List<Constant>, List<Type>, Type> returnsFunction) {
       this.returnsFunction = returnsFunction;
       return this;
     }
@@ -1840,17 +1908,25 @@ public class BuiltInTable {
       returnsFromFirstAsDataType(
           (firstDataType) -> {
             var result = constructDataType(returnTypeClass, firstDataType.bitWidth());
-            Objects.requireNonNull(result);
+            requireNonNull(result);
             return result;
           });
       return this;
+    }
+
+    public BuiltInBuilder returnsFirstFloatType() {
+      return returnsFromFirstFloatSize(BitsType::bits);
+    }
+
+    public BuiltInBuilder returnsSecondFloatType() {
+      return returnsFromFirstTwoFloatSizes((s0, s1) -> BitsType.bits(s1));
     }
 
     public <T extends DataType> BuiltInBuilder returnsFirstBitWidthAndStatus(
         Class<T> returnTypeClass) {
       returnsFromFirstAsDataType((firstDataType) -> {
         var valType = constructDataType(returnTypeClass, firstDataType.bitWidth());
-        Objects.requireNonNull(valType);
+        requireNonNull(valType);
         return Type.struct(
             BUILTIN_RESULT, valType,
             BUILTIN_STATUS, Type.status()
@@ -1879,6 +1955,42 @@ public class BuiltInTable {
       return this;
     }
 
+    public <T extends DataType> BuiltInBuilder returnsFromSecondConstSize(
+        Class<T> returnTypeClass) {
+      return returns((constArgs, args) -> {
+        ensure(constArgs.size() >= 2, "Expected at least two constant argument, but found %d.",
+            constArgs.size());
+        return requireNonNull(constructDataType(returnTypeClass, constInt(constArgs.get(1))));
+      });
+    }
+
+    public BuiltInBuilder returnsFromFirstFloatSize(Function<Integer, Type> returnFunction) {
+      return returns((constArgs, args) -> {
+        ensure(!constArgs.isEmpty(), "Expected at least one constant argument, but found none.");
+        return returnFunction.apply(floatTypeSize(constArgs.get(0)));
+      });
+    }
+
+    public BuiltInBuilder returnsFromFirstTwoFloatSizes(
+        BiFunction<Integer, Integer, Type> returnFunction) {
+      return returns((constArgs, args) -> {
+        ensure(constArgs.size() >= 2, "Expected at least two constant argument, but found %d.",
+            constArgs.size());
+        return returnFunction.apply(
+            floatTypeSize(constArgs.get(0)), floatTypeSize(constArgs.get(1)));
+      });
+    }
+
+    private int floatTypeSize(Constant arg) {
+      ensure(arg instanceof Constant.FloatType, "Expected a float type, but found %s", arg);
+      return ((Constant.FloatType) arg).size();
+    }
+
+    private int constInt(Constant arg) {
+      ensure(arg instanceof Constant.Value, "Expected a value type, but found %s", arg);
+      return ((Constant.Value) arg).intValue();
+    }
+
 
     public BuiltIn build() {
 
@@ -1894,39 +2006,37 @@ public class BuiltInTable {
 
       return new BuiltIn(name, operator, signature, kind, hasSameBitWidth) {
         @Override
-        public Optional<Constant> compute(List<Constant> args) {
+        public Optional<Constant> compute(List<Constant> constArgs, List<Constant> args) {
           if (computeFunction == null) {
-            return super.compute(args);
+            return super.compute(constArgs, args);
           }
 
-          var argTypes = args.stream()
-              .map(Constant::type)
-              .toList();
-          if (!takes(argTypes)) {
+          var argTypes = args.stream().map(Constant::type).toList();
+          if (!takes(constArgs, argTypes)) {
             throw new ViamError("Types of arguments does not match type signature of " + signature)
                 .addContext("built-in", this)
-                .addContext("constants", List.of(args));
+                .addContext("constants", List.of(constArgs, args));
           }
-          return computeFunction.apply(args)
+          return computeFunction.apply(constArgs, args)
               .map(result -> result instanceof Constant.Value value
-                  ? value.trivialCastTo(returns(argTypes))
+                  ? value.trivialCastTo(returns(constArgs, argTypes))
                   : result);
         }
 
         @Override
-        public boolean takes(List<Type> argTypes) {
+        public boolean takes(List<Constant> constArgs, List<Type> argTypes) {
           // always check general case first
-          var generalConstraintsValid = super.takes(argTypes);
+          var generalConstraintsValid = super.takes(constArgs, argTypes);
           if (generalConstraintsValid) {
             // if general case doesn't fail, then test specific constraints
-            return takesFunction.apply(argTypes);
+            return takesFunction.apply(constArgs, argTypes);
           }
           return false;
         }
 
         @Override
-        public Type returns(List<Type> argTypes) {
-          return returnsFunction.apply(argTypes);
+        public Type returns(List<Constant> constArgs, List<Type> argTypes) {
+          return returnsFunction.apply(constArgs, argTypes);
         }
       };
     }

--- a/vadl/main/vadl/types/FloatStatusType.java
+++ b/vadl/main/vadl/types/FloatStatusType.java
@@ -16,6 +16,8 @@
 
 package vadl.types;
 
+import java.util.Map;
+
 /**
  * A class that represents the VADL float status type.
  *
@@ -37,13 +39,13 @@ public class FloatStatusType extends StructType {
   public static final String INEXACT = "nx";
 
   protected FloatStatusType() {
-    super(Type.struct(
+    super(Type.struct(Map.of(
         INVALID, Type.bool(),
         DIVISION_BY_ZERO, Type.bool(),
         OVERFLOW, Type.bool(),
         UNDERFLOW, Type.bool(),
         INEXACT, Type.bool()
-    ).fields());
+    )).fields());
   }
 
   @Override

--- a/vadl/main/vadl/types/FloatStatusType.java
+++ b/vadl/main/vadl/types/FloatStatusType.java
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.types;
+
+/**
+ * A class that represents the VADL float status type.
+ *
+ * <p>It is actually a struct of with five boolean fields.
+ * These five elements represent status flags:
+ * <li>nv</li>
+ * <li>dz</li>
+ * <li>of</li>
+ * <li>uf</li>
+ * <li>nx</li>
+ * in that order.
+ */
+public class FloatStatusType extends StructType {
+
+  public static final String INVALID = "nv";
+  public static final String DIVISION_BY_ZERO = "dz";
+  public static final String OVERFLOW = "of";
+  public static final String UNDERFLOW = "uf";
+  public static final String INEXACT = "nx";
+
+  protected FloatStatusType() {
+    super(Type.struct(
+        INVALID, Type.bool(),
+        DIVISION_BY_ZERO, Type.bool(),
+        OVERFLOW, Type.bool(),
+        UNDERFLOW, Type.bool(),
+        INEXACT, Type.bool()
+    ).fields());
+  }
+
+  @Override
+  public String name() {
+    return "FloatStatus";
+  }
+
+}

--- a/vadl/main/vadl/types/FloatType.java
+++ b/vadl/main/vadl/types/FloatType.java
@@ -17,7 +17,21 @@
 package vadl.types;
 
 /**
- * A class that represents the VADL float type.
+ * A class that represents the built-in type for float-type expressions.
+ *
+ * <pre>{@code
+ * // This declares a float format
+ * [ IEEE : 32 ]
+ * float-type binary32
+ *
+ * // It can later be used as an expression
+ * VADL::fcvtfs::<binary32, 32>(...)
+ * //             ^^^^^^^^ this is an expression with the type `FloatType`
+ * }</pre>
+ *
+ * <strong>Note:</strong> FloatType is NOT a {@link DataType}. It is NOT the type of float
+ * expressions. Float expressions are {@link BitsType}. There exist no conversions between this
+ * and any other type.
  */
 public class FloatType extends Type {
 

--- a/vadl/main/vadl/types/FloatType.java
+++ b/vadl/main/vadl/types/FloatType.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -14,18 +14,17 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-package vadl.ast.nodes;
+package vadl.types;
 
-import java.util.List;
-import javax.annotation.Nullable;
-import vadl.utils.WithLocation;
+/**
+ * A class that represents the VADL float type.
+ */
+public class FloatType extends Type {
 
-@SuppressWarnings({"MissingJavadocType", "MissingJavadocMethod"})
-public sealed interface IsCallExpr extends WithLocation permits CallIndexExpr, IsSymExpr {
-  public IsId path();
+  protected FloatType() { }
 
-  @Nullable
-  public List<Expr> symbolArgs();
-
-  public void prettyPrint(int indent, StringBuilder builder);
+  @Override
+  public String name() {
+    return "FloatType";
+  }
 }

--- a/vadl/main/vadl/types/RelationType.java
+++ b/vadl/main/vadl/types/RelationType.java
@@ -28,18 +28,25 @@ import java.util.stream.Collectors;
 public class RelationType extends Type {
 
   private final List<Class<? extends Type>> argTypeClass;
+  private final List<Class<? extends Type>> constArgTypeClass;
   private final boolean hasVarArgs;
   private final Class<? extends Type> resultTypeClass;
 
-  protected RelationType(List<Class<? extends Type>> argTypes, boolean hasVarArgs,
+  protected RelationType(List<Class<? extends Type>> argTypes,
+                         List<Class<? extends Type>> constArgTypeClass, boolean hasVarArgs,
                          Class<? extends Type> resultType) {
     this.argTypeClass = argTypes;
+    this.constArgTypeClass = constArgTypeClass;
     this.hasVarArgs = hasVarArgs;
     this.resultTypeClass = resultType;
   }
 
   public List<Class<? extends Type>> argTypeClasses() {
     return argTypeClass;
+  }
+
+  public List<Class<? extends Type>> constArgTypeClass() {
+    return constArgTypeClass;
   }
 
   public boolean hasVarArgs() {
@@ -52,10 +59,18 @@ public class RelationType extends Type {
 
   @Override
   public String name() {
-    return "("
-        + argTypeClass.stream().map(Class::getSimpleName)
-        .collect(Collectors.joining(", "))
-        + ") -> "
-        + resultTypeClass.getSimpleName();
+    var sb = new StringBuilder();
+    if (!constArgTypeClass.isEmpty()) {
+      sb.append("<");
+      sb.append(constArgTypeClass.stream().map(Class::getSimpleName)
+          .collect(Collectors.joining(", ")));
+      sb.append(">");
+    }
+    sb.append("(");
+    sb.append(argTypeClass.stream().map(Class::getSimpleName)
+        .collect(Collectors.joining(", ")));
+    sb.append(") -> ");
+    sb.append(resultTypeClass.getSimpleName());
+    return sb.toString();
   }
 }

--- a/vadl/main/vadl/types/Type.java
+++ b/vadl/main/vadl/types/Type.java
@@ -202,25 +202,6 @@ public abstract class Type {
     return struct(fields);
   }
 
-  /**
-   * Retrieves the struct type with the specified subtypes.
-   *
-   * @return the struct type with the specified subtypes
-   */
-  public static StructType struct(String field1, Type type1,
-                                  String field2, Type type2,
-                                  String field3, Type type3,
-                                  String field4, Type type4,
-                                  String field5, Type type5) {
-    var fields = new LinkedHashMap<String, Type>();
-    fields.put(field1, type1);
-    fields.put(field2, type2);
-    fields.put(field3, type3);
-    fields.put(field4, type4);
-    fields.put(field5, type5);
-    return struct(fields);
-  }
-
   private static @Nullable StatusType statusType = null;
 
   /**
@@ -480,7 +461,6 @@ public abstract class Type {
   /// These are all the builtin types that exist in the language.
   /// Some of them cannot be initialized like them since they require a size, like `SInt<16>`
   /// which is why they are named bases.
-  public static final Set<String> builtinTypeBases = Set.of(
-      "Bool", "String", "Bits", "UInt", "SInt", "Instruction", "FetchResult"
-  );
+  public static final Set<String> builtinTypeBases =
+      Set.of("Bool", "String", "Bits", "UInt", "SInt", "Instruction", "FetchResult");
 }

--- a/vadl/main/vadl/types/Type.java
+++ b/vadl/main/vadl/types/Type.java
@@ -120,6 +120,20 @@ public abstract class Type {
         .computeIfAbsent(bitWidth, k -> new UIntType(bitWidth));
   }
 
+  private static @Nullable FloatType floatType = null;
+
+  /**
+   * Retrieves the instance of FloatType.
+   *
+   * @return the FloatType object
+   */
+  public static FloatType floatType() {
+    if (floatType == null) {
+      floatType = new FloatType();
+    }
+    return floatType;
+  }
+
   /**
    * Returns a DummyType object.
    *
@@ -188,6 +202,25 @@ public abstract class Type {
     return struct(fields);
   }
 
+  /**
+   * Retrieves the struct type with the specified subtypes.
+   *
+   * @return the struct type with the specified subtypes
+   */
+  public static StructType struct(String field1, Type type1,
+                                  String field2, Type type2,
+                                  String field3, Type type3,
+                                  String field4, Type type4,
+                                  String field5, Type type5) {
+    var fields = new LinkedHashMap<String, Type>();
+    fields.put(field1, type1);
+    fields.put(field2, type2);
+    fields.put(field3, type3);
+    fields.put(field4, type4);
+    fields.put(field5, type5);
+    return struct(fields);
+  }
+
   private static @Nullable StatusType statusType = null;
 
   /**
@@ -200,6 +233,20 @@ public abstract class Type {
       statusType = new StatusType();
     }
     return statusType;
+  }
+
+  private static @Nullable FloatStatusType floatStatusType = null;
+
+  /**
+   * Retrieves the float status type instance.
+   *
+   * @return the float status type instance
+   */
+  public static FloatStatusType floatStatus() {
+    if (floatStatusType == null) {
+      floatStatusType = new FloatStatusType();
+    }
+    return floatStatusType;
   }
 
   private static @Nullable VoidType voidType = null;
@@ -239,23 +286,53 @@ public abstract class Type {
    */
   public static RelationType relation(List<Class<? extends Type>> argTypes,
                                       Class<? extends Type> returnType) {
-    return relation(argTypes, false, returnType);
+    return relation(argTypes, List.of(), false, returnType);
   }
 
   /**
    * Retrieves the generic relation type.
    *
-   * @param argTypes   the list of argument type classes
-   * @param hasVarArgs the flag indicating if the last argument of kind varargs
-   * @param returnType the return type class
+   * @param argTypes      the list of argument type classes
+   * @param constArgTypes the list of constant argument type classes
+   * @param returnType    the return type class
+   * @return the RelationType instance
+   */
+  public static RelationType relation(List<Class<? extends Type>> argTypes,
+                                      List<Class<? extends Type>> constArgTypes,
+                                      Class<? extends Type> returnType) {
+    return relation(argTypes, constArgTypes, false, returnType);
+  }
+
+  /**
+   * Retrieves the generic relation type.
+   *
+   * @param argTypes      the list of argument type classes
+   * @param hasVarArgs    the flag indicating if the last argument of kind varargs
+   * @param returnType    the return type class
    * @return the RelationType instance
    */
   public static RelationType relation(List<Class<? extends Type>> argTypes,
                                       boolean hasVarArgs,
                                       Class<? extends Type> returnType) {
-    var hashCode = Objects.hash(argTypes, hasVarArgs, returnType);
-    return relationTypes
-        .computeIfAbsent(hashCode, k -> new RelationType(argTypes, hasVarArgs, returnType));
+    return relation(argTypes, List.of(), hasVarArgs, returnType);
+  }
+
+  /**
+   * Retrieves the generic relation type.
+   *
+   * @param argTypes      the list of argument type classes
+   * @param constArgTypes the list of constant argument type classes
+   * @param hasVarArgs    the flag indicating if the last argument of kind varargs
+   * @param returnType    the return type class
+   * @return the RelationType instance
+   */
+  public static RelationType relation(List<Class<? extends Type>> argTypes,
+                                      List<Class<? extends Type>> constArgTypes,
+                                      boolean hasVarArgs,
+                                      Class<? extends Type> returnType) {
+    var hashCode = Objects.hash(argTypes, constArgTypes, hasVarArgs, returnType);
+    return relationTypes.computeIfAbsent(hashCode, k ->
+        new RelationType(argTypes, constArgTypes, hasVarArgs, returnType));
   }
 
   /**
@@ -265,7 +342,7 @@ public abstract class Type {
    * @return the RelationType instance
    */
   public static RelationType relation(Class<? extends Type> returnType) {
-    return relation(List.of(), false, returnType);
+    return relation(List.of(), List.of(), false, returnType);
   }
 
   /**
@@ -291,7 +368,7 @@ public abstract class Type {
   public static RelationType relation(Class<? extends Type> firstArg,
                                       Class<? extends Type> secondArg,
                                       Class<? extends Type> returnType) {
-    return relation(List.of(firstArg, secondArg), false, returnType);
+    return relation(List.of(firstArg, secondArg), List.of(), false, returnType);
   }
 
   private static final HashMap<Integer, ConcreteRelationType> concreteRelationTypes =
@@ -403,6 +480,7 @@ public abstract class Type {
   /// These are all the builtin types that exist in the language.
   /// Some of them cannot be initialized like them since they require a size, like `SInt<16>`
   /// which is why they are named bases.
-  public static final Set<String> builtinTypeBases =
-      Set.of("Bool", "String", "Bits", "UInt", "SInt", "Instruction", "FetchResult");
+  public static final Set<String> builtinTypeBases = Set.of(
+      "Bool", "String", "Bits", "UInt", "SInt", "Instruction", "FetchResult"
+  );
 }

--- a/vadl/main/vadl/utils/functionInterfaces/QuadConsumer.java
+++ b/vadl/main/vadl/utils/functionInterfaces/QuadConsumer.java
@@ -1,0 +1,51 @@
+package vadl.utils.functionInterfaces;
+
+import java.util.Objects;
+
+/**
+ * Represents an operation that accepts four input arguments and returns no result.
+ * This is the four-arity specialization of {@code Consumer}.
+ * Unlike most other functional interfaces, {@code QuadConsumer} is expected
+ * to operate via side effects.
+ *
+ * @param <T> the type of the first argument to the operation
+ * @param <U> the type of the second argument to the operation
+ * @param <V> the type of the third argument to the operation
+ * @param <W> the type of the fourth argument to the operation
+ * @see java.util.function.Consumer
+ * @see java.util.function.BiConsumer
+ */
+@FunctionalInterface
+public interface QuadConsumer<T, U, V, W> {
+
+  /**
+   * Performs this operation on the given arguments.
+   *
+   * @param t the first input argument
+   * @param u the second input argument
+   * @param v the third input argument
+   * @param w the fourth input argument
+   */
+  void accept(T t, U u, V v, W w);
+
+  /**
+   * Returns a composed {@code QuadConsumer} that performs, in sequence, this
+   * operation followed by the {@code after} operation. If performing either
+   * operation throws an exception, it is relayed to the caller of the
+   * composed operation. If performing this operation throws an exception,
+   * the {@code after} operation will not be performed.
+   *
+   * @param after the operation to perform after this operation
+   * @return a composed {@code QuadConsumer} that performs in sequence this
+   *     operation followed by the {@code after} operation
+   * @throws NullPointerException if {@code after} is null
+   */
+  default QuadConsumer<T, U, V, W> andThen(
+      QuadConsumer<? super T, ? super U, ? super V, ? super W> after) {
+    Objects.requireNonNull(after);
+    return (t, u, v, w) -> {
+      accept(t, u, v, w);
+      after.accept(t, u, v, w);
+    };
+  }
+}

--- a/vadl/main/vadl/viam/Constant.java
+++ b/vadl/main/vadl/viam/Constant.java
@@ -16,6 +16,7 @@
 
 package vadl.viam;
 
+import static java.util.Objects.requireNonNull;
 import static vadl.error.Diagnostic.warning;
 import static vadl.types.BuiltInTable.BUILTIN_RESULT;
 import static vadl.types.BuiltInTable.BUILTIN_STATUS;
@@ -42,6 +43,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.jetbrains.annotations.Contract;
 import vadl.error.DeferredDiagnosticStore;
 import vadl.types.BitsType;
@@ -443,7 +445,7 @@ public abstract class Constant {
             .multiply(b.integer()); // multiply with other value
 
         var newType = Type.constructDataType(divType.getClass(), 2 * divType.bitWidth());
-        Objects.requireNonNull(newType);
+        requireNonNull(newType);
 
         return fromInteger(newValue, newType);
       } else {
@@ -467,7 +469,7 @@ public abstract class Constant {
       var divType = signed
           ? Type.signedInt(type().bitWidth())
           : Type.unsignedInt(type().bitWidth());
-      Objects.requireNonNull(divType);
+      requireNonNull(divType);
 
       var a = this.trivialCastTo(divType);
       var b = other.trivialCastTo(divType);
@@ -510,7 +512,7 @@ public abstract class Constant {
       var divType = signed
           ? Type.signedInt(type().bitWidth())
           : Type.unsignedInt(type().bitWidth());
-      Objects.requireNonNull(divType);
+      requireNonNull(divType);
 
       var a = this.trivialCastTo(divType);
       var b = other.trivialCastTo(divType);
@@ -1412,7 +1414,7 @@ public abstract class Constant {
      * @return The Constant value at the specified name.
      */
     public Constant get(String name) {
-      return Objects.requireNonNull(values.get(name),
+      return requireNonNull(values.get(name),
           "Struct does not contain a value with name %s".formatted(name));
     }
 
@@ -1548,6 +1550,82 @@ public abstract class Constant {
         return get(OVERFLOW, Value.class);
       }
 
+    }
+  }
+
+  /**
+   * Represents a constant float-type.
+   *
+   * <p>It stores a reference to the {@link FloatFormat}.
+   */
+  public static class FloatType extends Constant {
+
+    @Nullable
+    private final FloatFormat format;
+
+    private final Integer size;
+    private final String name;
+
+    /**
+     * Constructs a float-type constant from a float format definition.
+     *
+     * @param format The float format definition.
+     */
+    public FloatType(FloatFormat format) {
+      super(Type.floatType());
+      this.format = format;
+      // the type-checker checks that float-type definitions have a size, and thus an encoding
+      this.size = requireNonNull(format.encoding()).size;
+      this.name = format.simpleName();
+    }
+
+    /**
+     * Constructs a dummy float-type constant from a float format encoding size. This is used by
+     * the type checker when the float format definition is not yet available.
+     *
+     * @param size The float format encoding size, i.e. the bit-size of the float type.
+     * @param name The name of the float format.
+     */
+    public FloatType(int size, String name) {
+      super(Type.floatType());
+      this.format = null;
+      this.size = size;
+      this.name = name;
+    }
+
+    @Nullable
+    public FloatFormat format() {
+      return format;
+    }
+
+    public Integer size() {
+      return size;
+    }
+
+    @Override
+    public java.lang.String toString() {
+      return name + ": " + type().toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      if (!super.equals(o)) {
+        return false;
+      }
+      FloatType floatType = (FloatType) o;
+      return Objects.equals(format, floatType.format) && Objects.equals(size,
+          floatType.size) && Objects.equals(name, floatType.name);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(super.hashCode(), format, size, name);
     }
   }
 

--- a/vadl/main/vadl/viam/DefinitionVisitor.java
+++ b/vadl/main/vadl/viam/DefinitionVisitor.java
@@ -44,6 +44,8 @@ public interface DefinitionVisitor {
 
   void visit(Group group);
 
+  void visit(FloatFormat floatFormat);
+
   void visit(Format format);
 
   void visit(Format.Field formatField);
@@ -138,6 +140,7 @@ public interface DefinitionVisitor {
       isa.ownMemories().forEach(e -> e.accept(this));
       isa.artificialResources().forEach(e -> e.accept(this));
       isa.ownInstructions().forEach(e -> e.accept(this));
+      isa.ownFloatFormats().forEach(e -> e.accept(this));
       isa.ownPseudoInstructions().forEach(e -> e.accept(this));
       var pc = isa.pc();
       if (pc != null) {
@@ -196,6 +199,12 @@ public interface DefinitionVisitor {
     public void visit(Group group) {
       beforeTraversal(group);
       afterTraversal(group);
+    }
+
+    @Override
+    public void visit(FloatFormat floatFormat) {
+      beforeTraversal(floatFormat);
+      afterTraversal(floatFormat);
     }
 
     @Override
@@ -480,6 +489,11 @@ public interface DefinitionVisitor {
 
     @Override
     public void visit(Group group) {
+
+    }
+
+    @Override
+    public void visit(FloatFormat floatFormat) {
 
     }
 

--- a/vadl/main/vadl/viam/FloatExceptionFlag.java
+++ b/vadl/main/vadl/viam/FloatExceptionFlag.java
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText : © 2026 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.viam;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+/**
+ * Enum representing float exception flags.
+ *
+ * <p>The supported flags are:
+ * <ul>
+ *    <li>INVALID</li>
+ *    <li>DIV_BY_ZERO</li>
+ *    <li>OVERFLOW</li>
+ *    <li>UNDERFLOW</li>
+ *    <li>INEXACT</li>
+ * </ul>
+ */
+public enum FloatExceptionFlag {
+  INVALID("invalid", 0),
+  DIV_BY_ZERO("div_by_zero", 1),
+  OVERFLOW("overflow", 2),
+  UNDERFLOW("underflow", 3),
+  INEXACT("inexact", 4);
+
+  public final String name;
+
+  /**
+   * See softfloat-types.h
+   */
+  public final int qemuFlagOffset;
+
+  FloatExceptionFlag(String name, int qemuFlagOffset) {
+    this.name = name;
+    this.qemuFlagOffset = qemuFlagOffset;
+  }
+
+  public static Optional<FloatExceptionFlag> from(String name) {
+    return Arrays.stream(values()).filter(f -> f.name.equals(name)).findFirst();
+  }
+}

--- a/vadl/main/vadl/viam/FloatFormat.java
+++ b/vadl/main/vadl/viam/FloatFormat.java
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText : © 2026 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.viam;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nullable;
+import vadl.types.Type;
+
+/**
+ * Describes a float format. This covers bit-size, encoding and interpretation.
+ */
+public class FloatFormat extends Definition implements DefProp.WithType {
+
+  /**
+   * Represents all supported float encodings.
+   */
+  public enum Encoding {
+    IEEE32(32, true),
+    IEEE64(64, true);
+
+    public final int size;
+    public final boolean ieee;
+
+    Encoding(int size, boolean ieee) {
+      this.size = size;
+      this.ieee = ieee;
+    }
+
+    /**
+     * Returns the IEEE encoding for the given bit-size.
+     */
+    public static @Nullable Encoding ieee(int size) {
+      return switch (size) {
+        case 32 -> IEEE32;
+        case 64 -> IEEE64;
+        default -> null;
+      };
+    }
+  }
+
+  @Nullable
+  private Encoding encoding = null;
+
+  public FloatFormat(Identifier identifier) {
+    super(identifier);
+  }
+
+  public void setEncoding(@CheckForNull Encoding encoding) {
+    this.encoding = encoding;
+  }
+
+  /**
+   * The encoding of the float format.
+   */
+  @Nullable
+  public Encoding encoding() {
+    return encoding;
+  }
+
+  /**
+   * The name of the float format in lower case.
+   */
+  public String nameLower() {
+    return simpleName().toLowerCase();
+  }
+
+  @Override
+  public Type type() {
+    return Type.floatType();
+  }
+
+  @Override
+  public void accept(DefinitionVisitor visitor) {
+    visitor.visit(this);
+  }
+
+  @Override
+  public void verify() {
+    super.verify();
+    // FIXME: for now this is checked here, but this should create a diagnostic instead of ViamError
+    ensure(encoding != null, "Encoding not specified");
+  }
+
+  @Override
+  public String toString() {
+    return identifier.simpleName();
+  }
+}

--- a/vadl/main/vadl/viam/FloatFormat.java
+++ b/vadl/main/vadl/viam/FloatFormat.java
@@ -91,8 +91,7 @@ public class FloatFormat extends Definition implements DefProp.WithType {
   @Override
   public void verify() {
     super.verify();
-    // FIXME: for now this is checked here, but this should create a diagnostic instead of ViamError
-    ensure(encoding != null, "Encoding not specified");
+    ensure(encoding != null, "Encoding missing");
   }
 
   @Override

--- a/vadl/main/vadl/viam/InstructionSetArchitecture.java
+++ b/vadl/main/vadl/viam/InstructionSetArchitecture.java
@@ -34,6 +34,7 @@ public class InstructionSetArchitecture extends Definition {
   @Nullable
   private final Counter pc;
 
+  private final List<FloatFormat> floatFormats;
   private final List<Format> formats;
   private final List<Function> functions;
   private final List<Operation> operations;
@@ -72,6 +73,7 @@ public class InstructionSetArchitecture extends Definition {
                                     @Nullable Counter pc,
                                     List<Memory> memories,
                                     List<ArtificialResource> artificialResources,
+                                    List<FloatFormat> floatFormats,
                                     @Nullable Group group
   ) {
     super(identifier);
@@ -87,6 +89,7 @@ public class InstructionSetArchitecture extends Definition {
     this.pc = pc;
     this.memories = memories;
     this.artificialResources = artificialResources;
+    this.floatFormats = floatFormats;
     this.group = group;
 
     // set parent architecture of instructions
@@ -170,6 +173,14 @@ public class InstructionSetArchitecture extends Definition {
     return registers;
   }
 
+
+  /**
+   * Returns the {@link FloatFormat}s <b>owned</b> by this ISA.
+   * So it might not include definitions accessible through the super ISA.
+   */
+  public List<FloatFormat> ownFloatFormats() {
+    return floatFormats;
+  }
 
   /**
    * Returns the {@link Format}s <b>owned</b> by this ISA.

--- a/vadl/main/vadl/viam/annotations/FloatFlagAnnotation.java
+++ b/vadl/main/vadl/viam/annotations/FloatFlagAnnotation.java
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText : © 2026 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.viam.annotations;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
+import vadl.viam.Annotation;
+import vadl.viam.FloatExceptionFlag;
+import vadl.viam.RegisterTensor;
+
+/**
+ * Annotation for registers that store float exception flags.
+ *
+ * <p>Maps each bit index of the register to either a {@link FloatExceptionFlag}, which
+ * can be either sticky or non-sticky, or {@code null}.
+ */
+public class FloatFlagAnnotation extends Annotation<RegisterTensor> {
+
+  private final Map<Integer, FloatExceptionFlag> sticky = new HashMap<>();
+  private final Map<Integer, FloatExceptionFlag> nonSticky = new HashMap<>();
+
+  @Override
+  public Class<RegisterTensor> parentDefinitionClass() {
+    return RegisterTensor.class;
+  }
+
+  public boolean isSticky(int index) {
+    return sticky.containsKey(index);
+  }
+
+  @Nullable
+  public FloatExceptionFlag get(int index) {
+    return isSticky(index) ? sticky.get(index) : nonSticky.get(index);
+  }
+
+  public void set(int index, boolean isSticky, FloatExceptionFlag flag) {
+    (isSticky ? sticky : nonSticky).put(index, flag);
+  }
+
+  public Map<Integer, FloatExceptionFlag> stickyFlags() {
+    return sticky;
+  }
+
+  public Map<Integer, FloatExceptionFlag> nonStickyFlags() {
+    return nonSticky;
+  }
+
+}

--- a/vadl/main/vadl/viam/graph/dependency/BuiltInCall.java
+++ b/vadl/main/vadl/viam/graph/dependency/BuiltInCall.java
@@ -23,6 +23,7 @@ import vadl.javaannotations.viam.DataValue;
 import vadl.types.BuiltInTable;
 import vadl.types.BuiltInTable.BuiltIn;
 import vadl.types.Type;
+import vadl.viam.Constant;
 import vadl.viam.graph.Canonicalizable;
 import vadl.viam.graph.GraphNodeVisitor;
 import vadl.viam.graph.Node;
@@ -40,9 +41,19 @@ public class BuiltInCall extends AbstractFunctionCallNode implements Canonicaliz
   @DataValue
   protected BuiltIn builtIn;
 
-  public BuiltInCall(BuiltIn builtIn, NodeList<ExpressionNode> args, Type type) {
+  @DataValue
+  protected List<Constant> constArgs;
+
+  @SuppressWarnings("checkstyle:MissingJavadocMethod")
+  public BuiltInCall(BuiltIn builtIn, List<Constant> constArgs,
+                     NodeList<ExpressionNode> args, Type type) {
     super(args, type);
     this.builtIn = builtIn;
+    this.constArgs = constArgs;
+  }
+
+  public BuiltInCall(BuiltIn builtIn, NodeList<ExpressionNode> args, Type type) {
+    this(builtIn, List.of(), args, type);
   }
 
   /**
@@ -78,6 +89,17 @@ public class BuiltInCall extends AbstractFunctionCallNode implements Canonicaliz
     return this.builtIn;
   }
 
+  /**
+   * Gets the constant args, i.e. the args in the pointy brackets {@code <...>}.
+   */
+  public List<Constant> constArgs() {
+    return constArgs;
+  }
+
+  public void setConstArgs(List<Constant> constArgs) {
+    this.constArgs = constArgs;
+  }
+
   public ExpressionNode arg(int index) {
     return args.get(index);
   }
@@ -96,7 +118,7 @@ public class BuiltInCall extends AbstractFunctionCallNode implements Canonicaliz
           .toList();
 
       return builtIn
-          .compute(args)
+          .compute(constArgs, args)
           .map(e -> (Node) new ConstantNode(e))
           .orElse(this);
     }
@@ -130,11 +152,11 @@ public class BuiltInCall extends AbstractFunctionCallNode implements Canonicaliz
         "Number of arguments must match, %s vs %s", argTypeClasses.size(), this.arguments().size());
 
     var actualArgTypes = this.arguments().stream().map(ExpressionNode::type).toList();
-    ensure(builtIn.takes(actualArgTypes),
-        "Arguments' types do not match with the type of the builtin. Args: %s",
-        actualArgTypes);
+    ensure(builtIn.takes(constArgs, actualArgTypes),
+        "Arguments' types do not match with the type of the builtin. Const args: %s, Args: %s",
+        constArgs, actualArgTypes);
 
-    var builtInResultType = builtIn.returns(actualArgTypes);
+    var builtInResultType = builtIn.returns(constArgs, actualArgTypes);
     ensure(builtInResultType.isTrivialCastTo(this.type()),
         "BuiltIns' result type does not match node's type. %s vs %s", builtInResultType, this.type()
     );
@@ -143,13 +165,14 @@ public class BuiltInCall extends AbstractFunctionCallNode implements Canonicaliz
   @Override
   public ExpressionNode copy() {
     return new BuiltInCall(builtIn,
+        constArgs.stream().toList(),
         new NodeList<>(this.arguments().stream().map(x -> (ExpressionNode) x.copy()).toList()),
         this.type());
   }
 
   @Override
   public Node shallowCopy() {
-    return new BuiltInCall(builtIn, args, type());
+    return new BuiltInCall(builtIn, constArgs, args, type());
   }
 
 
@@ -157,6 +180,7 @@ public class BuiltInCall extends AbstractFunctionCallNode implements Canonicaliz
   protected void collectData(List<Object> collection) {
     super.collectData(collection);
     collection.add(builtIn);
+    collection.add(constArgs);
   }
 
   @Override
@@ -169,6 +193,16 @@ public class BuiltInCall extends AbstractFunctionCallNode implements Canonicaliz
       sb.append(")");
     } else {
       sb.append(builtIn.name());
+      if (!constArgs.isEmpty()) {
+        sb.append("::<");
+        for (int i = 0; i < constArgs.size(); i++) {
+          if (i > 0) {
+            sb.append(", ");
+          }
+          sb.append(constArgs.get(i).toString());
+        }
+        sb.append(">");
+      }
       sb.append("(");
 
       for (int i = 0; i < args.size(); i++) {

--- a/vadl/test/vadl/iss/passes/IssTensorAssignmentToForallPassTest.java
+++ b/vadl/test/vadl/iss/passes/IssTensorAssignmentToForallPassTest.java
@@ -176,6 +176,7 @@ public class IssTensorAssignmentToForallPassTest extends AbstractTest {
         null,
         Collections.emptyList(),
         Collections.emptyList(),
+        Collections.emptyList(),
         null
     ));
 

--- a/vadl/test/vadl/viam/ViamSnapshotDumper.java
+++ b/vadl/test/vadl/viam/ViamSnapshotDumper.java
@@ -189,6 +189,17 @@ public class ViamSnapshotDumper extends DefinitionVisitor.Empty {
     }
 
     @Override
+    public void visit(FloatFormat floatFormat) {
+      lineAt(atIndent, "Type: %s".formatted(compactType(floatFormat.type())));
+      var encoding = floatFormat.encoding();
+      lineAt(atIndent, "Encoding: %s".formatted(
+          encoding == null
+              ? "-"
+              : "%s(%s)".formatted(encoding.name(), encoding.size)
+      ));
+    }
+
+    @Override
     public void visit(Format.Field field) {
       lineAt(atIndent, "Type: %s".formatted(compactType(field.type())));
       lineAt(atIndent, "BitSlice: %s".formatted(field.bitSlice()));

--- a/vadl/test/vadl/viam/passes/constant_propagation/CanonicalizationPassTest.java
+++ b/vadl/test/vadl/viam/passes/constant_propagation/CanonicalizationPassTest.java
@@ -95,6 +95,7 @@ class CanonicalizationPassTest extends AbstractTest {
         null,
         Collections.emptyList(),
         Collections.emptyList(),
+        Collections.emptyList(),
         null
     );
 


### PR DESCRIPTION
- Adds float-type definition
- Adds annotation `[ IEEE : <size> ]` for float-type
- Adds annotation `[ [sticky] fe flag <flag-name> : <format-field> ]` for registers
- Adds new syntax for SymbolExpr: `id::path::<const params>(params)`
- Adds new VIAM nodes and built-in types
  - FloatFormat node
  - Constant.FloatType
  - VIAM annotation for float exception flags
  - The built-in type FloatType, which is the type of FloatFormat
- Adds constant-param-based type inference and checking for built-ins