### PR TITLE
frontend: Support reverse search in advanced AST dump

### DIFF
--- a/vadl-cli/main/vadl/cli/BaseCommand.java
+++ b/vadl-cli/main/vadl/cli/BaseCommand.java
@@ -261,7 +261,7 @@ public abstract class BaseCommand implements Callable<Integer> {
     }
 
     withTimings("Advanced AST Dump", () -> {
-      var content = new AstAdvancedDumper().dump(ast, vfs, getTimeString());
+      var content = AstAdvancedDumper.dump(ast, vfs, getTimeString());
       dumpFile("ast-dump-advanced.html", content);
     });
   }

--- a/vadl-frontend/main/vadl/ast/AstAdvancedDumper.java
+++ b/vadl-frontend/main/vadl/ast/AstAdvancedDumper.java
@@ -19,7 +19,10 @@ package vadl.ast;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -38,7 +41,21 @@ import vadl.utils.WithLocation;
  */
 public class AstAdvancedDumper {
 
-  private AstDumpLabler labler = new AstDumpLabler();
+  private final AstDumpLabler labler = new AstDumpLabler();
+  private final Path sourcePath;
+  private final String source;
+  private final int[] lineStarts;
+  private final List<SourceIndexEntry> sourceIndex = new ArrayList<>();
+  private int nextNodeId;
+
+  private record SourceIndexEntry(int start, int end, int nodeId, int depth) {
+  }
+
+  private AstAdvancedDumper(Path sourcePath, String source) {
+    this.sourcePath = sourcePath.normalize();
+    this.source = source;
+    this.lineStarts = findLineStarts(source);
+  }
 
   /**
    * Dumps the AST into a textual representation.
@@ -55,10 +72,12 @@ public class AstAdvancedDumper {
       throw new RuntimeException(e);
     }
 
-    var dumper = new AstAdvancedDumper();
+    var dumper = new AstAdvancedDumper(Objects.requireNonNull(ast.filePath), source);
+    var astMaps = dumper.astToMaps(ast);
     var renderedDump = new StringWriter();
     TemplateRenderer.render("astDump/advanced.html",
-        Map.of("ast", dumper.astToMaps(ast), "source", source, "timestamp", timeString),
+        Map.of("ast", astMaps, "source", source, "timestamp", timeString,
+            "sourceIndex", dumper.sourceIndexAsJavaScript()),
         renderedDump);
     return renderedDump.toString();
   }
@@ -68,23 +87,28 @@ public class AstAdvancedDumper {
    * custom classes, which caused issues with GraalVM Native Images.
    */
   private List<Map<String, Object>> astToMaps(Ast ast) {
-    return ast.definitions.stream().map(this::nodeToMap).toList();
+    return ast.definitions.stream().map(node -> nodeToMap(node, 0)).toList();
   }
 
-  private Map<String, Object> nodeToMap(Node node) {
+  private Map<String, Object> nodeToMap(Node node, int depth) {
     var map = new HashMap<String, Object>();
     var label = label(node);
+    var nodeId = nextNodeId++;
+    var location = node.location();
+    map.put("htmlId", "ast-node-" + nodeId);
     map.put("description", label.description());
-    map.put("children", label.children().stream().map(this::nodeToMap).toList());
-    map.put("location", locationToMap(node));
-    map.put("expandedFrom", node.location().expandedFromStack().stream()
+    map.put("children",
+        label.children().stream().map(child -> nodeToMap(child, depth + 1)).toList());
+    map.put("location", locationToMap(location));
+    map.put("expandedFrom", location == null ? List.of() : location.expandedFromStack().stream()
         .map(this::locationToMap).toList());
+    addToSourceIndex(location, nodeId, depth);
     return map;
   }
 
   @Nullable
-  private Map<String, Object> locationToMap(WithLocation locatable) {
-    var location = locatable.location();
+  private Map<String, Object> locationToMap(@Nullable WithLocation locatable) {
+    var location = locatable == null ? null : locatable.location();
     if (location == null || !location.isValid()) {
       return null;
     }
@@ -96,6 +120,71 @@ public class AstAdvancedDumper {
     map.put("endLine", location.end().line());
     map.put("endColumn", location.end().column());
     return map;
+  }
+
+  private void addToSourceIndex(@Nullable WithLocation locatable, int nodeId, int depth) {
+    var location = locatable == null ? null : locatable.location();
+    if (location == null || !location.isValid() || location.path() == null
+        || !location.path().normalize().equals(sourcePath)) {
+      return;
+    }
+
+    var start = offsetAt(location.begin().line(), location.begin().column());
+    var endOffset = offsetAt(location.end().line(), location.end().column());
+    var end = endOffset < 0 ? -1 : Math.min(source.length(), endOffset + 1);
+    if (start < 0 || end <= start) {
+      return;
+    }
+
+    sourceIndex.add(new SourceIndexEntry(start, end, nodeId, depth));
+  }
+
+  private int offsetAt(int line, int column) {
+    if (line < 1 || line > lineStarts.length || column < 1) {
+      return -1;
+    }
+
+    var lineStart = lineStarts[line - 1];
+    var lineEnd = line < lineStarts.length ? lineStarts[line] - 1 : source.length();
+    if (column > lineEnd - lineStart + 1) {
+      return -1;
+    }
+    return lineStart + column - 1;
+  }
+
+  private String sourceIndexAsJavaScript() {
+    sourceIndex.sort(Comparator.comparingInt(SourceIndexEntry::start)
+        .thenComparing(Comparator.comparingInt(SourceIndexEntry::end).reversed())
+        .thenComparingInt(SourceIndexEntry::nodeId));
+
+    var builder = new StringBuilder("[");
+    var maxEnd = 0;
+    for (var index = 0; index < sourceIndex.size(); index++) {
+      var entry = sourceIndex.get(index);
+      maxEnd = Math.max(maxEnd, entry.end());
+      if (index > 0) {
+        builder.append(',');
+      }
+      builder.append('[')
+          .append(entry.start()).append(',')
+          .append(entry.end()).append(',')
+          .append(entry.nodeId()).append(',')
+          .append(entry.depth()).append(',')
+          .append(maxEnd)
+          .append(']');
+    }
+    return builder.append(']').toString();
+  }
+
+  private static int[] findLineStarts(String source) {
+    var starts = new ArrayList<Integer>();
+    starts.add(0);
+    for (var index = 0; index < source.length(); index++) {
+      if (source.charAt(index) == '\n') {
+        starts.add(index + 1);
+      }
+    }
+    return starts.stream().mapToInt(Integer::intValue).toArray();
   }
 
   /**

--- a/vadl/main/resources/templates/astDump/advanced.html
+++ b/vadl/main/resources/templates/astDump/advanced.html
@@ -28,6 +28,7 @@
         <th:block th:with="location=${node.location}">
           <div th:if="${location != null}"
                class="p-2 border-3 border-dashed border-transparent rounded-r-lg cursor-pointer"
+               th:id="${node.htmlId}"
                th:attr="data-path=${location.path},
                         data-start-line=${location.startLine},
                         data-start-col=${location.startColumn},
@@ -48,7 +49,8 @@
           </div>
 
           <div th:unless="${location != null}"
-               class="p-2 rounded-r-lg">
+               class="p-2 rounded-r-lg"
+               th:id="${node.htmlId}">
             <span th:text="${node.description}">Node name</span>
           </div>
         </th:block>
@@ -110,12 +112,17 @@
   const expandedFromTitleElement = document.getElementById("expandedFromTitle");
   const expandedFromListElement = document.getElementById("expandedFromList");
   const source = sourceElement.textContent;
+  // Entries are [start, end, node id, AST depth, greatest end up to this entry].
+  // They are generated and sorted in Java to avoid scanning the AST DOM on page load.
+  const sourceIndex = [(${sourceIndex})];
   lineNumbersElement.textContent = Array.from(
           {length: source.split("\n").length},
           (_, index) => index + 1
   ).join("\n");
   let activeNodeElement = null;
   let lockedNodeElement = null;
+  let sourceHoverFrame = null;
+  let pendingSourceHover = null;
 
   // Assumes lines and columns are 1-based, and end is exclusive.
   function offsetAt(line, column) {
@@ -196,11 +203,13 @@
     expandedFromListElement.replaceChildren(...entries);
   }
 
-  function highlight(nodeElement) {
-    if (lockedNodeElement !== null && nodeElement !== lockedNodeElement) {
-      return;
-    }
+  function expandedLocationsOf(nodeElement) {
+    return Array.from(
+            nodeElement.querySelectorAll(".expanded-from-location")
+    ).map(locationOf);
+  }
 
+  function activateAstNode(nodeElement) {
     if (activeNodeElement !== null && activeNodeElement !== nodeElement) {
       activeNodeElement.classList.remove("bg-emerald-100");
     }
@@ -209,13 +218,18 @@
 
     const location = locationOf(nodeElement);
     document.getElementById("locationName").textContent = formatLocation(location);
+    renderExpandedFrom(expandedLocationsOf(nodeElement));
+  }
 
+  function highlight(nodeElement, scrollSource = true) {
+    if (lockedNodeElement !== null && nodeElement !== lockedNodeElement) {
+      return;
+    }
+
+    activateAstNode(nodeElement);
+    const location = locationOf(nodeElement);
     const primaryRange = sourceRange(location, "primary");
-    const expandedLocations = Array.from(
-            nodeElement.querySelectorAll(".expanded-from-location")
-    )
-            .map(locationOf);
-    renderExpandedFrom(expandedLocations);
+    const expandedLocations = expandedLocationsOf(nodeElement);
 
     if (primaryRange.end <= primaryRange.start) {
       sourceElement.textContent = source;
@@ -269,7 +283,7 @@
 
     sourceElement.replaceChildren(content);
 
-    if (autoScrollElement.checked && primaryMark !== null) {
+    if (scrollSource && autoScrollElement.checked && primaryMark !== null) {
       primaryMark.scrollIntoView({
         behavior: "smooth",
         block: "center",
@@ -296,6 +310,123 @@
     } else {
       renderExpandedFrom([]);
     }
+  }
+
+  function sourceOffsetFromPoint(x, y) {
+    let offsetNode;
+    let offset;
+    if (document.caretPositionFromPoint) {
+      const position = document.caretPositionFromPoint(x, y);
+      if (position === null) {
+        return null;
+      }
+      offsetNode = position.offsetNode;
+      offset = position.offset;
+    } else if (document.caretRangeFromPoint) {
+      const caretRange = document.caretRangeFromPoint(x, y);
+      if (caretRange === null) {
+        return null;
+      }
+      offsetNode = caretRange.startContainer;
+      offset = caretRange.startOffset;
+    } else {
+      return null;
+    }
+
+    if (offsetNode !== sourceElement && !sourceElement.contains(offsetNode)) {
+      return null;
+    }
+
+    const range = document.createRange();
+    range.selectNodeContents(sourceElement);
+    try {
+      range.setEnd(offsetNode, offset);
+    } catch (error) {
+      return null;
+    }
+    return range.toString().length;
+  }
+
+  function sourceIndexEntryAt(offset) {
+    let lower = 0;
+    let upper = sourceIndex.length;
+    while (lower < upper) {
+      const middle = Math.floor((lower + upper) / 2);
+      if (sourceIndex[middle][0] <= offset) {
+        lower = middle + 1;
+      } else {
+        upper = middle;
+      }
+    }
+
+    let best = null;
+    for (let index = lower - 1; index >= 0; index--) {
+      const entry = sourceIndex[index];
+      if (entry[4] <= offset) {
+        break;
+      }
+      if (entry[0] > offset || entry[1] <= offset) {
+        continue;
+      }
+
+      if (best === null
+              || entry[1] - entry[0] < best[1] - best[0]
+              || (entry[1] - entry[0] === best[1] - best[0]
+                      && entry[3] > best[3])
+              || (entry[1] - entry[0] === best[1] - best[0]
+                      && entry[3] === best[3] && entry[2] < best[2])) {
+        best = entry;
+      }
+    }
+    return best;
+  }
+
+  function highlightFromSource(x, y) {
+    if (lockedNodeElement !== null) {
+      return;
+    }
+
+    const offset = sourceOffsetFromPoint(x, y);
+    const entry = offset === null ? null : sourceIndexEntryAt(offset);
+    if (entry === null) {
+      if (activeNodeElement !== null) {
+        clearHighlight();
+      }
+      return;
+    }
+
+    const nodeElement = document.getElementById(`ast-node-${entry[2]}`);
+    if (nodeElement === null || activeNodeElement === nodeElement) {
+      return;
+    }
+
+    highlight(nodeElement, false);
+    if (autoScrollElement.checked) {
+      nodeElement.scrollIntoView({
+        behavior: "auto",
+        block: "nearest",
+        inline: "nearest"
+      });
+    }
+  }
+
+  function queueSourceHighlight(event) {
+    if (lockedNodeElement !== null) {
+      return;
+    }
+    pendingSourceHover = {x: event.clientX, y: event.clientY};
+    if (sourceHoverFrame !== null) {
+      return;
+    }
+
+    sourceHoverFrame = requestAnimationFrame(() => {
+      sourceHoverFrame = null;
+      const point = pendingSourceHover;
+      pendingSourceHover = null;
+      if (point !== null) {
+        highlightFromSource(point.x, point.y);
+      }
+    });
   }
 
   function toggleLock(nodeElement) {
@@ -332,6 +463,8 @@
   }
 
   showExpandedFromElement.addEventListener("change", syncExpandedFromDisplay);
+  sourceElement.addEventListener("pointermove", queueSourceHighlight);
+  sourceElement.addEventListener("pointerleave", clearHighlight);
   sourceElement.addEventListener("scroll", () => {
     lineNumbersElement.scrollTop = sourceElement.scrollTop;
   });


### PR DESCRIPTION
Allows to hover over source code on right side to get the corresponding AST node on the left side.

<img width="1466" height="935" alt="Screenshot 2026-08-27 at 16 17 07" src="https://github.com/user-attachments/assets/f4e5b384-53f1-45dc-a318-bfe2870c6542" />


The Java side rendered builds a sorted list of source locations and their corresponding AST node ids as multiple arrays, which are traversed using binary search at hover time using javascript. The representation design was used to minimize loading time when opening the HTML dump in the browser.
