### PR TITLE
linker: Add indirect relocations

### DIFF
--- a/sys/risc-v/rv3264im.vadl
+++ b/sys/risc-v/rv3264im.vadl
@@ -296,7 +296,7 @@ $Arch3264 ( // ((((((((((((((((((((((((((((((((((((((((
   relocation pcrel_hi( symbol : Bits<32> ) -> UInt<20> = ( ( symbol + 0x800 as Bits<32> ) >> 12 ) as UInt<20>
   [relative]
   [syntax : "%{}({})"]
-  relocation pcrel_lo( symbol : Bits<32> ) -> SInt<12> = (symbol + 4) as SInt<12>
+  relocation pcrel_lo( symbol : Bits<32> ) -> SInt<12> = symbol as SInt<12>
 
   [global offset]
   [syntax : "%{}({})"]

--- a/sys/risc-v/rv3264im.vadl
+++ b/sys/risc-v/rv3264im.vadl
@@ -295,6 +295,7 @@ $Arch3264 ( // ((((((((((((((((((((((((((((((((((((((((
   [syntax : "%{}({})"]
   relocation pcrel_hi( symbol : Bits<32> ) -> UInt<20> = ( ( symbol + 0x800 as Bits<32> ) >> 12 ) as UInt<20>
   [relative]
+  [paired]
   [syntax : "%{}({})"]
   relocation pcrel_lo( symbol : Bits<32> ) -> SInt<12> = symbol as SInt<12>
 

--- a/sys/risc-v/rv64im.vadl
+++ b/sys/risc-v/rv64im.vadl
@@ -106,6 +106,61 @@ application binary interface ABI for RV64IM = {
    }
 }
 
+[ comment string: "#" ]
+[ generate rules ]
+assembly description ASM for ABI = {
+
+  modifiers = {
+    "hi" -> RV64IM::hi,
+    "lo" -> RV64IM::lo,
+    "pcrel_hi" -> RV64IM::pcrel_hi,
+    "pcrel_lo" -> RV64IM::pcrel_lo,
+    "got_pcrel_hi" -> RV64IM::got_pcrel_hi
+  }
+
+  directives = {
+    ".align" -> ALIGN_POW2,
+    ".dword" -> QUAD,
+    ".word" -> BYTE4
+  }
+
+  grammar = {
+    ImmediateOperand :
+      Expression @operand
+      | op = (
+          "%" mod = ("lo" | "hi" | "pcrel_lo" | "pcrel_hi" | "got_pcrel_hi") @modifier
+          "(" val = Expression ")"
+        ) @operand
+    ;
+
+    JalrInstruction @instruction:
+      var rdTmp = null @operand
+      var rs1Tmp = null @operand
+      var immTmp = null @operand
+      mnemonic = "JALR" @operand
+      ( ?(LaIdEq(1, ","))
+          rdTmp = Register@operand ","
+          ( ?(LaIdEq(1, ","))                     // jalr rd, rs, imm
+              rs1Tmp = Register@operand ","
+              immTmp = ImmediateOperand
+            |
+              immTmp = ImmediateOperand           // jalr rd, imm(rs)
+              "(" rs1Tmp = Register@operand  ")"
+          )
+      | rdTmp = (x1_string @register) @operand    // jalr rs
+        rs1Tmp = Register@operand
+        immTmp = zero_const @operand
+      )
+      rd = rdTmp
+      rs1 = rs1Tmp
+      immS = immTmp
+    ;
+  }
+
+  function x1_string -> String = "x1"
+  function zero_const -> SInt<64> = 0
+}
+
 [ htif ]
 processor Spike implements RV64IM with ABI = {
   constant reset_vec_addr = 0x1000

--- a/sys/risc-v/rv64im.vadl
+++ b/sys/risc-v/rv64im.vadl
@@ -155,6 +155,21 @@ assembly description ASM for ABI = {
       rs1 = rs1Tmp
       immS = immTmp
     ;
+
+    JalInstruction @instruction:
+        var rdTmp = null @operand
+        var immTmp = null @operand
+        mnemonic = "JAL" @operand
+        ( ?(LaIdEq(1, ","))
+            rdTmp = Register@operand ","
+            immTmp = ImmediateOperand
+          |
+            rdTmp = (x1_string @register) @operand    // jal imm
+            immTmp = ImmediateOperand
+        )
+        rd = rdTmp
+        immS = immTmp
+      ;
   }
 
   function x1_string -> String = "x1"

--- a/vadl-frontend/main/vadl/ast/AnnotationTable.java
+++ b/vadl-frontend/main/vadl/ast/AnnotationTable.java
@@ -493,6 +493,11 @@ public class AnnotationTable {
           var lit = (StringLiteral) annotation.definition.values.getFirst();
           def.addAnnotation(new RelocationSyntaxAnnotation(lit.value));
         }).build();
+
+    annotationOn(RelocationDefinition.class, "paired", EnableAnnotation::new)
+        .applyViam((def, annotation, lowering) -> {
+          ((Relocation) def).setIsPaired(true);
+        }).build();
   }
 
   /**
@@ -1107,7 +1112,6 @@ interface AnnotationDeclaration {
 }
 
 
-
 // ---------- GENERAL ANNOTATION CLASSES ----------
 
 /**
@@ -1676,7 +1680,7 @@ class ExprAnnotation extends Annotation {
 
     // Suppress these generic error messages, in case more specific errors already exist.
     // (this assumes that existing errors are related)
-    final var hasError =  !tc.getErrors().isEmpty() || DeferredDiagnosticStore.hasError();
+    final var hasError = !tc.getErrors().isEmpty() || DeferredDiagnosticStore.hasError();
 
     Diagnostic.ensure(hasError || expr.type != null,
         () -> error("Invalid annotation expression", expr)

--- a/vadl/main/resources/templates/lcb/lld/ELF/Arch/Target.cpp
+++ b/vadl/main/resources/templates/lcb/lld/ELF/Arch/Target.cpp
@@ -117,7 +117,11 @@ namespace lld
             }
             [/th:block]
 
-            default : llvm_unreachable("unknown relocation");
+            default:
+            {
+                std::string msg = "unknown relocation type: " + std::to_string(rel.type);
+                llvm_unreachable(msg.c_str());
+            }
             }
         }
 

--- a/vadl/main/resources/templates/lcb/lld/ELF/Arch/Target.cpp
+++ b/vadl/main/resources/templates/lcb/lld/ELF/Arch/Target.cpp
@@ -51,7 +51,7 @@ namespace lld
         } // end anonymous namespace
 
         RelType [(${namespace})]::getDynRel(RelType type) const {
-            return type == symbolicRel ? type : static_cast<RelType>(R_rv64im_NONE);
+            return type == symbolicRel ? type : static_cast<RelType>(R_[(${namespace})]_NONE);
         }
 
         RelExpr [(${namespace})]::getRelExpr(const RelType type, const Symbol &s,

--- a/vadl/main/resources/templates/lcb/lld/ELF/Arch/Target.cpp
+++ b/vadl/main/resources/templates/lcb/lld/ELF/Arch/Target.cpp
@@ -33,9 +33,26 @@ namespace lld
                 RelExpr getRelExpr(RelType type, const Symbol &s,
                                    const uint8_t *loc) const override;
                 void relocate(uint8_t * loc, const Relocation &rel, uint64_t val) const override;
+                RelType getDynRel(RelType type) const override;
+
+                [(${namespace})]() {
+                  if (config->is64) {
+                    symbolicRel = R_[(${namespace})]_64;
+                    relativeRel = R_[(${namespace})]_64;
+                  } else {
+                    symbolicRel = R_[(${namespace})]_32;
+                    relativeRel = R_[(${namespace})]_32;
+                  }
+                }
             };
 
+
+
         } // end anonymous namespace
+
+        RelType [(${namespace})]::getDynRel(RelType type) const {
+            return type == symbolicRel ? type : static_cast<RelType>(R_rv64im_NONE);
+        }
 
         RelExpr [(${namespace})]::getRelExpr(const RelType type, const Symbol &s,
                                             const uint8_t *loc) const

--- a/vadl/main/resources/templates/lcb/lld/ELF/InputSection.cpp
+++ b/vadl/main/resources/templates/lcb/lld/ELF/InputSection.cpp
@@ -1,0 +1,1517 @@
+//===- InputSection.cpp ---------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "InputSection.h"
+#include "Config.h"
+#include "InputFiles.h"
+#include "OutputSections.h"
+#include "Relocations.h"
+#include "SymbolTable.h"
+#include "Symbols.h"
+#include "SyntheticSections.h"
+#include "Target.h"
+#include "lld/Common/CommonLinkerContext.h"
+#include "llvm/Support/Compiler.h"
+#include "llvm/Support/Compression.h"
+#include "llvm/Support/Endian.h"
+#include "llvm/Support/xxhash.h"
+#include <algorithm>
+#include <mutex>
+#include <optional>
+#include <vector>
+
+using namespace llvm;
+using namespace llvm::ELF;
+using namespace llvm::object;
+using namespace llvm::support;
+using namespace llvm::support::endian;
+using namespace llvm::sys;
+using namespace lld;
+using namespace lld::elf;
+
+DenseSet<std::pair<const Symbol *, uint64_t>> elf::ppc64noTocRelax;
+
+// Returns a string to construct an error message.
+std::string lld::toString(const InputSectionBase *sec) {
+  return (toString(sec->file) + ":(" + sec->name + ")").str();
+}
+
+template <class ELFT>
+static ArrayRef<uint8_t> getSectionContents(ObjFile<ELFT> &file,
+                                            const typename ELFT::Shdr &hdr) {
+  if (hdr.sh_type == SHT_NOBITS)
+    return ArrayRef<uint8_t>(nullptr, hdr.sh_size);
+  return check(file.getObj().getSectionContents(hdr));
+}
+
+InputSectionBase::InputSectionBase(InputFile *file, uint64_t flags,
+                                   uint32_t type, uint64_t entsize,
+                                   uint32_t link, uint32_t info,
+                                   uint32_t addralign, ArrayRef<uint8_t> data,
+                                   StringRef name, Kind sectionKind)
+    : SectionBase(sectionKind, name, flags, entsize, addralign, type, info,
+                  link),
+      file(file), content_(data.data()), size(data.size()) {
+  // In order to reduce memory allocation, we assume that mergeable
+  // sections are smaller than 4 GiB, which is not an unreasonable
+  // assumption as of 2017.
+  if (sectionKind == SectionBase::Merge && content().size() > UINT32_MAX)
+    error(toString(this) + ": section too large");
+
+  // The ELF spec states that a value of 0 means the section has
+  // no alignment constraints.
+  uint32_t v = std::max<uint32_t>(addralign, 1);
+  if (!isPowerOf2_64(v))
+    fatal(toString(this) + ": sh_addralign is not a power of 2");
+  this->addralign = v;
+
+  // If SHF_COMPRESSED is set, parse the header. The legacy .zdebug format is no
+  // longer supported.
+  if (flags & SHF_COMPRESSED)
+    invokeELFT(parseCompressedHeader,);
+}
+
+// SHF_INFO_LINK and SHF_GROUP are normally resolved and not copied to the
+// output section. However, for relocatable linking without
+// --force-group-allocation, the SHF_GROUP flag and section groups are retained.
+static uint64_t getFlags(uint64_t flags) {
+  flags &= ~(uint64_t)SHF_INFO_LINK;
+  if (config->resolveGroups)
+    flags &= ~(uint64_t)SHF_GROUP;
+  return flags;
+}
+
+template <class ELFT>
+InputSectionBase::InputSectionBase(ObjFile<ELFT> &file,
+                                   const typename ELFT::Shdr &hdr,
+                                   StringRef name, Kind sectionKind)
+    : InputSectionBase(&file, getFlags(hdr.sh_flags), hdr.sh_type,
+                       hdr.sh_entsize, hdr.sh_link, hdr.sh_info,
+                       hdr.sh_addralign, getSectionContents(file, hdr), name,
+                       sectionKind) {
+  // We reject object files having insanely large alignments even though
+  // they are allowed by the spec. I think 4GB is a reasonable limitation.
+  // We might want to relax this in the future.
+  if (hdr.sh_addralign > UINT32_MAX)
+    fatal(toString(&file) + ": section sh_addralign is too large");
+}
+
+size_t InputSectionBase::getSize() const {
+  if (auto *s = dyn_cast<SyntheticSection>(this))
+    return s->getSize();
+  return size - bytesDropped;
+}
+
+template <class ELFT>
+static void decompressAux(const InputSectionBase &sec, uint8_t *out,
+                          size_t size) {
+  auto *hdr = reinterpret_cast<const typename ELFT::Chdr *>(sec.content_);
+  auto compressed = ArrayRef<uint8_t>(sec.content_, sec.compressedSize)
+                        .slice(sizeof(typename ELFT::Chdr));
+  if (Error e = hdr->ch_type == ELFCOMPRESS_ZLIB
+                    ? compression::zlib::decompress(compressed, out, size)
+                    : compression::zstd::decompress(compressed, out, size))
+    fatal(toString(&sec) +
+          ": decompress failed: " + llvm::toString(std::move(e)));
+}
+
+void InputSectionBase::decompress() const {
+  uint8_t *uncompressedBuf;
+  {
+    static std::mutex mu;
+    std::lock_guard<std::mutex> lock(mu);
+    uncompressedBuf = bAlloc().Allocate<uint8_t>(size);
+  }
+
+  invokeELFT(decompressAux, *this, uncompressedBuf, size);
+  content_ = uncompressedBuf;
+  compressed = false;
+}
+
+template <class ELFT>
+RelsOrRelas<ELFT> InputSectionBase::relsOrRelas(bool supportsCrel) const {
+  if (relSecIdx == 0)
+    return {};
+  RelsOrRelas<ELFT> ret;
+  auto *f = cast<ObjFile<ELFT>>(file);
+  typename ELFT::Shdr shdr = f->template getELFShdrs<ELFT>()[relSecIdx];
+  if (shdr.sh_type == SHT_CREL) {
+    // Return an iterator if supported by caller.
+    if (supportsCrel) {
+      ret.crels = Relocs<typename ELFT::Crel>(
+          (const uint8_t *)f->mb.getBufferStart() + shdr.sh_offset);
+      return ret;
+    }
+    InputSectionBase *const &relSec = f->getSections()[relSecIdx];
+    // Otherwise, allocate a buffer to hold the decoded RELA relocations. When
+    // called for the first time, relSec is null (without --emit-relocs) or an
+    // InputSection with false decodedCrel.
+    if (!relSec || !cast<InputSection>(relSec)->decodedCrel) {
+      auto *sec = makeThreadLocal<InputSection>(*f, shdr, name);
+      f->cacheDecodedCrel(relSecIdx, sec);
+      sec->type = SHT_RELA;
+      sec->decodedCrel = true;
+
+      RelocsCrel<ELFT::Is64Bits> entries(sec->content_);
+      sec->size = entries.size() * sizeof(typename ELFT::Rela);
+      auto *relas = makeThreadLocalN<typename ELFT::Rela>(entries.size());
+      sec->content_ = reinterpret_cast<uint8_t *>(relas);
+      for (auto [i, r] : llvm::enumerate(entries)) {
+        relas[i].r_offset = r.r_offset;
+        relas[i].setSymbolAndType(r.r_symidx, r.r_type, false);
+        relas[i].r_addend = r.r_addend;
+      }
+    }
+    ret.relas = {ArrayRef(
+        reinterpret_cast<const typename ELFT::Rela *>(relSec->content_),
+        relSec->size / sizeof(typename ELFT::Rela))};
+    return ret;
+  }
+
+  const void *content = f->mb.getBufferStart() + shdr.sh_offset;
+  size_t size = shdr.sh_size;
+  if (shdr.sh_type == SHT_REL) {
+    ret.rels = {ArrayRef(reinterpret_cast<const typename ELFT::Rel *>(content),
+                         size / sizeof(typename ELFT::Rel))};
+  } else {
+    assert(shdr.sh_type == SHT_RELA);
+    ret.relas = {
+        ArrayRef(reinterpret_cast<const typename ELFT::Rela *>(content),
+                 size / sizeof(typename ELFT::Rela))};
+  }
+  return ret;
+}
+
+uint64_t SectionBase::getOffset(uint64_t offset) const {
+  switch (kind()) {
+  case Output: {
+    auto *os = cast<OutputSection>(this);
+    // For output sections we treat offset -1 as the end of the section.
+    return offset == uint64_t(-1) ? os->size : offset;
+  }
+  case Regular:
+  case Synthetic:
+  case Spill:
+    return cast<InputSection>(this)->outSecOff + offset;
+  case EHFrame: {
+    // Two code paths may reach here. First, clang_rt.crtbegin.o and GCC
+    // crtbeginT.o may reference the start of an empty .eh_frame to identify the
+    // start of the output .eh_frame. Just return offset.
+    //
+    // Second, InputSection::copyRelocations on .eh_frame. Some pieces may be
+    // discarded due to GC/ICF. We should compute the output section offset.
+    const EhInputSection *es = cast<EhInputSection>(this);
+    if (!es->content().empty())
+      if (InputSection *isec = es->getParent())
+        return isec->outSecOff + es->getParentOffset(offset);
+    return offset;
+  }
+  case Merge:
+    const MergeInputSection *ms = cast<MergeInputSection>(this);
+    if (InputSection *isec = ms->getParent())
+      return isec->outSecOff + ms->getParentOffset(offset);
+    return ms->getParentOffset(offset);
+  }
+  llvm_unreachable("invalid section kind");
+}
+
+uint64_t SectionBase::getVA(uint64_t offset) const {
+  const OutputSection *out = getOutputSection();
+  return (out ? out->addr : 0) + getOffset(offset);
+}
+
+OutputSection *SectionBase::getOutputSection() {
+  InputSection *sec;
+  if (auto *isec = dyn_cast<InputSection>(this))
+    sec = isec;
+  else if (auto *ms = dyn_cast<MergeInputSection>(this))
+    sec = ms->getParent();
+  else if (auto *eh = dyn_cast<EhInputSection>(this))
+    sec = eh->getParent();
+  else
+    return cast<OutputSection>(this);
+  return sec ? sec->getParent() : nullptr;
+}
+
+// When a section is compressed, `rawData` consists with a header followed
+// by zlib-compressed data. This function parses a header to initialize
+// `uncompressedSize` member and remove the header from `rawData`.
+template <typename ELFT> void InputSectionBase::parseCompressedHeader() {
+  flags &= ~(uint64_t)SHF_COMPRESSED;
+
+  // New-style header
+  if (content().size() < sizeof(typename ELFT::Chdr)) {
+    error(toString(this) + ": corrupted compressed section");
+    return;
+  }
+
+  auto *hdr = reinterpret_cast<const typename ELFT::Chdr *>(content().data());
+  if (hdr->ch_type == ELFCOMPRESS_ZLIB) {
+    if (!compression::zlib::isAvailable())
+      error(toString(this) + " is compressed with ELFCOMPRESS_ZLIB, but lld is "
+                             "not built with zlib support");
+  } else if (hdr->ch_type == ELFCOMPRESS_ZSTD) {
+    if (!compression::zstd::isAvailable())
+      error(toString(this) + " is compressed with ELFCOMPRESS_ZSTD, but lld is "
+                             "not built with zstd support");
+  } else {
+    error(toString(this) + ": unsupported compression type (" +
+          Twine(hdr->ch_type) + ")");
+    return;
+  }
+
+  compressed = true;
+  compressedSize = size;
+  size = hdr->ch_size;
+  addralign = std::max<uint32_t>(hdr->ch_addralign, 1);
+}
+
+InputSection *InputSectionBase::getLinkOrderDep() const {
+  assert(flags & SHF_LINK_ORDER);
+  if (!link)
+    return nullptr;
+  return cast<InputSection>(file->getSections()[link]);
+}
+
+// Find a symbol that encloses a given location.
+Defined *InputSectionBase::getEnclosingSymbol(uint64_t offset,
+                                              uint8_t type) const {
+  if (file->isInternal())
+    return nullptr;
+  for (Symbol *b : file->getSymbols())
+    if (Defined *d = dyn_cast<Defined>(b))
+      if (d->section == this && d->value <= offset &&
+          offset < d->value + d->size && (type == 0 || type == d->type))
+        return d;
+  return nullptr;
+}
+
+// Returns an object file location string. Used to construct an error message.
+std::string InputSectionBase::getLocation(uint64_t offset) const {
+  std::string secAndOffset =
+      (name + "+0x" + Twine::utohexstr(offset) + ")").str();
+
+  // We don't have file for synthetic sections.
+  if (file == nullptr)
+    return (config->outputFile + ":(" + secAndOffset).str();
+
+  std::string filename = toString(file);
+  if (Defined *d = getEnclosingFunction(offset))
+    return filename + ":(function " + toString(*d) + ": " + secAndOffset;
+
+  return filename + ":(" + secAndOffset;
+}
+
+// This function is intended to be used for constructing an error message.
+// The returned message looks like this:
+//
+//   foo.c:42 (/home/alice/possibly/very/long/path/foo.c:42)
+//
+//  Returns an empty string if there's no way to get line info.
+std::string InputSectionBase::getSrcMsg(const Symbol &sym,
+                                        uint64_t offset) const {
+  return file->getSrcMsg(sym, *this, offset);
+}
+
+// Returns a filename string along with an optional section name. This
+// function is intended to be used for constructing an error
+// message. The returned message looks like this:
+//
+//   path/to/foo.o:(function bar)
+//
+// or
+//
+//   path/to/foo.o:(function bar) in archive path/to/bar.a
+std::string InputSectionBase::getObjMsg(uint64_t off) const {
+  std::string filename = std::string(file->getName());
+
+  std::string archive;
+  if (!file->archiveName.empty())
+    archive = (" in archive " + file->archiveName).str();
+
+  // Find a symbol that encloses a given location. getObjMsg may be called
+  // before ObjFile::initSectionsAndLocalSyms where local symbols are
+  // initialized.
+  if (Defined *d = getEnclosingSymbol(off))
+    return filename + ":(" + toString(*d) + ")" + archive;
+
+  // If there's no symbol, print out the offset in the section.
+  return (filename + ":(" + name + "+0x" + utohexstr(off) + ")" + archive)
+      .str();
+}
+
+PotentialSpillSection::PotentialSpillSection(const InputSectionBase &source,
+                                             InputSectionDescription &isd)
+    : InputSection(source.file, source.flags, source.type, source.addralign, {},
+                   source.name, SectionBase::Spill),
+      isd(&isd) {}
+
+InputSection InputSection::discarded(nullptr, 0, 0, 0, ArrayRef<uint8_t>(), "");
+
+InputSection::InputSection(InputFile *f, uint64_t flags, uint32_t type,
+                           uint32_t addralign, ArrayRef<uint8_t> data,
+                           StringRef name, Kind k)
+    : InputSectionBase(f, flags, type,
+                       /*Entsize*/ 0, /*Link*/ 0, /*Info*/ 0, addralign, data,
+                       name, k) {
+  assert(f || this == &InputSection::discarded);
+}
+
+template <class ELFT>
+InputSection::InputSection(ObjFile<ELFT> &f, const typename ELFT::Shdr &header,
+                           StringRef name)
+    : InputSectionBase(f, header, name, InputSectionBase::Regular) {}
+
+// Copy SHT_GROUP section contents. Used only for the -r option.
+template <class ELFT> void InputSection::copyShtGroup(uint8_t *buf) {
+  // ELFT::Word is the 32-bit integral type in the target endianness.
+  using u32 = typename ELFT::Word;
+  ArrayRef<u32> from = getDataAs<u32>();
+  auto *to = reinterpret_cast<u32 *>(buf);
+
+  // The first entry is not a section number but a flag.
+  *to++ = from[0];
+
+  // Adjust section numbers because section numbers in an input object files are
+  // different in the output. We also need to handle combined or discarded
+  // members.
+  ArrayRef<InputSectionBase *> sections = file->getSections();
+  DenseSet<uint32_t> seen;
+  for (uint32_t idx : from.slice(1)) {
+    OutputSection *osec = sections[idx]->getOutputSection();
+    if (osec && seen.insert(osec->sectionIndex).second)
+      *to++ = osec->sectionIndex;
+  }
+}
+
+InputSectionBase *InputSection::getRelocatedSection() const {
+  if (file->isInternal() || !isStaticRelSecType(type))
+    return nullptr;
+  ArrayRef<InputSectionBase *> sections = file->getSections();
+  return sections[info];
+}
+
+template <class ELFT, class RelTy>
+void InputSection::copyRelocations(uint8_t *buf) {
+  if (config->relax && !config->relocatable &&
+      (config->emachine == EM_RISCV || config->emachine == EM_LOONGARCH)) {
+    // On LoongArch and RISC-V, relaxation might change relocations: copy
+    // from internal ones that are updated by relaxation.
+    InputSectionBase *sec = getRelocatedSection();
+    copyRelocations<ELFT, RelTy>(buf, llvm::make_range(sec->relocations.begin(),
+                                                       sec->relocations.end()));
+  } else {
+    // Convert the raw relocations in the input section into Relocation objects
+    // suitable to be used by copyRelocations below.
+    struct MapRel {
+      const ObjFile<ELFT> &file;
+      Relocation operator()(const RelTy &rel) const {
+        // RelExpr is not used so set to a dummy value.
+        return Relocation{R_NONE, rel.getType(config->isMips64EL), rel.r_offset,
+                          getAddend<ELFT>(rel), &file.getRelocTargetSym(rel)};
+      }
+    };
+
+    using RawRels = ArrayRef<RelTy>;
+    using MapRelIter =
+        llvm::mapped_iterator<typename RawRels::iterator, MapRel>;
+    auto mapRel = MapRel{*getFile<ELFT>()};
+    RawRels rawRels = getDataAs<RelTy>();
+    auto rels = llvm::make_range(MapRelIter(rawRels.begin(), mapRel),
+                                 MapRelIter(rawRels.end(), mapRel));
+    copyRelocations<ELFT, RelTy>(buf, rels);
+  }
+}
+
+// This is used for -r and --emit-relocs. We can't use memcpy to copy
+// relocations because we need to update symbol table offset and section index
+// for each relocation. So we copy relocations one by one.
+template <class ELFT, class RelTy, class RelIt>
+void InputSection::copyRelocations(uint8_t *buf,
+                                   llvm::iterator_range<RelIt> rels) {
+  const TargetInfo &target = *elf::target;
+  InputSectionBase *sec = getRelocatedSection();
+  (void)sec->contentMaybeDecompress(); // uncompress if needed
+
+  for (const Relocation &rel : rels) {
+    RelType type = rel.type;
+    const ObjFile<ELFT> *file = getFile<ELFT>();
+    Symbol &sym = *rel.sym;
+
+    auto *p = reinterpret_cast<typename ELFT::Rela *>(buf);
+    buf += sizeof(RelTy);
+
+    if (RelTy::HasAddend)
+      p->r_addend = rel.addend;
+
+    // Output section VA is zero for -r, so r_offset is an offset within the
+    // section, but for --emit-relocs it is a virtual address.
+    p->r_offset = sec->getVA(rel.offset);
+    p->setSymbolAndType(in.symTab->getSymbolIndex(sym), type,
+                        config->isMips64EL);
+
+    if (sym.type == STT_SECTION) {
+      // We combine multiple section symbols into only one per
+      // section. This means we have to update the addend. That is
+      // trivial for Elf_Rela, but for Elf_Rel we have to write to the
+      // section data. We do that by adding to the Relocation vector.
+
+      // .eh_frame is horribly special and can reference discarded sections. To
+      // avoid having to parse and recreate .eh_frame, we just replace any
+      // relocation in it pointing to discarded sections with R_*_NONE, which
+      // hopefully creates a frame that is ignored at runtime. Also, don't warn
+      // on .gcc_except_table and debug sections.
+      //
+      // See the comment in maybeReportUndefined for PPC32 .got2 and PPC64 .toc
+      auto *d = dyn_cast<Defined>(&sym);
+      if (!d) {
+        if (!isDebugSection(*sec) && sec->name != ".eh_frame" &&
+            sec->name != ".gcc_except_table" && sec->name != ".got2" &&
+            sec->name != ".toc") {
+          uint32_t secIdx = cast<Undefined>(sym).discardedSecIdx;
+          Elf_Shdr_Impl<ELFT> sec = file->template getELFShdrs<ELFT>()[secIdx];
+          warn("relocation refers to a discarded section: " +
+               CHECK(file->getObj().getSectionName(sec), file) +
+               "\n>>> referenced by " + getObjMsg(p->r_offset));
+        }
+        p->setSymbolAndType(0, 0, false);
+        continue;
+      }
+      SectionBase *section = d->section;
+      assert(section->isLive());
+
+      int64_t addend = rel.addend;
+      const uint8_t *bufLoc = sec->content().begin() + rel.offset;
+      if (!RelTy::HasAddend)
+        addend = target.getImplicitAddend(bufLoc, type);
+
+      if (config->emachine == EM_MIPS &&
+          target.getRelExpr(type, sym, bufLoc) == R_MIPS_GOTREL) {
+        // Some MIPS relocations depend on "gp" value. By default,
+        // this value has 0x7ff0 offset from a .got section. But
+        // relocatable files produced by a compiler or a linker
+        // might redefine this default value and we must use it
+        // for a calculation of the relocation result. When we
+        // generate EXE or DSO it's trivial. Generating a relocatable
+        // output is more difficult case because the linker does
+        // not calculate relocations in this mode and loses
+        // individual "gp" values used by each input object file.
+        // As a workaround we add the "gp" value to the relocation
+        // addend and save it back to the file.
+        addend += sec->getFile<ELFT>()->mipsGp0;
+      }
+
+      if (RelTy::HasAddend)
+        p->r_addend = sym.getVA(addend) - section->getOutputSection()->addr;
+      // For SHF_ALLOC sections relocated by REL, append a relocation to
+      // sec->relocations so that relocateAlloc transitively called by
+      // writeSections will update the implicit addend. Non-SHF_ALLOC sections
+      // utilize relocateNonAlloc to process raw relocations and do not need
+      // this sec->relocations change.
+      else if (config->relocatable && (sec->flags & SHF_ALLOC) &&
+               type != target.noneRel)
+        sec->addReloc({R_ABS, type, rel.offset, addend, &sym});
+    } else if (config->emachine == EM_PPC && type == R_PPC_PLTREL24 &&
+               p->r_addend >= 0x8000 && sec->file->ppc32Got2) {
+      // Similar to R_MIPS_GPREL{16,32}. If the addend of R_PPC_PLTREL24
+      // indicates that r30 is relative to the input section .got2
+      // (r_addend>=0x8000), after linking, r30 should be relative to the output
+      // section .got2 . To compensate for the shift, adjust r_addend by
+      // ppc32Got->outSecOff.
+      p->r_addend += sec->file->ppc32Got2->outSecOff;
+    }
+  }
+}
+
+// The ARM and AArch64 ABI handle pc-relative relocations to undefined weak
+// references specially. The general rule is that the value of the symbol in
+// this context is the address of the place P. A further special case is that
+// branch relocations to an undefined weak reference resolve to the next
+// instruction.
+static uint32_t getARMUndefinedRelativeWeakVA(RelType type, uint32_t a,
+                                              uint32_t p) {
+  switch (type) {
+  // Unresolved branch relocations to weak references resolve to next
+  // instruction, this will be either 2 or 4 bytes on from P.
+  case R_ARM_THM_JUMP8:
+  case R_ARM_THM_JUMP11:
+    return p + 2 + a;
+  case R_ARM_CALL:
+  case R_ARM_JUMP24:
+  case R_ARM_PC24:
+  case R_ARM_PLT32:
+  case R_ARM_PREL31:
+  case R_ARM_THM_JUMP19:
+  case R_ARM_THM_JUMP24:
+    return p + 4 + a;
+  case R_ARM_THM_CALL:
+    // We don't want an interworking BLX to ARM
+    return p + 5 + a;
+  // Unresolved non branch pc-relative relocations
+  // R_ARM_TARGET2 which can be resolved relatively is not present as it never
+  // targets a weak-reference.
+  case R_ARM_MOVW_PREL_NC:
+  case R_ARM_MOVT_PREL:
+  case R_ARM_REL32:
+  case R_ARM_THM_ALU_PREL_11_0:
+  case R_ARM_THM_MOVW_PREL_NC:
+  case R_ARM_THM_MOVT_PREL:
+  case R_ARM_THM_PC12:
+    return p + a;
+  // p + a is unrepresentable as negative immediates can't be encoded.
+  case R_ARM_THM_PC8:
+    return p;
+  }
+  llvm_unreachable("ARM pc-relative relocation expected\n");
+}
+
+// The comment above getARMUndefinedRelativeWeakVA applies to this function.
+static uint64_t getAArch64UndefinedRelativeWeakVA(uint64_t type, uint64_t p) {
+  switch (type) {
+  // Unresolved branch relocations to weak references resolve to next
+  // instruction, this is 4 bytes on from P.
+  case R_AARCH64_CALL26:
+  case R_AARCH64_CONDBR19:
+  case R_AARCH64_JUMP26:
+  case R_AARCH64_TSTBR14:
+    return p + 4;
+  // Unresolved non branch pc-relative relocations
+  case R_AARCH64_PREL16:
+  case R_AARCH64_PREL32:
+  case R_AARCH64_PREL64:
+  case R_AARCH64_ADR_PREL_LO21:
+  case R_AARCH64_LD_PREL_LO19:
+  case R_AARCH64_PLT32:
+    return p;
+  }
+  llvm_unreachable("AArch64 pc-relative relocation expected\n");
+}
+
+static uint64_t getRISCVUndefinedRelativeWeakVA(uint64_t type, uint64_t p) {
+  switch (type) {
+  case R_RISCV_BRANCH:
+  case R_RISCV_JAL:
+  case R_RISCV_CALL:
+  case R_RISCV_CALL_PLT:
+  case R_RISCV_RVC_BRANCH:
+  case R_RISCV_RVC_JUMP:
+  case R_RISCV_PLT32:
+    return p;
+  default:
+    return 0;
+  }
+}
+
+// ARM SBREL relocations are of the form S + A - B where B is the static base
+// The ARM ABI defines base to be "addressing origin of the output segment
+// defining the symbol S". We defined the "addressing origin"/static base to be
+// the base of the PT_LOAD segment containing the Sym.
+// The procedure call standard only defines a Read Write Position Independent
+// RWPI variant so in practice we should expect the static base to be the base
+// of the RW segment.
+static uint64_t getARMStaticBase(const Symbol &sym) {
+  OutputSection *os = sym.getOutputSection();
+  if (!os || !os->ptLoad || !os->ptLoad->firstSec)
+    fatal("SBREL relocation to " + sym.getName() + " without static base");
+  return os->ptLoad->firstSec->addr;
+}
+
+// For R_RISCV_PC_INDIRECT (R_RISCV_PCREL_LO12_{I,S}), the symbol actually
+// points the corresponding R_RISCV_PCREL_HI20 relocation, and the target VA
+// is calculated using PCREL_HI20's symbol.
+//
+// This function returns the R_RISCV_PCREL_HI20 relocation from
+// R_RISCV_PCREL_LO12's symbol and addend.
+static Relocation *getRISCVPCRelHi20(const Symbol *sym, uint64_t addend) {
+  const Defined *d = cast<Defined>(sym);
+  if (!d->section) {
+    errorOrWarn("R_RISCV_PCREL_LO12 relocation points to an absolute symbol: " +
+                sym->getName());
+    return nullptr;
+  }
+  InputSection *isec = cast<InputSection>(d->section);
+
+  if (addend != 0)
+    warn("non-zero addend in R_RISCV_PCREL_LO12 relocation to " +
+         isec->getObjMsg(d->value) + " is ignored");
+
+  // Relocations are sorted by offset, so we can use std::equal_range to do
+  // binary search.
+  Relocation r;
+  r.offset = d->value;
+  auto range =
+      std::equal_range(isec->relocs().begin(), isec->relocs().end(), r,
+                       [](const Relocation &lhs, const Relocation &rhs) {
+                         return lhs.offset < rhs.offset;
+                       });
+
+  for (auto it = range.first; it != range.second; ++it)
+    if (it->type == R_RISCV_PCREL_HI20 || it->type == R_RISCV_GOT_HI20 ||
+        it->type == R_RISCV_TLS_GD_HI20 || it->type == R_RISCV_TLS_GOT_HI20)
+      return &*it;
+
+  errorOrWarn("R_RISCV_PCREL_LO12 relocation points to " +
+              isec->getObjMsg(d->value) +
+              " without an associated R_RISCV_PCREL_HI20 relocation");
+  return nullptr;
+}
+
+// A TLS symbol's virtual address is relative to the TLS segment. Add a
+// target-specific adjustment to produce a thread-pointer-relative offset.
+static int64_t getTlsTpOffset(const Symbol &s) {
+  // On targets that support TLSDESC, _TLS_MODULE_BASE_@tpoff = 0.
+  if (&s == ElfSym::tlsModuleBase)
+    return 0;
+
+  // There are 2 TLS layouts. Among targets we support, x86 uses TLS Variant 2
+  // while most others use Variant 1. At run time TP will be aligned to p_align.
+
+  // Variant 1. TP will be followed by an optional gap (which is the size of 2
+  // pointers on ARM/AArch64, 0 on other targets), followed by alignment
+  // padding, then the static TLS blocks. The alignment padding is added so that
+  // (TP + gap + padding) is congruent to p_vaddr modulo p_align.
+  //
+  // Variant 2. Static TLS blocks, followed by alignment padding are placed
+  // before TP. The alignment padding is added so that (TP - padding -
+  // p_memsz) is congruent to p_vaddr modulo p_align.
+  PhdrEntry *tls = Out::tlsPhdr;
+  switch (config->emachine) {
+    // Variant 1.
+  case EM_ARM:
+  case EM_AARCH64:
+    return s.getVA(0) + config->wordsize * 2 +
+           ((tls->p_vaddr - config->wordsize * 2) & (tls->p_align - 1));
+  case EM_MIPS:
+  case EM_PPC:
+  case EM_PPC64:
+    // Adjusted Variant 1. TP is placed with a displacement of 0x7000, which is
+    // to allow a signed 16-bit offset to reach 0x1000 of TCB/thread-library
+    // data and 0xf000 of the program's TLS segment.
+    return s.getVA(0) + (tls->p_vaddr & (tls->p_align - 1)) - 0x7000;
+  case EM_LOONGARCH:
+  case EM_RISCV:
+    // See the comment in handleTlsRelocation. For TLSDESC=>IE,
+    // R_RISCV_TLSDESC_{LOAD_LO12,ADD_LO12_I,CALL} also reach here. While
+    // `tls` may be null, the return value is ignored.
+    if (s.type != STT_TLS)
+      return 0;
+    return s.getVA(0) + (tls->p_vaddr & (tls->p_align - 1));
+
+    // Variant 2.
+  case EM_HEXAGON:
+  case EM_S390:
+  case EM_SPARCV9:
+  case EM_386:
+  case EM_X86_64:
+    return s.getVA(0) - tls->p_memsz -
+           ((-tls->p_vaddr - tls->p_memsz) & (tls->p_align - 1));
+  default:
+    llvm_unreachable("unhandled Config->EMachine");
+  }
+}
+
+static Relocation *getPairReloc(const Symbol *sym, uint64_t addend) {
+  const Defined *d = cast<Defined>(sym);
+  if (!d->section) {
+    errorOrWarn("PAIRED relocation points to an absolute symbol: " +
+                sym->getName());
+    return nullptr;
+  }
+  InputSection *isec = cast<InputSection>(d->section);
+
+  if (addend != 0)
+    warn("non-zero addend in PAIRED relocation to " +
+         isec->getObjMsg(d->value) + " is ignored");
+
+  // Relocations are sorted by offset, so we can use std::equal_range to do
+  // binary search.
+  Relocation r;
+  r.offset = d->value;
+  auto range =
+      std::equal_range(isec->relocs().begin(), isec->relocs().end(), r,
+                       [](const Relocation &lhs, const Relocation &rhs) {
+                         return lhs.offset < rhs.offset;
+                       });
+
+  for (auto it = range.first; it != range.second; ++it)
+      return &*it;
+
+  return nullptr;
+}
+
+uint64_t InputSectionBase::getRelocTargetVA(const InputFile *file, RelType type,
+                                            int64_t a, uint64_t p,
+                                            const Symbol &sym, RelExpr expr) {
+  switch (expr) {
+  case R_[(${namespace})]_INDIRECT:
+    if (const Relocation* pairReloc = getPairReloc(&sym, a)) {
+      return getRelocTargetVA(file, pairReloc->type, pairReloc->addend, sym.getVA(),
+                                    *pairReloc->sym, pairReloc->expr);
+    }
+    return 0;
+  case R_ABS:
+  case R_DTPREL:
+  case R_RELAX_TLS_LD_TO_LE_ABS:
+  case R_RELAX_GOT_PC_NOPIC:
+  case R_AARCH64_AUTH:
+  case R_RISCV_ADD:
+  case R_RISCV_LEB128:
+    return sym.getVA(a);
+  case R_ADDEND:
+    return a;
+  case R_RELAX_HINT:
+    return 0;
+  case R_ARM_SBREL:
+    return sym.getVA(a) - getARMStaticBase(sym);
+  case R_GOT:
+  case R_RELAX_TLS_GD_TO_IE_ABS:
+    return sym.getGotVA() + a;
+  case R_LOONGARCH_GOT:
+    // The LoongArch TLS GD relocs reuse the R_LARCH_GOT_PC_LO12 reloc type
+    // for their page offsets. The arithmetics are different in the TLS case
+    // so we have to duplicate some logic here.
+    if (sym.hasFlag(NEEDS_TLSGD) && type != R_LARCH_TLS_IE_PC_LO12)
+      // Like R_LOONGARCH_TLSGD_PAGE_PC but taking the absolute value.
+      return in.got->getGlobalDynAddr(sym) + a;
+    return getRelocTargetVA(file, type, a, p, sym, R_GOT);
+  case R_GOTONLY_PC:
+    return in.got->getVA() + a - p;
+  case R_GOTPLTONLY_PC:
+    return in.gotPlt->getVA() + a - p;
+  case R_GOTREL:
+  case R_PPC64_RELAX_TOC:
+    return sym.getVA(a) - in.got->getVA();
+  case R_GOTPLTREL:
+    return sym.getVA(a) - in.gotPlt->getVA();
+  case R_GOTPLT:
+  case R_RELAX_TLS_GD_TO_IE_GOTPLT:
+    return sym.getGotVA() + a - in.gotPlt->getVA();
+  case R_TLSLD_GOT_OFF:
+  case R_GOT_OFF:
+  case R_RELAX_TLS_GD_TO_IE_GOT_OFF:
+    return sym.getGotOffset() + a;
+  case R_AARCH64_GOT_PAGE_PC:
+  case R_AARCH64_RELAX_TLS_GD_TO_IE_PAGE_PC:
+    return getAArch64Page(sym.getGotVA() + a) - getAArch64Page(p);
+  case R_AARCH64_GOT_PAGE:
+    return sym.getGotVA() + a - getAArch64Page(in.got->getVA());
+  case R_GOT_PC:
+  case R_RELAX_TLS_GD_TO_IE:
+    return sym.getGotVA() + a - p;
+  case R_GOTPLT_GOTREL:
+    return sym.getGotPltVA() + a - in.got->getVA();
+  case R_GOTPLT_PC:
+    return sym.getGotPltVA() + a - p;
+  case R_LOONGARCH_GOT_PAGE_PC:
+    if (sym.hasFlag(NEEDS_TLSGD))
+      return getLoongArchPageDelta(in.got->getGlobalDynAddr(sym) + a, p, type);
+    return getLoongArchPageDelta(sym.getGotVA() + a, p, type);
+  case R_MIPS_GOTREL:
+    return sym.getVA(a) - in.mipsGot->getGp(file);
+  case R_MIPS_GOT_GP:
+    return in.mipsGot->getGp(file) + a;
+  case R_MIPS_GOT_GP_PC: {
+    // R_MIPS_LO16 expression has R_MIPS_GOT_GP_PC type iif the target
+    // is _gp_disp symbol. In that case we should use the following
+    // formula for calculation "AHL + GP - P + 4". For details see p. 4-19 at
+    // ftp://www.linux-mips.org/pub/linux/mips/doc/ABI/mipsabi.pdf
+    // microMIPS variants of these relocations use slightly different
+    // expressions: AHL + GP - P + 3 for %lo() and AHL + GP - P - 1 for %hi()
+    // to correctly handle less-significant bit of the microMIPS symbol.
+    uint64_t v = in.mipsGot->getGp(file) + a - p;
+    if (type == R_MIPS_LO16 || type == R_MICROMIPS_LO16)
+      v += 4;
+    if (type == R_MICROMIPS_LO16 || type == R_MICROMIPS_HI16)
+      v -= 1;
+    return v;
+  }
+  case R_MIPS_GOT_LOCAL_PAGE:
+    // If relocation against MIPS local symbol requires GOT entry, this entry
+    // should be initialized by 'page address'. This address is high 16-bits
+    // of sum the symbol's value and the addend.
+    return in.mipsGot->getVA() + in.mipsGot->getPageEntryOffset(file, sym, a) -
+           in.mipsGot->getGp(file);
+  case R_MIPS_GOT_OFF:
+  case R_MIPS_GOT_OFF32:
+    // In case of MIPS if a GOT relocation has non-zero addend this addend
+    // should be applied to the GOT entry content not to the GOT entry offset.
+    // That is why we use separate expression type.
+    return in.mipsGot->getVA() + in.mipsGot->getSymEntryOffset(file, sym, a) -
+           in.mipsGot->getGp(file);
+  case R_MIPS_TLSGD:
+    return in.mipsGot->getVA() + in.mipsGot->getGlobalDynOffset(file, sym) -
+           in.mipsGot->getGp(file);
+  case R_MIPS_TLSLD:
+    return in.mipsGot->getVA() + in.mipsGot->getTlsIndexOffset(file) -
+           in.mipsGot->getGp(file);
+  case R_AARCH64_PAGE_PC: {
+    uint64_t val = sym.isUndefWeak() ? p + a : sym.getVA(a);
+    return getAArch64Page(val) - getAArch64Page(p);
+  }
+  case R_RISCV_PC_INDIRECT: {
+    if (const Relocation *hiRel = getRISCVPCRelHi20(&sym, a))
+      return getRelocTargetVA(file, hiRel->type, hiRel->addend, sym.getVA(),
+                              *hiRel->sym, hiRel->expr);
+    return 0;
+  }
+  case R_LOONGARCH_PAGE_PC:
+    return getLoongArchPageDelta(sym.getVA(a), p, type);
+  case R_PC:
+  case R_ARM_PCA: {
+    uint64_t dest;
+    if (expr == R_ARM_PCA)
+      // Some PC relative ARM (Thumb) relocations align down the place.
+      p = p & 0xfffffffc;
+    if (sym.isUndefined()) {
+      // On ARM and AArch64 a branch to an undefined weak resolves to the next
+      // instruction, otherwise the place. On RISC-V, resolve an undefined weak
+      // to the same instruction to cause an infinite loop (making the user
+      // aware of the issue) while ensuring no overflow.
+      // Note: if the symbol is hidden, its binding has been converted to local,
+      // so we just check isUndefined() here.
+      if (config->emachine == EM_ARM)
+        dest = getARMUndefinedRelativeWeakVA(type, a, p);
+      else if (config->emachine == EM_AARCH64)
+        dest = getAArch64UndefinedRelativeWeakVA(type, p) + a;
+      else if (config->emachine == EM_PPC)
+        dest = p;
+      else if (config->emachine == EM_RISCV)
+        dest = getRISCVUndefinedRelativeWeakVA(type, p) + a;
+      else
+        dest = sym.getVA(a);
+    } else {
+      dest = sym.getVA(a);
+    }
+    return dest - p;
+  }
+  case R_PLT:
+    return sym.getPltVA() + a;
+  case R_PLT_PC:
+  case R_PPC64_CALL_PLT:
+    return sym.getPltVA() + a - p;
+  case R_LOONGARCH_PLT_PAGE_PC:
+    return getLoongArchPageDelta(sym.getPltVA() + a, p, type);
+  case R_PLT_GOTPLT:
+    return sym.getPltVA() + a - in.gotPlt->getVA();
+  case R_PLT_GOTREL:
+    return sym.getPltVA() + a - in.got->getVA();
+  case R_PPC32_PLTREL:
+    // R_PPC_PLTREL24 uses the addend (usually 0 or 0x8000) to indicate r30
+    // stores _GLOBAL_OFFSET_TABLE_ or .got2+0x8000. The addend is ignored for
+    // target VA computation.
+    return sym.getPltVA() - p;
+  case R_PPC64_CALL: {
+    uint64_t symVA = sym.getVA(a);
+    // If we have an undefined weak symbol, we might get here with a symbol
+    // address of zero. That could overflow, but the code must be unreachable,
+    // so don't bother doing anything at all.
+    if (!symVA)
+      return 0;
+
+    // PPC64 V2 ABI describes two entry points to a function. The global entry
+    // point is used for calls where the caller and callee (may) have different
+    // TOC base pointers and r2 needs to be modified to hold the TOC base for
+    // the callee. For local calls the caller and callee share the same
+    // TOC base and so the TOC pointer initialization code should be skipped by
+    // branching to the local entry point.
+    return symVA - p + getPPC64GlobalEntryToLocalEntryOffset(sym.stOther);
+  }
+  case R_PPC64_TOCBASE:
+    return getPPC64TocBase() + a;
+  case R_RELAX_GOT_PC:
+  case R_PPC64_RELAX_GOT_PC:
+    return sym.getVA(a) - p;
+  case R_RELAX_TLS_GD_TO_LE:
+  case R_RELAX_TLS_IE_TO_LE:
+  case R_RELAX_TLS_LD_TO_LE:
+  case R_TPREL:
+    // It is not very clear what to return if the symbol is undefined. With
+    // --noinhibit-exec, even a non-weak undefined reference may reach here.
+    // Just return A, which matches R_ABS, and the behavior of some dynamic
+    // loaders.
+    if (sym.isUndefined())
+      return a;
+    return getTlsTpOffset(sym) + a;
+  case R_RELAX_TLS_GD_TO_LE_NEG:
+  case R_TPREL_NEG:
+    if (sym.isUndefined())
+      return a;
+    return -getTlsTpOffset(sym) + a;
+  case R_SIZE:
+    return sym.getSize() + a;
+  case R_TLSDESC:
+    return in.got->getTlsDescAddr(sym) + a;
+  case R_TLSDESC_PC:
+    return in.got->getTlsDescAddr(sym) + a - p;
+  case R_TLSDESC_GOTPLT:
+    return in.got->getTlsDescAddr(sym) + a - in.gotPlt->getVA();
+  case R_AARCH64_TLSDESC_PAGE:
+    return getAArch64Page(in.got->getTlsDescAddr(sym) + a) - getAArch64Page(p);
+  case R_LOONGARCH_TLSDESC_PAGE_PC:
+    return getLoongArchPageDelta(in.got->getTlsDescAddr(sym) + a, p, type);
+  case R_TLSGD_GOT:
+    return in.got->getGlobalDynOffset(sym) + a;
+  case R_TLSGD_GOTPLT:
+    return in.got->getGlobalDynAddr(sym) + a - in.gotPlt->getVA();
+  case R_TLSGD_PC:
+    return in.got->getGlobalDynAddr(sym) + a - p;
+  case R_LOONGARCH_TLSGD_PAGE_PC:
+    return getLoongArchPageDelta(in.got->getGlobalDynAddr(sym) + a, p, type);
+  case R_TLSLD_GOTPLT:
+    return in.got->getVA() + in.got->getTlsIndexOff() + a - in.gotPlt->getVA();
+  case R_TLSLD_GOT:
+    return in.got->getTlsIndexOff() + a;
+  case R_TLSLD_PC:
+    return in.got->getTlsIndexVA() + a - p;
+  default:
+    llvm_unreachable("invalid expression");
+  }
+}
+
+// This function applies relocations to sections without SHF_ALLOC bit.
+// Such sections are never mapped to memory at runtime. Debug sections are
+// an example. Relocations in non-alloc sections are much easier to
+// handle than in allocated sections because it will never need complex
+// treatment such as GOT or PLT (because at runtime no one refers them).
+// So, we handle relocations for non-alloc sections directly in this
+// function as a performance optimization.
+template <class ELFT, class RelTy>
+void InputSection::relocateNonAlloc(uint8_t *buf, Relocs<RelTy> rels) {
+  const unsigned bits = sizeof(typename ELFT::uint) * 8;
+  const TargetInfo &target = *elf::target;
+  const auto emachine = config->emachine;
+  const bool isDebug = isDebugSection(*this);
+  const bool isDebugLine = isDebug && name == ".debug_line";
+  std::optional<uint64_t> tombstone;
+  if (isDebug) {
+    if (name == ".debug_loc" || name == ".debug_ranges")
+      tombstone = 1;
+    else if (name == ".debug_names")
+      tombstone = UINT64_MAX; // tombstone value
+    else
+      tombstone = 0;
+  }
+  for (const auto &patAndValue : llvm::reverse(config->deadRelocInNonAlloc))
+    if (patAndValue.first.match(this->name)) {
+      tombstone = patAndValue.second;
+      break;
+    }
+
+  const InputFile *f = this->file;
+  for (auto it = rels.begin(), end = rels.end(); it != end; ++it) {
+    const RelTy &rel = *it;
+    const RelType type = rel.getType(config->isMips64EL);
+    const uint64_t offset = rel.r_offset;
+    uint8_t *bufLoc = buf + offset;
+    int64_t addend = getAddend<ELFT>(rel);
+    if (!RelTy::HasAddend)
+      addend += target.getImplicitAddend(bufLoc, type);
+
+    Symbol &sym = f->getRelocTargetSym(rel);
+    RelExpr expr = target.getRelExpr(type, sym, bufLoc);
+    if (expr == R_NONE)
+      continue;
+    auto *ds = dyn_cast<Defined>(&sym);
+
+    if (emachine == EM_RISCV && type == R_RISCV_SET_ULEB128) {
+      if (++it != end &&
+          it->getType(/*isMips64EL=*/false) == R_RISCV_SUB_ULEB128 &&
+          it->r_offset == offset) {
+        uint64_t val;
+        if (!ds && tombstone) {
+          val = *tombstone;
+        } else {
+          val = sym.getVA(addend) -
+                (f->getRelocTargetSym(*it).getVA(0) + getAddend<ELFT>(*it));
+        }
+        if (overwriteULEB128(bufLoc, val) >= 0x80)
+          errorOrWarn(getLocation(offset) + ": ULEB128 value " + Twine(val) +
+                      " exceeds available space; references '" +
+                      lld::toString(sym) + "'");
+        continue;
+      }
+      errorOrWarn(getLocation(offset) +
+                  ": R_RISCV_SET_ULEB128 not paired with R_RISCV_SUB_SET128");
+      return;
+    }
+
+    if (tombstone && (expr == R_ABS || expr == R_DTPREL)) {
+      // Resolve relocations in .debug_* referencing (discarded symbols or ICF
+      // folded section symbols) to a tombstone value. Resolving to addend is
+      // unsatisfactory because the result address range may collide with a
+      // valid range of low address, or leave multiple CUs claiming ownership of
+      // the same range of code, which may confuse consumers.
+      //
+      // To address the problems, we use -1 as a tombstone value for most
+      // .debug_* sections. We have to ignore the addend because we don't want
+      // to resolve an address attribute (which may have a non-zero addend) to
+      // -1+addend (wrap around to a low address).
+      //
+      // R_DTPREL type relocations represent an offset into the dynamic thread
+      // vector. The computed value is st_value plus a non-negative offset.
+      // Negative values are invalid, so -1 can be used as the tombstone value.
+      //
+      // If the referenced symbol is relative to a discarded section (due to
+      // --gc-sections, COMDAT, etc), it has been converted to a Undefined.
+      // `ds->folded` catches the ICF folded case. However, resolving a
+      // relocation in .debug_line to -1 would stop debugger users from setting
+      // breakpoints on the folded-in function, so exclude .debug_line.
+      //
+      // For pre-DWARF-v5 .debug_loc and .debug_ranges, -1 is a reserved value
+      // (base address selection entry), use 1 (which is used by GNU ld for
+      // .debug_ranges).
+      //
+      // TODO To reduce disruption, we use 0 instead of -1 as the tombstone
+      // value. Enable -1 in a future release.
+      if (!ds || (ds->folded && !isDebugLine)) {
+        // If -z dead-reloc-in-nonalloc= is specified, respect it.
+        uint64_t value = SignExtend64<bits>(*tombstone);
+        // For a 32-bit local TU reference in .debug_names, X86_64::relocate
+        // requires that the unsigned value for R_X86_64_32 is truncated to
+        // 32-bit. Other 64-bit targets's don't discern signed/unsigned 32-bit
+        // absolute relocations and do not need this change.
+        if (emachine == EM_X86_64 && type == R_X86_64_32)
+          value = static_cast<uint32_t>(value);
+        target.relocateNoSym(bufLoc, type, value);
+        continue;
+      }
+    }
+
+    // For a relocatable link, content relocated by relocation types with an
+    // explicit addend, such as RELA, remain unchanged and we can stop here.
+    // While content relocated by relocation types with an implicit addend, such
+    // as REL, needs the implicit addend updated.
+    if (config->relocatable && (RelTy::HasAddend || sym.type != STT_SECTION))
+      continue;
+
+    // R_ABS/R_DTPREL and some other relocations can be used from non-SHF_ALLOC
+    // sections.
+    if (LLVM_LIKELY(expr == R_ABS) || expr == R_DTPREL || expr == R_GOTPLTREL ||
+        expr == R_RISCV_ADD) {
+      target.relocateNoSym(bufLoc, type, SignExtend64<bits>(sym.getVA(addend)));
+      continue;
+    }
+
+    if (expr == R_SIZE) {
+      target.relocateNoSym(bufLoc, type,
+                           SignExtend64<bits>(sym.getSize() + addend));
+      continue;
+    }
+
+    std::string msg = getLocation(offset) + ": has non-ABS relocation " +
+                      toString(type) + " against symbol '" + toString(sym) +
+                      "'";
+    if (expr != R_PC && !(emachine == EM_386 && type == R_386_GOTPC)) {
+      errorOrWarn(msg);
+      return;
+    }
+
+    // If the control reaches here, we found a PC-relative relocation in a
+    // non-ALLOC section. Since non-ALLOC section is not loaded into memory
+    // at runtime, the notion of PC-relative doesn't make sense here. So,
+    // this is a usage error. However, GNU linkers historically accept such
+    // relocations without any errors and relocate them as if they were at
+    // address 0. For bug-compatibility, we accept them with warnings. We
+    // know Steel Bank Common Lisp as of 2018 have this bug.
+    //
+    // GCC 8.0 or earlier have a bug that they emit R_386_GOTPC relocations
+    // against _GLOBAL_OFFSET_TABLE_ for .debug_info. The bug has been fixed in
+    // 2017 (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=82630), but we need to
+    // keep this bug-compatible code for a while.
+    warn(msg);
+    target.relocateNoSym(
+        bufLoc, type,
+        SignExtend64<bits>(sym.getVA(addend - offset - outSecOff)));
+  }
+}
+
+template <class ELFT>
+void InputSectionBase::relocate(uint8_t *buf, uint8_t *bufEnd) {
+  if ((flags & SHF_EXECINSTR) && LLVM_UNLIKELY(getFile<ELFT>()->splitStack))
+    adjustSplitStackFunctionPrologues<ELFT>(buf, bufEnd);
+
+  if (flags & SHF_ALLOC) {
+    target->relocateAlloc(*this, buf);
+    return;
+  }
+
+  auto *sec = cast<InputSection>(this);
+  // For a relocatable link, also call relocateNonAlloc() to rewrite applicable
+  // locations with tombstone values.
+  invokeOnRelocs(*sec, sec->relocateNonAlloc<ELFT>, buf);
+}
+
+// For each function-defining prologue, find any calls to __morestack,
+// and replace them with calls to __morestack_non_split.
+static void switchMorestackCallsToMorestackNonSplit(
+    DenseSet<Defined *> &prologues,
+    SmallVector<Relocation *, 0> &morestackCalls) {
+
+  // If the target adjusted a function's prologue, all calls to
+  // __morestack inside that function should be switched to
+  // __morestack_non_split.
+  Symbol *moreStackNonSplit = symtab.find("__morestack_non_split");
+  if (!moreStackNonSplit) {
+    error("mixing split-stack objects requires a definition of "
+          "__morestack_non_split");
+    return;
+  }
+
+  // Sort both collections to compare addresses efficiently.
+  llvm::sort(morestackCalls, [](const Relocation *l, const Relocation *r) {
+    return l->offset < r->offset;
+  });
+  std::vector<Defined *> functions(prologues.begin(), prologues.end());
+  llvm::sort(functions, [](const Defined *l, const Defined *r) {
+    return l->value < r->value;
+  });
+
+  auto it = morestackCalls.begin();
+  for (Defined *f : functions) {
+    // Find the first call to __morestack within the function.
+    while (it != morestackCalls.end() && (*it)->offset < f->value)
+      ++it;
+    // Adjust all calls inside the function.
+    while (it != morestackCalls.end() && (*it)->offset < f->value + f->size) {
+      (*it)->sym = moreStackNonSplit;
+      ++it;
+    }
+  }
+}
+
+static bool enclosingPrologueAttempted(uint64_t offset,
+                                       const DenseSet<Defined *> &prologues) {
+  for (Defined *f : prologues)
+    if (f->value <= offset && offset < f->value + f->size)
+      return true;
+  return false;
+}
+
+// If a function compiled for split stack calls a function not
+// compiled for split stack, then the caller needs its prologue
+// adjusted to ensure that the called function will have enough stack
+// available. Find those functions, and adjust their prologues.
+template <class ELFT>
+void InputSectionBase::adjustSplitStackFunctionPrologues(uint8_t *buf,
+                                                         uint8_t *end) {
+  DenseSet<Defined *> prologues;
+  SmallVector<Relocation *, 0> morestackCalls;
+
+  for (Relocation &rel : relocs()) {
+    // Ignore calls into the split-stack api.
+    if (rel.sym->getName().starts_with("__morestack")) {
+      if (rel.sym->getName() == "__morestack")
+        morestackCalls.push_back(&rel);
+      continue;
+    }
+
+    // A relocation to non-function isn't relevant. Sometimes
+    // __morestack is not marked as a function, so this check comes
+    // after the name check.
+    if (rel.sym->type != STT_FUNC)
+      continue;
+
+    // If the callee's-file was compiled with split stack, nothing to do.  In
+    // this context, a "Defined" symbol is one "defined by the binary currently
+    // being produced". So an "undefined" symbol might be provided by a shared
+    // library. It is not possible to tell how such symbols were compiled, so be
+    // conservative.
+    if (Defined *d = dyn_cast<Defined>(rel.sym))
+      if (InputSection *isec = cast_or_null<InputSection>(d->section))
+        if (!isec || !isec->getFile<ELFT>() || isec->getFile<ELFT>()->splitStack)
+          continue;
+
+    if (enclosingPrologueAttempted(rel.offset, prologues))
+      continue;
+
+    if (Defined *f = getEnclosingFunction(rel.offset)) {
+      prologues.insert(f);
+      if (target->adjustPrologueForCrossSplitStack(buf + f->value, end,
+                                                   f->stOther))
+        continue;
+      if (!getFile<ELFT>()->someNoSplitStack)
+        error(lld::toString(this) + ": " + f->getName() +
+              " (with -fsplit-stack) calls " + rel.sym->getName() +
+              " (without -fsplit-stack), but couldn't adjust its prologue");
+    }
+  }
+
+  if (target->needsMoreStackNonSplit)
+    switchMorestackCallsToMorestackNonSplit(prologues, morestackCalls);
+}
+
+template <class ELFT> void InputSection::writeTo(uint8_t *buf) {
+  if (LLVM_UNLIKELY(type == SHT_NOBITS))
+    return;
+  // If -r or --emit-relocs is given, then an InputSection
+  // may be a relocation section.
+  if (LLVM_UNLIKELY(type == SHT_RELA)) {
+    copyRelocations<ELFT, typename ELFT::Rela>(buf);
+    return;
+  }
+  if (LLVM_UNLIKELY(type == SHT_REL)) {
+    copyRelocations<ELFT, typename ELFT::Rel>(buf);
+    return;
+  }
+
+  // If -r is given, we may have a SHT_GROUP section.
+  if (LLVM_UNLIKELY(type == SHT_GROUP)) {
+    copyShtGroup<ELFT>(buf);
+    return;
+  }
+
+  // If this is a compressed section, uncompress section contents directly
+  // to the buffer.
+  if (compressed) {
+    auto *hdr = reinterpret_cast<const typename ELFT::Chdr *>(content_);
+    auto compressed = ArrayRef<uint8_t>(content_, compressedSize)
+                          .slice(sizeof(typename ELFT::Chdr));
+    size_t size = this->size;
+    if (Error e = hdr->ch_type == ELFCOMPRESS_ZLIB
+                      ? compression::zlib::decompress(compressed, buf, size)
+                      : compression::zstd::decompress(compressed, buf, size))
+      fatal(toString(this) +
+            ": decompress failed: " + llvm::toString(std::move(e)));
+    uint8_t *bufEnd = buf + size;
+    relocate<ELFT>(buf, bufEnd);
+    return;
+  }
+
+  // Copy section contents from source object file to output file
+  // and then apply relocations.
+  memcpy(buf, content().data(), content().size());
+  relocate<ELFT>(buf, buf + content().size());
+}
+
+void InputSection::replace(InputSection *other) {
+  addralign = std::max(addralign, other->addralign);
+
+  // When a section is replaced with another section that was allocated to
+  // another partition, the replacement section (and its associated sections)
+  // need to be placed in the main partition so that both partitions will be
+  // able to access it.
+  if (partition != other->partition) {
+    partition = 1;
+    for (InputSection *isec : dependentSections)
+      isec->partition = 1;
+  }
+
+  other->repl = repl;
+  other->markDead();
+}
+
+template <class ELFT>
+EhInputSection::EhInputSection(ObjFile<ELFT> &f,
+                               const typename ELFT::Shdr &header,
+                               StringRef name)
+    : InputSectionBase(f, header, name, InputSectionBase::EHFrame) {}
+
+SyntheticSection *EhInputSection::getParent() const {
+  return cast_or_null<SyntheticSection>(parent);
+}
+
+// .eh_frame is a sequence of CIE or FDE records.
+// This function splits an input section into records and returns them.
+template <class ELFT> void EhInputSection::split() {
+  const RelsOrRelas<ELFT> rels = relsOrRelas<ELFT>(/*supportsCrel=*/false);
+  // getReloc expects the relocations to be sorted by r_offset. See the comment
+  // in scanRelocs.
+  if (rels.areRelocsRel()) {
+    SmallVector<typename ELFT::Rel, 0> storage;
+    split<ELFT>(sortRels(rels.rels, storage));
+  } else {
+    SmallVector<typename ELFT::Rela, 0> storage;
+    split<ELFT>(sortRels(rels.relas, storage));
+  }
+}
+
+template <class ELFT, class RelTy>
+void EhInputSection::split(ArrayRef<RelTy> rels) {
+  ArrayRef<uint8_t> d = content();
+  const char *msg = nullptr;
+  unsigned relI = 0;
+  while (!d.empty()) {
+    if (d.size() < 4) {
+      msg = "CIE/FDE too small";
+      break;
+    }
+    uint64_t size = endian::read32<ELFT::Endianness>(d.data());
+    if (size == 0) // ZERO terminator
+      break;
+    uint32_t id = endian::read32<ELFT::Endianness>(d.data() + 4);
+    size += 4;
+    if (LLVM_UNLIKELY(size > d.size())) {
+      // If it is 0xFFFFFFFF, the next 8 bytes contain the size instead,
+      // but we do not support that format yet.
+      msg = size == UINT32_MAX + uint64_t(4)
+                ? "CIE/FDE too large"
+                : "CIE/FDE ends past the end of the section";
+      break;
+    }
+
+    // Find the first relocation that points to [off,off+size). Relocations
+    // have been sorted by r_offset.
+    const uint64_t off = d.data() - content().data();
+    while (relI != rels.size() && rels[relI].r_offset < off)
+      ++relI;
+    unsigned firstRel = -1;
+    if (relI != rels.size() && rels[relI].r_offset < off + size)
+      firstRel = relI;
+    (id == 0 ? cies : fdes).emplace_back(off, this, size, firstRel);
+    d = d.slice(size);
+  }
+  if (msg)
+    errorOrWarn("corrupted .eh_frame: " + Twine(msg) + "\n>>> defined in " +
+                getObjMsg(d.data() - content().data()));
+}
+
+// Return the offset in an output section for a given input offset.
+uint64_t EhInputSection::getParentOffset(uint64_t offset) const {
+  auto it = partition_point(
+      fdes, [=](EhSectionPiece p) { return p.inputOff <= offset; });
+  if (it == fdes.begin() || it[-1].inputOff + it[-1].size <= offset) {
+    it = partition_point(
+        cies, [=](EhSectionPiece p) { return p.inputOff <= offset; });
+    if (it == cies.begin()) // invalid piece
+      return offset;
+  }
+  if (it[-1].outputOff == -1) // invalid piece
+    return offset - it[-1].inputOff;
+  return it[-1].outputOff + (offset - it[-1].inputOff);
+}
+
+static size_t findNull(StringRef s, size_t entSize) {
+  for (unsigned i = 0, n = s.size(); i != n; i += entSize) {
+    const char *b = s.begin() + i;
+    if (std::all_of(b, b + entSize, [](char c) { return c == 0; }))
+      return i;
+  }
+  llvm_unreachable("");
+}
+
+// Split SHF_STRINGS section. Such section is a sequence of
+// null-terminated strings.
+void MergeInputSection::splitStrings(StringRef s, size_t entSize) {
+  const bool live = !(flags & SHF_ALLOC) || !config->gcSections;
+  const char *p = s.data(), *end = s.data() + s.size();
+  if (!std::all_of(end - entSize, end, [](char c) { return c == 0; }))
+    fatal(toString(this) + ": string is not null terminated");
+  if (entSize == 1) {
+    // Optimize the common case.
+    do {
+      size_t size = strlen(p);
+      pieces.emplace_back(p - s.begin(), xxh3_64bits(StringRef(p, size)), live);
+      p += size + 1;
+    } while (p != end);
+  } else {
+    do {
+      size_t size = findNull(StringRef(p, end - p), entSize);
+      pieces.emplace_back(p - s.begin(), xxh3_64bits(StringRef(p, size)), live);
+      p += size + entSize;
+    } while (p != end);
+  }
+}
+
+// Split non-SHF_STRINGS section. Such section is a sequence of
+// fixed size records.
+void MergeInputSection::splitNonStrings(ArrayRef<uint8_t> data,
+                                        size_t entSize) {
+  size_t size = data.size();
+  assert((size % entSize) == 0);
+  const bool live = !(flags & SHF_ALLOC) || !config->gcSections;
+
+  pieces.resize_for_overwrite(size / entSize);
+  for (size_t i = 0, j = 0; i != size; i += entSize, j++)
+    pieces[j] = {i, (uint32_t)xxh3_64bits(data.slice(i, entSize)), live};
+}
+
+template <class ELFT>
+MergeInputSection::MergeInputSection(ObjFile<ELFT> &f,
+                                     const typename ELFT::Shdr &header,
+                                     StringRef name)
+    : InputSectionBase(f, header, name, InputSectionBase::Merge) {}
+
+MergeInputSection::MergeInputSection(uint64_t flags, uint32_t type,
+                                     uint64_t entsize, ArrayRef<uint8_t> data,
+                                     StringRef name)
+    : InputSectionBase(nullptr, flags, type, entsize, /*Link*/ 0, /*Info*/ 0,
+                       /*Alignment*/ entsize, data, name, SectionBase::Merge) {}
+
+// This function is called after we obtain a complete list of input sections
+// that need to be linked. This is responsible to split section contents
+// into small chunks for further processing.
+//
+// Note that this function is called from parallelForEach. This must be
+// thread-safe (i.e. no memory allocation from the pools).
+void MergeInputSection::splitIntoPieces() {
+  assert(pieces.empty());
+
+  if (flags & SHF_STRINGS)
+    splitStrings(toStringRef(contentMaybeDecompress()), entsize);
+  else
+    splitNonStrings(contentMaybeDecompress(), entsize);
+}
+
+SectionPiece &MergeInputSection::getSectionPiece(uint64_t offset) {
+  if (content().size() <= offset)
+    fatal(toString(this) + ": offset is outside the section");
+  return partition_point(
+      pieces, [=](SectionPiece p) { return p.inputOff <= offset; })[-1];
+}
+
+// Return the offset in an output section for a given input offset.
+uint64_t MergeInputSection::getParentOffset(uint64_t offset) const {
+  const SectionPiece &piece = getSectionPiece(offset);
+  return piece.outputOff + (offset - piece.inputOff);
+}
+
+template InputSection::InputSection(ObjFile<ELF32LE> &, const ELF32LE::Shdr &,
+                                    StringRef);
+template InputSection::InputSection(ObjFile<ELF32BE> &, const ELF32BE::Shdr &,
+                                    StringRef);
+template InputSection::InputSection(ObjFile<ELF64LE> &, const ELF64LE::Shdr &,
+                                    StringRef);
+template InputSection::InputSection(ObjFile<ELF64BE> &, const ELF64BE::Shdr &,
+                                    StringRef);
+
+template void InputSection::writeTo<ELF32LE>(uint8_t *);
+template void InputSection::writeTo<ELF32BE>(uint8_t *);
+template void InputSection::writeTo<ELF64LE>(uint8_t *);
+template void InputSection::writeTo<ELF64BE>(uint8_t *);
+
+template RelsOrRelas<ELF32LE>
+InputSectionBase::relsOrRelas<ELF32LE>(bool) const;
+template RelsOrRelas<ELF32BE>
+InputSectionBase::relsOrRelas<ELF32BE>(bool) const;
+template RelsOrRelas<ELF64LE>
+InputSectionBase::relsOrRelas<ELF64LE>(bool) const;
+template RelsOrRelas<ELF64BE>
+InputSectionBase::relsOrRelas<ELF64BE>(bool) const;
+
+template MergeInputSection::MergeInputSection(ObjFile<ELF32LE> &,
+                                              const ELF32LE::Shdr &, StringRef);
+template MergeInputSection::MergeInputSection(ObjFile<ELF32BE> &,
+                                              const ELF32BE::Shdr &, StringRef);
+template MergeInputSection::MergeInputSection(ObjFile<ELF64LE> &,
+                                              const ELF64LE::Shdr &, StringRef);
+template MergeInputSection::MergeInputSection(ObjFile<ELF64BE> &,
+                                              const ELF64BE::Shdr &, StringRef);
+
+template EhInputSection::EhInputSection(ObjFile<ELF32LE> &,
+                                        const ELF32LE::Shdr &, StringRef);
+template EhInputSection::EhInputSection(ObjFile<ELF32BE> &,
+                                        const ELF32BE::Shdr &, StringRef);
+template EhInputSection::EhInputSection(ObjFile<ELF64LE> &,
+                                        const ELF64LE::Shdr &, StringRef);
+template EhInputSection::EhInputSection(ObjFile<ELF64BE> &,
+                                        const ELF64BE::Shdr &, StringRef);
+
+template void EhInputSection::split<ELF32LE>();
+template void EhInputSection::split<ELF32BE>();
+template void EhInputSection::split<ELF64LE>();
+template void EhInputSection::split<ELF64BE>();

