### PR TITLE
lsp/frontend: Fix Model SourceLocation

### DIFF
--- a/vadl-frontend/main/vadl/ast/MacroExpander.java
+++ b/vadl-frontend/main/vadl/ast/MacroExpander.java
@@ -157,6 +157,7 @@ import vadl.ast.nodes.SymbolExpr;
 import vadl.ast.nodes.TemplateParam;
 import vadl.ast.nodes.TypeLiteral;
 import vadl.ast.nodes.TypedFormatField;
+import vadl.ast.nodes.UnOp;
 import vadl.ast.nodes.UnaryExpr;
 import vadl.ast.nodes.UsingDefinition;
 import vadl.ast.nodes.WildcardLiteral;
@@ -316,12 +317,14 @@ class MacroExpander
         for (var entry : recordInstance.entries) {
           entries.add(expandNode(entry));
         }
-        yield new RecordInstance(recordInstance.type, entries, recordInstance.sourceLocation);
+        yield new RecordInstance(recordInstance.type, entries,
+            copyLoc(recordInstance.sourceLocation));
       }
       case EncodingDefinition.EncsNode encs -> expandEncs(encs);
       case PlaceholderNode placeholderNode -> expand(placeholderNode);
       case MacroInstanceNode macroInstanceNode -> expand(macroInstanceNode);
       case MacroMatchNode macroMatchNode -> expand(macroMatchNode);
+      case UnOp unOp -> new UnOp(unOp.operator, copyLoc(unOp.location));
       case null, default -> node;
     };
   }
@@ -1066,8 +1069,8 @@ class MacroExpander
   public Definition visit(ProcessDefinition processDefinition) {
     var templateParams = new ArrayList<TemplateParam>(processDefinition.templateParams.size());
     for (var templateParam : processDefinition.templateParams) {
-      templateParams.add(new TemplateParam(templateParam.identifier(),
-          templateParam.type,
+      templateParams.add(new TemplateParam(expandExpr(templateParam.identifier()),
+          expandExpr(templateParam.type),
           templateParam.value == null ? null : expandExpr(templateParam.value)));
     }
 
@@ -1128,7 +1131,7 @@ class MacroExpander
   public Definition visit(SpecialPurposeRegisterDefinition definition) {
     return new SpecialPurposeRegisterDefinition(
         definition.purpose,
-        definition.exprs,
+        expandExprs(definition.exprs),
         copyLoc(definition.loc)
     );
   }
@@ -1281,12 +1284,12 @@ class MacroExpander
   @Override
   public Definition visit(AsmDescriptionDefinition definition) {
     return new AsmDescriptionDefinition(
-        definition.id,
-        definition.abi,
-        definition.modifiers,
-        definition.directives,
-        definition.rules,
-        definition.commonDefinitions,
+        expandExpr(definition.id),
+        expandExpr(definition.abi),
+        expandDefinitions(definition.modifiers),
+        expandDefinitions(definition.directives),
+        expandDefinitions(definition.rules),
+        expandDefinitions(definition.commonDefinitions),
         copyLoc(definition.loc)
     );
   }
@@ -1729,14 +1732,14 @@ class MacroExpander
   private List<Parameter> expandParams(List<Parameter> params) {
     var expandedParams = new ArrayList<>(params);
     expandedParams.replaceAll(param ->
-        new Parameter(param.identifier(), expandExpr(param.typeLiteral)));
+        new Parameter(expandExpr(param.identifier()), expandExpr(param.typeLiteral)));
     return expandedParams;
   }
 
   private List<StageOutputDefinition> expandStageOutputs(List<StageOutputDefinition> outputs) {
     var expanded = new ArrayList<>(outputs);
     expanded.replaceAll(param ->
-        new StageOutputDefinition(param.identifier(), expandExpr(param.typeLiteral)));
+        new StageOutputDefinition(expandExpr(param.identifier()), expandExpr(param.typeLiteral)));
     return expanded;
   }
 

--- a/vadl-frontend/main/vadl/ast/MacroExpander.java
+++ b/vadl-frontend/main/vadl/ast/MacroExpander.java
@@ -46,6 +46,7 @@ import vadl.ast.nodes.AsmModifierDefinition;
 import vadl.ast.nodes.AssemblyDefinition;
 import vadl.ast.nodes.AssignmentStatement;
 import vadl.ast.nodes.BasicSyntaxType;
+import vadl.ast.nodes.BinOp;
 import vadl.ast.nodes.BinaryExpr;
 import vadl.ast.nodes.BinaryLiteral;
 import vadl.ast.nodes.BlockStatement;
@@ -324,6 +325,7 @@ class MacroExpander
       case PlaceholderNode placeholderNode -> expand(placeholderNode);
       case MacroInstanceNode macroInstanceNode -> expand(macroInstanceNode);
       case MacroMatchNode macroMatchNode -> expand(macroMatchNode);
+      case BinOp binOp -> new BinOp(binOp.operator, copyLoc(binOp.location));
       case UnOp unOp -> new UnOp(unOp.operator, copyLoc(unOp.location));
       case null, default -> node;
     };

