### PR TITLE
frontend: Add float built-ins

### DIFF
--- a/docs/refman/refmanual.md
+++ b/docs/refman/refmanual.md
@@ -437,6 +437,147 @@ function cto( a : Bits<N> ) -> UInt<N> // counting trailing ones
 
 \endlisting
 
+## Float Operations
+
+Listing \r{basic_float_operations} lists built-in float operations. They must be parametrized with
+float type(s), which define the float format to operate with. Listing \r{lst_float_type} shows how this
+can be done to convert between different float formats and from float to integer.
+
+### IEEE Float Type
+
+Currently only the IEEE-754-2019 formats `binary32` and `binary64` are supported. The semantics of all
+built-ins which use these formats, are as defined by the standard.
+
+If the result of an operations is `NaN`, it is always a canonical `qNaN`, except for min/max operations,
+which behave according to IEEE's `minimumNumber` and `maximumNumber` operations.
+
+When an operand of any float operation is a `sNaN`, it sets the invalid flag. `flt` and `fle` perform
+signaling comparisons, meaning they also set the invalid flag when an operand is any `NaN`, not just `sNaN`.
+In the future, this will be configurable.
+
+\listing{lst_float_type, VADL Float Type Definitions and Usage}
+
+~~~{.vadl}
+[ IEEE : 32 ]
+float-type binary32
+[ IEEE : 64 ]
+float-type binary64
+ 
+instruction set architecture test = {
+register X : Bits<32>   // 32-bit integer register
+
+register F32 : Bits<32> // 32-bit float register
+register F64 : Bits<64> // 64-bit float register
+ 
+format F : Bits<8> = {opcode : Bits<8>}
+instruction instr1 : F =
+    F32 := VADL::fcvt::<binary64, binary32>(F64, 0b000) // 64-bit float to 32-bit flaot conversion
+instruction instr2 : F =
+    X := VADL::fcvtfs::<binary32, 32>(F32, 0b000)       // 32-bit float to 32-bit signed int conversion
+}
+~~~
+
+\endlisting
+
+### Float Exception Flags
+
+Listing \r{lst_float_exception_flags} shows how to store float exception flags in registers. All built-ins
+which produce float exceptions write to the flags in the marked registers.
+
+Each flag can be stored in sticky (accrued) and non-sticky form. Sticky means, that the flags stays set and
+will not be unset by float operations. Each flag (sticky and non-sticky) can only be stored once.
+
+|    flag     |                                                                                             |
+|:-----------:|:--------------------------------------------------------------------------------------------|
+|   invalid   | Invalid operation, e.g. sqrt of a negative number, returns qNaN                             |
+| div_by_zero | Operation on finite operands with exact infinite result, e.g. 1/0 or log(0)                 |
+|  overflow   | Finite result is too large, returns +/- infinity                                            |
+|  underflow  | Finite result is denormal and inexact                                                       |
+|   inexact   | Unrounded result cannot be represented exactly, returns rounded result                      |
+
+\listing{lst_float_exception_flags, VADL Float Exception Flags}
+
+~~~{.vadl}
+instruction set architecture test = {
+
+[        fe flag invalid     : nv2 ]
+[ sticky fe flag invalid     : nv ]
+[ sticky fe flag div_by_zero : dz ]
+[ sticky fe flag overflow    : of ]
+[ sticky fe flag underflow   : uf ]
+[ sticky fe flag inexact     : nx ]
+register FEFlags : F
+
+format F : Bits<8> =
+  { dummy    [7..6]
+  , nv2      [5]
+  , nv       [4]
+  , dz       [3]
+  , of       [2]
+  , uf       [1]
+  , nx       [0]
+  }
+}
+~~~
+
+\endlisting
+
+### Rounding Modes
+
+|              mode              | value |
+|:------------------------------:|:-----:|
+| Round to nearest, ties to even | 0b000 |
+|            Round up            | 0b001 |
+|           Round down           | 0b010 |
+|         Round to zero          | 0b011 |
+| Round to nearest, ties to away | 0b100 |
+
+\listing{basic_float_operations, VADL Float Operations}
+
+~~~{.vadl}
+// arithmetic
+function fsqrt::< t : FloatType >( a : Bits<t.size>, rm : Bits<3> ) -> Bits<t.size>
+function fadd::< t : FloatType >( a : Bits<t.size>, b : Bits<t.size>, rm : Bits<3> ) -> Bits<t.size>
+function fsub::< t : FloatType >( a : Bits<t.size>, b : Bits<t.size>, rm : Bits<3> ) -> Bits<t.size>
+function fmul::< t : FloatType >( a : Bits<t.size>, b : Bits<t.size>, rm : Bits<3> ) -> Bits<t.size>
+function fdiv::< t : FloatType >( a : Bits<t.size>, b : Bits<t.size>, rm : Bits<3> ) -> Bits<t.size>
+
+// fused multiply-add operations
+// (a * b) + c
+function fmadd ::< t : FloatType >( a : Bits<t.size>, b : Bits<t.size>, c : Bits<t.size>, rm : Bits<3> ) -> Bits<t.size>
+// (a * b) - c
+function fmsub ::< t : FloatType >( a : Bits<t.size>, b : Bits<t.size>, c : Bits<t.size>, rm : Bits<3> ) -> Bits<t.size>
+// -(a * b) - c
+function fnmadd::< t : FloatType >( a : Bits<t.size>, b : Bits<t.size>, c : Bits<t.size>, rm : Bits<3> ) -> Bits<t.size>
+// -(a * b) + c
+function fnmsub::< t : FloatType >( a : Bits<t.size>, b : Bits<t.size>, c : Bits<t.size>, rm : Bits<3> ) -> Bits<t.size>
+
+function fmin::< t : FloatType >( a : Bits<t.size>, b : Bits<t.size> ) -> Bits<t.size>
+function fmax::< t : FloatType >( a : Bits<t.size>, b : Bits<t.size> ) -> Bits<t.size>
+
+// comparison
+function flt::< t : FloatType >( a : Bits<t.size>, b : Bits<t.size> ) -> Bool // a < b
+function fle::< t : FloatType >( a : Bits<t.size>, b : Bits<t.size> ) -> Bool // a <= b
+function feq::< t : FloatType >( a : Bits<t.size>, b : Bits<t.size> ) -> Bool // a == b
+
+// conversion
+function fcvt::< t : FloatType, u : FloatType >( a : Bits<t.size>, rm : Bits<3> ) -> Bits<u.type>
+function fcvtfs::< t : FloatType, s : UInt >( a : Bits<t.size>, rm : Bits<3> ) -> SInt<s>
+function fcvtfu::< t : FloatType, s : UInt >( a : Bits<t.size>, rm : Bits<3> ) -> UInt<s>
+function fcvtsf::< t : FloatType >( a : SInt<N>, rm : Bits<3> ) -> Bits<t.size>
+function fcvtuf::< t : FloatType >( a : UInt<N>, rm : Bits<3> ) -> Bits<t.size>
+
+// classification
+function fisinf   ::< t : FloatType >( a : Bits<t.size> ) -> Bool // a is +/- inf
+function fiszero  ::< t : FloatType >( a : Bits<t.size> ) -> Bool // a == 0
+function fisneg   ::< t : FloatType >( a : Bits<t.size> ) -> Bool // sign-bit of a is set
+function fisdenorm::< t : FloatType >( a : Bits<t.size> ) -> Bool // a is denormal
+function fissnan  ::< t : FloatType >( a : Bits<t.size> ) -> Bool // a is sNaN
+function fisqnan  ::< t : FloatType >( a : Bits<t.size> ) -> Bool // a is qNaN
+~~~
+
+\endlisting
+
 ## Assembly Directives
 
 \lbl{table_assembly_directives}

