### PR TITLE
[#1061] Add utf-8 support for VADL source files

### DIFF
--- a/vadl-frontend/main/vadl/ast/Scanner.frame
+++ b/vadl-frontend/main/vadl/ast/Scanner.frame
@@ -310,7 +310,7 @@ public class Scanner {
 -->initialization
 	}
 	
-	public Scanner (String fileName) {
+	public Scanner(String fileName) {
 		buffer = new Buffer(fileName);
 		Init();
 	}
@@ -324,15 +324,21 @@ public class Scanner {
 		pos = -1; line = 1; col = 0; charPos = -1;
 		oldEols = 0;
 		NextCh();
-		if (ch == 0xEF) { // check optional byte order mark for UTF-8
+
+		// check and skip optional byte order mark for UTF-8
+		if (ch == 0xEF) {
 			NextCh(); int ch1 = ch;
 			NextCh(); int ch2 = ch;
 			if (ch1 != 0xBB || ch2 != 0xBF) {
 				throw new FatalError("Illegal byte order mark at start of file");
 			}
-			buffer = new UTF8Buffer(buffer); col = 0; charPos = -1;
 			NextCh();
+			col = 0; charPos = -1;
 		}
+
+		// VADL files are interpreted as UTF-8
+		buffer = new UTF8Buffer(buffer);
+
 		pt = tokens = new Token();  // first token is a dummy
 	}
 	

--- a/vadl-frontend/main/vadl/ast/vadl.ATG
+++ b/vadl-frontend/main/vadl/ast/vadl.ATG
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2024 TU Wien <vadl@tuwien.ac.at>
+﻿// SPDX-FileCopyrightText : © 2024 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 // This program is free software: you can redistribute it and/or modify

--- a/vadl-frontend/test/resources/frontend-snapshots/parser/group.vadl
+++ b/vadl-frontend/test/resources/frontend-snapshots/parser/group.vadl
@@ -1,0 +1,45 @@
+instruction set architecture ISA = {
+  program counter PC : Bits<32>
+
+  format AType : Bits<32> = {
+    a : Bits<20>,
+    b : Bits<5>,
+    c : Bits<7>
+  }
+
+  format BType : Bits<32> = {
+    a : Bits<20>,
+    b : Bits<5>,
+    d : Bits<7>
+  }
+
+  instruction A : AType = PC := 0
+  encoding A = {a = 0b00}
+  assembly A = (mnemonic, "")
+
+  instruction B : BType = PC := 0
+  encoding B = {a = 0b01}
+  assembly B = (mnemonic, "")
+
+  operation OpA = {A}
+  operation OpB = {B}
+  operation OpC = {}
+  operation OpAll = {OpA,OpB}
+
+  [assert : VLIW(0) ∈ OpC]
+  group VLIW = OpA.OpB.OpAll
+}
+
+
+//  Reported Diagnostics:
+//
+//  warning: This expression is always false
+//       ╭── test/resources/frontend-snapshots/parser/group.vadl:29:13
+//       │
+//    29 │   [assert : VLIW(0) ∈ OpC]
+//       │             ^^^^^^^^^^^^^
+//       │
+//       None of the possible concrete instructions matched by the left side are part of operation `OpC`.
+//
+//
+// Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl-frontend/test/resources/frontend-snapshots/parser/utf8-group.vadl
+++ b/vadl-frontend/test/resources/frontend-snapshots/parser/utf8-group.vadl
@@ -1,0 +1,49 @@
+﻿// <--- This file has a UTF-8 BOM (Byte Order Mark) at the beginning of the file. (0xEF, 0xBB, 0xBF)
+//
+//      We test that the diagnostic is aligned correctly, even with the BOM present, and a unicode operator (∈) in the
+//      source code.
+instruction set architecture ISA = {
+  program counter PC : Bits<32>
+
+  format AType : Bits<32> = {
+    a : Bits<20>,
+    b : Bits<5>,
+    c : Bits<7>
+  }
+
+  format BType : Bits<32> = {
+    a : Bits<20>,
+    b : Bits<5>,
+    d : Bits<7>
+  }
+
+  instruction A : AType = PC := 0
+  encoding A = {a = 0b00}
+  assembly A = (mnemonic, "")
+
+  instruction B : BType = PC := 0
+  encoding B = {a = 0b01}
+  assembly B = (mnemonic, "")
+
+  operation OpA = {A}
+  operation OpB = {B}
+  operation OpC = {}
+  operation OpAll = {OpA,OpB}
+
+  [assert : VLIW(0) ∈ OpC]
+  group VLIW = OpA.OpB.OpAll
+}
+
+
+//  Reported Diagnostics:
+//
+//  warning: This expression is always false
+//       ╭── test/resources/frontend-snapshots/parser/utf8-group.vadl:33:13
+//       │
+//    33 │   [assert : VLIW(0) ∈ OpC]
+//       │             ^^^^^^^^^^^^^
+//       │
+//       None of the possible concrete instructions matched by the left side are part of operation `OpC`.
+//
+//
+// Part of the class vadl.ast.FrontendSnapshotTests

--- a/vadl-frontend/test/resources/frontend-snapshots/typechecker/operationElementOfTrivialWarning.vadl
+++ b/vadl-frontend/test/resources/frontend-snapshots/typechecker/operationElementOfTrivialWarning.vadl
@@ -36,7 +36,7 @@ instruction set architecture ISA = {
 //       ╭── test/resources/frontend-snapshots/typechecker/operationElementOfTrivialWarning.vadl:27:13
 //       │
 //    27 │   [assert : VLIW(0) ∈ OpB]
-//       │             ^^^^^^^^^^^^^^^
+//       │             ^^^^^^^^^^^^^
 //       │
 //       None of the possible concrete instructions matched by the left side are part of operation `OpB`.
 //
@@ -44,7 +44,7 @@ instruction set architecture ISA = {
 //       ╭── test/resources/frontend-snapshots/typechecker/operationElementOfTrivialWarning.vadl:28:13
 //       │
 //    28 │   [assert : VLIW(0) ∉ OpB]
-//       │             ^^^^^^^^^^^^^^^
+//       │             ^^^^^^^^^^^^^
 //       │
 //       None of the possible concrete instructions matched by the left side are part of operation `OpB`.
 //


### PR DESCRIPTION
Fixes #1061 

With the introduction/use of the `∈` operator (#1042), the first unicode character, it has become apparent that the Scanner/Buffer did not correctly handle unicode.

The `Scanner.frame` in Coco/R (Java) already ships with an utf-8 buffer, however it is only conditionally selected, based on the File's utf-8 preamble (or 'byte order mark'/BOM).

Since Coco/R bootstraps itself, i.e. the vadl.ATG grammar is parsed using the same default `Scanner.frame` we were using until now, the symbols in the VADL grammar have not been interpreted correctly as unicode. This caused the scanner to interpret `∈` symbol as a 3-byte sequence, and Coco/R generated a scanner to detect those 3 bytes as an appropriate token (-kind) exactly. 

So, while we were able to detect the operator, the `length` of the token was `3`, which resulted in the source locations to be incorrectly shifted.

-- 

By adding the utf-8 preamble to the `vadl.ATG` (`ZWNBSP`, resp. `U+FEFF`) the Coco/R library now interprets the symbols in the grammar as utf-8 as well.

In addition, this PR now always interprets `*.vadl` source files in utf-8, regardless of whether they contain the BOM or not.