--- a/vadl/main/resources/templates/lcb/lld/ELF/Relocations.h
+++ b/vadl/main/resources/templates/lcb/lld/ELF/Relocations.h
@@ -1,0 +1,338 @@
+//===- Relocations.h -------------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLD_ELF_RELOCATIONS_H
+#define LLD_ELF_RELOCATIONS_H
+
+#include "lld/Common/LLVM.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/Object/ELFTypes.h"
+#include <vector>
+
+namespace lld::elf {
+class Symbol;
+class InputSection;
+class InputSectionBase;
+class OutputSection;
+class SectionBase;
+
+// Represents a relocation type, such as R_X86_64_PC32 or R_ARM_THM_CALL.
+using RelType = uint32_t;
+using JumpModType = uint32_t;
+
+// List of target-independent relocation types. Relocations read
+// from files are converted to these types so that the main code
+// doesn't have to know about architecture-specific details.
+enum RelExpr {
+  R_ABS,
+  R_ADDEND,
+  R_DTPREL,
+  R_GOT,
+  R_GOT_OFF,
+  R_GOT_PC,
+  R_GOTONLY_PC,
+  R_GOTPLTONLY_PC,
+  R_GOTPLT,
+  R_GOTPLTREL,
+  R_GOTREL,
+  R_GOTPLT_GOTREL,
+  R_GOTPLT_PC,
+  R_NONE,
+  R_PC,
+  R_PLT,
+  R_PLT_PC,
+  R_PLT_GOTPLT,
+  R_PLT_GOTREL,
+  R_RELAX_HINT,
+  R_RELAX_GOT_PC,
+  R_RELAX_GOT_PC_NOPIC,
+  R_RELAX_TLS_GD_TO_IE,
+  R_RELAX_TLS_GD_TO_IE_ABS,
+  R_RELAX_TLS_GD_TO_IE_GOT_OFF,
+  R_RELAX_TLS_GD_TO_IE_GOTPLT,
+  R_RELAX_TLS_GD_TO_LE,
+  R_RELAX_TLS_GD_TO_LE_NEG,
+  R_RELAX_TLS_IE_TO_LE,
+  R_RELAX_TLS_LD_TO_LE,
+  R_RELAX_TLS_LD_TO_LE_ABS,
+  R_SIZE,
+  R_TPREL,
+  R_TPREL_NEG,
+  R_TLSDESC,
+  R_TLSDESC_CALL,
+  R_TLSDESC_PC,
+  R_TLSDESC_GOTPLT,
+  R_TLSGD_GOT,
+  R_TLSGD_GOTPLT,
+  R_TLSGD_PC,
+  R_TLSIE_HINT,
+  R_TLSLD_GOT,
+  R_TLSLD_GOTPLT,
+  R_TLSLD_GOT_OFF,
+  R_TLSLD_HINT,
+  R_TLSLD_PC,
+
+  // The following is abstract relocation types used for only one target.
+  //
+  // Even though RelExpr is intended to be a target-neutral representation
+  // of a relocation type, there are some relocations whose semantics are
+  // unique to a target. Such relocation are marked with R_<TARGET_NAME>.
+  R_AARCH64_GOT_PAGE_PC,
+  R_AARCH64_GOT_PAGE,
+  R_AARCH64_PAGE_PC,
+  R_AARCH64_RELAX_TLS_GD_TO_IE_PAGE_PC,
+  R_AARCH64_TLSDESC_PAGE,
+  R_AARCH64_AUTH,
+  R_ARM_PCA,
+  R_ARM_SBREL,
+  R_MIPS_GOTREL,
+  R_MIPS_GOT_GP,
+  R_MIPS_GOT_GP_PC,
+  R_MIPS_GOT_LOCAL_PAGE,
+  R_MIPS_GOT_OFF,
+  R_MIPS_GOT_OFF32,
+  R_MIPS_TLSGD,
+  R_MIPS_TLSLD,
+  R_PPC32_PLTREL,
+  R_PPC64_CALL,
+  R_PPC64_CALL_PLT,
+  R_PPC64_RELAX_TOC,
+  R_PPC64_TOCBASE,
+  R_PPC64_RELAX_GOT_PC,
+  R_RISCV_ADD,
+  R_RISCV_LEB128,
+  R_RISCV_PC_INDIRECT,
+  // Same as R_PC but with page-aligned semantics.
+  R_LOONGARCH_PAGE_PC,
+  // Same as R_PLT_PC but with page-aligned semantics.
+  R_LOONGARCH_PLT_PAGE_PC,
+  // In addition to having page-aligned semantics, LoongArch GOT relocs are
+  // also reused for TLS, making the semantics differ from other architectures.
+  R_LOONGARCH_GOT,
+  R_LOONGARCH_GOT_PAGE_PC,
+  R_LOONGARCH_TLSGD_PAGE_PC,
+  R_LOONGARCH_TLSDESC_PAGE_PC,
+
+  R_[(${namespace})]_INDIRECT,
+};
+
+// Architecture-neutral representation of relocation.
+struct Relocation {
+  RelExpr expr;
+  RelType type;
+  uint64_t offset;
+  int64_t addend;
+  Symbol *sym;
+};
+
+// Manipulate jump instructions with these modifiers.  These are used to relax
+// jump instruction opcodes at basic block boundaries and are particularly
+// useful when basic block sections are enabled.
+struct JumpInstrMod {
+  uint64_t offset;
+  JumpModType original;
+  unsigned size;
+};
+
+// This function writes undefined symbol diagnostics to an internal buffer.
+// Call reportUndefinedSymbols() after calling scanRelocations() to emit
+// the diagnostics.
+template <class ELFT> void scanRelocations();
+template <class ELFT> void checkNoCrossRefs();
+void reportUndefinedSymbols();
+void postScanRelocations();
+void addGotEntry(Symbol &sym);
+
+void hexagonTLSSymbolUpdate(ArrayRef<OutputSection *> outputSections);
+bool hexagonNeedsTLSSymbol(ArrayRef<OutputSection *> outputSections);
+
+class ThunkSection;
+class Thunk;
+class InputSectionDescription;
+
+class ThunkCreator {
+public:
+  // Return true if Thunks have been added to OutputSections
+  bool createThunks(uint32_t pass, ArrayRef<OutputSection *> outputSections);
+
+private:
+  void mergeThunks(ArrayRef<OutputSection *> outputSections);
+
+  ThunkSection *getISDThunkSec(OutputSection *os, InputSection *isec,
+                               InputSectionDescription *isd,
+                               const Relocation &rel, uint64_t src);
+
+  ThunkSection *getISThunkSec(InputSection *isec);
+
+  void createInitialThunkSections(ArrayRef<OutputSection *> outputSections);
+
+  std::pair<Thunk *, bool> getThunk(InputSection *isec, Relocation &rel,
+                                    uint64_t src);
+
+  ThunkSection *addThunkSection(OutputSection *os, InputSectionDescription *,
+                                uint64_t off);
+
+  bool normalizeExistingThunk(Relocation &rel, uint64_t src);
+
+  // Record all the available Thunks for a (Symbol, addend) pair, where Symbol
+  // is represented as a (section, offset) pair. There may be multiple
+  // relocations sharing the same (section, offset + addend) pair. We may revert
+  // a relocation back to its original non-Thunk target, and restore the
+  // original addend, so we cannot fold offset + addend. A nested pair is used
+  // because DenseMapInfo is not specialized for std::tuple.
+  llvm::DenseMap<std::pair<std::pair<SectionBase *, uint64_t>, int64_t>,
+                 std::vector<Thunk *>>
+      thunkedSymbolsBySectionAndAddend;
+  llvm::DenseMap<std::pair<Symbol *, int64_t>, std::vector<Thunk *>>
+      thunkedSymbols;
+
+  // Find a Thunk from the Thunks symbol definition, we can use this to find
+  // the Thunk from a relocation to the Thunks symbol definition.
+  llvm::DenseMap<Symbol *, Thunk *> thunks;
+
+  // Track InputSections that have an inline ThunkSection placed in front
+  // an inline ThunkSection may have control fall through to the section below
+  // so we need to make sure that there is only one of them.
+  // The Mips LA25 Thunk is an example of an inline ThunkSection.
+  llvm::DenseMap<InputSection *, ThunkSection *> thunkedSections;
+
+  // The number of completed passes of createThunks this permits us
+  // to do one time initialization on Pass 0 and put a limit on the
+  // number of times it can be called to prevent infinite loops.
+  uint32_t pass = 0;
+};
+
+// Decode LEB128 without error checking. Only used by performance critical code
+// like RelocsCrel.
+inline uint64_t readLEB128(const uint8_t *&p, uint64_t leb) {
+  uint64_t acc = 0, shift = 0, byte;
+  do {
+    byte = *p++;
+    acc |= (byte - 128 * (byte >= leb)) << shift;
+    shift += 7;
+  } while (byte >= 128);
+  return acc;
+}
+inline uint64_t readULEB128(const uint8_t *&p) { return readLEB128(p, 128); }
+inline int64_t readSLEB128(const uint8_t *&p) { return readLEB128(p, 64); }
+
+// This class implements a CREL iterator that does not allocate extra memory.
+template <bool is64> struct RelocsCrel {
+  using uint = std::conditional_t<is64, uint64_t, uint32_t>;
+  struct const_iterator {
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = llvm::object::Elf_Crel_Impl<is64>;
+    using difference_type = ptrdiff_t;
+    using pointer = value_type *;
+    using reference = const value_type &;
+    uint32_t count;
+    uint8_t flagBits, shift;
+    const uint8_t *p;
+    llvm::object::Elf_Crel_Impl<is64> crel{};
+    const_iterator(size_t hdr, const uint8_t *p)
+        : count(hdr / 8), flagBits(hdr & 4 ? 3 : 2), shift(hdr % 4), p(p) {
+      if (count)
+        step();
+    }
+    void step() {
+      // See object::decodeCrel.
+      const uint8_t b = *p++;
+      crel.r_offset += b >> flagBits << shift;
+      if (b >= 0x80)
+        crel.r_offset +=
+            ((readULEB128(p) << (7 - flagBits)) - (0x80 >> flagBits)) << shift;
+      if (b & 1)
+        crel.r_symidx += readSLEB128(p);
+      if (b & 2)
+        crel.r_type += readSLEB128(p);
+      if (b & 4 && flagBits == 3)
+        crel.r_addend += static_cast<uint>(readSLEB128(p));
+    }
+    llvm::object::Elf_Crel_Impl<is64> operator*() const { return crel; };
+    const llvm::object::Elf_Crel_Impl<is64> *operator->() const {
+      return &crel;
+    }
+    // For llvm::enumerate.
+    bool operator==(const const_iterator &r) const { return count == r.count; }
+    bool operator!=(const const_iterator &r) const { return count != r.count; }
+    const_iterator &operator++() {
+      if (--count)
+        step();
+      return *this;
+    }
+    // For RelocationScanner::scanOne.
+    void operator+=(size_t n) {
+      for (; n; --n)
+        operator++();
+    }
+  };
+
+  size_t hdr = 0;
+  const uint8_t *p = nullptr;
+
+  constexpr RelocsCrel() = default;
+  RelocsCrel(const uint8_t *p) : hdr(readULEB128(p)) { this->p = p; }
+  size_t size() const { return hdr / 8; }
+  const_iterator begin() const { return {hdr, p}; }
+  const_iterator end() const { return {0, nullptr}; }
+};
+
+template <class RelTy> struct Relocs : ArrayRef<RelTy> {
+  Relocs() = default;
+  Relocs(ArrayRef<RelTy> a) : ArrayRef<RelTy>(a) {}
+};
+
+template <bool is64>
+struct Relocs<llvm::object::Elf_Crel_Impl<is64>> : RelocsCrel<is64> {
+  using RelocsCrel<is64>::RelocsCrel;
+};
+
+// Return a int64_t to make sure we get the sign extension out of the way as
+// early as possible.
+template <class ELFT>
+static inline int64_t getAddend(const typename ELFT::Rel &rel) {
+  return 0;
+}
+template <class ELFT>
+static inline int64_t getAddend(const typename ELFT::Rela &rel) {
+  return rel.r_addend;
+}
+template <class ELFT>
+static inline int64_t getAddend(const typename ELFT::Crel &rel) {
+  return rel.r_addend;
+}
+
+template <typename RelTy>
+inline Relocs<RelTy> sortRels(Relocs<RelTy> rels,
+                              SmallVector<RelTy, 0> &storage) {
+  auto cmp = [](const RelTy &a, const RelTy &b) {
+    return a.r_offset < b.r_offset;
+  };
+  if (!llvm::is_sorted(rels, cmp)) {
+    storage.assign(rels.begin(), rels.end());
+    llvm::stable_sort(storage, cmp);
+    rels = Relocs<RelTy>(storage);
+  }
+  return rels;
+}
+
+template <bool is64>
+inline Relocs<llvm::object::Elf_Crel_Impl<is64>>
+sortRels(Relocs<llvm::object::Elf_Crel_Impl<is64>> rels,
+         SmallVector<llvm::object::Elf_Crel_Impl<is64>, 0> &storage) {
+  return {};
+}
+
+// Returns true if Expr refers a GOT entry. Note that this function returns
+// false for TLS variables even though they need GOT, because TLS variables uses
+// GOT differently than the regular variables.
+bool needsGot(RelExpr expr);
+} // namespace lld::elf
+
+#endif