--- a/vadl-frontend/test/resources/frontend-snapshots/typechecker/divisionByZeroErrorWithModels.vadl
+++ b/vadl-frontend/test/resources/frontend-snapshots/typechecker/divisionByZeroErrorWithModels.vadl
@@ -1,0 +1,24 @@
+// Before #1052 this code reported a wrong source location.
+model abc() : Ex = { 0 }
+
+model xyz(): Defs = {
+  constant flo = (5 + $abc) / $abc
+}
+
+$xyz()
+
+
+//  Reported Diagnostics:
+//
+//  error: Constant value required
+//       ╭── test/resources/frontend-snapshots/typechecker/divisionByZeroErrorWithModels.vadl:5:19
+//       │
+//     5 │   constant flo = (5 + $abc) / $abc
+//       │                   ^^^^^^^^^^^^^^^^ Division by zero cannot be computed.
+//       │
+//       ├─ From this model invocation (outermost call first):
+//       │       test/resources/frontend-snapshots/typechecker/divisionByZeroErrorWithModels.vadl:8:1
+//       │
+//
+//
+// Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl-frontend/test/vadl/ast/FrontendSnapshotTests.java
+++ b/vadl-frontend/test/vadl/ast/FrontendSnapshotTests.java
@@ -38,7 +38,7 @@ import vadl.viam.Specification;
 import vadl.viam.ViamSnapshotDumper;
 import vadl.viam.passes.verification.ViamVerifier;
 
-/// Runs all files in the test/resources/frontend/snapshots directory.
+/// Runs all files in the test/resources/frontend-snapshots directory.
 /// The files are fed into the compilation pipeline and the thrown diagnostics are stored.
 /// Then the original file is read again and compared if it reported the same diagnostics.
 ///
@@ -50,7 +50,7 @@ import vadl.viam.passes.verification.ViamVerifier;
 /// large block at the bottom and the convention is to include them at the top. Here are some
 /// examples:
 /// - `INCLUDE-AST-DUMP` will also insert the whole AST dump
-/// - `INCLUDE-PRETTY-PRINT` will also insert the a pretty printed AST (in it all macros are
+/// - `INCLUDE-PRETTY-PRINT` will also insert a pretty printed AST (in it all macros are
 /// expanded)
 /// - `INCLUDE-VIAM-DUMP` will also insert the whole VIAM dump
 public class FrontendSnapshotTests {

--- a/vadl-lsp/main/vadl/lsp/AstFinderByPosition.java
+++ b/vadl-lsp/main/vadl/lsp/AstFinderByPosition.java
@@ -88,6 +88,23 @@ public abstract class AstFinderByPosition<N extends Node> extends RecursiveAstVi
       } catch (NullPointerException e) {
         return false;
       }
