### PR TITLE
lcb: Inline instructions assembly functions

### DIFF
--- a/vadl/main/vadl/gcb/passes/assembly/AssemblyFunctionInlinerPass.java
+++ b/vadl/main/vadl/gcb/passes/assembly/AssemblyFunctionInlinerPass.java
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText : © 2026 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.gcb.passes.assembly;
+
+import java.io.IOException;
+import java.util.List;
+import javax.annotation.Nullable;
+import vadl.configuration.GeneralConfiguration;
+import vadl.pass.Pass;
+import vadl.pass.PassName;
+import vadl.pass.PassResults;
+import vadl.viam.InstructionSetArchitecture;
+import vadl.viam.Specification;
+import vadl.viam.passes.functionInliner.Inliner;
+
+/**
+ * Inlines function calls inside every instruction's and pseudo instruction's
+ * {@code assembly} definition.
+ */
+public class AssemblyFunctionInlinerPass extends Pass {
+
+  public AssemblyFunctionInlinerPass(GeneralConfiguration configuration) {
+    super(configuration);
+  }
+
+  @Override
+  public PassName getName() {
+    return new PassName("AssemblyFunctionInlinerPass");
+  }
+
+  @Nullable
+  @Override
+  public Object execute(PassResults passResults, Specification viam) throws IOException {
+    viam.isa().map(InstructionSetArchitecture::ownInstructions).orElse(List.of())
+        .forEach(instruction -> Inliner.inlineFuncs(instruction.assembly().function().behavior()));
+
+    viam.isa().map(InstructionSetArchitecture::ownPseudoInstructions).orElse(List.of())
+        .forEach(instruction -> Inliner.inlineFuncs(instruction.assembly().function().behavior()));
+
+    return null;
+  }
+}

--- a/vadl/main/vadl/lcb/codegen/assembly/AssemblyInstructionPrinterCodeGenerator.java
+++ b/vadl/main/vadl/lcb/codegen/assembly/AssemblyInstructionPrinterCodeGenerator.java
@@ -24,7 +24,6 @@ import vadl.lcb.passes.llvmLowering.tablegen.model.tableGenOperand.ReferencesImm
 import vadl.pass.PassResults;
 import vadl.viam.PrintableInstruction;
 import vadl.viam.graph.control.ReturnNode;