--- a/vadl/main/vadl/iss/passes/common/IssNormalizationPass.java
+++ b/vadl/main/vadl/iss/passes/common/IssNormalizationPass.java
@@ -811,6 +811,131 @@ class IssNormalizer implements VadlBuiltInNoStatusDispatcher<BuiltInCall> {
   }
 
   @Override
+  public void handleFSQRT(BuiltInCall input) {
+    // do nothing (float ops are done by helper function, which handle everything)
+  }
+
+  @Override
+  public void handleFADD(BuiltInCall input) {
+    // do nothing (float ops are done by helper function, which handle everything)
+  }
+
+  @Override
+  public void handleFSUB(BuiltInCall input) {
+    // do nothing (float ops are done by helper function, which handle everything)
+  }
+
+  @Override
+  public void handleFMUL(BuiltInCall input) {
+    // do nothing (float ops are done by helper function, which handle everything)
+  }
+
+  @Override
+  public void handleFDIV(BuiltInCall input) {
+    // do nothing (float ops are done by helper function, which handle everything)
+  }
+
+  @Override
+  public void handleFMADD(BuiltInCall input) {
+    // do nothing (float ops are done by helper function, which handle everything)
+  }
+
+  @Override
+  public void handleFMSUB(BuiltInCall input) {
+    // do nothing (float ops are done by helper function, which handle everything)
+  }
+
+  @Override
+  public void handleFNMADD(BuiltInCall input) {
+    // do nothing (float ops are done by helper function, which handle everything)
+  }
+
+  @Override
+  public void handleFNMSUB(BuiltInCall input) {
+    // do nothing (float ops are done by helper function, which handle everything)
+  }
+
+  @Override
+  public void handleFMIN(BuiltInCall input) {
+    // do nothing (float ops are done by helper function, which handle everything)
+  }
+
+  @Override
+  public void handleFMAX(BuiltInCall input) {
+    // do nothing (float ops are done by helper function, which handle everything)
+  }
+
+  @Override
+  public void handleFLT(BuiltInCall input) {
+    // do nothing (float ops are done by helper function, which handle everything)
+  }
+
+  @Override
+  public void handleFLE(BuiltInCall input) {
+    // do nothing (float ops are done by helper function, which handle everything)
+  }
+
+  @Override
+  public void handleFEQ(BuiltInCall input) {
+    // do nothing (float ops are done by helper function, which handle everything)
+  }
+
+  @Override
+  public void handleFCVT(BuiltInCall input) {
+    // do nothing (float ops are done by helper function, which handle everything)
+  }
+
+  @Override
+  public void handleFCVTFS(BuiltInCall input) {
+    // do nothing (float ops are done by helper function, which handle everything)
+  }
+
+  @Override
+  public void handleFCVTFU(BuiltInCall input) {
+    // do nothing (float ops are done by helper function, which handle everything)
+  }
+
+  @Override
+  public void handleFCVTSF(BuiltInCall input) {
+    // do nothing (float ops are done by helper function, which handle everything)
+  }
+
+  @Override
+  public void handleFCVTUF(BuiltInCall input) {
+    // do nothing (float ops are done by helper function, which handle everything)
+  }
+
+  @Override
+  public void handleFISINF(BuiltInCall input) {
+    // do nothing (float ops are done by helper function, which handle everything)
+  }
+
+  @Override
+  public void handleFISZERO(BuiltInCall input) {
+    // do nothing (float ops are done by helper function, which handle everything)
+  }
+
+  @Override
+  public void handleFISNEG(BuiltInCall input) {
+    // do nothing (float ops are done by helper function, which handle everything)
+  }
+
+  @Override
+  public void handleFISDENORM(BuiltInCall input) {
+    // do nothing (float ops are done by helper function, which handle everything)
+  }
+
+  @Override
+  public void handleFISSNAN(BuiltInCall input) {
+    // do nothing (float ops are done by helper function, which handle everything)
+  }
+
+  @Override
+  public void handleFISQNAN(BuiltInCall input) {
+    // do nothing (float ops are done by helper function, which handle everything)
+  }
+
+  @Override
   public void handleConcat(BuiltInCall input) {
     // do nothing (result is already fine)
   }