+
+      // Ignore TypedNodes that may be part of a Model Definition (and thus their Type may depend
+      // on one particular Model Invocation)
+      // - i.e. they have an ExpandedLocation and their primary location is not fully contained
+      //   within the outermost invocation's location.
+      if (n.location() instanceof SourceLocation.ExpandedLocation(
+          SourceLocation.DirectLocation primaryLocation,
+          vadl.utils.RopeList<SourceLocation.DirectLocation> expandedFrom
+        )
+      ) {
+        var outerLocation = expandedFrom.toList().getLast();
+        if (!primaryLocation.begin().isWithin(outerLocation)
+            || !primaryLocation.end().isWithin(outerLocation)) {
+          return false;
+        }
+      }
+
       return true;
     });
     return visitor.find();

--- a/vadl/main/vadl/utils/SourceLocation.java
+++ b/vadl/main/vadl/utils/SourceLocation.java
@@ -192,10 +192,6 @@ public sealed interface SourceLocation extends WithLocation, Comparable<SourceLo
     }
 
     // All minSize outer layers are the same for both locations; let's return them
-    if (!Objects.equals(thisStack.get(minSize - 1).path(), otherStack.get(minSize - 1).path())) {
-      throw new IllegalArgumentException("Cannot join source locations from different files.");
-    }
-
     return thisStack.size() < otherStack.size() ? this : other;
   }
 

--- a/vadl/main/vadl/utils/SourceLocation.java
+++ b/vadl/main/vadl/utils/SourceLocation.java
@@ -161,47 +161,42 @@ public sealed interface SourceLocation extends WithLocation, Comparable<SourceLo
           thisExpandedLoc.expandedFrom);
     }
 
-    // The expansion stacks differ, let's find a shared substack or use the innermost invocation.
+    // The expansion stacks differ, let's find a shared substack (starting at the outermost
+    // invocation).
     // NOTE: If this regularly happens, investigate it further to provide better help.
     var thisStack = this.fullExpandedFromStack().reversed();
     var otherStack = other.fullExpandedFromStack().reversed();
 
-    var firstLocation = thisStack.getLast();
-    var secondLocation = otherStack.getLast();
-
     int minSize = Math.min(thisStack.size(), otherStack.size());