-import vadl.viam.passes.functionInliner.Inliner;
 
 /**
  * Wrapper class for the visitor.
@@ -41,12 +40,12 @@ public class AssemblyInstructionPrinterCodeGenerator {
     // There are two cases
     // The first case is that all immediates are really immediates.
     // And the second case is that the immediate is actually a label.
-    final var immediates = tableGenInstruction.getInOperands().stream()
+    var immediates = tableGenInstruction.getInOperands().stream()
         .filter(x -> x instanceof ReferencesImmediateOperand
             || x instanceof GcbInstructionBareSymbolOperand)
         .toList();
 
-    final var isImm = immediates.stream().map(x -> String.format("MI->getOperand(%s).isImm()",
+    var isImm = immediates.stream().map(x -> String.format("MI->getOperand(%s).isImm()",
             tableGenInstruction.getInOperands().indexOf(x) + tableGenInstruction.getOutOperands()
                 .size()))
         .collect(Collectors.joining(" && "));
@@ -56,10 +55,8 @@ public class AssemblyInstructionPrinterCodeGenerator {
     var handler2 =
         new AssemblyInstructionPrinterLabelHandler(passResults, instruction, tableGenInstruction);
 
-    var assemblyBehavior = instruction.assembly().function().behavior();
-    Inliner.inlineFuncs(assemblyBehavior);
-
-    var returnNodes = assemblyBehavior.getNodes(ReturnNode.class).toList();
+    var returnNodes =
+        instruction.assembly().function().behavior().getNodes(ReturnNode.class).toList();
     var returnNode = returnNodes.getFirst();
 
     AssemblyInstructionPrinterImmediateHandlerDispatcher.dispatch(handler, handler.ctx(),

--- a/vadl/main/vadl/lcb/codegen/assembly/AssemblyInstructionPrinterCodeGenerator.java
+++ b/vadl/main/vadl/lcb/codegen/assembly/AssemblyInstructionPrinterCodeGenerator.java
@@ -56,10 +56,10 @@ public class AssemblyInstructionPrinterCodeGenerator {
     var handler2 =
         new AssemblyInstructionPrinterLabelHandler(passResults, instruction, tableGenInstruction);
 
-    var assemblyBehaviorCopy = instruction.assembly().function().behavior().copy();
-    Inliner.inlineFuncs(assemblyBehaviorCopy);
+    var assemblyBehavior = instruction.assembly().function().behavior();
+    Inliner.inlineFuncs(assemblyBehavior);
 
-    var returnNodes = assemblyBehaviorCopy.getNodes(ReturnNode.class).toList();
+    var returnNodes = assemblyBehavior.getNodes(ReturnNode.class).toList();
     var returnNode = returnNodes.getFirst();
 
     AssemblyInstructionPrinterImmediateHandlerDispatcher.dispatch(handler, handler.ctx(),

--- a/vadl/main/vadl/lcb/codegen/assembly/AssemblyInstructionPrinterCodeGenerator.java
+++ b/vadl/main/vadl/lcb/codegen/assembly/AssemblyInstructionPrinterCodeGenerator.java
@@ -24,6 +24,7 @@ import vadl.lcb.passes.llvmLowering.tablegen.model.tableGenOperand.ReferencesImm
 import vadl.pass.PassResults;
 import vadl.viam.PrintableInstruction;
 import vadl.viam.graph.control.ReturnNode;
+import vadl.viam.passes.functionInliner.Inliner;
 
 /**
  * Wrapper class for the visitor.
@@ -40,12 +41,12 @@ public class AssemblyInstructionPrinterCodeGenerator {
     // There are two cases
     // The first case is that all immediates are really immediates.
     // And the second case is that the immediate is actually a label.
-    var immediates = tableGenInstruction.getInOperands().stream()
+    final var immediates = tableGenInstruction.getInOperands().stream()
         .filter(x -> x instanceof ReferencesImmediateOperand
             || x instanceof GcbInstructionBareSymbolOperand)
         .toList();
 
-    var isImm = immediates.stream().map(x -> String.format("MI->getOperand(%s).isImm()",
+    final var isImm = immediates.stream().map(x -> String.format("MI->getOperand(%s).isImm()",
             tableGenInstruction.getInOperands().indexOf(x) + tableGenInstruction.getOutOperands()
                 .size()))
         .collect(Collectors.joining(" && "));
@@ -55,8 +56,10 @@ public class AssemblyInstructionPrinterCodeGenerator {
     var handler2 =
         new AssemblyInstructionPrinterLabelHandler(passResults, instruction, tableGenInstruction);
 
-    var returnNodes =
-        instruction.assembly().function().behavior().getNodes(ReturnNode.class).toList();
+    var assemblyBehaviorCopy = instruction.assembly().function().behavior().copy();
+    Inliner.inlineFuncs(assemblyBehaviorCopy);
+
+    var returnNodes = assemblyBehaviorCopy.getNodes(ReturnNode.class).toList();
     var returnNode = returnNodes.getFirst();
 
     AssemblyInstructionPrinterImmediateHandlerDispatcher.dispatch(handler, handler.ctx(),

--- a/vadl/main/vadl/pass/order/GcbPassOrder.java
+++ b/vadl/main/vadl/pass/order/GcbPassOrder.java
@@ -29,6 +29,7 @@ import vadl.gcb.passes.InstructionPatternPruningPass;
 import vadl.gcb.passes.PredicateFunctionInlinerPass;
 import vadl.gcb.passes.SetMissingConfigurationValuesPass;
 import vadl.gcb.passes.assembly.AssemblyConcatBuiltinMergingPass;
+import vadl.gcb.passes.assembly.AssemblyFunctionInlinerPass;
 import vadl.gcb.passes.encodingGeneration.GenerateFieldAccessEncodingAndPredicateFunctionsPass;
 import vadl.gcb.passes.operands.GenerateInstructionOperandsPass;
 import vadl.pass.PassOrder;
@@ -59,6 +60,7 @@ public final class GcbPassOrder {
     order.add(new GenerateValueRangeImmediatePass(configuration));
     order.add(new GenerateFieldAccessEncodingAndPredicateFunctionsPass(configuration));
     order.add(new PredicateFunctionInlinerPass(configuration));
+    order.add(new AssemblyFunctionInlinerPass(configuration));
     order.add(new AssemblyConcatBuiltinMergingPass(configuration));
     order.add(new DetermineRegisterUsesAndDefsPass(configuration));
     order.add(new GenerateInstructionOperandsPass(configuration));


### PR DESCRIPTION
This PR introduces a new pass in the GCB pipeline, which inlines assembly functions of instructions. The inlining of assembly-behaviours was removed in https://github.com/OpenVADL/openvadl/issues/1022 and caused problems in the assembly-parser-generator.

~This PR fixes the generation of the LLVM instruction assembly printer. Functions defined in VADL and used in the assembly-definition of an instruction were not inlined correctly anymore, which caused "undefined reference" errors while compiling the generated compiler.~
~This is a regression introduced in https://github.com/OpenVADL/openvadl/issues/1022.~