### PR TITLE
iss: Fix shift built-in normalization

### DIFF
--- a/vadl/main/vadl/iss/passes/common/IssNormalizationPass.java
+++ b/vadl/main/vadl/iss/passes/common/IssNormalizationPass.java
@@ -606,13 +606,13 @@ class IssNormalizer implements VadlBuiltInNoStatusDispatcher<BuiltInCall> {
       // b % N == b & (N - 1)
       var rhs = Constant.Value.of(valT.bitWidth() - 1, shiftT).toNode();
       // b -> b & (N - 1)
-      shift.replace(BuiltInTable.AND.call(shift, rhs));
+      input.replaceInput(shift, behavior.addWithInputs(BuiltInTable.AND.call(shift, rhs)));
       return;
     }
 
     // replace by modulo (b -> b % N)
     var valN = Constant.Value.of(valT.bitWidth(), shiftT).toNode();
-    shift.replace(BuiltInTable.UMOD.call(shift, valN));
+    input.replaceInput(shift, behavior.addWithInputs(BuiltInTable.UMOD.call(shift, valN)));
   }
 
   @Override


### PR DESCRIPTION
Previously, the shift amount node was replaced with a normalized version. If the shift amount had another independent usage, that usage would also mistakenly be affected.
Now the replacement only affects the shift built-in.

Closes #1068 