### PR TITLE
frontend: Fix OOM crash advanced AST dumps with large files

### DIFF
--- a/vadl-cli/main/vadl/cli/BaseCommand.java
+++ b/vadl-cli/main/vadl/cli/BaseCommand.java
@@ -23,6 +23,7 @@ import static picocli.CommandLine.TypeConversionException;
 
 import com.google.errorprone.annotations.concurrent.LazyInit;
 import java.io.IOException;
+import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -139,6 +140,11 @@ public abstract class BaseCommand implements Callable<Integer> {
   private record Timing(String name, long durationNS) {
   }
 
+  @FunctionalInterface
+  private interface DumpWriter {
+    void write(Writer writer) throws IOException;
+  }
+
   /**
    * Dumps should contain their date this method returns the date in a uniform string.
    * Format is YYYY-MM-DD hh:mm:ss
@@ -163,6 +169,16 @@ public abstract class BaseCommand implements Callable<Integer> {
    * @param content  of the dump.
    */
   private void dumpFile(String fileName, CharSequence content) {
+    dumpFile(fileName, writer -> writer.append(content));
+  }
+
+  /**
+   * Dump a file.
+   *
+   * @param fileName of the dump.
+   * @param dumpWriter writes the dump directly to the file.
+   */
+  private void dumpFile(String fileName, DumpWriter dumpWriter) {
     var folderPath = Paths.get(output.toString(), "dump");
     if (!folderPath.toFile().exists()) {
       folderPath.toFile().mkdirs();
@@ -170,7 +186,7 @@ public abstract class BaseCommand implements Callable<Integer> {
 
     var filePath = Paths.get(folderPath.toString(), fileName);
     try (var writer = Files.newBufferedWriter(filePath, StandardCharsets.UTF_8)) {
-      writer.append(content);
+      dumpWriter.write(writer);
     } catch (IOException e) {
       e.printStackTrace();
       throw Diagnostic.error("Unable to write file %s".formatted(filePath.toString()),
@@ -261,8 +277,8 @@ public abstract class BaseCommand implements Callable<Integer> {
     }
 
     withTimings("Advanced AST Dump", () -> {
-      var content = AstAdvancedDumper.dump(ast, vfs, getTimeString());
-      dumpFile("ast-dump-advanced.html", content);
+      dumpFile("ast-dump-advanced.html",
+          writer -> AstAdvancedDumper.dump(ast, vfs, getTimeString(), writer));
     });
   }
 

--- a/vadl-frontend/main/vadl/ast/AstAdvancedDumper.java
+++ b/vadl-frontend/main/vadl/ast/AstAdvancedDumper.java
@@ -17,7 +17,7 @@
 package vadl.ast;
 
 import java.io.IOException;
-import java.io.StringWriter;
+import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -58,12 +58,12 @@ public class AstAdvancedDumper {
   }
 
   /**
-   * Dumps the AST into a textual representation.
+   * Dumps the AST into a writer.
    *
    * @param ast to dump.
-   * @return an HTML representation of the tree.
+   * @param writer destination for the HTML representation of the tree
    */
-  public static String dump(Ast ast, VirtualFileSystem vfs, String timeString) {
+  public static void dump(Ast ast, VirtualFileSystem vfs, String timeString, Writer writer) {
     String source = null;
     try {
       source = new String(vfs.getInputStream(Objects.requireNonNull(ast.filePath)).readAllBytes(),
@@ -74,12 +74,10 @@ public class AstAdvancedDumper {
 
     var dumper = new AstAdvancedDumper(Objects.requireNonNull(ast.filePath), source);
     var astMaps = dumper.astToMaps(ast);
-    var renderedDump = new StringWriter();
     TemplateRenderer.render("astDump/advanced.html",
         Map.of("ast", astMaps, "source", source, "timestamp", timeString,
             "sourceIndex", dumper.sourceIndexAsJavaScript()),
-        renderedDump);
-    return renderedDump.toString();
+        writer);
   }
 
   /**


### PR DESCRIPTION
By directly streaming the expanded template to a file it doesn't have to be kept in memory and so the OOM error is avoided.

However, generating the dump is still quite slow (42s on my machine for aarch32) and the generated 1.9GB file never stops loading in my browser (I gave up after 10min) so it is still far from usable for large specs. :/

Fixes: #1079 