-    for (int i = 0; i <= minSize; i++) {
-      if (i == minSize) {
-        // Reached end: use last of smaller, next of larger
-        if (thisStack.size() < otherStack.size()) {
-          secondLocation = otherStack.get(i);
-        } else if (thisStack.size() > otherStack.size()) {
-          firstLocation = thisStack.get(i);
-        }
-        break;
-      }
-
+    for (int i = 0; i < minSize; i++) {
       if (!thisStack.get(i).equals(otherStack.get(i))) {
-        firstLocation = thisStack.get(i);
-        secondLocation = otherStack.get(i);
-        thisStack = thisStack.subList(i, thisStack.size());
-        otherStack = otherStack.subList(i, otherStack.size());
-        break;
+        // After checking i layers of model invocations (starting at outermost), finally the
+        // locations diverge - stop here and join for new primaryLocation, keeping all previous
+        // layers as expandedFrom
+        var firstLocation = thisStack.get(i);
+        var secondLocation = otherStack.get(i);
+        var expandedFrom = thisStack.subList(0, i).reversed();
+
+        if (!Objects.equals(firstLocation.path(), secondLocation.path())) {
+          throw new IllegalArgumentException("Cannot join source locations from different files.");
+        }
+
+        var begin =
+            firstLocation.begin().compareTo(secondLocation.begin()) < 0 ? firstLocation.begin() :
+                secondLocation.begin();
+        var end = firstLocation.end().compareTo(secondLocation.end()) > 0 ? firstLocation.end() :
+            secondLocation.end();
+
+        return SourceLocation.of(firstLocation.path(), begin, end, expandedFrom);
       }
     }
 
-    if (!Objects.equals(firstLocation.path(), secondLocation.path())) {
+    // All minSize outer layers are the same for both locations; let's return them
+    if (!Objects.equals(thisStack.get(minSize - 1).path(), otherStack.get(minSize - 1).path())) {
       throw new IllegalArgumentException("Cannot join source locations from different files.");
     }
 
-    var begin =
-        firstLocation.begin().compareTo(secondLocation.begin()) < 0 ? firstLocation.begin() :
-            secondLocation.begin();
-    var end = firstLocation.end().compareTo(secondLocation.end()) > 0 ? firstLocation.end() :
-        secondLocation.end();
-    var expanedFrom = Objects.equals(thisStack, otherStack) ? thisStack : null;
-
-    return SourceLocation.of(firstLocation.path(), begin, end, expanedFrom);
+    return thisStack.size() < otherStack.size() ? this : other;
   }
 
   /**

--- a/vadl/test/vadl/utils/SourceLocationTest.java
+++ b/vadl/test/vadl/utils/SourceLocationTest.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -91,5 +92,91 @@ public class SourceLocationTest {
     SourceLocation location = new SourceLocation.DirectLocation(miniVadlPath, new SourceLocation.Position(1, 5));
     assertThat(location.toUriString(), startsWith("file:/"));
     assertThat(location.toUriString(), endsWith("mini.vadl:1:5 .. 1:5"));
+  }
+
+  @Test
+  public void testJoin_DirectLocations() {
+    var resultStart = new SourceLocation.Position(1, 5);
+    var resultEnd = new SourceLocation.Position(4, 2);
+
+    var locationA = new SourceLocation.DirectLocation(miniVadlPath,
+        resultStart, new SourceLocation.Position(2, 3));
+    var locationB = new SourceLocation.DirectLocation(miniVadlPath,
+        new SourceLocation.Position(4, 1), resultEnd);
+
+    var result1 = locationA.join(locationB);
+    var result2 = locationB.join(locationA);
+
+    assertEquals(new SourceLocation.DirectLocation(miniVadlPath, resultStart, resultEnd), result1);
+    assertEquals(result1, result2, "join() should be commutative");
+  }
+
+  @Test
+  public void testJoin_DirectAndExpandedLocation() {
+    var resultStart = new SourceLocation.Position(2, 1);
+    var resultEnd = new SourceLocation.Position(10, 3);
+
+    var locationA = new SourceLocation.DirectLocation(miniVadlPath,
+        resultStart, new SourceLocation.Position(2, 3));
+    var locationB = SourceLocation.of(miniVadlPath,
+        // This primary location should be ignored
+        new SourceLocation.Position(44, 33), new SourceLocation.Position(111, 222),
+        List.of(new SourceLocation.DirectLocation(miniVadlPath,
+            new SourceLocation.Position(4, 1), resultEnd)));
+
+    var result1 = locationA.join(locationB);
+    var result2 = locationB.join(locationA);
+
+    assertEquals(new SourceLocation.DirectLocation(miniVadlPath, resultStart, resultEnd), result1);
+    assertEquals(result1, result2, "join() should be commutative");
+  }
+
+  @Test
+  public void testJoin_ExpandedLocationsWithSameExpandedFrom() {
+    var expandedFrom = List.of(
+        new SourceLocation.DirectLocation(miniVadlPath,
+            new SourceLocation.Position(30, 1), new SourceLocation.Position(30, 12)),
+        new SourceLocation.DirectLocation(miniVadlPath,
+            new SourceLocation.Position(20, 4), new SourceLocation.Position(20, 15))
+    );
+    var resultStart = new SourceLocation.Position(2, 1);
+    var resultEnd = new SourceLocation.Position(10, 3);
+
+    var locationA = SourceLocation.of(miniVadlPath,
+        resultStart, new SourceLocation.Position(2, 3),
+        expandedFrom);
+    var locationB = SourceLocation.of(miniVadlPath,
+        new SourceLocation.Position(10, 1), resultEnd,
+        expandedFrom);
+
+    var result1 = locationA.join(locationB);
+    var result2 = locationB.join(locationA);
+
+    assertEquals(SourceLocation.of(miniVadlPath, resultStart, resultEnd, expandedFrom), result1);
+    assertEquals(result1, result2, "join() should be commutative");
+  }
+
+  @Test
+  public void testJoin_ExpandedLocationsWithDifferentExpandedFrom() {
+    var resultStart = new SourceLocation.Position(2, 1);
+    var resultEnd = new SourceLocation.Position(20, 15);
+    var expandedFrom1 = new SourceLocation.DirectLocation(miniVadlPath,
+        new SourceLocation.Position(30, 1), new SourceLocation.Position(30, 12));
+    var expandedFrom2 = new SourceLocation.DirectLocation(miniVadlPath,
+        new SourceLocation.Position(20, 4), resultEnd);
+
+    var locationA = SourceLocation.of(miniVadlPath,
+        resultStart, new SourceLocation.Position(2, 3),
+        List.of(expandedFrom1));
+    var locationB = SourceLocation.of(miniVadlPath,
+        // This primary location should be ignored
+        new SourceLocation.Position(10, 1), new SourceLocation.Position(10, 3),
+        List.of(expandedFrom2, expandedFrom1));
+
+    var result1 = locationA.join(locationB);
+    var result2 = locationB.join(locationA);
+
+    assertEquals(SourceLocation.of(miniVadlPath, resultStart, resultEnd, List.of(expandedFrom1)), result1);
+    assertEquals(result1, result2, "join() should be commutative");
   }
 }

--- a/vadl/test/vadl/utils/SourceLocationTest.java
+++ b/vadl/test/vadl/utils/SourceLocationTest.java
@@ -100,14 +100,21 @@ public class SourceLocationTest {
     var resultEnd = new SourceLocation.Position(4, 2);
 
     var locationA = new SourceLocation.DirectLocation(miniVadlPath,
-        resultStart, new SourceLocation.Position(2, 3));
+        resultStart,
+        new SourceLocation.Position(2, 3)
+    );
     var locationB = new SourceLocation.DirectLocation(miniVadlPath,
-        new SourceLocation.Position(4, 1), resultEnd);
+        new SourceLocation.Position(4, 1),
+        resultEnd
+    );
 
     var result1 = locationA.join(locationB);
     var result2 = locationB.join(locationA);
 
-    assertEquals(new SourceLocation.DirectLocation(miniVadlPath, resultStart, resultEnd), result1);
+    assertEquals(
+        new SourceLocation.DirectLocation(miniVadlPath, resultStart, resultEnd),
+        result1
+    );
     assertEquals(result1, result2, "join() should be commutative");
   }
 
@@ -117,17 +124,26 @@ public class SourceLocationTest {
     var resultEnd = new SourceLocation.Position(10, 3);
 
     var locationA = new SourceLocation.DirectLocation(miniVadlPath,
-        resultStart, new SourceLocation.Position(2, 3));
+        resultStart,
+        new SourceLocation.Position(2, 3)
+    );
     var locationB = SourceLocation.of(miniVadlPath,
         // This primary location should be ignored
-        new SourceLocation.Position(44, 33), new SourceLocation.Position(111, 222),
+        new SourceLocation.Position(44, 33),
+        new SourceLocation.Position(111, 222),
+
         List.of(new SourceLocation.DirectLocation(miniVadlPath,
-            new SourceLocation.Position(4, 1), resultEnd)));
+            new SourceLocation.Position(4, 1), resultEnd)
+        )
+    );
 
     var result1 = locationA.join(locationB);
     var result2 = locationB.join(locationA);
 
-    assertEquals(new SourceLocation.DirectLocation(miniVadlPath, resultStart, resultEnd), result1);
+    assertEquals(
+        new SourceLocation.DirectLocation(miniVadlPath, resultStart, resultEnd),
+        result1
+    );
     assertEquals(result1, result2, "join() should be commutative");
   }
 
@@ -135,24 +151,35 @@ public class SourceLocationTest {
   public void testJoin_ExpandedLocationsWithSameExpandedFrom() {
     var expandedFrom = List.of(
         new SourceLocation.DirectLocation(miniVadlPath,
-            new SourceLocation.Position(30, 1), new SourceLocation.Position(30, 12)),
+            new SourceLocation.Position(30, 1),
+            new SourceLocation.Position(30, 12)
+        ),
         new SourceLocation.DirectLocation(miniVadlPath,
-            new SourceLocation.Position(20, 4), new SourceLocation.Position(20, 15))
+            new SourceLocation.Position(20, 4),
+            new SourceLocation.Position(20, 15)
+        )
     );
     var resultStart = new SourceLocation.Position(2, 1);
     var resultEnd = new SourceLocation.Position(10, 3);
 
     var locationA = SourceLocation.of(miniVadlPath,
-        resultStart, new SourceLocation.Position(2, 3),
-        expandedFrom);
+        resultStart,
+        new SourceLocation.Position(2, 3),
+        expandedFrom
+    );
     var locationB = SourceLocation.of(miniVadlPath,
-        new SourceLocation.Position(10, 1), resultEnd,
-        expandedFrom);
+        new SourceLocation.Position(10, 1),
+        resultEnd,
+        expandedFrom
+    );
 
     var result1 = locationA.join(locationB);
     var result2 = locationB.join(locationA);
 
-    assertEquals(SourceLocation.of(miniVadlPath, resultStart, resultEnd, expandedFrom), result1);
+    assertEquals(
+        SourceLocation.of(miniVadlPath, resultStart, resultEnd, expandedFrom),
+        result1
+    );
     assertEquals(result1, result2, "join() should be commutative");
   }
 
@@ -160,23 +187,36 @@ public class SourceLocationTest {
   public void testJoin_ExpandedLocationsWithDifferentExpandedFrom() {
     var resultStart = new SourceLocation.Position(2, 1);
     var resultEnd = new SourceLocation.Position(20, 15);
+
     var expandedFrom1 = new SourceLocation.DirectLocation(miniVadlPath,
-        new SourceLocation.Position(30, 1), new SourceLocation.Position(30, 12));
+        new SourceLocation.Position(30, 1),
+        new SourceLocation.Position(30, 12)
+    );
     var expandedFrom2 = new SourceLocation.DirectLocation(miniVadlPath,
-        new SourceLocation.Position(20, 4), resultEnd);
+        new SourceLocation.Position(20, 4),
+        resultEnd
+    );
 
     var locationA = SourceLocation.of(miniVadlPath,
-        resultStart, new SourceLocation.Position(2, 3),
-        List.of(expandedFrom1));
+        resultStart,
+        new SourceLocation.Position(2, 3),
+        List.of(expandedFrom1)
+    );
     var locationB = SourceLocation.of(miniVadlPath,
         // This primary location should be ignored
-        new SourceLocation.Position(10, 1), new SourceLocation.Position(10, 3),
-        List.of(expandedFrom2, expandedFrom1));
+        new SourceLocation.Position(10, 1),
+        new SourceLocation.Position(10, 3),
+
+        List.of(expandedFrom2, expandedFrom1)
+    );
 
     var result1 = locationA.join(locationB);
     var result2 = locationB.join(locationA);
 
-    assertEquals(SourceLocation.of(miniVadlPath, resultStart, resultEnd, List.of(expandedFrom1)), result1);
+    assertEquals(
+        SourceLocation.of(miniVadlPath, resultStart, resultEnd, List.of(expandedFrom1)),
+        result1
+    );
     assertEquals(result1, result2, "join() should be commutative");
   }
 }


### PR DESCRIPTION
This attempts to fix various bogus hover data provided by the language server; by doing two things:
- Ignoring entities situated inside model definitions, as we cannot know if their type is only valid for one particular model invocation.
- Have proper `ExpandedLocation` data for all entities that a model invocation has been expanded to. This is the only way to tell that an entity is connected to a model invocation.

I had to fix `SourceLocation.join()` and the `MacroExpander` - I do not know if my changes cause issues elsewhere.

For testing it's best to use VSCode as lsp client, as it properly highlights the area that is being hovered on - in IntelliJ I see no such indication.

Some examples where the behavior change is apparent (all in `rv3264im.vadl`):
- line 73: `$zero45` no longer has hover
- line 231 & 511: no longer have hover that spans from model definition to model invocation
- also on line 231: `addr` still has hover showing a type that is provided by the model (CTRL-Click on it, you'll see what I mean)
- on line 20, change to `Arch64` -> lines 250-280 no longer trigger a hover ranging over the entire model invocation