--- a/vadl/main/vadl/types/BuiltInTable.java
+++ b/vadl/main/vadl/types/BuiltInTable.java
@@ -1040,6 +1040,317 @@ public class BuiltInTable {
           .build();
 
 
+  ///// FLOAT ARITHMETIC //////
+
+  /**
+   * {@code function fsqrt::< t : FloatType >( a : Bits<t.size>, rm : Bits<3> ) -> Bits<t.size> }
+   */
+  public static final BuiltIn FSQRT =
+      func("VADL::fsqrt",
+          Type.relation(List.of(BitsType.class, BitsType.class),
+              List.of(FloatType.class), BitsType.class))
+          .takesFloatArgsAndFrm(1)
+          .returnsFirstFloatType()
+          .build();
+
+  /**
+   * {@code function fadd::< t : FloatType >( a : Bits<t.size>, b : Bits<t.size>, rm : Bits<3> ) ->
+   *   Bits<t.size> }
+   */
+  public static final BuiltIn FADD =
+      func("VADL::fadd",
+          Type.relation(List.of(BitsType.class, BitsType.class, BitsType.class),
+              List.of(FloatType.class), BitsType.class))
+          .takesFloatArgsAndFrm(2)
+          .returnsFirstFloatType()
+          .build();
+
+  /**
+   * {@code function fadds::< t : FloatType >( a : Bits<t.size>, b : Bits<t.size>, rm : Bits<3> ) ->
+   *   ( Bits<t.size>, FloatStatus ) }
+   */
+  public static final BuiltIn FADDS =
+      func("VADL::fadds",
+          Type.relation(List.of(BitsType.class, BitsType.class, BitsType.class),
+              List.of(FloatType.class), StructType.class))
+          .takesFloatArgsAndFrm(2)
+          // TODO: returns function
+          .returnsFirstFloatType()
+          .build();
+
+  /**
+   * {@code function fsub::< t : FloatType >( a : Bits<t.size>, b : Bits<t.size>, rm : Bits<3> ) ->
+   *   Bits<t.size> }
+   */
+  public static final BuiltIn FSUB =
+      func("VADL::fsub",
+          Type.relation(List.of(BitsType.class, BitsType.class, BitsType.class),
+              List.of(FloatType.class), BitsType.class))
+          .takesFloatArgsAndFrm(2)
+          .returnsFirstFloatType()
+          .build();
+
+  /**
+   * {@code function fmul::< t : FloatType >( a : Bits<t.size>, b : Bits<t.size>, rm : Bits<3> ) ->
+   *   Bits<t.size> }
+   */
+  public static final BuiltIn FMUL =
+      func("VADL::fmul",
+          Type.relation(List.of(BitsType.class, BitsType.class, BitsType.class),
+              List.of(FloatType.class), BitsType.class))
+          .takesFloatArgsAndFrm(2)
+          .returnsFirstFloatType()
+          .build();
+
+  /**
+   * {@code function fdiv::< t : FloatType >( a : Bits<t.size>, b : Bits<t.size>, rm : Bits<3> ) ->
+   *   Bits<t.size> }
+   */
+  public static final BuiltIn FDIV =
+      func("VADL::fdiv",
+          Type.relation(List.of(BitsType.class, BitsType.class, BitsType.class),
+              List.of(FloatType.class), BitsType.class))
+          .takesFloatArgsAndFrm(2)
+          .returnsFirstFloatType()
+          .build();
+
+  /**
+   * {@code function fmadd::< t : FloatType >( a : Bits<t.size>, b : Bits<t.size>, c : Bits<t.size>,
+   * rm : Bits<3> ) -> Bits<t.size> }
+   */
+  public static final BuiltIn FMADD =
+      func("VADL::fmadd",
+          Type.relation(List.of(
+              BitsType.class, BitsType.class, BitsType.class, BitsType.class),
+              List.of(FloatType.class), BitsType.class))
+          .takesFloatArgsAndFrm(3)
+          .returnsFirstFloatType()
+          .build();
+
+  /**
+   * {@code function fmsub::< t : FloatType >( a : Bits<t.size>, b : Bits<t.size>, c : Bits<t.size>,
+   * rm : Bits<3> ) -> Bits<t.size> }
+   */
+  public static final BuiltIn FMSUB =
+      func("VADL::fmsub",
+          Type.relation(List.of(
+              BitsType.class, BitsType.class, BitsType.class, BitsType.class),
+              List.of(FloatType.class), BitsType.class))
+          .takesFloatArgsAndFrm(3)
+          .returnsFirstFloatType()
+          .build();
+
+  /**
+   * {@code function fnmadd::< t : FloatType >( a : Bits<t.size>, b : Bits<t.size>,
+   * c : Bits<t.size>, rm : Bits<3> ) -> Bits<t.size> }
+   */
+  public static final BuiltIn FNMADD =
+      func("VADL::fnmadd",
+          Type.relation(List.of(
+              BitsType.class, BitsType.class, BitsType.class, BitsType.class),
+              List.of(FloatType.class), BitsType.class))
+          .takesFloatArgsAndFrm(3)
+          .returnsFirstFloatType()
+          .build();
+
+  /**
+   * {@code function fnmsub::< t : FloatType >( a : Bits<t.size>, b : Bits<t.size>,
+   * c : Bits<t.size>, rm : Bits<3> ) -> Bits<t.size> }
+   */
+  public static final BuiltIn FNMSUB =
+      func("VADL::fnmsub",
+          Type.relation(List.of(
+              BitsType.class, BitsType.class, BitsType.class, BitsType.class),
+              List.of(FloatType.class), BitsType.class))
+          .takesFloatArgsAndFrm(3)
+          .returnsFirstFloatType()
+          .build();
+
+  /**
+   * {@code function fmin::< t : FloatType >( a : Bits<t.size>, b : Bits<t.size> ) -> Bits<t.size> }
+   */
+  public static final BuiltIn FMIN =
+      func("VADL::fmin",
+          Type.relation(List.of(BitsType.class, BitsType.class),
+              List.of(FloatType.class), BitsType.class))
+          .takesFloatArgs(2)
+          .returnsFirstFloatType()
+          .build();
+
+  /**
+   * {@code function fmax::< t : FloatType >( a : Bits<t.size>, b : Bits<t.size> ) -> Bits<t.size> }
+   */
+  public static final BuiltIn FMAX =
+      func("VADL::fmax",
+          Type.relation(List.of(BitsType.class, BitsType.class),
+              List.of(FloatType.class), BitsType.class))
+          .takesFloatArgs(2)
+          .returnsFirstFloatType()
+          .build();
+
+  ///// FLOAT COMPARISON //////
+
+  /**
+   * {@code function flt::< t : FloatType >( a : Bits<t.size>, b : Bits<t.size> ) -> Bool }
+   */
+  public static final BuiltIn FLT =
+      func("VADL::flt",
+          Type.relation(List.of(BitsType.class, BitsType.class),
+              List.of(FloatType.class), BoolType.class))
+          .takesFloatArgs(2)
+          .returns(Type.bool())
+          .build();
+
+  /**
+   * {@code function fle::< t : FloatType >( a : Bits<t.size>, b : Bits<t.size> ) -> Bool }
+   */
+  public static final BuiltIn FLE =
+      func("VADL::fle",
+          Type.relation(List.of(BitsType.class, BitsType.class),
+              List.of(FloatType.class), BoolType.class))
+          .takesFloatArgs(2)
+          .returns(Type.bool())
+          .build();
+
+  /**
+   * {@code function feq::< t : FloatType >( a : Bits<t.size>, b : Bits<t.size> ) -> Bool }
+   */
+  public static final BuiltIn FEQ =
+      func("VADL::feq",
+          Type.relation(List.of(BitsType.class, BitsType.class),
+              List.of(FloatType.class), BoolType.class))
+          .takesFloatArgs(2)
+          .returns(Type.bool())
+          .build();
+
+  ///// FLOAT CONVERSION //////
+
+  /**
+   * Float to float conversion.
+   * {@code function fcvt::< t : FloatType, u : FloatType >( a : Bits<t.size>, rm : Bits<3> ) ->
+   *   Bits<u.type> }
+   */
+  public static final BuiltIn FCVT =
+      func("VADL::fcvt",
+          Type.relation(List.of(BitsType.class, BitsType.class),
+              List.of(FloatType.class, FloatType.class), BitsType.class))
+          .takesFloatArgsAndFrm(1)
+          .returnsSecondFloatType()
+          .build();
+
+  /**
+   * Float to signed int conversion.
+   * {@code function fcvtfs::< t : FloatType, s : UInt >( a : Bits<t.size>, rm : Bits<3> ) ->
+   *   SInt<s> }
+   */
+  public static final BuiltIn FCVTFS =
+      func("VADL::fcvtfs",
+          Type.relation(List.of(BitsType.class, BitsType.class),
+              List.of(FloatType.class, UIntType.class), SIntType.class))
+          .takesFloatArgsAndFrm(1)
+          .returnsFromSecondConstSize(SIntType.class)
+          .build();
+
+  /**
+   * Float to unsigned int conversion.
+   * {@code function fcvtfu::< t : FloatType, s : UInt >( a : Bits<t.size>, rm : Bits<3> ) ->
+   *   UInt<s> }
+   */
+  public static final BuiltIn FCVTFU =
+      func("VADL::fcvtfu",
+          Type.relation(List.of(BitsType.class, BitsType.class),
+              List.of(FloatType.class, UIntType.class), UIntType.class))
+          .takesFloatArgsAndFrm(1)
+          .returnsFromSecondConstSize(UIntType.class)
+          .build();
+
+  /**
+   * Signed int to float conversion.
+   * {@code function fcvtsf::< t : FloatType >( a : SInt<N>, rm : Bits<3> ) -> Bits<t.size> }
+   */
+  public static final BuiltIn FCVTSF =
+      func("VADL::fcvtsf",
+          Type.relation(List.of(SIntType.class, BitsType.class),
+              List.of(FloatType.class), BitsType.class))
+          .takesFrm(1)
+          .returnsFirstFloatType()
+          .build();
+
+  /**
+   * Unsigned int to float conversion.
+   * {@code function fcvtuf::< t : FloatType >( a : UInt<N>, rm : Bits<3> ) -> Bits<t.size> }
+   */
+  public static final BuiltIn FCVTUF =
+      func("VADL::fcvtuf",
+          Type.relation(List.of(UIntType.class, BitsType.class),
+              List.of(FloatType.class), BitsType.class))
+          .takesFrm(1)
+          .returnsFirstFloatType()
+          .build();
+
+  ///// FLOAT CLASSIFICATION //////
+
+  /**
+   * {@code function fisinf::< t : FloatType >( a : Bits<t.size> ) -> Bool }
+   */
+  public static final BuiltIn FISINF =
+      func("VADL::fisinf",
+          Type.relation(List.of(BitsType.class), List.of(FloatType.class), BoolType.class))
+          .takesFloatArgs(1)
+          .returns(Type.bool())
+          .build();
+
+  /**
+   * {@code function fiszero::< t : FloatType >( a : Bits<t.size> ) -> Bool }
+   */
+  public static final BuiltIn FISZERO =
+      func("VADL::fiszero",
+          Type.relation(List.of(BitsType.class), List.of(FloatType.class), BoolType.class))
+          .takesFloatArgs(1)
+          .returns(Type.bool())
+          .build();
+
+  /**
+   * {@code function fisneg::< t : FloatType >( a : Bits<t.size> ) -> Bool }
+   */
+  public static final BuiltIn FISNEG =
+      func("VADL::fisneg",
+          Type.relation(List.of(BitsType.class), List.of(FloatType.class), BoolType.class))
+          .takesFloatArgs(1)
+          .returns(Type.bool())
+          .build();
+
+  /**
+   * {@code function fisdenorm::< t : FloatType >( a : Bits<t.size> ) -> Bool }
+   */
+  public static final BuiltIn FISDENORM =
+      func("VADL::fisdenorm",
+          Type.relation(List.of(BitsType.class), List.of(FloatType.class), BoolType.class))
+          .takesFloatArgs(1)
+          .returns(Type.bool())
+          .build();
+
+  /**
+   * {@code function fissnan::< t : FloatType >( a : Bits<t.size> ) -> Bool }
+   */
+  public static final BuiltIn FISSNAN =
+      func("VADL::fissnan",
+          Type.relation(List.of(BitsType.class), List.of(FloatType.class), BoolType.class))
+          .takesFloatArgs(1)
+          .returns(Type.bool())
+          .build();
+
+  /**
+   * {@code function fisqnan::< t : FloatType >( a : Bits<t.size> ) -> Bool }
+   */
+  public static final BuiltIn FISQNAN =
+      func("VADL::fisqnan",
+          Type.relation(List.of(BitsType.class), List.of(FloatType.class), BoolType.class))
+          .takesFloatArgs(1)
+          .returns(Type.bool())
+          .build();
+
+
   ///// FUNCTIONS //////
 
   /**
@@ -1410,6 +1721,43 @@ public class BuiltInTable {
       CTO
   );
 
+  public static final List<BuiltIn> FLOAT_ARITHMETIC_BUILT_INS = List.of(
+      FSQRT,
+      FADD,
+      FSUB,
+      FMUL,
+      FDIV,
+      FMADD,
+      FMSUB,
+      FNMADD,
+      FNMSUB,
+      FMIN,
+      FMAX
+  );
+
+  public static final List<BuiltIn> FLOAT_COMPARISON_BUILT_INS = List.of(
+      FLT,
+      FLE,
+      FEQ
+  );
+
+  public static final List<BuiltIn> FLOAT_CONVERSION_BUILT_INS = List.of(
+      FCVT,
+      FCVTFS,
+      FCVTFU,
+      FCVTSF,
+      FCVTUF
+  );
+
+  public static final List<BuiltIn> FLOAT_CLASSIFICATION_BUILT_INS = List.of(
+      FISINF,
+      FISZERO,
+      FISNEG,
+      FISDENORM,
+      FISSNAN,
+      FISQNAN
+  );
+
   public static final List<BuiltIn> FUNCTION_BUILT_INS = List.of(
       MNEMONIC,
       CONCATENATE_STRINGS,
@@ -1440,12 +1788,20 @@ public class BuiltInTable {
       INSTRUCTION_WRITE
   );
 
+  public static final List<BuiltIn> FLOAT_BUILT_INS = Stream.of(
+      FLOAT_ARITHMETIC_BUILT_INS.stream(),
+      FLOAT_COMPARISON_BUILT_INS.stream(),
+      FLOAT_CONVERSION_BUILT_INS.stream(),
+      FLOAT_CLASSIFICATION_BUILT_INS.stream()
+  ).flatMap(s -> s).toList();
+
   public static final List<BuiltIn> BUILT_INS = Stream.of(
       ARITHMETIC_BUILT_INS.stream(),
       LOGICAL_BUILT_INS.stream(),
       COMPARISON_BUILT_INS.stream(),
       SHIFTING_BUILT_INS.stream(),
       BITWISE_COUNTING_BUILT_INS.stream(),
+      FLOAT_BUILT_INS.stream(),
       FUNCTION_BUILT_INS.stream(),
       ASM_PARSER_BUILT_INS_LIST.stream(),
       MICRO_ARCHITECTURE_BUILT_INS.stream()

--- a/vadl/main/vadl/utils/VadlBuiltInEmptyNoStatusDispatcher.java
+++ b/vadl/main/vadl/utils/VadlBuiltInEmptyNoStatusDispatcher.java
@@ -191,6 +191,106 @@ public interface VadlBuiltInEmptyNoStatusDispatcher<T> extends VadlBuiltInNoStat
   }
 
   @Override
+  default void handleFSQRT(T input) {
+  }
+
+  @Override
+  default void handleFADD(T input) {
+  }
+
+  @Override
+  default void handleFSUB(T input) {
+  }
+
+  @Override
+  default void handleFMUL(T input) {
+  }
+
+  @Override
+  default void handleFDIV(T input) {
+  }
+
+  @Override
+  default void handleFMADD(T input) {
+  }
+
+  @Override
+  default void handleFMSUB(T input) {
+  }
+
+  @Override
+  default void handleFNMADD(T input) {
+  }
+
+  @Override
+  default void handleFNMSUB(T input) {
+  }
+
+  @Override
+  default void handleFMIN(T input) {
+  }
+
+  @Override
+  default void handleFMAX(T input) {
+  }
+
+  @Override
+  default void handleFLT(T input) {
+  }
+
+  @Override
+  default void handleFLE(T input) {
+  }
+
+  @Override
+  default void handleFEQ(T input) {
+  }
+
+  @Override
+  default void handleFCVT(T input) {
+  }
+
+  @Override
+  default void handleFCVTFS(T input) {
+  }
+
+  @Override
+  default void handleFCVTFU(T input) {
+  }
+
+  @Override
+  default void handleFCVTSF(T input) {
+  }
+
+  @Override
+  default void handleFCVTUF(T input) {
+  }
+
+  @Override
+  default void handleFISINF(T input) {
+  }
+
+  @Override
+  default void handleFISZERO(T input) {
+  }
+
+  @Override
+  default void handleFISNEG(T input) {
+  }
+
+  @Override
+  default void handleFISDENORM(T input) {
+  }
+
+  @Override
+  default void handleFISSNAN(T input) {
+  }
+
+  @Override
+  default void handleFISQNAN(T input) {
+  }
+
+  @Override
   default void handleConcat(T input) {
   }
 }

--- a/vadl/main/vadl/utils/VadlBuiltInFloatStatusOnlyDispatcher.java
+++ b/vadl/main/vadl/utils/VadlBuiltInFloatStatusOnlyDispatcher.java
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.utils;
+
+import vadl.types.BuiltInTable;
+
+/**
+ * A dispatcher that handles all {@code VADL::F*S} built-ins.
+ */
+public interface VadlBuiltInFloatStatusOnlyDispatcher<T> {
+
+  /**
+   * Calls the correct handler for the given built-in and uses the input as argument.
+   *
+   * @param input   is passed to the handler method.
+   * @param builtIn to find the correct handler method.
+   * @return true if the handler was found and called, false otherwise.
+   */
+  default boolean dispatch(T input, BuiltInTable.BuiltIn builtIn) {
+    if (builtIn == BuiltInTable.FADDS) {
+      handleFADDS(input);
+    } else {
+      return false;
+    }
+    return true;
+  }
+
+  void handleFADDS(T input);
+
+
+}

--- a/vadl/main/vadl/utils/VadlBuiltInNoStatusDispatcher.java
+++ b/vadl/main/vadl/utils/VadlBuiltInNoStatusDispatcher.java
@@ -113,6 +113,56 @@ public interface VadlBuiltInNoStatusDispatcher<T> {
       handleCTZ(input);
     } else if (builtIn == BuiltInTable.CTO) {
       handleCTO(input);
+    } else if (builtIn == BuiltInTable.FSQRT) {
+      handleFSQRT(input);
+    } else if (builtIn == BuiltInTable.FADD) {
+      handleFADD(input);
+    } else if (builtIn == BuiltInTable.FSUB) {
+      handleFSUB(input);
+    } else if (builtIn == BuiltInTable.FMUL) {
+      handleFMUL(input);
+    } else if (builtIn == BuiltInTable.FDIV) {
+      handleFDIV(input);
+    } else if (builtIn == BuiltInTable.FMADD) {
+      handleFMADD(input);
+    } else if (builtIn == BuiltInTable.FMSUB) {
+      handleFMSUB(input);
+    } else if (builtIn == BuiltInTable.FNMADD) {
+      handleFNMADD(input);
+    } else if (builtIn == BuiltInTable.FNMSUB) {
+      handleFNMSUB(input);
+    } else if (builtIn == BuiltInTable.FMIN) {
+      handleFMIN(input);
+    } else if (builtIn == BuiltInTable.FMAX) {
+      handleFMAX(input);
+    } else if (builtIn == BuiltInTable.FLT) {
+      handleFLT(input);
+    } else if (builtIn == BuiltInTable.FLE) {
+      handleFLE(input);
+    } else if (builtIn == BuiltInTable.FEQ) {
+      handleFEQ(input);
+    } else if (builtIn == BuiltInTable.FCVT) {
+      handleFCVT(input);
+    } else if (builtIn == BuiltInTable.FCVTFS) {
+      handleFCVTFS(input);
+    } else if (builtIn == BuiltInTable.FCVTFU) {
+      handleFCVTFU(input);
+    } else if (builtIn == BuiltInTable.FCVTSF) {
+      handleFCVTSF(input);
+    } else if (builtIn == BuiltInTable.FCVTUF) {
+      handleFCVTUF(input);
+    } else if (builtIn == BuiltInTable.FISINF) {
+      handleFISINF(input);
+    } else if (builtIn == BuiltInTable.FISZERO) {
+      handleFISZERO(input);
+    } else if (builtIn == BuiltInTable.FISNEG) {
+      handleFISNEG(input);
+    } else if (builtIn == BuiltInTable.FISDENORM) {
+      handleFISDENORM(input);
+    } else if (builtIn == BuiltInTable.FISSNAN) {
+      handleFISSNAN(input);
+    } else if (builtIn == BuiltInTable.FISQNAN) {
+      handleFISQNAN(input);
     } else if (builtIn == BuiltInTable.CONCATENATE_BITS) {
       handleConcat(input);
     } else {
@@ -204,6 +254,56 @@ public interface VadlBuiltInNoStatusDispatcher<T> {
   void handleCTZ(T input);
 
   void handleCTO(T input);
+
+  void handleFSQRT(T input);
+
+  void handleFADD(T input);
+
+  void handleFSUB(T input);
+
+  void handleFMUL(T input);
+
+  void handleFDIV(T input);
+
+  void handleFMADD(T input);
+
+  void handleFMSUB(T input);
+
+  void handleFNMADD(T input);
+
+  void handleFNMSUB(T input);
+
+  void handleFMIN(T input);
+
+  void handleFMAX(T input);
+
+  void handleFLT(T input);
+
+  void handleFLE(T input);
+
+  void handleFEQ(T input);
+
+  void handleFCVT(T input);
+
+  void handleFCVTFS(T input);
+
+  void handleFCVTFU(T input);
+
+  void handleFCVTSF(T input);
+
+  void handleFCVTUF(T input);
+
+  void handleFISINF(T input);
+
+  void handleFISZERO(T input);
+
+  void handleFISNEG(T input);
+
+  void handleFISDENORM(T input);
+
+  void handleFISSNAN(T input);
+
+  void handleFISQNAN(T input);
 
   void handleConcat(T input);
 

--- a/vadl/main/vadl/viam/passes/statusBuiltInInlinePass/StatusBuiltInInlinePass.java
+++ b/vadl/main/vadl/viam/passes/statusBuiltInInlinePass/StatusBuiltInInlinePass.java
@@ -23,6 +23,7 @@ import vadl.error.Diagnostic;
 import vadl.pass.Pass;
 import vadl.pass.PassName;
 import vadl.pass.PassResults;
+import vadl.utils.VadlBuiltInFloatStatusOnlyDispatcher;
 import vadl.utils.VadlBuiltInStatusOnlyDispatcher;
 import vadl.viam.Specification;
 import vadl.viam.graph.Graph;
@@ -52,8 +53,10 @@ public class StatusBuiltInInlinePass extends Pass {
   @Override
   public Object execute(PassResults passResults, Specification viam) throws IOException {
     return viam.isa().map(isa -> {
-      isa.ownInstructions().forEach(i ->
-          new StatusBuiltInInliner(i.behavior()).run());
+      isa.ownInstructions().forEach(i -> {
+        new StatusBuiltInInliner(i.behavior()).run();
+        new FloatStatusBuiltInInliner(i.behavior()).run();
+      });
       return null;
     });
   }
@@ -271,6 +274,37 @@ class StatusBuiltInInliner implements VadlBuiltInStatusOnlyDispatcher<BuiltInCal
 
   @Override
   public void handleRRXS(BuiltInCall input) {
+    throwNotImplemented(input);
+  }
+}
+
+/**
+ * Inlines all float status built-ins for the given graph.
+ * There is a {@link Inliner} for each status built-in.
+ */
+class FloatStatusBuiltInInliner implements VadlBuiltInFloatStatusOnlyDispatcher<BuiltInCall> {
+
+  private final Graph graph;
+
+  FloatStatusBuiltInInliner(Graph graph) {
+    this.graph = graph;
+  }
+
+  void run() {
+    graph.getNodes(BuiltInCall.class).forEach(n -> {
+      dispatch(n, n.builtIn());
+    });
+  }
+
+  private void throwNotImplemented(BuiltInCall input) {
+    throw Diagnostic.error("Built-In Lowering Not Implemented", input)
+        .description("OpenVADL does not yet implement the inlining of the %s built-in.",
+            input.builtIn().name())
+        .build();
+  }
+
+  @Override
+  public void handleFADDS(BuiltInCall input) {
     throwNotImplemented(input);
   }
 }


### PR DESCRIPTION
Adds built-in float functions necessary to fully specify the RISC-V F and D extension:
- arithmetic
- comparison
- conversion (float-float, float-int and int-float)
- classification

Also adds an example implementation for a built-in (VADL::adds) which also returns a float status. Since these variants are not required for RISC-V, I have not implemented them (they will be required ISAs which have trapping float exceptions).