--- a/vadl/main/resources/templates/lcb/llvm/lib/Target/AsmParser/AsmParser.cpp
+++ b/vadl/main/resources/templates/lcb/llvm/lib/Target/AsmParser/AsmParser.cpp
@@ -1,5 +1,6 @@
 #include "AsmRecursiveDescentParser.h"
 #include "MCTargetDesc/[(${namespace})]MCTargetDesc.h"
+#include "MCTargetDesc/[(${namespace})]MCInstExpander.h"
 #include "MCTargetDesc/[(${namespace})]TargetStreamer.h"
 #include "MCTargetDesc/AsmUtils.h"
 #include "TargetInfo/[(${namespace})]TargetInfo.h"
@@ -21,6 +22,7 @@ struct [(${namespace})]Operand;
 
 class [(${namespace})]AsmParser : public MCTargetAsmParser {
     MCAsmParser &Parser;
+    [(${namespace})]MCInstExpander InstExpander;
 
 [(${namespace})]TargetStreamer &getTargetStreamer() {
     MCTargetStreamer &TS = *getParser().getStreamer().getTargetStreamer();
@@ -55,7 +57,7 @@ bool parse_[(${instruction.name})](MCInst &Inst, OperandVector &Operands);
 public:
     [(${namespace})]AsmParser(const MCSubtargetInfo &sti, MCAsmParser &parser,
                 const MCInstrInfo &MII, const MCTargetOptions &Options)
-        : MCTargetAsmParser(Options, sti, MII), Parser(parser) {
+        : MCTargetAsmParser(Options, sti, MII), Parser(parser), InstExpander(parser.getContext()) {
         [# th:each="alias : ${aliases}" ]
             Parser.addAliasForDirective("[(${alias.alias})]", "[(${alias.target})]");
         [/]
@@ -165,7 +167,18 @@ bool [(${namespace})]AsmParser::MatchAndEmitInstruction(SMLoc IDLoc,
         [/]
     }
 
-    Out.emitInstruction(Inst, getSTI());
+    // Out.emitInstruction(Inst, getSTI());
+    if (InstExpander.isExpandable(Inst)) {
+        InstExpander.expand(Inst,
+            [&](const MCInst &MI) {
+                Out.emitInstruction(MI, getSTI());
+            },
+            [&](MCSymbol *Symbol) {
+                Out.emitLabel(Symbol);
+            });
+    } else {
+        Out.emitInstruction(Inst, getSTI());
+    }
 
     return false;
 }

--- a/vadl/main/resources/templates/lcb/llvm/lib/Target/AsmParser/AsmParser.cpp
+++ b/vadl/main/resources/templates/lcb/llvm/lib/Target/AsmParser/AsmParser.cpp
@@ -167,7 +167,6 @@ bool [(${namespace})]AsmParser::MatchAndEmitInstruction(SMLoc IDLoc,
         [/]
     }
 
-    // Out.emitInstruction(Inst, getSTI());
     if (InstExpander.isExpandable(Inst)) {
         InstExpander.expand(Inst,
             [&](const MCInst &MI) {

--- a/vadl/main/vadl/gcb/passes/relocation/model/CompilerRelocation.java
+++ b/vadl/main/vadl/gcb/passes/relocation/model/CompilerRelocation.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -141,6 +141,16 @@ public abstract class CompilerRelocation implements Renderable {
   public ElfRelocationName elfRelocationName() {
     return new ElfRelocationName(
         "R_" + relocation().identifier.lower());
+  }
+
+  /**
+   * Maps a {@link CompilerRelocation.Kind} to a LLVM relocation kind.
+   */
+  public String llvmKind(String target) {
+    if (relocation().isPaired()) {
+      return "R_" + target + "_INDIRECT";
+    }
+    return kind.llvmKind();
   }
 
   @Override

--- a/vadl/main/vadl/gcb/passes/relocation/model/HasRelocationComputationAndUpdate.java
+++ b/vadl/main/vadl/gcb/passes/relocation/model/HasRelocationComputationAndUpdate.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -80,4 +80,9 @@ public interface HasRelocationComputationAndUpdate {
    * Get the {@link CompilerRelocation.Kind} of the relocation.
    */
   CompilerRelocation.Kind kind();
+
+  /**
+   * Get the LLVM relocation kind of the relocation.
+   */
+  String llvmKind(String target);
 }

--- a/vadl/main/vadl/lcb/codegen/expansion/CompilerInstructionExpansionCodeGenerator.java
+++ b/vadl/main/vadl/lcb/codegen/expansion/CompilerInstructionExpansionCodeGenerator.java
@@ -193,6 +193,8 @@ public class CompilerInstructionExpansionCodeGenerator extends FunctionCodeGener
         if (dir instanceof NewLabelNode newLabelNode) {
           var sym = symbolTable.getNextVariable();
           labelSymbolNameLookup.put(newLabelNode, sym);
+          context.ln("MCSymbol *%s = Ctx.createTempSymbol(\"%s\");", sym,
+              newLabelNode.labelNode().labelName());
         }
         return dir;
       }
@@ -227,8 +229,7 @@ public class CompilerInstructionExpansionCodeGenerator extends FunctionCodeGener
               .ln("callback(%s);", sym);
         } else if (dir instanceof NewLabelNode newLabelNode) {
           var sym = requireNonNull(labelSymbolNameLookup.get(newLabelNode));
-          context.ln("MCSymbol *%s = Ctx.createTempSymbol();", sym)
-              .ln("callbackSymbol(%s);", sym);
+          context.ln("callbackSymbol(%s);", sym);
         }
 
         return dir;

--- a/vadl/main/vadl/lcb/template/lld/ELF/Arch/EmitLldArchFilePass.java
+++ b/vadl/main/vadl/lcb/template/lld/ELF/Arch/EmitLldArchFilePass.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -89,6 +89,7 @@ public class EmitLldArchFilePass extends LcbTemplateRenderingPass {
   @Override
   protected Map<String, Object> createVariables(final PassResults passResults,
                                                 Specification specification) {
+    var namespace = lcbConfiguration().targetName().value().toLowerCase();
     var output =
         (GenerateLinkerComponentsPass.Output) passResults.lastResultOf(
             GenerateLinkerComponentsPass.class);
@@ -112,7 +113,7 @@ public class EmitLldArchFilePass extends LcbTemplateRenderingPass {
           if (r instanceof AutomaticallyGeneratedRelocation) {
             var fun = encodingFunction(r, passResults);
             return new ElfRelocationInfo(r.elfRelocationName().value(),
-                r.kind().llvmKind(),
+                r.llvmKind(namespace),
                 r.valueRelocation().functionName().lower(),
                 r.fieldUpdateFunction().functionName().lower(),
                 fun.left(),
@@ -120,7 +121,7 @@ public class EmitLldArchFilePass extends LcbTemplateRenderingPass {
             );
           } else {
             return new ElfRelocationInfo(r.elfRelocationName().value(),
-                r.kind().llvmKind(),
+                r.llvmKind(namespace),
                 r.valueRelocation().functionName().lower(),
                 r.fieldUpdateFunction().functionName().lower(),
                 "",
@@ -132,8 +133,7 @@ public class EmitLldArchFilePass extends LcbTemplateRenderingPass {
 
     var elfInfo = createElfInfo();
 
-    return Map.of(CommonVarNames.NAMESPACE,
-        lcbConfiguration().targetName().value().toLowerCase(),
+    return Map.of(CommonVarNames.NAMESPACE, namespace,
         CommonVarNames.MAX_INSTRUCTION_WORDSIZE, elfInfo.maxInstructionWordSize(),
         CommonVarNames.IS_BIG_ENDIAN, elfInfo.isBigEndian(),
         "elfRelocations", elfRelocations);

--- a/vadl/main/vadl/lcb/template/lld/ELF/EmitInputSectionCppFilePass.java
+++ b/vadl/main/vadl/lcb/template/lld/ELF/EmitInputSectionCppFilePass.java
@@ -24,6 +24,9 @@ import vadl.lcb.template.LcbTemplateRenderingPass;
 import vadl.pass.PassResults;
 import vadl.viam.Specification;
 
+/**
+ * Emit the LLD InputSection file.
+ */
 public class EmitInputSectionCppFilePass extends LcbTemplateRenderingPass {
   public EmitInputSectionCppFilePass(LcbConfiguration lcbConfiguration)
       throws IOException {

--- a/vadl/main/vadl/lcb/template/lld/ELF/EmitInputSectionCppFilePass.java
+++ b/vadl/main/vadl/lcb/template/lld/ELF/EmitInputSectionCppFilePass.java
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText : © 2026 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.lcb.template.lld.ELF;
+
+import java.io.IOException;
+import java.util.Map;
+import vadl.configuration.LcbConfiguration;
+import vadl.lcb.template.CommonVarNames;
+import vadl.lcb.template.LcbTemplateRenderingPass;
+import vadl.pass.PassResults;
+import vadl.viam.Specification;
+
+public class EmitInputSectionCppFilePass extends LcbTemplateRenderingPass {
+  public EmitInputSectionCppFilePass(LcbConfiguration lcbConfiguration)
+      throws IOException {
+    super(lcbConfiguration);
+  }
+
+  @Override
+  protected String getTemplatePath() {
+    return "lcb/lld/ELF/InputSection.cpp";
+  }
+
+  @Override
+  protected String getOutputPath() {
+    return "lld/ELF/InputSection.cpp";
+  }
+
+  @Override
+  protected Map<String, Object> createVariables(final PassResults passResults,
+                                                Specification specification) {
+    return Map.of(CommonVarNames.NAMESPACE,
+        lcbConfiguration().targetName().value().toLowerCase());
+  }
+}

--- a/vadl/main/vadl/lcb/template/lld/ELF/EmitRelocationsHeaderFilePass.java
+++ b/vadl/main/vadl/lcb/template/lld/ELF/EmitRelocationsHeaderFilePass.java
@@ -24,6 +24,9 @@ import vadl.lcb.template.LcbTemplateRenderingPass;
 import vadl.pass.PassResults;
 import vadl.viam.Specification;
 
+/**
+ * Emit the LLD Relocations header file.
+ */
 public class EmitRelocationsHeaderFilePass extends LcbTemplateRenderingPass {
   public EmitRelocationsHeaderFilePass(LcbConfiguration lcbConfiguration)
       throws IOException {

--- a/vadl/main/vadl/lcb/template/lld/ELF/EmitRelocationsHeaderFilePass.java
+++ b/vadl/main/vadl/lcb/template/lld/ELF/EmitRelocationsHeaderFilePass.java
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText : © 2026 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.lcb.template.lld.ELF;
+
+import java.io.IOException;
+import java.util.Map;
+import vadl.configuration.LcbConfiguration;
+import vadl.lcb.template.CommonVarNames;
+import vadl.lcb.template.LcbTemplateRenderingPass;
+import vadl.pass.PassResults;
+import vadl.viam.Specification;
+
+public class EmitRelocationsHeaderFilePass extends LcbTemplateRenderingPass {
+  public EmitRelocationsHeaderFilePass(LcbConfiguration lcbConfiguration)
+      throws IOException {
+    super(lcbConfiguration);
+  }
+
+  @Override
+  protected String getTemplatePath() {
+    return "lcb/lld/ELF/Relocations.h";
+  }
+
+  @Override
+  protected String getOutputPath() {
+    return "lld/ELF/Relocations.h";
+  }
+
+  @Override
+  protected Map<String, Object> createVariables(final PassResults passResults,
+                                                Specification specification) {
+    return Map.of(CommonVarNames.NAMESPACE,
+        lcbConfiguration().targetName().value().toLowerCase());
+  }
+}

--- a/vadl/main/vadl/pass/order/LcbPassOrder.java
+++ b/vadl/main/vadl/pass/order/LcbPassOrder.java
@@ -135,6 +135,8 @@ public final class LcbPassOrder {
     order.add(new vadl.lcb.template.lld.ELF.Arch.EmitLldArchFilePass(configuration));
     order.add(new EmitLldVadlBuiltinsHeaderFilePass(configuration));
     order.add(new vadl.lcb.template.lld.ELF.EmitLldTargetCppFilePass(configuration));
+    order.add(new vadl.lcb.template.lld.ELF.EmitInputSectionCppFilePass(configuration));
+    order.add(new vadl.lcb.template.lld.ELF.EmitRelocationsHeaderFilePass(configuration));
     order.add(new vadl.lcb.template.EmitLcbMakeFilePass(configuration));
     order.add(new EmitTargetElfRelocsDefFilePass(configuration));
     order.add(new vadl.lcb.include.llvm.IR.EmitCMakeListsPass(configuration));

--- a/vadl/main/vadl/viam/Relocation.java
+++ b/vadl/main/vadl/viam/Relocation.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -51,6 +51,8 @@ public class Relocation extends Function {
 
   private Kind kind;
 
+  private boolean isPaired = false;
+
   public Relocation(Identifier identifier, Kind kind, Parameter[] parameters, Type returnType) {
     super(identifier, parameters, returnType);
     this.kind = kind;
@@ -64,6 +66,10 @@ public class Relocation extends Function {
 
   public void setKind(Kind kind) {
     this.kind = kind;
+  }
+
+  public void setIsPaired(boolean isPaired) {
+    this.isPaired = isPaired;
   }
 
   @Override
@@ -85,6 +91,26 @@ public class Relocation extends Function {
    */
   public Kind kind() {
     return kind;
+  }
+
+  /**
+   * Returns {@code true} when the relocation is supposed to be paired with another relocation.
+   * An example for this is the {@code %pcrel_lo} relocation of RISCV, where the relocation's type
+   * depends on the type of its paired relocation.
+   * <pre>{@code .Lpcrel_hi0:
+   *         auipc   a0, %got_pcrel_hi(Coeff)
+   *         ld      a0, %pcrel_lo(.Lpcrel_hi0)(a0)}</pre>
+   * Here the {@code %pcrel_lo} relocation is paired with a {@code got} relocation,
+   * therefore {@code %pcrel_lo} is also  {@code got} relative.
+   *
+   * <pre>{@code .Lpcrel_hi0:
+   *         auipc   a0, %pcrel_hi(Coeff)
+   *         addi    a0, a0, %pcrel_lo(.Lpcrel_hi0)}</pre>
+   * In this case {@code %pcrel_lo} is paired with a {@code pcrel} relocation,
+   * therefore {@code %pcrel_lo} also is just {@code pcrel}.
+   */
+  public boolean isPaired() {
+    return isPaired;
   }
 
   /**

--- a/vadl/test/resources/images/lcb_execution_test_rv64im/Dockerfile
+++ b/vadl/test/resources/images/lcb_execution_test_rv64im/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.7
-FROM ghcr.io/openvadl/lcb-execution-test-rv64im-base-image@sha256:45115bb0a22747dd8d347051d2bcb5ee084f568c90afbdf71ef738b0849afb96
+FROM ghcr.io/openvadl/lcb-execution-test-rv64im-base-image@sha256:3cd1cfa0fd9db23ba514e38c9321add4e80f1da70bee0424e38d6af3db13d19a
 ARG TARGET
 ARG SCCACHE_REDIS_ENDPOINT
 ARG UPSTREAM_BUILD_TARGET

--- a/vadl/test/resources/images/lcb_execution_test_rv64im/base_image/Dockerfile
+++ b/vadl/test/resources/images/lcb_execution_test_rv64im/base_image/Dockerfile
@@ -15,3 +15,4 @@ COPY compile.sh .
 COPY filecheck.sh .
 COPY upstream.sh .
 COPY compare.sh .
+COPY lcb_integration.sh .

--- a/vadl/test/resources/images/lcb_execution_test_rv64im/base_image/Dockerfile
+++ b/vadl/test/resources/images/lcb_execution_test_rv64im/base_image/Dockerfile
@@ -1,5 +1,14 @@
 FROM ghcr.io/openvadl/lcb-test-base@sha256:0c91110246c88996b69bdffae4510f86959fabf57ebda51662a04a23b8b86aae AS riscv-toolchain
 
+# Build elf updater tool
+FROM rust:1.87 AS rust-builder
+WORKDIR /usr/src
+
+RUN apt-get update && apt-get install -y git
+RUN git clone https://github.com/kper/elf_machine_updater.git
+WORKDIR /usr/src/elf_machine_updater
+RUN cargo build --release
+
 # LLVM
 FROM ghcr.io/openvadl/llvm19-base@sha256:743dc3df521b6721ee4a74126aff198f40b6fc585d2c06b76869cabbb3d2c015
 RUN apt update -y
@@ -7,6 +16,9 @@ RUN apt-get install -y device-tree-compiler python3 python3-pip python3-pandas v
 COPY --from=riscv-toolchain /opt/riscv /opt/riscv
 COPY --from=riscv-toolchain /opt/qemu /opt/qemu
 COPY --from=riscv-toolchain /usr/local/bin/ /usr/local/bin
+
+COPY --from=rust-builder /usr/src/elf_machine_updater/target/release/elf_machine_updater /work/elf_machine_updater
+
 WORKDIR /work
 COPY helper /helper
 COPY lcb_wrapper.sh .

--- a/vadl/test/resources/images/lcb_execution_test_rv64im/base_image/helper/init.S
+++ b/vadl/test/resources/images/lcb_execution_test_rv64im/base_image/helper/init.S
@@ -43,7 +43,7 @@ _start:
 
     lui t0, %hi(__stack_shift)
     addi t0, t0, %lo(__stack_shift)
-    la tp, __stack_start
+    lla tp, __stack_start
     sll t0, s0, t0
     add tp, tp, t0
 
@@ -56,7 +56,7 @@ _start:
     # shutdown with exit code from main
     slli a0, a0, 1
     ori a0, a0, 1
-    la x2, tohost
+    lla x2, tohost
     sw a0, 0(x2)
     sw x0, 4(x2)
 

--- a/vadl/test/resources/images/lcb_execution_test_rv64im/base_image/lcb_integration.sh
+++ b/vadl/test/resources/images/lcb_execution_test_rv64im/base_image/lcb_integration.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -x
+
+# Compile from c source with the LCB Compiler
+/src/llvm-final/build/bin/clang --target=${TARGET} -S -O${OPT_LEVEL} -c /src/inputs/$INPUT -o /tmp/main.s
+chmod 777 /tmp/main.s
+cat /tmp/main.s
+
+# Assemble with the LCB Assembler
+/src/llvm-final/build/bin/llvm-mc -filetype=obj -arch=${TARGET} /tmp/main.s -o /tmp/main.o
+/src/llvm-final/build/bin/llvm-mc -filetype=obj -arch=${TARGET} /helper/init.S -o /tmp/init.o
+
+# Link with the LCB Linker
+/src/llvm-final/build/bin/ld.lld -static -T/helper/link.ld /tmp/main.o /tmp/init.o -o /tmp/main
+/work/elf_machine_updater update-machine --elf /tmp/main --value 243
+
+# Execute with QEMU
+qemu-system-${UPSTREAM_CLANG_TARGET} -d in_asm -nographic -machine spike -bios /tmp/main

--- a/vadl/test/resources/images/lcb_execution_test_rv64im/base_image/lcb_integration.sh
+++ b/vadl/test/resources/images/lcb_execution_test_rv64im/base_image/lcb_integration.sh
@@ -3,7 +3,7 @@
 set -x
 
 # Compile from c source with the LCB Compiler
-/src/llvm-final/build/bin/clang --target=${TARGET} -S -O${OPT_LEVEL} -c /src/inputs/$INPUT -o /tmp/main.s
+/src/llvm-final/build/bin/clang --target=${TARGET} -fPIC -S -O${OPT_LEVEL} -c /src/inputs/$INPUT -o /tmp/main.s
 chmod 777 /tmp/main.s
 cat /tmp/main.s
 

--- a/vadl/test/resources/llvm/riscv/asm/rv32im/codeemitter/PseudoInstructions.s
+++ b/vadl/test/resources/llvm/riscv/asm/rv32im/codeemitter/PseudoInstructions.s
@@ -13,14 +13,16 @@ EBREAK
 # CHECK: # encoding: [0x73,0x00,0x10,0x00]
 
 CALL my_function
-# CHECK: # encoding: [0x97,0x00,0x00,0x00,0xe7,0x80,0x00,0x00]
+# CHECK: # encoding: [0x97,0x00,0x00,0x00]
 # CHECK-NEXT: #   fixup A - offset: 0, value: %pcrel_hi(my_function), kind: fixup_pcrel_hi_RV3264Base_Utype_RELATIVE_imm
-# CHECK-NEXT: #   fixup B - offset: 4, value: %pcrel_lo(my_function), kind: fixup_pcrel_lo_RV3264Base_Itype_RELATIVE_imm
+# CHECK-NEXT: # encoding: [0xe7,0x80,0x00,0x00]
+# CHECK-NEXT: #   fixup A - offset: 0, value: %pcrel_lo(.Lhi_label0), kind: fixup_pcrel_lo_RV3264Base_Itype_RELATIVE_imm
 
 TAIL my_function
-# CHECK: # encoding: [0x17,0x03,0x00,0x00,0x67,0x00,0x03,0x00]
+# CHECK: # encoding: [0x17,0x03,0x00,0x00]
 # CHECK-NEXT: #   fixup A - offset: 0, value: %pcrel_hi(my_function), kind: fixup_pcrel_hi_RV3264Base_Utype_RELATIVE_imm
-# CHECK-NEXT: #   fixup B - offset: 4, value: %pcrel_lo(my_function), kind: fixup_pcrel_lo_RV3264Base_Itype_RELATIVE_imm
+# CHECK-NEXT: # encoding: [0x67,0x00,0x03,0x00]
+# CHECK-NEXT: #   fixup A - offset: 0, value: %pcrel_lo(.Lhi_label1), kind: fixup_pcrel_lo_RV3264Base_Itype_RELATIVE_imm
 
 J 100
 # CHECK: # encoding: [0x6f,0x00,0x40,0x06]
@@ -29,7 +31,7 @@ JR a5
 # CHECK: # encoding: [0x67,0x80,0x07,0x00]
 
 MV x0, x1
-# CHECK:[0x13,0x80,0x00,0x00]
+# CHECK: [0x13,0x80,0x00,0x00]
 
 NOT x2, x3
 # CHECK: [0x13,0xc1,0xf1,0xff]
@@ -69,14 +71,17 @@ BGTZ x6, 6
 # CHECK: [0x63,0x43,0x60,0x00]
 
 LLA x3, .lbl
-# CHECK: [0x97,0x01,0x00,0x00,0x93,0x81,0x01,0x00]
+# CHECK: [0x97,0x01,0x00,0x00]
 # CHECK-NEXT: #   fixup A - offset: 0, value: %pcrel_hi(.lbl), kind: fixup_pcrel_hi_RV3264Base_Utype_RELATIVE_imm
-# CHECK-NEXT: #   fixup B - offset: 4, value: %pcrel_lo(.Ltmp0), kind: fixup_pcrel_lo_RV3264Base_Itype_RELATIVE_imm
+# CHECK: [0x93,0x81,0x01,0x00]
+# CHECK-NEXT: #   fixup A - offset: 0, value: %pcrel_lo(.Lhi_label2), kind: fixup_pcrel_lo_RV3264Base_Itype_RELATIVE_imm
 
 LI x3, 0x12345
-# CHECK: [0xb7,0x21,0x01,0x00,0x93,0x81,0x51,0x34]
+# CHECK: [0xb7,0x21,0x01,0x00]
+# CHECK-NEXT: [0x93,0x81,0x51,0x34]
 
 LGA x3, my_label
-# CHECK: [0x97,0x01,0x00,0x00,0x83,0xa1,0x01,0x00]
+# CHECK: [0x97,0x01,0x00,0x00]
 # CHECK-NEXT: #   fixup A - offset: 0, value: %got_pcrel_hi(my_label), kind: fixup_got_pcrel_hi_RV3264Base_Utype_GLOBAL_OFFSET_TABLE_imm
-# CHECK-NEXT: #   fixup B - offset: 4, value: %pcrel_lo(my_label), kind: fixup_pcrel_lo_RV3264Base_Itype_RELATIVE_imm
+# CHECK: [0x83,0xa1,0x01,0x00]
+# CHECK-NEXT: #   fixup A - offset: 0, value: %pcrel_lo(.Lhi_label3), kind: fixup_pcrel_lo_RV3264Base_Itype_RELATIVE_imm

--- a/vadl/test/resources/llvm/riscv/asm/rv32im/parser/PseudoInstructions.s
+++ b/vadl/test/resources/llvm/riscv/asm/rv32im/parser/PseudoInstructions.s
@@ -2,10 +2,16 @@
 
 
 RET
-# CHECK: <MCInst #{{[0-9]+}} RET>
+# CHECK: <MCInst #{{[0-9]+}} JALR
+# CHECK-NEXT: <MCOperand Reg:2>
+# CHECK-NEXT: <MCOperand Reg:3>
+# CHECK-NEXT: <MCOperand Imm:0>>
 
 NOP
-# CHECK: <MCInst #{{[0-9]+}} NOP>
+# CHECK: <MCInst #{{[0-9]+}} ADDI
+# CHECK-NEXT: <MCOperand Reg:2>
+# CHECK-NEXT: <MCOperand Reg:2>
+# CHECK-NEXT: <MCOperand Imm:0>>
 
 ECALL
 # CHECK: <MCInst #{{[0-9]+}} ECALL>
@@ -15,97 +21,143 @@ EBREAK
 
 
 CALL my_function
-# CHECK: <MCInst #{{[0-9]+}} CALL
-# CHECK-NEXT: <MCOperand Expr:(my_function)>>
+# CHECK:      .Lhi_label0:
+# CHECK-NEXT: <MCInst #{{[0-9]+}} AUIPC
+# CHECK-NEXT: <MCOperand Reg:3>
+# CHECK-NEXT: <MCOperand Expr:(%pcrel_hi(my_function))>>
+# CHECK-NEXT: <MCInst #{{[0-9]+}} JALR
+# CHECK-NEXT: <MCOperand Reg:3>
+# CHECK-NEXT: <MCOperand Reg:3>
+# CHECK-NEXT: <MCOperand Expr:(%pcrel_lo(.Lhi_label0))>>
 
 TAIL my_function
-# CHECK: <MCInst #{{[0-9]+}} TAIL
-# CHECK-NEXT: <MCOperand Expr:(my_function)>>
+# CHECK:      .Lhi_label1:
+# CHECK-NEXT: <MCInst #{{[0-9]+}} AUIPC
+# CHECK-NEXT: <MCOperand Reg:8>
+# CHECK-NEXT: <MCOperand Expr:(%pcrel_hi(my_function))>>
+# CHECK-NEXT: <MCInst #{{[0-9]+}} JALR
+# CHECK-NEXT: <MCOperand Reg:2>
+# CHECK-NEXT: <MCOperand Reg:8>
+# CHECK-NEXT: <MCOperand Expr:(%pcrel_lo(.Lhi_label1))>>
 
 J 100
-# CHECK: <MCInst #{{[0-9]+}} J
+# CHECK: <MCInst #{{[0-9]+}} JAL
+# CHECK-NEXT: <MCOperand Reg:2>
 # CHECK-NEXT: <MCOperand Imm:100>>
 
 JR a5
-# CHECK: <MCInst #{{[0-9]+}} JR
-# CHECK-NEXT: <MCOperand Reg:17>>
+# CHECK: <MCInst #{{[0-9]+}} JALR
+# CHECK-NEXT: <MCOperand Reg:2>
+# CHECK-NEXT: <MCOperand Reg:17>
+# CHECK-NEXT: <MCOperand Imm:0>>
 
 MV x0, x1
-# CHECK: <MCInst #{{[0-9]+}} MV
+# CHECK: <MCInst #{{[0-9]+}} ADDI
 # CHECK-NEXT: <MCOperand Reg:2>
-# CHECK-NEXT: <MCOperand Reg:3>>
+# CHECK-NEXT: <MCOperand Reg:3>
+# CHECK-NEXT: <MCOperand Imm:0>>
 
 NOT x2, x3
-# CHECK: <MCInst #{{[0-9]+}} NOT
+# CHECK: <MCInst #{{[0-9]+}} XORI
 # CHECK-NEXT: <MCOperand Reg:4>
-# CHECK-NEXT: <MCOperand Reg:5>>
+# CHECK-NEXT: <MCOperand Reg:5>
+# CHECK-NEXT: <MCOperand Imm:4095>>
 
 NEG x4, x5
-# CHECK: <MCInst #{{[0-9]+}} NEG
+# CHECK: <MCInst #{{[0-9]+}} SUB
 # CHECK-NEXT: <MCOperand Reg:6>
+# CHECK-NEXT: <MCOperand Reg:2>
 # CHECK-NEXT: <MCOperand Reg:7>>
 
 SNEZ x6, x7
-# CHECK: <MCInst #{{[0-9]+}} SNEZ
+# CHECK: <MCInst #{{[0-9]+}} SLTU
 # CHECK-NEXT: <MCOperand Reg:8>
+# CHECK-NEXT: <MCOperand Reg:2>
 # CHECK-NEXT: <MCOperand Reg:9>>
 
 SLTZ x8, x9
-# CHECK: <MCInst #{{[0-9]+}} SLTZ
+# CHECK: <MCInst #{{[0-9]+}} SLT
 # CHECK-NEXT: <MCOperand Reg:10>
-# CHECK-NEXT: <MCOperand Reg:11>>
+# CHECK-NEXT: <MCOperand Reg:11>
+# CHECK-NEXT: <MCOperand Reg:2>>
 
 SGTZ x10, x11
-# CHECK: <MCInst #{{[0-9]+}} SGTZ
+# CHECK: <MCInst #{{[0-9]+}} SLT
 # CHECK-NEXT: <MCOperand Reg:12>
+# CHECK-NEXT: <MCOperand Reg:2>
 # CHECK-NEXT: <MCOperand Reg:13>>
 
 BEQZ x1, 1
-# CHECK: <MCInst #{{[0-9]+}} BEQZ
+# CHECK: <MCInst #{{[0-9]+}} BEQ
 # CHECK-NEXT: <MCOperand Reg:3>
+# CHECK-NEXT: <MCOperand Reg:2>
 # CHECK-NEXT: <MCOperand Imm:1>>
 
 BNEZ x2, 2
-# CHECK: <MCInst #{{[0-9]+}} BNEZ
+# CHECK: <MCInst #{{[0-9]+}} BNE
 # CHECK-NEXT: <MCOperand Reg:4>
+# CHECK-NEXT: <MCOperand Reg:2>
 # CHECK-NEXT: <MCOperand Imm:2>>
 
 BLEZ x3, 3
-# CHECK: <MCInst #{{[0-9]+}} BLEZ
+# CHECK: <MCInst #{{[0-9]+}} BGE
+# CHECK-NEXT: <MCOperand Reg:2>
 # CHECK-NEXT: <MCOperand Reg:5>
 # CHECK-NEXT: <MCOperand Imm:3>>
 
 BGEZ x4, 4
-# CHECK: <MCInst #{{[0-9]+}} BGEZ
+# CHECK: <MCInst #{{[0-9]+}} BGE
 # CHECK-NEXT: <MCOperand Reg:6>
+# CHECK-NEXT: <MCOperand Reg:2>
 # CHECK-NEXT: <MCOperand Imm:4>>
 
 BLTZ x5, 5
-# CHECK: <MCInst #{{[0-9]+}} BLTZ
+# CHECK: <MCInst #{{[0-9]+}} BLT
 # CHECK-NEXT: <MCOperand Reg:7>
+# CHECK-NEXT: <MCOperand Reg:2>
 # CHECK-NEXT: <MCOperand Imm:5>>
 
 BGTZ x6, 6
-# CHECK: <MCInst #{{[0-9]+}} BGTZ
+# CHECK: <MCInst #{{[0-9]+}} BLT
+# CHECK-NEXT: <MCOperand Reg:2>
 # CHECK-NEXT: <MCOperand Reg:8>
 # CHECK-NEXT: <MCOperand Imm:6>>
 
 LLA x0, my_label
-# CHECK: <MCInst #{{[0-9]+}} LLA
+# CHECK:      .Lhi_label2:
+# CHECK-NEXT: <MCInst #{{[0-9]+}} AUIPC
 # CHECK-NEXT: <MCOperand Reg:2>
-# CHECK-NEXT: <MCOperand Expr:(my_label)>>
+# CHECK-NEXT: <MCOperand Expr:(%pcrel_hi(my_label))>>
+# CHECK-NEXT: <MCInst #{{[0-9]+}} ADDI
+# CHECK-NEXT: <MCOperand Reg:2>
+# CHECK-NEXT: <MCOperand Reg:2>
+# CHECK-NEXT: <MCOperand Expr:(%pcrel_lo(.Lhi_label2))>>
 
 LI x1, my_label
-# CHECK: <MCInst #{{[0-9]+}} LI
+# CHECK: <MCInst #{{[0-9]+}} LUI
 # CHECK-NEXT: <MCOperand Reg:3>
-# CHECK-NEXT: <MCOperand Expr:(my_label)>>
+# CHECK-NEXT: <MCOperand Expr:(%hi(my_label))>>
+# CHECK-NEXT: <MCInst #{{[0-9]+}} ADDI
+# CHECK-NEXT: <MCOperand Reg:3>
+# CHECK-NEXT: <MCOperand Reg:3>
+# CHECK-NEXT: <MCOperand Expr:(%lo(my_label))>>
 
 LA x2, my_label
-# CHECK: <MCInst #{{[0-9]+}} LA
+LI x1, my_label
+# CHECK: <MCInst #{{[0-9]+}} LUI
 # CHECK-NEXT: <MCOperand Reg:4>
-# CHECK-NEXT: <MCOperand Expr:(my_label)>>
+# CHECK-NEXT: <MCOperand Expr:(%hi(my_label))>>
+# CHECK-NEXT: <MCInst #{{[0-9]+}} ADDI
+# CHECK-NEXT: <MCOperand Reg:4>
+# CHECK-NEXT: <MCOperand Reg:4>
+# CHECK-NEXT: <MCOperand Expr:(%lo(my_label))>>
 
 LGA x3, my_label
-# CHECK: <MCInst #{{[0-9]+}} LGA_32
+# CHECK:      .Lhi_label3:
+# CHECK-NEXT: <MCInst #{{[0-9]+}} AUIPC
 # CHECK-NEXT: <MCOperand Reg:5>
-# CHECK-NEXT: <MCOperand Expr:(my_label)>>
+# CHECK-NEXT: <MCOperand Expr:(%got_pcrel_hi(my_label))>>
+# CHECK-NEXT: <MCInst #{{[0-9]+}} LW
+# CHECK-NEXT: <MCOperand Reg:5>
+# CHECK-NEXT: <MCOperand Reg:5>
+# CHECK-NEXT: <MCOperand Expr:(%pcrel_lo(.Lhi_label3))>>

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O0/pic.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O0/pic.ll
@@ -8,9 +8,9 @@
 define ptr @f1() nounwind {
 ; CHECK-LABEL: f1: # @f1
 ; CHECK-LABEL: # %bb.0: # %entry
-; CHECK-LABEL: .Ltmp0
+; CHECK-LABEL: .Lhi_label0
 ; CHECK-NEXT: AUIPC a0,%got_pcrel_hi(external_var)
-; CHECK-NEXT: LW a0,%pcrel_lo(.Ltmp0)(a0)
+; CHECK-NEXT: LW a0,%pcrel_lo(.Lhi_label0)(a0)
 ; CHECK-NEXT: RET
 entry:
   ret ptr @external_var
@@ -19,9 +19,9 @@ entry:
 define ptr @f2() nounwind {
 ; CHECK-LABEL: f2: # @f2
 ; CHECK-LABEL: # %bb.0: # %entry
-; CHECK-LABEL: .Ltmp1
+; CHECK-LABEL: .Lhi_label1
 ; CHECK-NEXT: AUIPC a0,%pcrel_hi(internal_var)
-; CHECK-NEXT: ADDI a0,a0,%pcrel_lo(.Ltmp1)
+; CHECK-NEXT: ADDI a0,a0,%pcrel_lo(.Lhi_label1)
 ; CHECK-NEXT: RET
 entry:
   ret ptr @internal_var

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/pic.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv32im/O3/pic.ll
@@ -8,9 +8,9 @@
 define ptr @f1() nounwind {
 ; CHECK-LABEL: f1: # @f1
 ; CHECK-LABEL: # %bb.0: # %entry
-; CHECK-LABEL: .Ltmp0
+; CHECK-LABEL: .Lhi_label0
 ; CHECK-NEXT: AUIPC a0,%got_pcrel_hi(external_var)
-; CHECK-NEXT: LW a0,%pcrel_lo(.Ltmp0)(a0)
+; CHECK-NEXT: LW a0,%pcrel_lo(.Lhi_label0)(a0)
 ; CHECK-NEXT: RET
 entry:
   ret ptr @external_var
@@ -19,9 +19,9 @@ entry:
 define ptr @f2() nounwind {
 ; CHECK-LABEL: f2: # @f2
 ; CHECK-LABEL: # %bb.0: # %entry
-; CHECK-LABEL: .Ltmp1
+; CHECK-LABEL: .Lhi_label1
 ; CHECK-NEXT: AUIPC a0,%pcrel_hi(internal_var)
-; CHECK-NEXT: ADDI a0,a0,%pcrel_lo(.Ltmp1)
+; CHECK-NEXT: ADDI a0,a0,%pcrel_lo(.Lhi_label1)
 ; CHECK-NEXT: RET
 entry:
   ret ptr @internal_var

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O0/imm.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O0/imm.ll
@@ -55,9 +55,9 @@ define signext i32 @neg_i32_hi20_only() nounwind {
 
 define i64 @imm_end_xori_1() nounwind {
   ; CHECK-LABEL: imm_end_xori_1: # @imm_end_xori_1
-  ; CHECK-LABEL: .Ltmp0:
+  ; CHECK-LABEL: .Lhi_label0:
   ; CHECK-NEXT: AUIPC a0,%pcrel_hi(.LCPI7_0)
-  ; CHECK-NEXT: ADDI a0,a0,%pcrel_lo(.Ltmp0)
+  ; CHECK-NEXT: ADDI a0,a0,%pcrel_lo(.Lhi_label0)
   ; CHECK-NEXT: LD a0,0(a0)
   ; CHECK-NEXT: RET
   ret i64 -2305843009180139521 ; 0xE000_0000_01FF_FFFF
@@ -84,9 +84,9 @@ define void @imm_store_i16_neg1(ptr %p) nounwind {
 
 define void @imm_store_i32_neg1(ptr %p) nounwind {
   ; CHECK-LABEL: imm_store_i32_neg1: # @imm_store_i32_neg1
-  ; CHECK-LABEL: .Ltmp1:
+  ; CHECK-LABEL: .Lhi_label1:
   ; CHECK-NEXT: AUIPC a1,%pcrel_hi(.LCPI10_0)
-  ; CHECK-NEXT: ADDI a1,a1,%pcrel_lo(.Ltmp1)
+  ; CHECK-NEXT: ADDI a1,a1,%pcrel_lo(.Lhi_label1)
   ; CHECK-NEXT: LD a1,0(a1)
   ; CHECK-NEXT: SW a1,0(a0)
   ; CHECK-NEXT: RET

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O0/mul.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O0/mul.ll
@@ -25,9 +25,9 @@ define signext i32 @mul(i32 %a, i32 %b) nounwind {
 define signext i32 @mul_constant(i32 %a) nounwind {
 ; CHECK-LABEL: mul_constant: # @mul_constant
 ; CHECK-LABEL: # %bb.0:
-; CHECK-LABEL: .Ltmp0:
+; CHECK-LABEL: .Lhi_label0:
 ; CHECK-NEXT: AUIPC a1,%pcrel_hi(.LCPI2_0)
-; CHECK-NEXT: ADDI a1,a1,%pcrel_lo(.Ltmp0)
+; CHECK-NEXT: ADDI a1,a1,%pcrel_lo(.Lhi_label0)
 ; CHECK-NEXT: LD a1,0(a1)
 ; CHECK-NEXT: MUL a0,a0,a1
 ; CHECK-NEXT: SRAI a0,a0,32

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O0/pic.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O0/pic.ll
@@ -8,9 +8,9 @@
 define ptr @f1() nounwind {
 ; CHECK-LABEL: f1: # @f1
 ; CHECK-LABEL: # %bb.0: # %entry
-; CHECK-LABEL: .Ltmp0:
+; CHECK-LABEL: .Lhi_label0:
 ; CHECK-NEXT: AUIPC a0,%got_pcrel_hi(external_var)
-; CHECK-NEXT: LD a0,%pcrel_lo(.Ltmp0)(a0)
+; CHECK-NEXT: LD a0,%pcrel_lo(.Lhi_label0)(a0)
 ; CHECK-NEXT: RET
 entry:
   ret ptr @external_var
@@ -19,9 +19,9 @@ entry:
 define ptr @f2() nounwind {
 ; CHECK-LABEL: f2: # @f2
 ; CHECK-LABEL: # %bb.0: # %entry
-; CHECK-LABEL: .Ltmp1:
+; CHECK-LABEL: .Lhi_label1:
 ; CHECK-NEXT: AUIPC a0,%pcrel_hi(internal_var)
-; CHECK-NEXT: ADDI a0,a0,%pcrel_lo(.Ltmp1)
+; CHECK-NEXT: ADDI a0,a0,%pcrel_lo(.Lhi_label1)
 ; CHECK-NEXT: RET
 entry:
   ret ptr @internal_var

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O0/static_global_var.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O0/static_global_var.ll
@@ -12,20 +12,20 @@ define void @init_heap_beebs(ptr noundef %heap, i64 noundef %heap_size) #0 {
 ; CHECK-NEXT: SD a0,8(sp)
 ; CHECK-NEXT: SD a1,0(sp)
 ; CHECK-NEXT: LD a1,8(sp)
-; CHECK-LABEL: .Ltmp0:
+; CHECK-LABEL: .Lhi_label0:
 ; CHECK-NEXT: AUIPC a0,%pcrel_hi(heap_ptr)
-; CHECK-NEXT: ADDI a0,a0,%pcrel_lo(.Ltmp0)
+; CHECK-NEXT: ADDI a0,a0,%pcrel_lo(.Lhi_label0)
 ; CHECK-NEXT: SD a1,0(a0)
 ; CHECK-NEXT: LD a0,0(a0)
 ; CHECK-NEXT: LD a1,0(sp)
 ; CHECK-NEXT: ADD a1,a0,a1
-; CHECK-LABEL: .Ltmp1:
+; CHECK-LABEL: .Lhi_label1:
 ; CHECK-NEXT: AUIPC a0,%pcrel_hi(heap_end)
-; CHECK-NEXT: ADDI a0,a0,%pcrel_lo(.Ltmp1)
+; CHECK-NEXT: ADDI a0,a0,%pcrel_lo(.Lhi_label1)
 ; CHECK-NEXT: SD a1,0(a0)
-; CHECK-LABEL: .Ltmp2:
+; CHECK-LABEL: .Lhi_label2:
 ; CHECK-NEXT: AUIPC a0,%pcrel_hi(heap_requested)
-; CHECK-NEXT: ADDI a0,a0,%pcrel_lo(.Ltmp2)
+; CHECK-NEXT: ADDI a0,a0,%pcrel_lo(.Lhi_label2)
 ; CHECK-NEXT: ADDI a1,zero,0
 ; CHECK-NEXT: SD a1,0(a0)
 ; CHECK-NEXT: ADDI sp,sp,16

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/alu64.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/alu64.ll
@@ -184,9 +184,9 @@ define i64 @and(i64 %a, i64 %b) nounwind {
 define signext i32 @addiw(i32 signext %a) nounwind {
 ; CHECK-LABEL: addiw: # @addiw
 ; CHECK-LABEL: # %bb.0:
-; CHECK-LABEL: .Ltmp0:
+; CHECK-LABEL: .Lhi_label0:
 ; CHECK-NEXT: AUIPC a1,%pcrel_hi(.LCPI19_0)
-; CHECK-NEXT: ADDI a1,a1,%pcrel_lo(.Ltmp0)
+; CHECK-NEXT: ADDI a1,a1,%pcrel_lo(.Lhi_label0)
 ; CHECK-NEXT: LD a1,0(a1)
 ; CHECK-NEXT: SLLI a0,a0,32
 ; CHECK-NEXT: ADD a0,a0,a1
@@ -209,9 +209,9 @@ define signext i32 @slliw(i32 signext %a) nounwind {
 define signext i32 @srliw(i32 %a) nounwind {
 ; CHECK-LABEL: srliw: # @srliw
 ; CHECK-LABEL: # %bb.0:
-; CHECK-LABEL: .Ltmp1:
+; CHECK-LABEL: .Lhi_label1:
 ; CHECK-NEXT: AUIPC a1,%pcrel_hi(.LCPI21_0)
-; CHECK-NEXT: ADDI a1,a1,%pcrel_lo(.Ltmp1)
+; CHECK-NEXT: ADDI a1,a1,%pcrel_lo(.Lhi_label1)
 ; CHECK-NEXT: LD a1,0(a1)
 ; CHECK-NEXT: AND a0,a0,a1
 ; CHECK-NEXT: SRLI a0,a0,8
@@ -286,9 +286,9 @@ define signext i32 @sllw(i32 signext %a, i32 zeroext %b) nounwind {
 define signext i32 @srlw(i32 signext %a, i32 zeroext %b) nounwind {
 ; CHECK-LABEL: srlw: # @srlw
 ; CHECK-LABEL: # %bb.0:
-; CHECK-LABEL: .Ltmp2:
+; CHECK-LABEL: .Lhi_label2:
 ; CHECK-NEXT: AUIPC a2,%pcrel_hi(.LCPI28_0)
-; CHECK-NEXT: ADDI a2,a2,%pcrel_lo(.Ltmp2)
+; CHECK-NEXT: ADDI a2,a2,%pcrel_lo(.Lhi_label2)
 ; CHECK-NEXT: LD a2,0(a2)
 ; CHECK-NEXT: AND a0,a0,a2
 ; CHECK-NEXT: SRL a0,a0,a1
@@ -323,9 +323,9 @@ define i64 @add_hi_and_lo_negone(i64 %0) {
 define i64 @add_hi_zero_lo_negone(i64 %0) {
 ; CHECK-LABEL: add_hi_zero_lo_negone: # @add_hi_zero_lo_negone
 ; CHECK-LABEL: # %bb.0:
-; CHECK-LABEL: .Ltmp3:
+; CHECK-LABEL: .Lhi_label3:
 ; CHECK-NEXT: AUIPC a1,%pcrel_hi(.LCPI31_0)
-; CHECK-NEXT: ADDI a1,a1,%pcrel_lo(.Ltmp3)
+; CHECK-NEXT: ADDI a1,a1,%pcrel_lo(.Lhi_label3)
 ; CHECK-NEXT: LD a1,0(a1)
 ; CHECK-NEXT: ADD a0,a0,a1
 ; CHECK-NEXT: RET
@@ -336,9 +336,9 @@ define i64 @add_hi_zero_lo_negone(i64 %0) {
 define i64 @add_lo_negone(i64 %0) {
 ; CHECK-LABEL: add_lo_negone: # @add_lo_negone
 ; CHECK-LABEL: # %bb.0:
-; CHECK-LABEL: .Ltmp4:
+; CHECK-LABEL: .Lhi_label4:
 ; CHECK-NEXT: AUIPC a1,%pcrel_hi(.LCPI32_0)
-; CHECK-NEXT: ADDI a1,a1,%pcrel_lo(.Ltmp4)
+; CHECK-NEXT: ADDI a1,a1,%pcrel_lo(.Lhi_label4)
 ; CHECK-NEXT: LD a1,0(a1)
 ; CHECK-NEXT: ADD a0,a0,a1
 ; CHECK-NEXT: RET
@@ -349,9 +349,9 @@ define i64 @add_lo_negone(i64 %0) {
 define i64 @add_hi_one_lo_negone(i64 %0) {
 ; CHECK-LABEL: add_hi_one_lo_negone: # @add_hi_one_lo_negone
 ; CHECK-LABEL: # %bb.0:
-; CHECK-LABEL: .Ltmp5:
+; CHECK-LABEL: .Lhi_label5:
 ; CHECK-NEXT: AUIPC a1,%pcrel_hi(.LCPI33_0)
-; CHECK-NEXT: ADDI a1,a1,%pcrel_lo(.Ltmp5)
+; CHECK-NEXT: ADDI a1,a1,%pcrel_lo(.Lhi_label5)
 ; CHECK-NEXT: LD a1,0(a1)
 ; CHECK-NEXT: ADD a0,a0,a1
 ; CHECK-NEXT: RET

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/analyze-branch.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/analyze-branch.ll
@@ -12,9 +12,9 @@ define void @test_bcc_fallthrough_taken(i32 %in) nounwind {
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: ADDI sp,sp,-16
 ; CHECK-NEXT: SD ra,8(sp) # 8-byte Folded Spill
-; CHECK-LABEL: .Ltmp0:
+; CHECK-LABEL: .Lhi_label0:
 ; CHECK-NEXT: AUIPC a1,%pcrel_hi(.LCPI0_0)
-; CHECK-NEXT: ADDI a1,a1,%pcrel_lo(.Ltmp0)
+; CHECK-NEXT: ADDI a1,a1,%pcrel_lo(.Lhi_label0)
 ; CHECK-NEXT: LD a1,0(a1)
 ; CHECK-NEXT: AND a0,a0,a1
 ; CHECK-NEXT: ADDI a1,zero,42
@@ -50,9 +50,9 @@ define void @test_bcc_fallthrough_nottaken(i32 %in) nounwind {
 ; CHECK-LABEL: # %bb.0:
 ; CHECK-NEXT: ADDI sp,sp,-16
 ; CHECK-NEXT: SD ra,8(sp) # 8-byte Folded Spill
-; CHECK-LABEL: .Ltmp1:
+; CHECK-LABEL: .Lhi_label1:
 ; CHECK-NEXT: AUIPC a1,%pcrel_hi(.LCPI1_0)
-; CHECK-NEXT: ADDI a1,a1,%pcrel_lo(.Ltmp1)
+; CHECK-NEXT: ADDI a1,a1,%pcrel_lo(.Lhi_label1)
 ; CHECK-NEXT: LD a1,0(a1)
 ; CHECK-NEXT: AND a0,a0,a1
 ; CHECK-NEXT: ADDI a1,zero,42

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/branch-opt.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/branch-opt.ll
@@ -33,9 +33,9 @@ end_block:                                        ; preds = %block2, %block1
 define void @case1_a(ptr %a, i32 signext %b, ptr %c, ptr %d) {
 ; CHECK-LABEL: case1_a:
 ; CHECK:       # %bb.0:
-; CHECK-LABEL: .Ltmp0:
+; CHECK-LABEL: .Lhi_label0:
 ; CHECK-NEXT:    AUIPC a4,%pcrel_hi(.LCPI1_0)
-; CHECK-NEXT:    ADDI a4,a4,%pcrel_lo(.Ltmp0)
+; CHECK-NEXT:    ADDI a4,a4,%pcrel_lo(.Lhi_label0)
 ; CHECK-NEXT:    LD a4,0(a4)
 ; CHECK-NEXT:    SW a4,0(a0)
 ; CHECK-NEXT:    ADDI a0,zero,-2
@@ -96,9 +96,9 @@ end_block:                                        ; preds = %block2, %block1
 define void @case2_a(ptr %a, i32 signext %b, ptr %c, ptr %d) {
 ; CHECK-LABEL: case2_a:
 ; CHECK:       # %bb.0:
-; CHECK-LABEL: .Ltmp1:
+; CHECK-LABEL: .Lhi_label1:
 ; CHECK-NEXT: AUIPC a4,%pcrel_hi(.LCPI3_0)
-; CHECK-NEXT: ADDI a4,a4,%pcrel_lo(.Ltmp1)
+; CHECK-NEXT: ADDI a4,a4,%pcrel_lo(.Lhi_label1)
 ; CHECK-NEXT: LD a4,0(a4)
 ; CHECK-NEXT: SW a4,0(a0)
 ; CHECK-NEXT: ADDI a0,zero,-3

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/imm.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/imm.ll
@@ -55,9 +55,9 @@ define signext i32 @neg_i32_hi20_only() nounwind {
 
 define i64 @imm_end_xori_1() nounwind {
   ; CHECK-LABEL: imm_end_xori_1: # @imm_end_xori_1
-  ; CHECK-LABEL: .Ltmp0:
+  ; CHECK-LABEL: .Lhi_label0:
   ; CHECK-NEXT: AUIPC a0,%pcrel_hi(.LCPI7_0)
-  ; CHECK-NEXT: ADDI a0,a0,%pcrel_lo(.Ltmp0)
+  ; CHECK-NEXT: ADDI a0,a0,%pcrel_lo(.Lhi_label0)
   ; CHECK-NEXT: LD a0,0(a0)
   ; CHECK-NEXT: RET
   ret i64 -2305843009180139521 ; 0xE000_0000_01FF_FFFF
@@ -84,9 +84,9 @@ define void @imm_store_i16_neg1(ptr %p) nounwind {
 
 define void @imm_store_i32_neg1(ptr %p) nounwind {
   ; CHECK-LABEL: imm_store_i32_neg1: # @imm_store_i32_neg1
-  ; CHECK-LABEL: .Ltmp1:
+  ; CHECK-LABEL: .Lhi_label1:
   ; CHECK-NEXT: AUIPC a1,%pcrel_hi(.LCPI10_0)
-  ; CHECK-NEXT: ADDI a1,a1,%pcrel_lo(.Ltmp1)
+  ; CHECK-NEXT: ADDI a1,a1,%pcrel_lo(.Lhi_label1)
   ; CHECK-NEXT: LD a1,0(a1)
   ; CHECK-NEXT: SW a1,0(a0)
   ; CHECK-NEXT: RET

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/mul.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/mul.ll
@@ -25,9 +25,9 @@ define signext i32 @mul(i32 %a, i32 %b) nounwind {
 define signext i32 @mul_constant(i32 %a) nounwind {
 ; CHECK-LABEL: mul_constant: # @mul_constant
 ; CHECK-LABEL: # %bb.0:
-; CHECK-LABEL: .Ltmp0:
+; CHECK-LABEL: .Lhi_label0:
 ; CHECK-NEXT: AUIPC a1,%pcrel_hi(.LCPI2_0)
-; CHECK-NEXT: ADDI a1,a1,%pcrel_lo(.Ltmp0)
+; CHECK-NEXT: ADDI a1,a1,%pcrel_lo(.Lhi_label0)
 ; CHECK-NEXT: LD a1,0(a1)
 ; CHECK-NEXT: MUL a0,a0,a1
 ; CHECK-NEXT: SRAI a0,a0,32

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/pic.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/pic.ll
@@ -8,9 +8,9 @@
 define ptr @f1() nounwind {
 ; CHECK-LABEL: f1: # @f1
 ; CHECK-LABEL: # %bb.0: # %entry
-; CHECK-LABEL: .Ltmp0:
+; CHECK-LABEL: .Lhi_label0:
 ; CHECK-NEXT: AUIPC a0,%got_pcrel_hi(external_var)
-; CHECK-NEXT: LD a0,%pcrel_lo(.Ltmp0)(a0)
+; CHECK-NEXT: LD a0,%pcrel_lo(.Lhi_label0)(a0)
 ; CHECK-NEXT: RET
 entry:
   ret ptr @external_var
@@ -19,9 +19,9 @@ entry:
 define ptr @f2() nounwind {
 ; CHECK-LABEL: f2: # @f2
 ; CHECK-LABEL: # %bb.0: # %entry
-; CHECK-LABEL: .Ltmp1:
+; CHECK-LABEL: .Lhi_label1:
 ; CHECK-NEXT: AUIPC a0,%pcrel_hi(internal_var)
-; CHECK-NEXT: ADDI a0,a0,%pcrel_lo(.Ltmp1)
+; CHECK-NEXT: ADDI a0,a0,%pcrel_lo(.Lhi_label1)
 ; CHECK-NEXT: RET
 entry:
   ret ptr @internal_var

--- a/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/rotl-rotr.ll
+++ b/vadl/test/resources/llvm/riscv/llvmIR/rv64im/O3/rotl-rotr.ll
@@ -8,9 +8,9 @@ define i32 @rotl_32(i32 %x, i32 %y) nounwind {
 ; CHECK: # %bb.0:
 ; CHECK-NEXT: ADDI a2,zero,32
 ; CHECK-NEXT: SUB a2,a2,a1
-; CHECK-LABEL: .Ltmp0:
+; CHECK-LABEL: .Lhi_label0:
 ; CHECK-NEXT: AUIPC a3,%pcrel_hi(.LCPI0_0)
-; CHECK-NEXT: ADDI a3,a3,%pcrel_lo(.Ltmp0)
+; CHECK-NEXT: ADDI a3,a3,%pcrel_lo(.Lhi_label0)
 ; CHECK-NEXT: LD a3,0(a3)
 ; CHECK-NEXT: AND a2,a2,a3
 ; CHECK-NEXT: AND a4,a0,a3
@@ -29,9 +29,9 @@ define i32 @rotl_32(i32 %x, i32 %y) nounwind {
 define i32 @rotr_32(i32 %x, i32 %y) nounwind {
 ; CHECK-LABEL: rotr_32:
 ; CHECK: # %bb.0:
-; CHECK-LABEL: .Ltmp1:
+; CHECK-LABEL: .Lhi_label1:
 ; CHECK-NEXT: AUIPC a2,%pcrel_hi(.LCPI1_0)
-; CHECK-NEXT: ADDI a2,a2,%pcrel_lo(.Ltmp1)
+; CHECK-NEXT: ADDI a2,a2,%pcrel_lo(.Lhi_label1)
 ; CHECK-NEXT: LD a2,0(a2)
 ; CHECK-NEXT: AND a3,a1,a2
 ; CHECK-NEXT: AND a4,a0,a2
@@ -86,9 +86,9 @@ define i32 @rotl_32_mask(i32 %x, i32 %y) nounwind {
 ; CHECK: # %bb.0:
 ; CHECK-NEXT: SUB a2,zero,a1
 ; CHECK-NEXT: ANDI a2,a2,31
-; CHECK-LABEL: .Ltmp2:
+; CHECK-LABEL: .Lhi_label2:
 ; CHECK-NEXT: AUIPC a3,%pcrel_hi(.LCPI4_0)
-; CHECK-NEXT: ADDI a3,a3,%pcrel_lo(.Ltmp2)
+; CHECK-NEXT: ADDI a3,a3,%pcrel_lo(.Lhi_label2)
 ; CHECK-NEXT: LD a3,0(a3)
 ; CHECK-NEXT: AND a4,a0,a3
 ; CHECK-NEXT: SRL a2,a4,a2
@@ -107,9 +107,9 @@ define i32 @rotl_32_mask(i32 %x, i32 %y) nounwind {
 define i32 @rotl_32_mask_and_63_and_31(i32 %x, i32 %y) nounwind {
 ; CHECK-LABEL: rotl_32_mask_and_63_and_31:
 ; CHECK: # %bb.0:
-; CHECK-LABEL: .Ltmp3:
+; CHECK-LABEL: .Lhi_label3:
 ; CHECK-NEXT: AUIPC a2,%pcrel_hi(.LCPI5_0)
-; CHECK-NEXT: ADDI a2,a2,%pcrel_lo(.Ltmp3)
+; CHECK-NEXT: ADDI a2,a2,%pcrel_lo(.Lhi_label3)
 ; CHECK-NEXT: LD a2,0(a2)
 ; CHECK-NEXT: AND a2,a0,a2
 ; CHECK-NEXT: SUB a3,zero,a1
@@ -145,9 +145,9 @@ define i32 @rotl_32_mask_or_64_or_32(i32 %x, i32 %y) nounwind {
 define i32 @rotr_32_mask(i32 %x, i32 %y) nounwind {
 ; CHECK-LABEL: rotr_32_mask:
 ; CHECK: # %bb.0:
-; CHECK-LABEL: .Ltmp4:
+; CHECK-LABEL: .Lhi_label4:
 ; CHECK-NEXT: AUIPC a2,%pcrel_hi(.LCPI7_0)
-; CHECK-NEXT: ADDI a2,a2,%pcrel_lo(.Ltmp4)
+; CHECK-NEXT: ADDI a2,a2,%pcrel_lo(.Lhi_label4)
 ; CHECK-NEXT: LD a2,0(a2)
 ; CHECK-NEXT: AND a3,a1,a2
 ; CHECK-NEXT: AND a2,a0,a2
@@ -171,9 +171,9 @@ define i32 @rotr_32_mask_and_63_and_31(i32 %x, i32 %y) nounwind {
 ; CHECK-NEXT: SUB a2,zero,a1
 ; CHECK-NEXT: ANDI a2,a2,31
 ; CHECK-NEXT: SLL a2,a0,a2
-; CHECK-LABEL: .Ltmp5:
+; CHECK-LABEL: .Lhi_label5:
 ; CHECK-NEXT: AUIPC a3,%pcrel_hi(.LCPI8_0)
-; CHECK-NEXT: ADDI a3,a3,%pcrel_lo(.Ltmp5)
+; CHECK-NEXT: ADDI a3,a3,%pcrel_lo(.Lhi_label5)
 ; CHECK-NEXT: LD a3,0(a3)
 ; CHECK-NEXT: AND a0,a0,a3
 ; CHECK-NEXT: ANDI a1,a1,63

--- a/vadl/test/resources/llvm/varrisc/asm/PseudoInstructions.s
+++ b/vadl/test/resources/llvm/varrisc/asm/PseudoInstructions.s
@@ -1,35 +1,46 @@
 # RUN: /src/llvm-final/build/bin/llvm-mc -arch=varrisc -show-inst < $INPUT | /src/llvm-final/build/bin/FileCheck $INPUT
 
 BRA 0x12
-# CHECK: <MCInst #{{[0-9]+}} BRA
+# CHECK: <MCInst #{{[0-9]+}} BEQ
+# CHECK-NEXT: <MCOperand Reg:2>
+# CHECK-NEXT: <MCOperand Reg:2>
 # CHECK-NEXT: <MCOperand Imm:18>>
 
 BRA_L 0x12345678
-# CHECK: <MCInst #{{[0-9]+}} BRA_L
+# CHECK: <MCInst #{{[0-9]+}} BEQ_L
+# CHECK-NEXT: <MCOperand Reg:2>
+# CHECK-NEXT: <MCOperand Reg:2>
 # CHECK-NEXT: <MCOperand Imm:305419896>>
 
 BEQZ r1, 0x12
-# CHECK: <MCInst #{{[0-9]+}} BEQZ
+# CHECK: <MCInst #{{[0-9]+}} BEQ
 # CHECK-NEXT: <MCOperand Reg:3>
+# CHECK-NEXT: <MCOperand Reg:2>
 # CHECK-NEXT: <MCOperand Imm:18>>
 
 BEQZ_L r1, 0x12345678
-# CHECK: <MCInst #{{[0-9]+}} BEQZ_L
+# CHECK: <MCInst #{{[0-9]+}} BEQ_L
 # CHECK-NEXT: <MCOperand Reg:3>
+# CHECK-NEXT: <MCOperand Reg:2>
 # CHECK-NEXT: <MCOperand Imm:305419896>>
 
 JMP r10
-# CHECK: <MCInst #{{[0-9]+}} JMP
-# CHECK-NEXT: <MCOperand Reg:12>>
+# CHECK: <MCInst #{{[0-9]+}} JAL
+# CHECK-NEXT: <MCOperand Reg:12>
+# CHECK-NEXT: <MCOperand Reg:2>>
 
 RET
-# CHECK: <MCInst #{{[0-9]+}} RET>
+# CHECK: <MCInst #{{[0-9]+}} JAL
+# CHECK-NEXT: <MCOperand Reg:33>
+# CHECK-NEXT: <MCOperand Reg:2>>
 
 CALL mylabel
-# CHECK: <MCInst #{{[0-9]+}} CALL
+# CHECK: <MCInst #{{[0-9]+}} BAL_L
+# CHECK-NEXT: <MCOperand Reg:33>
 # CHECK-NEXT: <MCOperand Expr:(mylabel)>>
 
 LA r1, mylabel
-# CHECK: <MCInst #{{[0-9]+}} LA
+# CHECK: <MCInst #{{[0-9]+}} ADDI_L
 # CHECK-NEXT: <MCOperand Reg:3>
+# CHECK-NEXT: <MCOperand Reg:2>
 # CHECK-NEXT: <MCOperand Expr:(mylabel)>>

--- a/vadl/test/resources/llvm/varrisc/asm_no_suffix/ImmediateInstSelection.s
+++ b/vadl/test/resources/llvm/varrisc/asm_no_suffix/ImmediateInstSelection.s
@@ -141,43 +141,57 @@ BRA 511
 # CHECK-NEXT: <MCOperand Imm:1022>>
 
 BRA 512
-# CHECK: <MCInst #{{[0-9]+}} BRA
+# CHECK: <MCInst #{{[0-9]+}} BEQ
+# CHECK-NEXT: <MCOperand Reg:2>
+# CHECK-NEXT: <MCOperand Reg:2>
 # CHECK-NEXT: <MCOperand Imm:512>>
 
 BRA 1023
-# CHECK: <MCInst #{{[0-9]+}} BRA
+# CHECK: <MCInst #{{[0-9]+}} BEQ
+# CHECK-NEXT: <MCOperand Reg:2>
+# CHECK-NEXT: <MCOperand Reg:2>
 # CHECK-NEXT: <MCOperand Imm:1023>>
 
 BRA -1024
-# CHECK: <MCInst #{{[0-9]+}} BRA
+# CHECK: <MCInst #{{[0-9]+}} BEQ
+# CHECK-NEXT: <MCOperand Reg:2>
+# CHECK-NEXT: <MCOperand Reg:2>
 # CHECK-NEXT: <MCOperand Imm:-1024>>
 
 BRA 1024
-# CHECK: <MCInst #{{[0-9]+}} BRA_L
+# CHECK: <MCInst #{{[0-9]+}} BEQ_L
+# CHECK-NEXT: <MCOperand Reg:2>
+# CHECK-NEXT: <MCOperand Reg:2>
 # CHECK-NEXT: <MCOperand Imm:1024>>
 
 BRA -1025
-# CHECK: <MCInst #{{[0-9]+}} BRA_L
+# CHECK: <MCInst #{{[0-9]+}} BEQ_L
+# CHECK-NEXT: <MCOperand Reg:2>
+# CHECK-NEXT: <MCOperand Reg:2>
 # CHECK-NEXT: <MCOperand Imm:-1025>>
 
 
 
 BEQZ r1, 1023
-# CHECK: <MCInst #{{[0-9]+}} BEQZ
+# CHECK: <MCInst #{{[0-9]+}} BEQ
 # CHECK-NEXT: <MCOperand Reg:3>
+# CHECK-NEXT: <MCOperand Reg:2>
 # CHECK-NEXT: <MCOperand Imm:1023>>
 
 BEQZ r1, -1024
-# CHECK: <MCInst #{{[0-9]+}} BEQZ
+# CHECK: <MCInst #{{[0-9]+}} BEQ
 # CHECK-NEXT: <MCOperand Reg:3>
+# CHECK-NEXT: <MCOperand Reg:2>
 # CHECK-NEXT: <MCOperand Imm:-1024>>
 
 BEQZ r1, 1024
-# CHECK: <MCInst #{{[0-9]+}} BEQZ_L
+# CHECK: <MCInst #{{[0-9]+}} BEQ_L
 # CHECK-NEXT: <MCOperand Reg:3>
+# CHECK-NEXT: <MCOperand Reg:2>
 # CHECK-NEXT: <MCOperand Imm:1024>>
 
 BEQZ r1, -1025
-# CHECK: <MCInst #{{[0-9]+}} BEQZ_L
+# CHECK: <MCInst #{{[0-9]+}} BEQ_L
 # CHECK-NEXT: <MCOperand Reg:3>
+# CHECK-NEXT: <MCOperand Reg:2>
 # CHECK-NEXT: <MCOperand Imm:-1025>>

--- a/vadl/test/resources/llvm/varrisc/asm_no_suffix/PseudoInstructions.s
+++ b/vadl/test/resources/llvm/varrisc/asm_no_suffix/PseudoInstructions.s
@@ -5,40 +5,52 @@ BRA 10
 # CHECK-NEXT: <MCOperand Imm:20>>
 
 BRA 0x12345678
-# CHECK: <MCInst #{{[0-9]+}} BRA_L
+# CHECK: <MCInst #{{[0-9]+}} BEQ_L
+# CHECK-NEXT: <MCOperand Reg:2>
+# CHECK-NEXT: <MCOperand Reg:2>
 # CHECK-NEXT: <MCOperand Imm:305419896>>
 
 BRA .label
-# CHECK: <MCInst #{{[0-9]+}} BRA_L
+# CHECK: <MCInst #{{[0-9]+}} BEQ_L
+# CHECK-NEXT: <MCOperand Reg:2>
+# CHECK-NEXT: <MCOperand Reg:2>
 # CHECK-NEXT: <MCOperand Expr:(.label)>>
 
 BEQZ r1, 0x12
-# CHECK: <MCInst #{{[0-9]+}} BEQZ
+# CHECK: <MCInst #{{[0-9]+}} BEQ
 # CHECK-NEXT: <MCOperand Reg:3>
+# CHECK-NEXT: <MCOperand Reg:2>
 # CHECK-NEXT: <MCOperand Imm:18>>
 
 BEQZ r1, 1024
-# CHECK: <MCInst #{{[0-9]+}} BEQZ_L
+# CHECK: <MCInst #{{[0-9]+}} BEQ_L
 # CHECK-NEXT: <MCOperand Reg:3>
+# CHECK-NEXT: <MCOperand Reg:2>
 # CHECK-NEXT: <MCOperand Imm:1024>>
 
 BEQZ r1, .label
-# CHECK: <MCInst #{{[0-9]+}} BEQZ_L
+# CHECK: <MCInst #{{[0-9]+}} BEQ_L
 # CHECK-NEXT: <MCOperand Reg:3>
+# CHECK-NEXT: <MCOperand Reg:2>
 # CHECK-NEXT: <MCOperand Expr:(.label)>>
 
 JMP r10
-# CHECK: <MCInst #{{[0-9]+}} JMP
-# CHECK-NEXT: <MCOperand Reg:12>>
+# CHECK: <MCInst #{{[0-9]+}} JAL
+# CHECK-NEXT: <MCOperand Reg:12>
+# CHECK-NEXT: <MCOperand Reg:2>>
 
 RET
-# CHECK: <MCInst #{{[0-9]+}} RET>
+# CHECK: <MCInst #{{[0-9]+}} JAL
+# CHECK-NEXT: <MCOperand Reg:33>
+# CHECK-NEXT: <MCOperand Reg:2>>
 
 CALL mylabel
-# CHECK: <MCInst #{{[0-9]+}} CALL
+# CHECK: <MCInst #{{[0-9]+}} BAL_L
+# CHECK-NEXT: <MCOperand Reg:33>
 # CHECK-NEXT: <MCOperand Expr:(mylabel)>>
 
 LA r1, mylabel
-# CHECK: <MCInst #{{[0-9]+}} LA
+# CHECK: <MCInst #{{[0-9]+}} ADDI_L
 # CHECK-NEXT: <MCOperand Reg:3>
+# CHECK-NEXT: <MCOperand Reg:2>
 # CHECK-NEXT: <MCOperand Expr:(mylabel)>>

--- a/vadl/test/vadl/lcb/riscv/riscv32/asm/AsmCodeEmitterRiscv32FileCheckTest.java
+++ b/vadl/test/vadl/lcb/riscv/riscv32/asm/AsmCodeEmitterRiscv32FileCheckTest.java
@@ -16,10 +16,8 @@
 
 package vadl.lcb.riscv.riscv32.asm;
 
-import org.junit.jupiter.api.Disabled;
 import vadl.lcb.riscv.riscv32.AsmRiscv32FileCheckTest;
 
-@Disabled("Enable once indirect relocations in the linker are implemented.")
 public class AsmCodeEmitterRiscv32FileCheckTest extends AsmRiscv32FileCheckTest {
 
   @Override

--- a/vadl/test/vadl/lcb/riscv/riscv32/asm/AsmGenCodeEmitterRiscv32FileCheckTest.java
+++ b/vadl/test/vadl/lcb/riscv/riscv32/asm/AsmGenCodeEmitterRiscv32FileCheckTest.java
@@ -16,10 +16,8 @@
 
 package vadl.lcb.riscv.riscv32.asm;
 
-import org.junit.jupiter.api.Disabled;
 import vadl.lcb.riscv.riscv32.AsmGenRiscv32FileCheckTest;
 
-@Disabled("Enable once indirect relocations in the linker are implemented.")
 public class AsmGenCodeEmitterRiscv32FileCheckTest extends AsmGenRiscv32FileCheckTest {
   @Override
   protected String getComponent() {

--- a/vadl/test/vadl/lcb/riscv/riscv64/LcbRiscv64SimulationTest.java
+++ b/vadl/test/vadl/lcb/riscv/riscv64/LcbRiscv64SimulationTest.java
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText : © 2026 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.lcb.riscv.riscv64;
+
+import java.io.IOException;
+import java.util.List;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+import vadl.lcb.LcbDockerInputFileExecutionTest;
+import vadl.pass.exception.DuplicatedPassKeyException;
+
+public class LcbRiscv64SimulationTest extends LcbDockerInputFileExecutionTest {
+
+  @TestFactory
+  List<DynamicTest> optLevel0() throws DuplicatedPassKeyException, IOException {
+    return runEach("sys/risc-v/rv64im.vadl",
+        List.of("test/resources/llvm/riscv/qemu_nolibc/",
+            "test/resources/llvm/riscv/qemu_nolibc"),
+        0,
+        "sh /work/lcb_integration.sh"
+    );
+  }
+
+  @TestFactory
+  List<DynamicTest> optLevel3() throws DuplicatedPassKeyException, IOException {
+    return runEach("sys/risc-v/rv64im.vadl",
+        List.of("test/resources/llvm/riscv/qemu_nolibc/",
+            "test/resources/llvm/riscv/qemu_nolibc"),
+        3,
+        "sh /work/lcb_integration.sh"
+    );
+  }
+
+  @Override
+  protected String getTarget() {
+    return "rv64im";
+  }
+
+  @Override
+  protected String getUpstreamBuildTarget() {
+    return "RISCV";
+  }
+
+  @Override
+  protected String getUpstreamClangTarget() {
+    return "riscv64";
+  }
+
+  @Override
+  protected String getSpikeTarget() {
+    return "rv64im";
+  }
+
+  @Override
+  protected String getAbi() {
+    return "ilp64";
+  }
+
+}

--- a/vadl/test/vadl/lcb/riscv/riscv64/template/MCTargetDesc/EmitMCInstExpanderCppFilePassTest.java
+++ b/vadl/test/vadl/lcb/riscv/riscv64/template/MCTargetDesc/EmitMCInstExpanderCppFilePassTest.java
@@ -364,7 +364,7 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
         std::vector<MCInst> processorNameValueMCInstExpander::RV3264Base_LGA_64_expand(const MCInst& instruction, std::function<void(const MCInst &)> callback, std::function<void(MCSymbol* )> callbackSymbol ) const
         {
            std::vector< MCInst > result;
-           MCSymbol *a = Ctx.createTempSymbol();
+           MCSymbol *a = Ctx.createTempSymbol("hi_label");
            callbackSymbol(a);
            MCInst b = MCInst();
            b.setOpcode(processorNameValue::AUIPC);
@@ -417,7 +417,7 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
         std::vector<MCInst> processorNameValueMCInstExpander::RV3264Base_CALL_expand(const MCInst& instruction, std::function<void(const MCInst &)> callback, std::function<void(MCSymbol* )> callbackSymbol ) const
         {
            std::vector< MCInst > result;
-           MCSymbol *a = Ctx.createTempSymbol();
+           MCSymbol *a = Ctx.createTempSymbol("hi_label");
            callbackSymbol(a);
            MCInst b = MCInst();
            b.setOpcode(processorNameValue::AUIPC);
@@ -470,7 +470,7 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
         std::vector<MCInst> processorNameValueMCInstExpander::RV3264Base_TAIL_expand(const MCInst& instruction, std::function<void(const MCInst &)> callback, std::function<void(MCSymbol* )> callbackSymbol ) const
         {
            std::vector< MCInst > result;
-           MCSymbol *a = Ctx.createTempSymbol();
+           MCSymbol *a = Ctx.createTempSymbol("hi_label");
            callbackSymbol(a);
            MCInst b = MCInst();
            b.setOpcode(processorNameValue::AUIPC);
@@ -1027,7 +1027,7 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
         std::vector<MCInst> processorNameValueMCInstExpander::RV3264Base_LGA_32_expand(const MCInst& instruction, std::function<void(const MCInst &)> callback, std::function<void(MCSymbol* )> callbackSymbol ) const
         {
            std::vector< MCInst > result;
-           MCSymbol *a = Ctx.createTempSymbol();
+           MCSymbol *a = Ctx.createTempSymbol("hi_label");
            callbackSymbol(a);
            MCInst b = MCInst();
            b.setOpcode(processorNameValue::AUIPC);
@@ -1080,7 +1080,7 @@ public class EmitMCInstExpanderCppFilePassTest extends AbstractLcbTest {
         std::vector<MCInst> processorNameValueMCInstExpander::RV3264Base_LLA_expand(const MCInst& instruction, std::function<void(const MCInst &)> callback, std::function<void(MCSymbol* )> callbackSymbol ) const
         {
            std::vector< MCInst > result;
-           MCSymbol *a = Ctx.createTempSymbol();
+           MCSymbol *a = Ctx.createTempSymbol("hi_label");
            callbackSymbol(a);
            MCInst b = MCInst();
            b.setOpcode(processorNameValue::AUIPC);

--- a/vadl/test/vadl/lcb/riscv/riscv64/template/lld/ELF/Arch/EmitLldTargetRelocationsHeaderFilePassTest.java
+++ b/vadl/test/vadl/lcb/riscv/riscv64/template/lld/ELF/Arch/EmitLldTargetRelocationsHeaderFilePassTest.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+// SPDX-FileCopyrightText : © 2025-2026 TU Wien <vadl@tuwien.ac.at>
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
@@ -61,7 +61,7 @@ public class EmitLldTargetRelocationsHeaderFilePassTest extends AbstractLcbTest 
            return VADL_uextract(VADL_lsr(VADL_add(symbol, 32, ((uint32_t) 0x800 ), 32), 32, ((uint8_t) 0xc ), 4), 20);
         }
         int64_t RV3264Base_pcrel_lo(uint32_t symbol) {
-           return  VADL_sextract(VADL_uextract(VADL_add(symbol, 32, ((uint32_t) 0x4 ), 32), 12), 12);
+           return  VADL_sextract(VADL_uextract(symbol, 12), 12);
         }
         int64_t RV3264Base_got_pcrel_hi(uint32_t symbol) {
            return VADL_uextract(VADL_lsr(VADL_add(symbol, 32, ((uint32_t) 0x800 ), 32), 32, ((uint8_t) 0xc ), 4), 20);


### PR DESCRIPTION
Add the capability to generate indirect relocations to the OpenVADL linker.

An example of such a relocation is `pcrel_lo` of RISCV, where the relocation's type depends on the type of its paired relocation.

```
.Lpcrel_hi0:
   auipc   a0, %got_pcrel_hi(Coeff)
   ld      a0, %pcrel_lo(.Lpcrel_hi0)(a0)}
```
Here the `%pcrel_lo` relocation is paired with a global offset table (GOT) relocation, therefore `%pcrel_lo` is also GOT relative.

```
.Lpcrel_hi0:
   auipc   a0, %pcrel_hi(Coeff)
   ld      a0, %pcrel_lo(.Lpcrel_hi0)(a0)}
```
In this case `%pcrel_lo` is paired with a PC relative relocation, therefore  `%pcrel_lo` also is just PC relative.


Notable changes in this PR:
- Added the `paired` annotation to relocation definitions, to declare which relocations should behave as described above
- Added two LLD templates, in which the relocation indirection is implemented
- Moved pseudo expansion within the assembler from code emitter to parser, since access to a streamer is needed to emit labels. This also required to adjust the asm parser filecheck tests to check the expanded state of instructions.
- Added a Riscv64 LCB integration test (`LcbRiscv64SimulationTest`)
- Re-enabled two code emitter tests (disabled in #1064)
- Adjusted label names in LLVM IR filecheck tests