### PR TITLE
frontend: Add built-in check function

### DIFF
--- a/vadl-frontend/main/vadl/ast/AnnotationTable.java
+++ b/vadl-frontend/main/vadl/ast/AnnotationTable.java
@@ -69,6 +69,7 @@ import vadl.gcb.annotations.RelocationSyntaxAnnotation;
 import vadl.gcb.annotations.SkipPruningAnnotation;
 import vadl.gcb.annotations.StatusRegisterAnnotation;
 import vadl.types.BitsType;
+import vadl.types.FloatEncoding;
 import vadl.types.Type;
 import vadl.utils.Pair;
 import vadl.utils.functionInterfaces.QuadConsumer;
@@ -81,7 +82,6 @@ import vadl.viam.Counter;
 import vadl.viam.Encoding;
 import vadl.viam.Endianness;
 import vadl.viam.FloatExceptionFlag;
-import vadl.viam.FloatFormat;
 import vadl.viam.Format;
 import vadl.viam.Group;
 import vadl.viam.Instruction;
@@ -338,17 +338,17 @@ public class AnnotationTable {
     /// FLOAT RELATED ///
 
     annotationOn(FloatTypeDefinition.class, "IEEE", IEEEFloatFormatAnnotation::new)
-        .applyAst((def, annotation) -> def.size = annotation.constant.value().intValue())
-        .applyViam((def, annotation, lowering) -> {
-          var encoding = FloatFormat.Encoding.ieee(annotation.constant.value().intValue());
-          ensure(encoding != null,
+        .applyAst((def, annotation) -> {
+          var size = annotation.constant.value().intValue();
+          ensure(FloatEncoding.isValidIEEESize(size),
               () -> error("Invalid IEEE encoding size", annotation)
                   .description("The following sizes are supported: %s",
-                      Arrays.stream(FloatFormat.Encoding.values())
+                      Arrays.stream(FloatEncoding.values())
                           .map(e -> Integer.toString(e.size)).collect(Collectors.joining(", ")))
           );
-          ((FloatFormat) def).setEncoding(encoding);
-        }).build();
+          def.encoding = FloatEncoding.ieee(size);
+        })
+        .build();
 
     QuadConsumer<RegisterTensor, FloatFlagAnnotation, Boolean, FloatExceptionFlag>
         applyViamFloatFlag;
@@ -1318,16 +1318,16 @@ abstract class FormatFieldAnnotation extends Annotation {
 }
 
 /**
- * Marker interface for all annotations that set the {@link FloatTypeDefinition#size} field.
+ * Marker interface for all annotations that set the {@link FloatTypeDefinition#encoding} field.
  */
-interface FloatEncodingSizeAnnotation {
+interface FloatEncodingAnnotation {
 }
 
 /**
  * An annotation which makes a {@link FloatTypeDefinition} use IEEE-754 encoding with a given
  * size (32 or 64 bit).
  */
-class IEEEFloatFormatAnnotation extends ConstantAnnotation implements FloatEncodingSizeAnnotation {
+class IEEEFloatFormatAnnotation extends ConstantAnnotation implements FloatEncodingAnnotation {
 }
 
 /**

--- a/vadl-frontend/main/vadl/ast/TypeChecker.java
+++ b/vadl-frontend/main/vadl/ast/TypeChecker.java
@@ -1317,6 +1317,8 @@ public class TypeChecker
               .build());
     }
 
+    builtIn.check(constArgs, argTypes, location).ifPresent(this::addErrorAndContinueChecking);
+
     return new BuiltInCheckResult(argTypes, builtIn.returns(constArgs, argTypes));
   }
 
@@ -1337,7 +1339,7 @@ public class TypeChecker
     //       !!! There is a similar method in BehaviorLowering
     if (origin instanceof FloatTypeDefinition floatType) {
       check(floatType);
-      return new Constant.FloatType(requireNonNull(floatType.size), requireNonNull(name));
+      return new Constant.FloatType(requireNonNull(floatType.encoding), requireNonNull(name));
     }
 
     return constantEvaluator.eval(expr).toViamConstant();
@@ -1346,8 +1348,8 @@ public class TypeChecker
   @Override
   public Void visit(FloatTypeDefinition definition) {
     if (definition.annotations.stream().map(a -> a.annotation)
-        .noneMatch(FloatEncodingSizeAnnotation.class::isInstance)) {
-      addErrorAndStopChecking(error("Missing float-type encoding size", definition)
+        .noneMatch(FloatEncodingAnnotation.class::isInstance)) {
+      addErrorAndStopChecking(error("Missing float-type encoding", definition)
           .help("Annotate with e.g. `[ IEEE : <size> ]`")
           .build());
     }

--- a/vadl-frontend/main/vadl/ast/ViamLowering.java
+++ b/vadl-frontend/main/vadl/ast/ViamLowering.java
@@ -1127,7 +1127,7 @@ public class ViamLowering implements DefinitionVisitor<Optional<vadl.viam.Defini
   public Optional<vadl.viam.Definition> visit(FloatTypeDefinition definition) {
     var identifier =
         new vadl.viam.Identifier(definition.viamId, definition.identifier().location());
-    return Optional.of(new FloatFormat(identifier));
+    return Optional.of(new FloatFormat(identifier, requireNonNull(definition.encoding)));
   }
 
   @Override

--- a/vadl-frontend/main/vadl/ast/nodes/FloatTypeDefinition.java
+++ b/vadl-frontend/main/vadl/ast/nodes/FloatTypeDefinition.java
@@ -18,6 +18,7 @@ package vadl.ast.nodes;
 
 import java.util.Objects;
 import javax.annotation.Nullable;
+import vadl.types.FloatEncoding;
 import vadl.types.Type;
 import vadl.utils.SourceLocation;
 
@@ -32,12 +33,12 @@ public class FloatTypeDefinition extends Definition implements IdentifiableNode,
   public IdentifierOrPlaceholder identifier;
 
   /**
-   * Represents the bit-size of the represented float format. This is used by the type-checker
+   * Represents the encoding of the represented float format. This is used by the type-checker
    * to infer types when the float-type is used as a constant parameter in built-ins. This is not
    * set during parsing, and must be set by an annotation such as {@code [ IEEE : 32 ]}.
    */
   @Nullable
-  public Integer size;
+  public FloatEncoding encoding;
 
   public SourceLocation loc;
 

--- a/vadl-frontend/test/resources/frontend-snapshots/lowering/invalidFloatTypeMissingSize.vadl
+++ b/vadl-frontend/test/resources/frontend-snapshots/lowering/invalidFloatTypeMissingSize.vadl
@@ -9,7 +9,7 @@ instruction set architecture ISA = {
 
 //  Reported Diagnostics:
 //
-//  error: Missing float-type encoding size
+//  error: Missing float-type encoding
 //       ╭── test/resources/frontend-snapshots/lowering/invalidFloatTypeMissingSize.vadl:5:3
 //       │
 //     5 │   float-type binary32

--- a/vadl-frontend/test/resources/frontend-snapshots/lowering/invalidUsedFloatTypeMissingSize.vadl
+++ b/vadl-frontend/test/resources/frontend-snapshots/lowering/invalidUsedFloatTypeMissingSize.vadl
@@ -13,7 +13,7 @@ instruction set architecture ISA = {
 
 //  Reported Diagnostics:
 //
-//  error: Missing float-type encoding size
+//  error: Missing float-type encoding
 //       ╭── test/resources/frontend-snapshots/lowering/invalidUsedFloatTypeMissingSize.vadl:5:3
 //       │
 //     5 │   float-type binary32

--- a/vadl-frontend/test/resources/frontend-snapshots/typechecker/invalidFloatConvertBuiltinParams.vadl
+++ b/vadl-frontend/test/resources/frontend-snapshots/typechecker/invalidFloatConvertBuiltinParams.vadl
@@ -1,0 +1,157 @@
+// INCLUDE-AST-DUMP
+
+[ IEEE : 32 ]
+float-type ieee32
+
+function fcvt(a: Bits<32>) -> Bits<32> = VADL::fcvt::<ieee32, ieee32>(a, 0 as Bits<3>)
+function fcvtfs(a: Bits<32>) -> SInt<7> = VADL::fcvtfs::<ieee32, 7>(a, 0 as Bits<3>)
+function fcvtfu(a: Bits<32>) -> UInt<7> = VADL::fcvtfu::<ieee32, 7>(a, 0 as Bits<3>)
+function fcvtsf(a: SInt<7>) -> Bits<32> = VADL::fcvtsf::<ieee32>(a, 0 as Bits<3>)
+function fcvtuf(a: SInt<7>) -> Bits<32> = VADL::fcvtuf::<ieee32>(a, 0 as Bits<3>)
+
+
+//  Reported Diagnostics:
+//
+//  error: Cannot convert to same float encoding
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidFloatConvertBuiltinParams.vadl:6:42
+//       │
+//     6 │ function fcvt(a: Bits<32>) -> Bits<32> = VADL::fcvt::<ieee32, ieee32>(a, 0 as Bits<3>)
+//       │                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+//       │
+//
+//  error: Can only convert to 32 or 64 bit integers
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidFloatConvertBuiltinParams.vadl:7:43
+//       │
+//     7 │ function fcvtfs(a: Bits<32>) -> SInt<7> = VADL::fcvtfs::<ieee32, 7>(a, 0 as Bits<3>)
+//       │                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+//       │
+//
+//  error: Can only convert to 32 or 64 bit integers
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidFloatConvertBuiltinParams.vadl:8:43
+//       │
+//     8 │ function fcvtfu(a: Bits<32>) -> UInt<7> = VADL::fcvtfu::<ieee32, 7>(a, 0 as Bits<3>)
+//       │                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+//       │
+//
+//  error: Can only convert from 32 or 64 bit integers
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidFloatConvertBuiltinParams.vadl:9:43
+//       │
+//     9 │ function fcvtsf(a: SInt<7>) -> Bits<32> = VADL::fcvtsf::<ieee32>(a, 0 as Bits<3>)
+//       │                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+//       │
+//
+//  error: Can only convert from 32 or 64 bit integers
+//       ╭── test/resources/frontend-snapshots/typechecker/invalidFloatConvertBuiltinParams.vadl:10:43
+//       │
+//    10 │ function fcvtuf(a: SInt<7>) -> Bits<32> = VADL::fcvtuf::<ieee32>(a, 0 as Bits<3>)
+//       │                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+//       │
+//
+//
+//  Dumped AST:
+//
+//    FloatTypeDefinition name: "ieee32"
+//    . AnnotationDefinition
+//    . : Identifier name: "IEEE" type: null
+//    . : IntegerLiteral literal: 32 (32) type: Const<32>
+//    FunctionDefinition name: "fcvt"
+//    . Parameter name: "a"
+//    . : TypeLiteral type: Bits<32>
+//    . : ' Identifier name: "Bits" type: null
+//    . : ' IntegerLiteral literal: 32 (32) type: Const<32>
+//    . TypeLiteral type: Bits<32>
+//    . : Identifier name: "Bits" type: null
+//    . : IntegerLiteral literal: 32 (32) type: Const<32>
+//    . CallIndexExpr type: Bits<32>
+//    . : SymbolExpr type: null
+//    . : ' IdentifierPath name: "VADL::fcvt" type: null
+//    . : ' Identifier name: "ieee32" type: FloatType
+//    . : ' Identifier name: "ieee32" type: FloatType
+//    . : ArgsIndices
+//    . : ' Identifier name: "a" type: Bits<32>
+//    . : ' CastExpr type: Bits<3>
+//    . : ' | IntegerLiteral literal: 0 (0) type: Const<0>
+//    . : ' | TypeLiteral type: Bits<3>
+//    . : ' | . Identifier name: "Bits" type: null
+//    . : ' | . IntegerLiteral literal: 3 (3) type: Const<3>
+//    FunctionDefinition name: "fcvtfs"
+//    . Parameter name: "a"
+//    . : TypeLiteral type: Bits<32>
+//    . : ' Identifier name: "Bits" type: null
+//    . : ' IntegerLiteral literal: 32 (32) type: Const<32>
+//    . TypeLiteral type: SInt<7>
+//    . : Identifier name: "SInt" type: null
+//    . : IntegerLiteral literal: 7 (7) type: Const<7>
+//    . CallIndexExpr type: SInt<7>
+//    . : SymbolExpr type: null
+//    . : ' IdentifierPath name: "VADL::fcvtfs" type: null
+//    . : ' Identifier name: "ieee32" type: FloatType
+//    . : ' IntegerLiteral literal: 7 (7) type: Const<7>
+//    . : ArgsIndices
+//    . : ' Identifier name: "a" type: Bits<32>
+//    . : ' CastExpr type: Bits<3>
+//    . : ' | IntegerLiteral literal: 0 (0) type: Const<0>
+//    . : ' | TypeLiteral type: Bits<3>
+//    . : ' | . Identifier name: "Bits" type: null
+//    . : ' | . IntegerLiteral literal: 3 (3) type: Const<3>
+//    FunctionDefinition name: "fcvtfu"
+//    . Parameter name: "a"
+//    . : TypeLiteral type: Bits<32>
+//    . : ' Identifier name: "Bits" type: null
+//    . : ' IntegerLiteral literal: 32 (32) type: Const<32>
+//    . TypeLiteral type: UInt<7>
+//    . : Identifier name: "UInt" type: null
+//    . : IntegerLiteral literal: 7 (7) type: Const<7>
+//    . CallIndexExpr type: UInt<7>
+//    . : SymbolExpr type: null
+//    . : ' IdentifierPath name: "VADL::fcvtfu" type: null
+//    . : ' Identifier name: "ieee32" type: FloatType
+//    . : ' IntegerLiteral literal: 7 (7) type: Const<7>
+//    . : ArgsIndices
+//    . : ' Identifier name: "a" type: Bits<32>
+//    . : ' CastExpr type: Bits<3>
+//    . : ' | IntegerLiteral literal: 0 (0) type: Const<0>
+//    . : ' | TypeLiteral type: Bits<3>
+//    . : ' | . Identifier name: "Bits" type: null
+//    . : ' | . IntegerLiteral literal: 3 (3) type: Const<3>
+//    FunctionDefinition name: "fcvtsf"
+//    . Parameter name: "a"
+//    . : TypeLiteral type: SInt<7>
+//    . : ' Identifier name: "SInt" type: null
+//    . : ' IntegerLiteral literal: 7 (7) type: Const<7>
+//    . TypeLiteral type: Bits<32>
+//    . : Identifier name: "Bits" type: null
+//    . : IntegerLiteral literal: 32 (32) type: Const<32>
+//    . CallIndexExpr type: Bits<32>
+//    . : SymbolExpr type: null
+//    . : ' IdentifierPath name: "VADL::fcvtsf" type: null
+//    . : ' Identifier name: "ieee32" type: FloatType
+//    . : ArgsIndices
+//    . : ' Identifier name: "a" type: SInt<7>
+//    . : ' CastExpr type: Bits<3>
+//    . : ' | IntegerLiteral literal: 0 (0) type: Const<0>
+//    . : ' | TypeLiteral type: Bits<3>
+//    . : ' | . Identifier name: "Bits" type: null
+//    . : ' | . IntegerLiteral literal: 3 (3) type: Const<3>
+//    FunctionDefinition name: "fcvtuf"
+//    . Parameter name: "a"
+//    . : TypeLiteral type: SInt<7>
+//    . : ' Identifier name: "SInt" type: null
+//    . : ' IntegerLiteral literal: 7 (7) type: Const<7>
+//    . TypeLiteral type: Bits<32>
+//    . : Identifier name: "Bits" type: null
+//    . : IntegerLiteral literal: 32 (32) type: Const<32>
+//    . CallIndexExpr type: Bits<32>
+//    . : SymbolExpr type: null
+//    . : ' IdentifierPath name: "VADL::fcvtuf" type: null
+//    . : ' Identifier name: "ieee32" type: FloatType
+//    . : ArgsIndices
+//    . : ' Identifier name: "a" type: SInt<7>
+//    . : ' CastExpr type: Bits<3>
+//    . : ' | IntegerLiteral literal: 0 (0) type: Const<0>
+//    . : ' | TypeLiteral type: Bits<3>
+//    . : ' | . Identifier name: "Bits" type: null
+//    . : ' | . IntegerLiteral literal: 3 (3) type: Const<3>
+//
+//
+// Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl/main/vadl/iss/template/IssTemplateRenderingPass.java
+++ b/vadl/main/vadl/iss/template/IssTemplateRenderingPass.java
@@ -170,7 +170,7 @@ public abstract class IssTemplateRenderingPass extends AbstractTemplateRendering
   private List<List<Object>> getFloatBuiltinConfigs(Set<List<Constant>> configs) {
     return configs.stream().map(config -> config.stream().map(c -> switch (c) {
       case Constant.FloatType ft -> Map.of(
-          "bit_size", ft.size(),
+          "bit_size", ft.encoding().size,
           "name", requireNonNull(ft.format()).nameLower()
       );
       case Constant.Value v -> Integer.toString(v.intValue());

--- a/vadl/main/vadl/types/BuiltInTable.java
+++ b/vadl/main/vadl/types/BuiltInTable.java
@@ -34,6 +34,8 @@ import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import org.jetbrains.annotations.Contract;
 import org.slf4j.Logger;
+import vadl.error.Diagnostic;
+import vadl.utils.WithLocation;
 import vadl.utils.functionInterfaces.TriFunction;
 import vadl.viam.Constant;
 import vadl.viam.ViamError;
@@ -1235,6 +1237,7 @@ public class BuiltInTable {
               List.of(FloatType.class, FloatType.class), BitsType.class))
           .takesFloatArgsAndFrm(1)
           .returnsSecondFloatType()
+          .checkConvertingBetweenDifferentFloatEncodings()
           .build();
 
   /**
@@ -1248,6 +1251,7 @@ public class BuiltInTable {
               List.of(FloatType.class, UIntType.class), SIntType.class))
           .takesFloatArgsAndFrm(1)
           .returnsFromSecondConstSize(SIntType.class)
+          .checkConvertingTo3264Int()
           .build();
 
   /**
@@ -1261,6 +1265,7 @@ public class BuiltInTable {
               List.of(FloatType.class, UIntType.class), UIntType.class))
           .takesFloatArgsAndFrm(1)
           .returnsFromSecondConstSize(UIntType.class)
+          .checkConvertingTo3264Int()
           .build();
 
   /**
@@ -1273,6 +1278,7 @@ public class BuiltInTable {
               List.of(FloatType.class), BitsType.class))
           .takesFrm(1)
           .returnsFirstFloatType()
+          .checkConvertingFrom3264Int()
           .build();
 
   /**
@@ -1285,6 +1291,7 @@ public class BuiltInTable {
               List.of(FloatType.class), BitsType.class))
           .takesFrm(1)
           .returnsFirstFloatType()
+          .checkConvertingFrom3264Int()
           .build();
 
   ///// FLOAT CLASSIFICATION //////
@@ -2136,6 +2143,19 @@ public class BuiltInTable {
       return returns(List.of(), argTypes);
     }
 
+    /**
+     * Checks the validity of the constant arguments and argument types of the call.
+     * Optionally returns a diagnostic, if a problem is found.
+     * It assumes that the argument types are valid, such as a call to
+     * {@link #takes(List, List)} would return true.
+     *
+     * @param constArgs concrete constant arguments.
+     * @param argTypes  concrete types of argument for call.
+     * @param location  the location of the call.
+     * @return an optional diagnostic, if a problem is found
+     */
+    public abstract Optional<Diagnostic> check(List<Constant> constArgs, List<Type> argTypes,
+                                               WithLocation location);
 
     public final boolean matches(RelationType type) {
       return this.signature.equals(type);
@@ -2215,6 +2235,9 @@ public class BuiltInTable {
     private BiFunction<List<Constant>, List<Type>, Boolean> takesFunction;
     @Nullable
     private BiFunction<List<Constant>, List<Type>, Type> returnsFunction;
+    @Nullable
+    private TriFunction<List<Constant>, List<Type>, WithLocation, Optional<Diagnostic>>
+        checkFunction;
     private boolean hasSameBitWidth = false;
 
     BuiltInBuilder(String name, @Nullable String operator, RelationType signature,
@@ -2419,14 +2442,59 @@ public class BuiltInTable {
       });
     }
 
-    private int floatTypeSize(Constant arg) {
+    private FloatEncoding floatTypeEncoding(Constant arg) {
       ensure(arg instanceof Constant.FloatType, "Expected a float type, but found %s", arg);
-      return ((Constant.FloatType) arg).size();
+      return ((Constant.FloatType) arg).encoding();
+    }
+
+    private int floatTypeSize(Constant arg) {
+      return floatTypeEncoding(arg).size;
     }
 
     private int constInt(Constant arg) {
       ensure(arg instanceof Constant.Value, "Expected a value type, but found %s", arg);
       return ((Constant.Value) arg).intValue();
+    }
+
+    public BuiltInBuilder check(
+        TriFunction<List<Constant>, List<Type>, WithLocation, Optional<Diagnostic>> checkFunction) {
+      this.checkFunction = checkFunction;
+      return this;
+    }
+
+    public BuiltInBuilder checkConvertingBetweenDifferentFloatEncodings() {
+      return check((constArgs, argTypes, location) -> {
+        if (floatTypeEncoding(constArgs.get(0)) == floatTypeEncoding(constArgs.get(1))) {
+          return Optional.of(
+              Diagnostic.error("Cannot convert to same float encoding", location).build()
+          );
+        }
+        return Optional.empty();
+      });
+    }
+
+    public BuiltInBuilder checkConvertingTo3264Int() {
+      return check((constArgs, argTypes, location) -> {
+        var intBitSize = constInt(constArgs.get(1));
+        if (intBitSize != 32 && intBitSize != 64) {
+          return Optional.of(
+              Diagnostic.error("Can only convert to 32 or 64 bit integers", location).build()
+          );
+        }
+        return Optional.empty();
+      });
+    }
+
+    public BuiltInBuilder checkConvertingFrom3264Int() {
+      return check((constArgs, argTypes, location) -> {
+        var intBitSize = argTypes.getFirst().asDataType().bitWidth();
+        if (intBitSize != 32 && intBitSize != 64) {
+          return Optional.of(
+              Diagnostic.error("Can only convert from 32 or 64 bit integers", location).build()
+          );
+        }
+        return Optional.empty();
+      });
     }
 
 
@@ -2475,6 +2543,15 @@ public class BuiltInTable {
         @Override
         public Type returns(List<Constant> constArgs, List<Type> argTypes) {
           return returnsFunction.apply(constArgs, argTypes);
+        }
+
+        @Override
+        public Optional<Diagnostic> check(List<Constant> constArgs, List<Type> argTypes,
+                                          WithLocation location) {
+          if (checkFunction == null) {
+            return Optional.empty();
+          }
+          return checkFunction.apply(constArgs, argTypes, location);
         }
       };
     }

--- a/vadl/main/vadl/types/FloatEncoding.java
+++ b/vadl/main/vadl/types/FloatEncoding.java
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText : © 2026 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.types;
+
+import javax.annotation.Nullable;
+
+/**
+ * Represents all supported float encodings.
+ */
+public enum FloatEncoding {
+  IEEE32(32, true),
+  IEEE64(64, true);
+
+  public final int size;
+  public final boolean ieee;
+
+  FloatEncoding(int size, boolean ieee) {
+    this.size = size;
+    this.ieee = ieee;
+  }
+
+  /**
+   * Returns whether an IEEE encoding exists for the given size.
+   */
+  public static boolean isValidIEEESize(int size) {
+    return size == 32 || size == 64;
+  }
+
+  /**
+   * Returns the IEEE encoding for the given bit-size.
+   */
+  public static FloatEncoding ieee(int size) {
+    return switch (size) {
+      case 32 -> IEEE32;
+      case 64 -> IEEE64;
+      default -> throw new IllegalStateException("Unable to create IEEE encoding for size " + size);
+    };
+  }
+}

--- a/vadl/main/vadl/viam/Constant.java
+++ b/vadl/main/vadl/viam/Constant.java
@@ -49,6 +49,7 @@ import vadl.error.DeferredDiagnosticStore;
 import vadl.types.BitsType;
 import vadl.types.BoolType;
 import vadl.types.DataType;
+import vadl.types.FloatEncoding;
 import vadl.types.SIntType;
 import vadl.types.StructType;
 import vadl.types.Type;
@@ -1563,7 +1564,7 @@ public abstract class Constant {
     @Nullable
     private final FloatFormat format;
 
-    private final Integer size;
+    private final FloatEncoding encoding;
     private final String name;
 
     /**
@@ -1574,22 +1575,22 @@ public abstract class Constant {
     public FloatType(FloatFormat format) {
       super(Type.floatType());
       this.format = format;
-      // the type-checker checks that float-type definitions have a size, and thus an encoding
-      this.size = requireNonNull(format.encoding()).size;
+      // the type-checker checks that float-type definitions have an encoding
+      this.encoding = requireNonNull(format.encoding());
       this.name = format.simpleName();
     }
 
     /**
-     * Constructs a dummy float-type constant from a float format encoding size. This is used by
-     * the type checker when the float format definition is not yet available.
+     * Constructs a dummy float-type constant from a float format encoding. This is used by
+     * the type checker when the full float format definition is not yet available.
      *
-     * @param size The float format encoding size, i.e. the bit-size of the float type.
-     * @param name The name of the float format.
+     * @param encoding The float format encoding.
+     * @param name     The name of the float format.
      */
-    public FloatType(int size, String name) {
+    public FloatType(FloatEncoding encoding, String name) {
       super(Type.floatType());
       this.format = null;
-      this.size = size;
+      this.encoding = encoding;
       this.name = name;
     }
 
@@ -1598,8 +1599,8 @@ public abstract class Constant {
       return format;
     }
 
-    public Integer size() {
-      return size;
+    public FloatEncoding encoding() {
+      return encoding;
     }
 
     @Override
@@ -1619,13 +1620,13 @@ public abstract class Constant {
         return false;
       }
       FloatType floatType = (FloatType) o;
-      return Objects.equals(format, floatType.format) && Objects.equals(size,
-          floatType.size) && Objects.equals(name, floatType.name);
+      return Objects.equals(format, floatType.format) && Objects.equals(encoding,
+          floatType.encoding) && Objects.equals(name, floatType.name);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(super.hashCode(), format, size, name);
+      return Objects.hash(super.hashCode(), format, encoding, name);
     }
   }
 

--- a/vadl/main/vadl/viam/FloatFormat.java
+++ b/vadl/main/vadl/viam/FloatFormat.java
@@ -16,50 +16,21 @@
 
 package vadl.viam;
 
-import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
+import vadl.types.FloatEncoding;
 import vadl.types.Type;
 
 /**
- * Describes a float format. This covers bit-size, encoding and interpretation.
+ * VIAM definition representing a float format. This currently only contains a
+ * {@link FloatEncoding}, but will contain other things like NaN encoding and handling
+ * in the future.
  */
 public class FloatFormat extends Definition implements DefProp.WithType {
 
-  /**
-   * Represents all supported float encodings.
-   */
-  public enum Encoding {
-    IEEE32(32, true),
-    IEEE64(64, true);
+  private final FloatEncoding encoding;
 
-    public final int size;
-    public final boolean ieee;
-
-    Encoding(int size, boolean ieee) {
-      this.size = size;
-      this.ieee = ieee;
-    }
-
-    /**
-     * Returns the IEEE encoding for the given bit-size.
-     */
-    public static @Nullable Encoding ieee(int size) {
-      return switch (size) {
-        case 32 -> IEEE32;
-        case 64 -> IEEE64;
-        default -> null;
-      };
-    }
-  }
-
-  @Nullable
-  private Encoding encoding = null;
-
-  public FloatFormat(Identifier identifier) {
+  public FloatFormat(Identifier identifier, FloatEncoding encoding) {
     super(identifier);
-  }
-
-  public void setEncoding(@CheckForNull Encoding encoding) {
     this.encoding = encoding;
   }
 
@@ -67,7 +38,7 @@ public class FloatFormat extends Definition implements DefProp.WithType {
    * The encoding of the float format.
    */
   @Nullable
-  public Encoding encoding() {
+  public FloatEncoding encoding() {
     return encoding;
   }
 
@@ -86,12 +57,6 @@ public class FloatFormat extends Definition implements DefProp.WithType {
   @Override
   public void accept(DefinitionVisitor visitor) {
     visitor.visit(this);
-  }
-
-  @Override
-  public void verify() {
-    super.verify();
-    ensure(encoding != null, "Encoding missing");
   }
 
   @Override


### PR DESCRIPTION
Adds an optional check function to built-ins, which the type-checker calls. This check function can return a `Diagnostic`, which is thrown by the type-checker. This is currently only used to verify that the two float-types passed to `VADL::fcvt` do not have the same encoding, and that converting between float and int only involves 32- or 64-bit integers.

This check function will also be used after the transition to type parameters.

Also changes how float-types are stored in the AST. Previously, only the bit-size was stored in the AST. Now, the whole `FloatEncoding` is stored there.

Closes #1058