### PR TITLE
iss: Add lazy float exception flag computation

### DIFF
--- a/vadl/main/resources/templates/common/vadl-builtins.h
+++ b/vadl/main/resources/templates/common/vadl-builtins.h
@@ -599,7 +599,6 @@ static inline Bits VADL_clz(Bits a, Width w) {
     /* For w <= 64, the leading zeros are how many top bits (from left) are 0.
      * We'll shift the value down until the top bit is set or the value is 0.
      */
-    Bits topBitPos = w;
 
     Bits leading = 0ULL;
     while (leading < w) {

--- a/vadl/main/resources/templates/iss/target/gen-arch/cpu.c
+++ b/vadl/main/resources/templates/iss/target/gen-arch/cpu.c
@@ -104,6 +104,10 @@ static void [(${gen_arch_lower})]_cpu_reset_hold(Object *obj, ResetType type)
     [(${access.name})](env);[/]
 
 [(${reset})]
+
+  [# th:if="${float_facts.has_float_ops}"]
+  // TODO: this disables nan-propagation. this will be configurable via the vadl spec at some point
+  set_default_nan_mode(1, &env->fp_status);[/]
 }
 
 static ObjectClass* [(${gen_arch_lower})]_cpu_class_by_name(const char *cpu_model)

--- a/vadl/main/resources/templates/iss/target/gen-arch/cpu.c
+++ b/vadl/main/resources/templates/iss/target/gen-arch/cpu.c
@@ -106,8 +106,16 @@ static void [(${gen_arch_lower})]_cpu_reset_hold(Object *obj, ResetType type)
 [(${reset})]
 
   [# th:if="${float_facts.has_float_ops}"]
+  // float status and stick fe flags
+
+  // this sets all flags that are not sticky so they are not computed by default
+  set_float_exception_flags(~[(${float_facts.sticky_mask})], &env->fp_status);
   // TODO: this disables nan-propagation. this will be configurable via the vadl spec at some point
-  set_default_nan_mode(1, &env->fp_status);[/]
+  set_default_nan_mode(1, &env->fp_status);
+  [# th:if="${float_facts.has_non_sticky_flags}"]
+  // non-sticky fe flags
+  env->ns_fe_flags = 0;
+  [/][/]
 }
 
 static ObjectClass* [(${gen_arch_lower})]_cpu_class_by_name(const char *cpu_model)

--- a/vadl/main/resources/templates/iss/target/gen-arch/cpu.c
+++ b/vadl/main/resources/templates/iss/target/gen-arch/cpu.c
@@ -105,7 +105,7 @@ static void [(${gen_arch_lower})]_cpu_reset_hold(Object *obj, ResetType type)
 
 [(${reset})]
 
-  [# th:if="${float_facts.has_float_ops}"]
+  [# th:if="${float_facts.need_float_status}"]
   // float status and stick fe flags
 
   // this sets all flags that are not sticky so they are not computed by default

--- a/vadl/main/resources/templates/iss/target/gen-arch/cpu.h
+++ b/vadl/main/resources/templates/iss/target/gen-arch/cpu.h
@@ -25,9 +25,9 @@ extern const char * const [(${gen_arch_lower})]_cpu_[(${reg.name_lower})]_names[
 // e.g. it holds the state of all registers.
 typedef struct CPUArchState {
   // CPU registers
-  [# th:each="reg, iterState : ${register_tensors}"]
+  [# th:each="reg, iterState : ${register_tensors}"][# th:if="${!reg.isFullyLazy}"]
   uint[(${reg.cpu_state_type_width})]_t [(${reg.name_lower})][(${reg.c_array_def})][(${reg.cpu_state_alignment})];
-  [/]
+  [/][/]
 
   // Exception arguments (intermediate store during exception handling)
   [# th:each="exc : ${exc_info.exceptions}"] [# th:each="p : ${exc.params}"]

--- a/vadl/main/resources/templates/iss/target/gen-arch/cpu.h
+++ b/vadl/main/resources/templates/iss/target/gen-arch/cpu.h
@@ -34,8 +34,11 @@ typedef struct CPUArchState {
   [(${p.c_type})] [(${p.name_in_cpu})];
   [/][/]
 
-  [# th:each="fmt : ${float_formats}"]
-  float_status fp_status_[(${fmt.name})];[/]
+  [# th:if="${float_facts.has_float_ops}"]
+  float_status fp_status; // float status and stick fe flags
+  [# th:if="${float_facts.has_non_sticky_flags}"]
+  uint16_t ns_fe_flags;   // non-sticky fe flags
+  [/][/]
 
 } CPU[(${gen_arch_upper})]State;
 

--- a/vadl/main/resources/templates/iss/target/gen-arch/cpu.h
+++ b/vadl/main/resources/templates/iss/target/gen-arch/cpu.h
@@ -34,7 +34,7 @@ typedef struct CPUArchState {
   [(${p.c_type})] [(${p.name_in_cpu})];
   [/][/]
 
-  [# th:if="${float_facts.has_float_ops}"]
+  [# th:if="${float_facts.need_float_status}"]
   float_status fp_status; // float status and stick fe flags
   [# th:if="${float_facts.has_non_sticky_flags}"]
   uint16_t ns_fe_flags;   // non-sticky fe flags

--- a/vadl/main/resources/templates/iss/target/gen-arch/helper.c
+++ b/vadl/main/resources/templates/iss/target/gen-arch/helper.c
@@ -34,22 +34,31 @@ void helper_unsupported(CPU[(${gen_arch_upper})]State *env) {
 [(${instr})]
 [/]
 
+#define TS uint[(${target_size})]_t
+
+// lazy reg read/write helpers
+[# th:each="reg : ${register_tensors}"][# th:if="${reg.isLazy}"]
+TS helper_lazy_read_[(${reg.name_lower})](CPU[(${gen_arch_upper})]State *env) {
+  return get_[(${reg.name_lower})]_u[(${reg.value_width})](env);
+}
+void helper_lazy_write_[(${reg.name_lower})](CPU[(${gen_arch_upper})]State *env, TS value) {
+  set_[(${reg.name_lower})]_u[(${reg.value_width})](env, value);
+}
+[/][/]
+
 [# th:if="${float_facts.has_float_ops}"]
 // float helpers
 
-#define TS uint[(${target_size})]_t
-
-// unset all ns fe flags
+// unset all non-sticky (ns) float exception (fe) flags so they are computed
 #define NS_FE_FLAG_PROLOG \
   uint16_t old_s_fe_flags = get_float_exception_flags(s);                             \
   set_float_exception_flags(old_s_fe_flags & ~[(${float_facts.non_sticky_mask})], s);
 
 // it does not matter if non-ns fe flags are unset in env->ns_fe_flags, since those are never read
-// set all non-s fe flags
 #define NS_FE_FLAG_EPILOG \
   uint16_t new_fe_flags = get_float_exception_flags(s);                         \
   env->ns_fe_flags = new_fe_flags;                                              \
-  set_float_exception_flags(new_fe_flags | ~[(${float_facts.sticky_mask})], s);
+  set_float_exception_flags(new_fe_flags | old_s_fe_flags | ~[(${float_facts.sticky_mask})], s);
 
 #define FLOAT_HELPER_BODY(RET_TY, CALL, FMT, RM) \
   float_status *s = &env->fp_status;                                  \
@@ -141,3 +150,5 @@ void helper_unsupported(CPU[(${gen_arch_upper})]State *env) {
 [/]
 
 [/]
+
+#undef TS

--- a/vadl/main/resources/templates/iss/target/gen-arch/helper.c
+++ b/vadl/main/resources/templates/iss/target/gen-arch/helper.c
@@ -34,39 +34,29 @@ void helper_unsupported(CPU[(${gen_arch_upper})]State *env) {
 [(${instr})]
 [/]
 
+[# th:if="${float_facts.has_float_ops}"]
 // float helpers
 
 #define TS uint[(${target_size})]_t
 
-void prep_float_status(CPU[(${gen_arch_upper})]State *env, float_status *s, TS rm) {
-  uint16_t flags = 0xffff;
-  // un-set non sticky flags
-  [# th:each="reg : ${register_tensors}"][# th:each="flag : ${reg.non_sticky_fe_flags}"]
-  flags &= ~(1 << [(${flag.flag_idx})]);[/][/]
-  // un-set sticky flags that are not set
-  [# th:each="reg : ${register_tensors}"][# th:each="flag : ${reg.sticky_fe_flags}"]
-  flags &= ~((1 - ((env->[(${reg.name_lower})] >> [(${flag.idx})]) & 1)) << [(${flag.flag_idx})]);[/][/]
-  set_float_exception_flags(flags, s);
-  set_float_rounding_mode(rm, s);
-  // TODO: this disables nan-propagation. this will be configurable via the vadl spec at some point
-  set_default_nan_mode(1, s);
-}
+// unset all ns fe flags
+#define NS_FE_FLAG_PROLOG \
+  uint16_t old_s_fe_flags = get_float_exception_flags(s);                             \
+  set_float_exception_flags(old_s_fe_flags & ~[(${float_facts.non_sticky_mask})], s);
 
-void set_float_status(CPU[(${gen_arch_upper})]State *env, float_status *s) {
-  // DEV NOTE: for now we write directly to the flags register. This means that the helper is not pure and
-  //           thus slower. In the future, we should optimize this.
-  uint16_t flags = get_float_exception_flags(s);
-  [# th:each="reg : ${register_tensors}"][# th:each="flag : ${reg.sticky_fe_flags}"]
-  env->[(${reg.name_lower})] |= (flags >> [(${flag.flag_idx})] & 1) << [(${flag.idx})];[/][/]
-  [# th:each="reg : ${register_tensors}"][# th:each="flag : ${reg.non_sticky_fe_flags}"]
-  env->[(${reg.name_lower})] &= ~((1 - (flags >> [(${flag.flag_idx})] & 1)) << [(${flag.idx})]);[/][/]
-}
+// it does not matter if non-ns fe flags are unset in env->ns_fe_flags, since those are never read
+// set all non-s fe flags
+#define NS_FE_FLAG_EPILOG \
+  uint16_t new_fe_flags = get_float_exception_flags(s);                         \
+  env->ns_fe_flags = new_fe_flags;                                              \
+  set_float_exception_flags(new_fe_flags | ~[(${float_facts.sticky_mask})], s);
 
 #define FLOAT_HELPER_BODY(RET_TY, CALL, FMT, RM) \
-  float_status *s = &env->fp_status_##FMT;                                                  \
-  prep_float_status(env, s, RM);                                                            \
-  RET_TY result = CALL;                                                                     \
-  set_float_status(env, s);                                                                 \
+  float_status *s = &env->fp_status;                                  \
+  set_float_rounding_mode(RM, s);                                     \
+  [# th:if="${float_facts.has_non_sticky_flags}"]NS_FE_FLAG_PROLOG[/] \
+  RET_TY result = CALL;                                               \
+  [# th:if="${float_facts.has_non_sticky_flags}"]NS_FE_FLAG_EPILOG[/] \
   return result;
 
 #define FLOAT_HELPER_1(S, FMT, NAME, QEMU_FUN) \
@@ -148,4 +138,6 @@ void set_float_status(CPU[(${gen_arch_upper})]State *env, float_status *s) {
 [/][# th:each="c : ${float_builtins.fisdenorm}"]FLOAT_HELPER_CLASS([(${c[0].bit_size})], [(${c[0].name})], fisdenorm, is_denormal) // TODO: less efficient than is_zero_or_denormal
 [/][# th:each="c : ${float_builtins.fissnan}"]FLOAT_HELPER_CLASSS([(${c[0].bit_size})], [(${c[0].name})], fissnan, is_signaling_nan)
 [/][# th:each="c : ${float_builtins.fisqnan}"]FLOAT_HELPER_CLASSS([(${c[0].bit_size})], [(${c[0].name})], fisqnan, is_quiet_nan)
+[/]
+
 [/]

--- a/vadl/main/resources/templates/iss/target/gen-arch/helper.h
+++ b/vadl/main/resources/templates/iss/target/gen-arch/helper.h
@@ -11,33 +11,36 @@ DEF_HELPER_1(unsupported, noreturn, env)
 [(${instr})]
 [/]
 
+[# th:if="${float_facts.has_float_ops}"]
 // float helpers
 
 #define TS i[(${target_size})]
-[# th:each="c : ${float_builtins.fsqrt}"]DEF_HELPER_FLAGS_3([(${c[0].name})]_fsqrt, 0, TS, env, TS, TS)
-[/][# th:each="c : ${float_builtins.fadd}"]DEF_HELPER_FLAGS_4([(${c[0].name})]_fadd, 0, TS, env, TS, TS, TS)
-[/][# th:each="c : ${float_builtins.fsub}"]DEF_HELPER_FLAGS_4([(${c[0].name})]_fsub, 0, TS, env, TS, TS, TS)
-[/][# th:each="c : ${float_builtins.fmul}"]DEF_HELPER_FLAGS_4([(${c[0].name})]_fmul, 0, TS, env, TS, TS, TS)
-[/][# th:each="c : ${float_builtins.fdiv}"]DEF_HELPER_FLAGS_4([(${c[0].name})]_fdiv, 0, TS, env, TS, TS, TS)
-[/][# th:each="c : ${float_builtins.fmadd}"]DEF_HELPER_FLAGS_5([(${c[0].name})]_fmadd, 0, TS, env, TS, TS, TS, TS)
-[/][# th:each="c : ${float_builtins.fmsub}"]DEF_HELPER_FLAGS_5([(${c[0].name})]_fmsub, 0, TS, env, TS, TS, TS, TS)
-[/][# th:each="c : ${float_builtins.fnmadd}"]DEF_HELPER_FLAGS_5([(${c[0].name})]_fnmadd, 0, TS, env, TS, TS, TS, TS)
-[/][# th:each="c : ${float_builtins.fnmsub}"]DEF_HELPER_FLAGS_5([(${c[0].name})]_fnmsub, 0, TS, env, TS, TS, TS, TS)
-[/][# th:each="c : ${float_builtins.fmin}"]DEF_HELPER_FLAGS_3([(${c[0].name})]_fmin, 0, TS, env, TS, TS)
-[/][# th:each="c : ${float_builtins.fmax}"]DEF_HELPER_FLAGS_3([(${c[0].name})]_fmax, 0, TS, env, TS, TS)
-[/][# th:each="c : ${float_builtins.flt}"]DEF_HELPER_FLAGS_3([(${c[0].name})]_flt, 0, TS, env, TS, TS)
-[/][# th:each="c : ${float_builtins.fle}"]DEF_HELPER_FLAGS_3([(${c[0].name})]_fle, 0, TS, env, TS, TS)
-[/][# th:each="c : ${float_builtins.feq}"]DEF_HELPER_FLAGS_3([(${c[0].name})]_feq, 0, TS, env, TS, TS)
+[# th:each="c : ${float_builtins.fsqrt}"]DEF_HELPER_FLAGS_3([(${c[0].name})]_fsqrt, TCG_CALL_NO_REG, TS, env, TS, TS)
+[/][# th:each="c : ${float_builtins.fadd}"]DEF_HELPER_FLAGS_4([(${c[0].name})]_fadd, TCG_CALL_NO_REG, TS, env, TS, TS, TS)
+[/][# th:each="c : ${float_builtins.fsub}"]DEF_HELPER_FLAGS_4([(${c[0].name})]_fsub, TCG_CALL_NO_REG, TS, env, TS, TS, TS)
+[/][# th:each="c : ${float_builtins.fmul}"]DEF_HELPER_FLAGS_4([(${c[0].name})]_fmul, TCG_CALL_NO_REG, TS, env, TS, TS, TS)
+[/][# th:each="c : ${float_builtins.fdiv}"]DEF_HELPER_FLAGS_4([(${c[0].name})]_fdiv, TCG_CALL_NO_REG, TS, env, TS, TS, TS)
+[/][# th:each="c : ${float_builtins.fmadd}"]DEF_HELPER_FLAGS_5([(${c[0].name})]_fmadd, TCG_CALL_NO_REG, TS, env, TS, TS, TS, TS)
+[/][# th:each="c : ${float_builtins.fmsub}"]DEF_HELPER_FLAGS_5([(${c[0].name})]_fmsub, TCG_CALL_NO_REG, TS, env, TS, TS, TS, TS)
+[/][# th:each="c : ${float_builtins.fnmadd}"]DEF_HELPER_FLAGS_5([(${c[0].name})]_fnmadd, TCG_CALL_NO_REG, TS, env, TS, TS, TS, TS)
+[/][# th:each="c : ${float_builtins.fnmsub}"]DEF_HELPER_FLAGS_5([(${c[0].name})]_fnmsub, TCG_CALL_NO_REG, TS, env, TS, TS, TS, TS)
+[/][# th:each="c : ${float_builtins.fmin}"]DEF_HELPER_FLAGS_3([(${c[0].name})]_fmin, TCG_CALL_NO_REG, TS, env, TS, TS)
+[/][# th:each="c : ${float_builtins.fmax}"]DEF_HELPER_FLAGS_3([(${c[0].name})]_fmax, TCG_CALL_NO_REG, TS, env, TS, TS)
+[/][# th:each="c : ${float_builtins.flt}"]DEF_HELPER_FLAGS_3([(${c[0].name})]_flt, TCG_CALL_NO_REG, TS, env, TS, TS)
+[/][# th:each="c : ${float_builtins.fle}"]DEF_HELPER_FLAGS_3([(${c[0].name})]_fle, TCG_CALL_NO_REG, TS, env, TS, TS)
+[/][# th:each="c : ${float_builtins.feq}"]DEF_HELPER_FLAGS_3([(${c[0].name})]_feq, TCG_CALL_NO_REG, TS, env, TS, TS)
 [/][# th:each="c : ${float_builtins.fcvt}"]
-[# th:if='${c[0].type == "f" && c[1].type == "f"}']DEF_HELPER_FLAGS_3([(${c[0].name})]_[(${c[1].name})]_fcvt, 0, TS, env, TS, TS)[/]
-[# th:if='${c[0].type == "f" && c[1].type == "s"}']DEF_HELPER_FLAGS_3([(${c[0].name})]_[(${c[1].bit_size})]_fcvtfs, 0, TS, env, TS, TS)[/]
-[# th:if='${c[0].type == "f" && c[1].type == "u"}']DEF_HELPER_FLAGS_3([(${c[0].name})]_[(${c[1].bit_size})]_fcvtfu, 0, TS, env, TS, TS)[/]
-[# th:if='${c[0].type == "s" && c[1].type == "f"}']DEF_HELPER_FLAGS_3([(${c[1].name})]_[(${c[0].bit_size})]_fcvtsf, 0, TS, env, TS, TS)[/]
-[# th:if='${c[0].type == "u" && c[1].type == "f"}']DEF_HELPER_FLAGS_3([(${c[1].name})]_[(${c[0].bit_size})]_fcvtuf, 0, TS, env, TS, TS)[/]
-[/][# th:each="c : ${float_builtins.fisinf}"]DEF_HELPER_FLAGS_2([(${c[0].name})]_fisinf, 0, TS, env, TS)
-[/][# th:each="c : ${float_builtins.fiszero}"]DEF_HELPER_FLAGS_2([(${c[0].name})]_fiszero, 0, TS, env, TS)
-[/][# th:each="c : ${float_builtins.fisneg}"]DEF_HELPER_FLAGS_2([(${c[0].name})]_fisneg, 0, TS, env, TS)
-[/][# th:each="c : ${float_builtins.fisdenorm}"]DEF_HELPER_FLAGS_2([(${c[0].name})]_fisdenorm, 0, TS, env, TS)
-[/][# th:each="c : ${float_builtins.fissnan}"]DEF_HELPER_FLAGS_2([(${c[0].name})]_fissnan, 0, TS, env, TS)
-[/][# th:each="c : ${float_builtins.fisqnan}"]DEF_HELPER_FLAGS_2([(${c[0].name})]_fisqnan, 0, TS, env, TS)
+[# th:if='${c[0].type == "f" && c[1].type == "f"}']DEF_HELPER_FLAGS_3([(${c[0].name})]_[(${c[1].name})]_fcvt, TCG_CALL_NO_REG, TS, env, TS, TS)[/]
+[# th:if='${c[0].type == "f" && c[1].type == "s"}']DEF_HELPER_FLAGS_3([(${c[0].name})]_[(${c[1].bit_size})]_fcvtfs, TCG_CALL_NO_REG, TS, env, TS, TS)[/]
+[# th:if='${c[0].type == "f" && c[1].type == "u"}']DEF_HELPER_FLAGS_3([(${c[0].name})]_[(${c[1].bit_size})]_fcvtfu, TCG_CALL_NO_REG, TS, env, TS, TS)[/]
+[# th:if='${c[0].type == "s" && c[1].type == "f"}']DEF_HELPER_FLAGS_3([(${c[1].name})]_[(${c[0].bit_size})]_fcvtsf, TCG_CALL_NO_REG, TS, env, TS, TS)[/]
+[# th:if='${c[0].type == "u" && c[1].type == "f"}']DEF_HELPER_FLAGS_3([(${c[1].name})]_[(${c[0].bit_size})]_fcvtuf, TCG_CALL_NO_REG, TS, env, TS, TS)[/]
+[/][# th:each="c : ${float_builtins.fisinf}"]DEF_HELPER_FLAGS_2([(${c[0].name})]_fisinf, TCG_CALL_NO_REG, TS, env, TS)
+[/][# th:each="c : ${float_builtins.fiszero}"]DEF_HELPER_FLAGS_2([(${c[0].name})]_fiszero, TCG_CALL_NO_REG, TS, env, TS)
+[/][# th:each="c : ${float_builtins.fisneg}"]DEF_HELPER_FLAGS_2([(${c[0].name})]_fisneg, TCG_CALL_NO_REG, TS, env, TS)
+[/][# th:each="c : ${float_builtins.fisdenorm}"]DEF_HELPER_FLAGS_2([(${c[0].name})]_fisdenorm, TCG_CALL_NO_REG, TS, env, TS)
+[/][# th:each="c : ${float_builtins.fissnan}"]DEF_HELPER_FLAGS_2([(${c[0].name})]_fissnan, TCG_CALL_NO_REG, TS, env, TS)
+[/][# th:each="c : ${float_builtins.fisqnan}"]DEF_HELPER_FLAGS_2([(${c[0].name})]_fisqnan, TCG_CALL_NO_REG, TS, env, TS)
+[/]
+
 [/]

--- a/vadl/main/resources/templates/iss/target/gen-arch/helper.h
+++ b/vadl/main/resources/templates/iss/target/gen-arch/helper.h
@@ -11,36 +11,44 @@ DEF_HELPER_1(unsupported, noreturn, env)
 [(${instr})]
 [/]
 
+#define TS i[(${target_size})]
+
+// lazy reg read/write helpers
+[# th:each="reg : ${register_tensors}"][# th:if="${reg.isLazy}"]
+DEF_HELPER_FLAGS_1(lazy_read_[(${reg.name_lower})], TCG_CALL_NO_WG, TS, env)
+DEF_HELPER_FLAGS_2(lazy_write_[(${reg.name_lower})], 0, void, env, TS)
+[/][/]
+
 [# th:if="${float_facts.has_float_ops}"]
 // float helpers
-
-#define TS i[(${target_size})]
-[# th:each="c : ${float_builtins.fsqrt}"]DEF_HELPER_FLAGS_3([(${c[0].name})]_fsqrt, TCG_CALL_NO_REG, TS, env, TS, TS)
-[/][# th:each="c : ${float_builtins.fadd}"]DEF_HELPER_FLAGS_4([(${c[0].name})]_fadd, TCG_CALL_NO_REG, TS, env, TS, TS, TS)
-[/][# th:each="c : ${float_builtins.fsub}"]DEF_HELPER_FLAGS_4([(${c[0].name})]_fsub, TCG_CALL_NO_REG, TS, env, TS, TS, TS)
-[/][# th:each="c : ${float_builtins.fmul}"]DEF_HELPER_FLAGS_4([(${c[0].name})]_fmul, TCG_CALL_NO_REG, TS, env, TS, TS, TS)
-[/][# th:each="c : ${float_builtins.fdiv}"]DEF_HELPER_FLAGS_4([(${c[0].name})]_fdiv, TCG_CALL_NO_REG, TS, env, TS, TS, TS)
-[/][# th:each="c : ${float_builtins.fmadd}"]DEF_HELPER_FLAGS_5([(${c[0].name})]_fmadd, TCG_CALL_NO_REG, TS, env, TS, TS, TS, TS)
-[/][# th:each="c : ${float_builtins.fmsub}"]DEF_HELPER_FLAGS_5([(${c[0].name})]_fmsub, TCG_CALL_NO_REG, TS, env, TS, TS, TS, TS)
-[/][# th:each="c : ${float_builtins.fnmadd}"]DEF_HELPER_FLAGS_5([(${c[0].name})]_fnmadd, TCG_CALL_NO_REG, TS, env, TS, TS, TS, TS)
-[/][# th:each="c : ${float_builtins.fnmsub}"]DEF_HELPER_FLAGS_5([(${c[0].name})]_fnmsub, TCG_CALL_NO_REG, TS, env, TS, TS, TS, TS)
-[/][# th:each="c : ${float_builtins.fmin}"]DEF_HELPER_FLAGS_3([(${c[0].name})]_fmin, TCG_CALL_NO_REG, TS, env, TS, TS)
-[/][# th:each="c : ${float_builtins.fmax}"]DEF_HELPER_FLAGS_3([(${c[0].name})]_fmax, TCG_CALL_NO_REG, TS, env, TS, TS)
-[/][# th:each="c : ${float_builtins.flt}"]DEF_HELPER_FLAGS_3([(${c[0].name})]_flt, TCG_CALL_NO_REG, TS, env, TS, TS)
-[/][# th:each="c : ${float_builtins.fle}"]DEF_HELPER_FLAGS_3([(${c[0].name})]_fle, TCG_CALL_NO_REG, TS, env, TS, TS)
-[/][# th:each="c : ${float_builtins.feq}"]DEF_HELPER_FLAGS_3([(${c[0].name})]_feq, TCG_CALL_NO_REG, TS, env, TS, TS)
+[# th:each="c : ${float_builtins.fsqrt}"]DEF_HELPER_FLAGS_3([(${c[0].name})]_fsqrt, TCG_CALL_NO_RWG, TS, env, TS, TS)
+[/][# th:each="c : ${float_builtins.fadd}"]DEF_HELPER_FLAGS_4([(${c[0].name})]_fadd, TCG_CALL_NO_RWG, TS, env, TS, TS, TS)
+[/][# th:each="c : ${float_builtins.fsub}"]DEF_HELPER_FLAGS_4([(${c[0].name})]_fsub, TCG_CALL_NO_RWG, TS, env, TS, TS, TS)
+[/][# th:each="c : ${float_builtins.fmul}"]DEF_HELPER_FLAGS_4([(${c[0].name})]_fmul, TCG_CALL_NO_RWG, TS, env, TS, TS, TS)
+[/][# th:each="c : ${float_builtins.fdiv}"]DEF_HELPER_FLAGS_4([(${c[0].name})]_fdiv, TCG_CALL_NO_RWG, TS, env, TS, TS, TS)
+[/][# th:each="c : ${float_builtins.fmadd}"]DEF_HELPER_FLAGS_5([(${c[0].name})]_fmadd, TCG_CALL_NO_RWG, TS, env, TS, TS, TS, TS)
+[/][# th:each="c : ${float_builtins.fmsub}"]DEF_HELPER_FLAGS_5([(${c[0].name})]_fmsub, TCG_CALL_NO_RWG, TS, env, TS, TS, TS, TS)
+[/][# th:each="c : ${float_builtins.fnmadd}"]DEF_HELPER_FLAGS_5([(${c[0].name})]_fnmadd, TCG_CALL_NO_RWG, TS, env, TS, TS, TS, TS)
+[/][# th:each="c : ${float_builtins.fnmsub}"]DEF_HELPER_FLAGS_5([(${c[0].name})]_fnmsub, TCG_CALL_NO_RWG, TS, env, TS, TS, TS, TS)
+[/][# th:each="c : ${float_builtins.fmin}"]DEF_HELPER_FLAGS_3([(${c[0].name})]_fmin, TCG_CALL_NO_RWG, TS, env, TS, TS)
+[/][# th:each="c : ${float_builtins.fmax}"]DEF_HELPER_FLAGS_3([(${c[0].name})]_fmax, TCG_CALL_NO_RWG, TS, env, TS, TS)
+[/][# th:each="c : ${float_builtins.flt}"]DEF_HELPER_FLAGS_3([(${c[0].name})]_flt, TCG_CALL_NO_RWG, TS, env, TS, TS)
+[/][# th:each="c : ${float_builtins.fle}"]DEF_HELPER_FLAGS_3([(${c[0].name})]_fle, TCG_CALL_NO_RWG, TS, env, TS, TS)
+[/][# th:each="c : ${float_builtins.feq}"]DEF_HELPER_FLAGS_3([(${c[0].name})]_feq, TCG_CALL_NO_RWG, TS, env, TS, TS)
 [/][# th:each="c : ${float_builtins.fcvt}"]
-[# th:if='${c[0].type == "f" && c[1].type == "f"}']DEF_HELPER_FLAGS_3([(${c[0].name})]_[(${c[1].name})]_fcvt, TCG_CALL_NO_REG, TS, env, TS, TS)[/]
-[# th:if='${c[0].type == "f" && c[1].type == "s"}']DEF_HELPER_FLAGS_3([(${c[0].name})]_[(${c[1].bit_size})]_fcvtfs, TCG_CALL_NO_REG, TS, env, TS, TS)[/]
-[# th:if='${c[0].type == "f" && c[1].type == "u"}']DEF_HELPER_FLAGS_3([(${c[0].name})]_[(${c[1].bit_size})]_fcvtfu, TCG_CALL_NO_REG, TS, env, TS, TS)[/]
-[# th:if='${c[0].type == "s" && c[1].type == "f"}']DEF_HELPER_FLAGS_3([(${c[1].name})]_[(${c[0].bit_size})]_fcvtsf, TCG_CALL_NO_REG, TS, env, TS, TS)[/]
-[# th:if='${c[0].type == "u" && c[1].type == "f"}']DEF_HELPER_FLAGS_3([(${c[1].name})]_[(${c[0].bit_size})]_fcvtuf, TCG_CALL_NO_REG, TS, env, TS, TS)[/]
-[/][# th:each="c : ${float_builtins.fisinf}"]DEF_HELPER_FLAGS_2([(${c[0].name})]_fisinf, TCG_CALL_NO_REG, TS, env, TS)
-[/][# th:each="c : ${float_builtins.fiszero}"]DEF_HELPER_FLAGS_2([(${c[0].name})]_fiszero, TCG_CALL_NO_REG, TS, env, TS)
-[/][# th:each="c : ${float_builtins.fisneg}"]DEF_HELPER_FLAGS_2([(${c[0].name})]_fisneg, TCG_CALL_NO_REG, TS, env, TS)
-[/][# th:each="c : ${float_builtins.fisdenorm}"]DEF_HELPER_FLAGS_2([(${c[0].name})]_fisdenorm, TCG_CALL_NO_REG, TS, env, TS)
-[/][# th:each="c : ${float_builtins.fissnan}"]DEF_HELPER_FLAGS_2([(${c[0].name})]_fissnan, TCG_CALL_NO_REG, TS, env, TS)
-[/][# th:each="c : ${float_builtins.fisqnan}"]DEF_HELPER_FLAGS_2([(${c[0].name})]_fisqnan, TCG_CALL_NO_REG, TS, env, TS)
+[# th:if='${c[0].type == "f" && c[1].type == "f"}']DEF_HELPER_FLAGS_3([(${c[0].name})]_[(${c[1].name})]_fcvt, TCG_CALL_NO_RWG, TS, env, TS, TS)[/]
+[# th:if='${c[0].type == "f" && c[1].type == "s"}']DEF_HELPER_FLAGS_3([(${c[0].name})]_[(${c[1].bit_size})]_fcvtfs, TCG_CALL_NO_RWG, TS, env, TS, TS)[/]
+[# th:if='${c[0].type == "f" && c[1].type == "u"}']DEF_HELPER_FLAGS_3([(${c[0].name})]_[(${c[1].bit_size})]_fcvtfu, TCG_CALL_NO_RWG, TS, env, TS, TS)[/]
+[# th:if='${c[0].type == "s" && c[1].type == "f"}']DEF_HELPER_FLAGS_3([(${c[1].name})]_[(${c[0].bit_size})]_fcvtsf, TCG_CALL_NO_RWG, TS, env, TS, TS)[/]
+[# th:if='${c[0].type == "u" && c[1].type == "f"}']DEF_HELPER_FLAGS_3([(${c[1].name})]_[(${c[0].bit_size})]_fcvtuf, TCG_CALL_NO_RWG, TS, env, TS, TS)[/]
+[/][# th:each="c : ${float_builtins.fisinf}"]DEF_HELPER_FLAGS_2([(${c[0].name})]_fisinf, TCG_CALL_NO_RWG, TS, env, TS)
+[/][# th:each="c : ${float_builtins.fiszero}"]DEF_HELPER_FLAGS_2([(${c[0].name})]_fiszero, TCG_CALL_NO_RWG, TS, env, TS)
+[/][# th:each="c : ${float_builtins.fisneg}"]DEF_HELPER_FLAGS_2([(${c[0].name})]_fisneg, TCG_CALL_NO_RWG, TS, env, TS)
+[/][# th:each="c : ${float_builtins.fisdenorm}"]DEF_HELPER_FLAGS_2([(${c[0].name})]_fisdenorm, TCG_CALL_NO_RWG, TS, env, TS)
+[/][# th:each="c : ${float_builtins.fissnan}"]DEF_HELPER_FLAGS_2([(${c[0].name})]_fissnan, TCG_CALL_NO_RWG, TS, env, TS)
+[/][# th:each="c : ${float_builtins.fisqnan}"]DEF_HELPER_FLAGS_2([(${c[0].name})]_fisqnan, TCG_CALL_NO_RWG, TS, env, TS)
 [/]
 
 [/]
+
+#undef TS

--- a/vadl/main/resources/templates/iss/target/gen-arch/translate.c
+++ b/vadl/main/resources/templates/iss/target/gen-arch/translate.c
@@ -17,7 +17,7 @@
 #undef  HELPER_H
 
 // define the registers tcgs
-[# th:each="reg : ${register_tensors}" th:if="${reg.is_tcg}"]
+[# th:each="reg : ${register_tensors}" th:if="${reg.is_tcg && !reg.isLazy}"]
 static TCGv cpu_[(${reg.name_lower})][(${reg.c_array_def})];
 [/]
 
@@ -94,7 +94,7 @@ static inline uint32_t [(${reg.gvec_offset_helper_name})](DisasContext *ctx[(${r
 }
 [/]
 
-[# th:each="reg : ${register_tensors}" th:if="${reg.is_tcg}"]
+[# th:each="reg : ${register_tensors}" th:if="${reg.is_tcg && !reg.isLazy}"]
 static TCGv get_[(${reg.name_lower})](DisasContext *ctx [(${reg.getter_params})])
 {   [# th:each="dim : ${reg.index_dims}"]
     assert( [(${dim.arg_name})] < [(${dim["size"]})]); [/]
@@ -198,7 +198,7 @@ typedef struct IsJmpState {
 	bool jmpslt_free;
 } IsJmpState;
 
-IsJmpState is_jmp_create_state() {
+static IsJmpState is_jmp_create_state(void) {
   IsJmpState state = {
     .end_tb = false,
     .can_chain = true,
@@ -207,7 +207,7 @@ IsJmpState is_jmp_create_state() {
   return state;
 }
 
-void is_jmp_direct_jmp(DisasContext *ctx, IsJmpState *s, bool use_jmpslt, target_ulong addr) {
+static void is_jmp_direct_jmp(DisasContext *ctx, IsJmpState *s, bool use_jmpslt, target_ulong addr) {
 	if (use_jmpslt && s->can_chain && s->jmpslt_free) {
 		s->jmpslt_free = false;
 		gen_goto_tb(ctx, 1, addr);
@@ -218,26 +218,26 @@ void is_jmp_direct_jmp(DisasContext *ctx, IsJmpState *s, bool use_jmpslt, target
 	s->end_tb = true;
 }
 
-void is_jmp_indirect_jmp(IsJmpState *s) {
+static void is_jmp_indirect_jmp(IsJmpState *s) {
   // pc update happens in translation function
 	tcg_gen_lookup_and_goto_ptr();
 	s->end_tb = true;
 }
 
-void is_jmp_static_tb_state_write(IsJmpState *s) {
+static void is_jmp_static_tb_state_write(IsJmpState *s) {
 	s->end_tb = true;
 }
 
-void is_jmp_dynamic_tb_state_write(IsJmpState *s) {
+static void is_jmp_dynamic_tb_state_write(IsJmpState *s) {
 	s->end_tb = true;
 	s->can_chain = false;
 }
 
-void is_jmp_helper_call(IsJmpState *s) {
+static void is_jmp_helper_call(IsJmpState *s) {
   s->end_tb = true;
 }
 
-void is_jmp_set(DisasContext *ctx, IsJmpState* s) {
+static void is_jmp_set(DisasContext *ctx, IsJmpState* s) {
 	if (s->end_tb) {
 		if (s->can_chain) {
 			// the TB must end, but we can chain

--- a/vadl/main/vadl/iss/IssUtils.java
+++ b/vadl/main/vadl/iss/IssUtils.java
@@ -21,6 +21,7 @@ import static vadl.iss.passes.TcgPassUtils.regInfo;
 import com.google.errorprone.annotations.FormatMethod;
 import java.util.List;
 import vadl.error.Diagnostic;
+import vadl.iss.passes.extensions.RegInfo;
 import vadl.viam.RegisterTensor;
 import vadl.viam.graph.Node;
 
@@ -44,6 +45,10 @@ public class IssUtils {
 
   public static boolean isTcgReg(RegisterTensor registerTensor) {
     return regInfo(registerTensor).isTcgScalar();
+  }
+
+  public static boolean isLazyReg(RegisterTensor registerTensor) {
+    return regInfo(registerTensor).isLazy();
   }
 
   /**

--- a/vadl/main/vadl/iss/codegen/IssMemoryRegionInitCodeGen.java
+++ b/vadl/main/vadl/iss/codegen/IssMemoryRegionInitCodeGen.java
@@ -70,7 +70,7 @@ public class IssMemoryRegionInitCodeGen extends IssProcGen {
    */
   public String fetch() {
     var machineName = config.machineName();
-    ctx().wr("static void init_%s() {\n", memInfo.name().toLowerCase())
+    ctx().wr("static void init_%s(void) {\n", memInfo.name().toLowerCase())
         .spacedIn()
         .ln("uint8_t init_vec[%d] = {0};", memInfo.initVecSize());
 

--- a/vadl/main/vadl/iss/passes/common/IssInfoRetrievalPass.java
+++ b/vadl/main/vadl/iss/passes/common/IssInfoRetrievalPass.java
@@ -255,12 +255,13 @@ public class IssInfoRetrievalPass extends AbstractIssPass {
 
   // checks that there are no duplicate float exception flags
   private void checkFeFlags(Specification viam, List<DiagnosticBuilder> diagnostics) {
-    checkEachFeFlagOccursOnce(viam, diagnostics, true);
-    checkEachFeFlagOccursOnce(viam, diagnostics, false);
+    checkEachFeFlagOccursAtMostOnce(viam, diagnostics, true);
+    checkEachFeFlagOccursAtMostOnce(viam, diagnostics, false);
   }
 
-  private void checkEachFeFlagOccursOnce(Specification viam, List<DiagnosticBuilder> diagnostics,
-                                         boolean sticky) {
+  private void checkEachFeFlagOccursAtMostOnce(Specification viam,
+                                               List<DiagnosticBuilder> diagnostics,
+                                               boolean sticky) {
     withIsa(viam, isa -> {
       var flagLocations = new HashMap<FloatExceptionFlag, List<WithLocation>>();
       isa.registerTensors().stream()

--- a/vadl/main/vadl/iss/passes/common/IssRegisterAccessInfoRetrievalPass.java
+++ b/vadl/main/vadl/iss/passes/common/IssRegisterAccessInfoRetrievalPass.java
@@ -20,6 +20,7 @@ import static java.util.Objects.requireNonNull;
 import static vadl.iss.passes.TcgPassUtils.regInfo;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Set;
 import javax.annotation.Nullable;
 import vadl.configuration.IssConfiguration;
@@ -34,6 +35,7 @@ import vadl.pass.PassResults;
 import vadl.utils.ViamUtils;
 import vadl.viam.ArtificialResource;
 import vadl.viam.Specification;
+import vadl.viam.annotations.FloatFlagAnnotation;
 import vadl.viam.graph.Graph;
 import vadl.viam.graph.dependency.ReadRegTensorNode;
 import vadl.viam.graph.dependency.WriteRegTensorNode;
@@ -75,6 +77,24 @@ public class IssRegisterAccessInfoRetrievalPass extends AbstractIssPass {
           .filter(behavior -> !(behavior.parentDefinition() instanceof ArtificialResource))
           .forEach(behavior -> collectAccessorDescriptors(behavior, registry));
     });
+
+    // add custom ones for registers with float exception flag, because the gdb stub needs
+    // to use getters in cpu.c
+    viam.isa().get().registerTensors().stream()
+        .filter(r -> r.hasAnnotation(FloatFlagAnnotation.class))
+        .forEach(r -> {
+          var info = regInfo(r);
+          r.ensure(r.indexDimensions().isEmpty(),
+              "Float exception flags are only supported on single registers");
+          registry.addBaseAccessor(new RegInfo.BaseAccessorDescriptor(
+              info, RegInfo.AccessType.READ, List.of(), r.resultType().bitWidth(),
+              r.resultType().bitWidth(), 0, r
+          ));
+          registry.addBaseAccessor(new RegInfo.BaseAccessorDescriptor(
+              info, RegInfo.AccessType.WRITE, List.of(), r.resultType().bitWidth(),
+              r.resultType().bitWidth(), 0, r
+          ));
+        });
 
     // add custom one for program counter
     var pc = requireNonNull(viam.isa().get().pc());

--- a/vadl/main/vadl/iss/passes/common/IssRegisterAccessInfoRetrievalPass.java
+++ b/vadl/main/vadl/iss/passes/common/IssRegisterAccessInfoRetrievalPass.java
@@ -34,8 +34,8 @@ import vadl.pass.PassName;
 import vadl.pass.PassResults;
 import vadl.utils.ViamUtils;
 import vadl.viam.ArtificialResource;
+import vadl.viam.RegisterTensor;
 import vadl.viam.Specification;
-import vadl.viam.annotations.FloatFlagAnnotation;
 import vadl.viam.graph.Graph;
 import vadl.viam.graph.dependency.ReadRegTensorNode;
 import vadl.viam.graph.dependency.WriteRegTensorNode;
@@ -73,28 +73,14 @@ public class IssRegisterAccessInfoRetrievalPass extends AbstractIssPass {
     viam.processor().ifPresent(processor -> {
       processor.isa().artificialResources()
           .forEach(alias -> collectAllAliasAccessorDescriptors(alias, registry));
+      // add custom ones for lazy registers, because the gdb stub and cpu dump
+      // need to use getters in cpu.c
+      processor.isa().registerTensors()
+          .forEach(reg -> collectAllLazyRegisterDescriptors(reg, registry));
       ViamUtils.findAllBehaviors(processor)
           .filter(behavior -> !(behavior.parentDefinition() instanceof ArtificialResource))
           .forEach(behavior -> collectAccessorDescriptors(behavior, registry));
     });
-
-    // add custom ones for registers with float exception flag, because the gdb stub needs
-    // to use getters in cpu.c
-    viam.isa().get().registerTensors().stream()
-        .filter(r -> r.hasAnnotation(FloatFlagAnnotation.class))
-        .forEach(r -> {
-          var info = regInfo(r);
-          r.ensure(r.indexDimensions().isEmpty(),
-              "Float exception flags are only supported on single registers");
-          registry.addBaseAccessor(new RegInfo.BaseAccessorDescriptor(
-              info, RegInfo.AccessType.READ, List.of(), r.resultType().bitWidth(),
-              r.resultType().bitWidth(), 0, r
-          ));
-          registry.addBaseAccessor(new RegInfo.BaseAccessorDescriptor(
-              info, RegInfo.AccessType.WRITE, List.of(), r.resultType().bitWidth(),
-              r.resultType().bitWidth(), 0, r
-          ));
-        });
 
     // add custom one for program counter
     var pc = requireNonNull(viam.isa().get().pc());
@@ -187,6 +173,27 @@ public class IssRegisterAccessInfoRetrievalPass extends AbstractIssPass {
     for (var type : RegInfo.AccessType.values()) {
       collectAliasAccessorDescriptor(alias, type, registry);
     }
+  }
+
+  private void collectAllLazyRegisterDescriptors(RegisterTensor reg, IssAccessorRegistry registry) {
+    for (var type : RegInfo.AccessType.values()) {
+      collectLazyAccessorDescriptor(reg, type, registry);
+    }
+  }
+
+  private void collectLazyAccessorDescriptor(RegisterTensor reg,
+                                             RegInfo.AccessType type,
+                                             IssAccessorRegistry registry) {
+    var info = regInfo(reg);
+    if (info.laziness() == RegInfo.Laziness.NONE) {
+      return;
+    }
+    reg.ensure(reg.indexDimensions().isEmpty(),
+        "Lazy registers can only be single registers");
+    registry.addBaseAccessor(new RegInfo.BaseAccessorDescriptor(
+        info, type, List.of(), reg.resultType().bitWidth(),
+        reg.resultType().bitWidth(), 0, reg
+    ));
   }
 
   private boolean shouldCollectDescriptor(Graph behavior, ReadRegTensorNode node,

--- a/vadl/main/vadl/iss/passes/extensions/RegInfo.java
+++ b/vadl/main/vadl/iss/passes/extensions/RegInfo.java
@@ -189,18 +189,6 @@ public class RegInfo extends DefinitionExtension<RegisterTensor> implements Rend
     );
   }
 
-  private List<Map<String, String>> feFlags(
-      Function<FloatFlagAnnotation, Map<Integer, FloatExceptionFlag>> flags) {
-    if (!reg().hasAnnotation(FloatFlagAnnotation.class)) {
-      return List.of();
-    }
-    var ann = reg().expectAnnotation(FloatFlagAnnotation.class);
-    return flags.apply(ann).entrySet().stream().map(e -> Map.of(
-        "idx", Integer.toString(e.getKey()),
-        "flag_idx", Integer.toString(e.getValue().qemuFlagOffset)
-    )).toList();
-  }
-
   /**
    * Returns the execution class used for backend selection.
    */
@@ -306,8 +294,6 @@ public class RegInfo extends DefinitionExtension<RegisterTensor> implements Rend
       renderObj.put("is_gvec_capable", isGvecCapable());
       renderObj.put("is_tb_state", isTbState());
       renderObj.put("tb_state_parts", tbStateParts());
-      renderObj.put("sticky_fe_flags", feFlags(FloatFlagAnnotation::stickyFlags));
-      renderObj.put("non_sticky_fe_flags", feFlags(FloatFlagAnnotation::nonStickyFlags));
       renderObj.put("exec_class", execClass().name());
       renderObj.put("constraints", renderConstraints(dims));
       renderObj.put("getter_params", renderParamsComma);
@@ -936,11 +922,58 @@ public class RegInfo extends DefinitionExtension<RegisterTensor> implements Rend
 
       // emit index access
       var access = "env->" + owner.nameLower() + owner.cArrayIndex("i");
+
       switch (type) {
-        case READ -> cb.returnStmt(access);
-        case WRITE -> cb.stmt(access + " = value");
+        case READ -> {
+          var resultName = "result_" + owner.nameLower();
+          cb.stmt("%s %s = %s".formatted(accessValueCType(), resultName, access));
+          emitFEFlagReconstructionOnRead(cb, resultName, true);
+          emitFEFlagReconstructionOnRead(cb, resultName, false);
+          cb.returnStmt(resultName);
+        }
+        case WRITE -> {
+          emitFEFlagReconstructionOnWrite(cb, true);
+          emitFEFlagReconstructionOnWrite(cb, false);
+          cb.stmt(access + " = value");
+        }
       }
       return cb.toString();
+    }
+
+    private void emitFEFlagReconstructionOnRead(CStringBuilder cb, String resultName,
+                                                boolean sticky) {
+      var ffAnn = owner.reg().annotation(FloatFlagAnnotation.class);
+      if (ffAnn == null || ffAnn.flags(sticky).isEmpty()) {
+        return;
+      }
+      var flagVarName = sticky ? "s_fe_flags" : "ns_fe_flags";
+
+      // unset all fe flag bits in the result
+      cb.stmt("%s &= 0x%sULL".formatted(resultName, Long.toHexString(~ffAnn.flagMask(sticky))));
+      cb.stmt("uint16_t %s = %s".formatted(
+          flagVarName, sticky ? "get_float_exception_flags(&env->fp_status)" : "env->ns_fe_flags"
+      ));
+      ffAnn.flags(sticky).forEach((idx, flag) -> cb.stmt("%s |= ((%s >> %d) & 1) << %d"
+          .formatted(resultName, flagVarName, flag.qemuFlagOffset, idx)));
+    }
+
+    private void emitFEFlagReconstructionOnWrite(CStringBuilder cb, boolean sticky) {
+      var ffAnn = owner.reg().annotation(FloatFlagAnnotation.class);
+      if (ffAnn == null || ffAnn.flags(sticky).isEmpty()) {
+        return;
+      }
+      var flagVarName = sticky ? "s_fe_flags" : "ns_fe_flags";
+
+      // by default, all unused flags are set
+      int initialValue = ~ffAnn.qemuFlagMask(sticky);
+      cb.stmt("uint16_t %s = 0x%s".formatted(flagVarName, Integer.toHexString(initialValue)));
+      ffAnn.flags(sticky).forEach((idx, flag) -> cb.stmt("%s |= ((value >> %d) & 1) << %d"
+          .formatted(flagVarName, idx, flag.qemuFlagOffset)));
+      if (sticky) {
+        cb.stmt("set_float_exception_flags(%s, &env->fp_status)".formatted(flagVarName));
+      } else {
+        cb.stmt("env->ns_fe_flags = %s".formatted(flagVarName));
+      }
     }
 
     /**

--- a/vadl/main/vadl/iss/passes/extensions/RegInfo.java
+++ b/vadl/main/vadl/iss/passes/extensions/RegInfo.java
@@ -24,7 +24,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.function.Function;
 import java.util.stream.IntStream;
 import javax.annotation.Nullable;
 import vadl.configuration.IssConfiguration;
@@ -39,7 +38,6 @@ import vadl.viam.ArtificialResource;
 import vadl.viam.Constant;
 import vadl.viam.Definition;
 import vadl.viam.DefinitionExtension;
-import vadl.viam.FloatExceptionFlag;
 import vadl.viam.RegisterResource;
 import vadl.viam.RegisterTensor;
 import vadl.viam.annotations.FloatFlagAnnotation;
@@ -61,6 +59,7 @@ public class RegInfo extends DefinitionExtension<RegisterTensor> implements Rend
   private Map<String, Object> renderObj;
   private final IssConfiguration config;
   private final ExecClass execClass;
+  private final Laziness laziness;
 
   /**
    * Constructs a RegInfo for the given register tensor.
@@ -76,6 +75,7 @@ public class RegInfo extends DefinitionExtension<RegisterTensor> implements Rend
                  List<WriteRegTensorNode> writes) {
     this.config = config;
     this.execClass = determineExecClass(reg, reads, writes);
+    this.laziness = determineLaziness(reg);
   }
 
   /**
@@ -90,6 +90,30 @@ public class RegInfo extends DefinitionExtension<RegisterTensor> implements Rend
      * Register is stored as a CPU-state byte array for helper access and future gvec offsets.
      */
     CPU_VECTOR
+  }
+
+  /**
+   * Determines how much of the register is lazy.
+   *
+   * <p>Some parts or the whole register may be lazy. Lazy parts are not stored or updated in
+   * the TCG global. Instead, they are sourced from other parts of the CPU-state (e.g. from
+   * the {@code float_status}). Thus, no TCG globals are created for registers containing lazy
+   * parts. They are read/written via CPU helpers. When a register is fully lazy, there is no
+   * need to generate a field for it in the CPU-state.
+   */
+  public enum Laziness {
+    /**
+     * No part of the register is lazy.
+     */
+    NONE,
+    /**
+     * Only parts, but not the whole register is lazy.
+     */
+    PARTIAL,
+    /**
+     * The whole register is lazy. No global is created in the CPU-state.
+     */
+    FULL
   }
 
   /**
@@ -197,6 +221,27 @@ public class RegInfo extends DefinitionExtension<RegisterTensor> implements Rend
   }
 
   /**
+   * Returns the laziness of the register.
+   */
+  public Laziness laziness() {
+    return laziness;
+  }
+
+  /**
+   * Returns whether the register contains lazy parts.
+   */
+  public boolean isLazy() {
+    return laziness != Laziness.NONE;
+  }
+
+  /**
+   * Returns whether the register contains only lazy parts.
+   */
+  public boolean isFullyLazy() {
+    return laziness == Laziness.FULL;
+  }
+
+  /**
    * Returns whether this register is stored as an array in the CPU state.
    */
   public boolean hasCpuStateArrayStorage() {
@@ -295,6 +340,8 @@ public class RegInfo extends DefinitionExtension<RegisterTensor> implements Rend
       renderObj.put("is_tb_state", isTbState());
       renderObj.put("tb_state_parts", tbStateParts());
       renderObj.put("exec_class", execClass().name());
+      renderObj.put("isLazy", isLazy());
+      renderObj.put("isFullyLazy", isFullyLazy());
       renderObj.put("constraints", renderConstraints(dims));
       renderObj.put("getter_params", renderParamsComma);
       if (isTcgScalar()) {
@@ -534,6 +581,15 @@ public class RegInfo extends DefinitionExtension<RegisterTensor> implements Rend
         || writes.stream()
         .anyMatch(write -> isVectorAccess(reg, write.indices().size()));
     return hasVectorStyleAccess ? ExecClass.CPU_VECTOR : ExecClass.TCG_SCALAR;
+  }
+
+  private static Laziness determineLaziness(RegisterTensor reg) {
+    if (!reg.hasAnnotation(FloatFlagAnnotation.class)) {
+      return Laziness.NONE;
+    }
+    return reg.expectAnnotation(FloatFlagAnnotation.class).slice().covers(reg.totalWidth())
+        ? Laziness.FULL
+        : Laziness.PARTIAL;
   }
 
   /**
@@ -920,28 +976,50 @@ public class RegInfo extends DefinitionExtension<RegisterTensor> implements Rend
         }
       }
 
-      // emit index access
-      var access = "env->" + owner.nameLower() + owner.cArrayIndex("i");
+      var globalAccess = "env->" + owner.nameLower() + owner.cArrayIndex("i");
 
       switch (type) {
         case READ -> {
-          var resultName = "result_" + owner.nameLower();
-          cb.stmt("%s %s = %s".formatted(accessValueCType(), resultName, access));
-          emitFEFlagReconstructionOnRead(cb, resultName, true);
-          emitFEFlagReconstructionOnRead(cb, resultName, false);
-          cb.returnStmt(resultName);
+          if (owner.laziness == Laziness.NONE) {
+            cb.returnStmt(globalAccess);
+          } else {
+            var resultName = "result_" + owner.nameLower();
+            cb.stmt("%s %s = %s".formatted(accessValueCType(), resultName,
+                owner.laziness == Laziness.PARTIAL ? globalAccess : "0"));
+            emitLazyRead(cb, resultName);
+            cb.returnStmt(resultName);
+          }
         }
         case WRITE -> {
-          emitFEFlagReconstructionOnWrite(cb, true);
-          emitFEFlagReconstructionOnWrite(cb, false);
-          cb.stmt(access + " = value");
+          if (owner.laziness != Laziness.NONE) {
+            emitLazyWrite(cb);
+          }
+          if (owner.laziness != Laziness.FULL) {
+            cb.stmt(globalAccess + " = value");
+          }
         }
       }
       return cb.toString();
     }
 
-    private void emitFEFlagReconstructionOnRead(CStringBuilder cb, String resultName,
-                                                boolean sticky) {
+    /**
+     * Generates the logic for constructing the read value for the lazy parts.
+     */
+    private void emitLazyRead(CStringBuilder cb, String resultName) {
+      emitFEFlagRead(cb, resultName, true);
+      emitFEFlagRead(cb, resultName, false);
+    }
+
+    /**
+     * Generates the logic for storing the lazy parts of the written value.
+     */
+    private void emitLazyWrite(CStringBuilder cb) {
+      emitFEFlagWrite(cb, true);
+      emitFEFlagWrite(cb, false);
+    }
+
+    private void emitFEFlagRead(CStringBuilder cb, String resultName,
+                                boolean sticky) {
       var ffAnn = owner.reg().annotation(FloatFlagAnnotation.class);
       if (ffAnn == null || ffAnn.flags(sticky).isEmpty()) {
         return;
@@ -957,7 +1035,7 @@ public class RegInfo extends DefinitionExtension<RegisterTensor> implements Rend
           .formatted(resultName, flagVarName, flag.qemuFlagOffset, idx)));
     }
 
-    private void emitFEFlagReconstructionOnWrite(CStringBuilder cb, boolean sticky) {
+    private void emitFEFlagWrite(CStringBuilder cb, boolean sticky) {
       var ffAnn = owner.reg().annotation(FloatFlagAnnotation.class);
       if (ffAnn == null || ffAnn.flags(sticky).isEmpty()) {
         return;
@@ -965,7 +1043,7 @@ public class RegInfo extends DefinitionExtension<RegisterTensor> implements Rend
       var flagVarName = sticky ? "s_fe_flags" : "ns_fe_flags";
 
       // by default, all unused flags are set
-      int initialValue = ~ffAnn.qemuFlagMask(sticky);
+      int initialValue = ~ffAnn.qemuFlagMask(sticky) & 0xffff;
       cb.stmt("uint16_t %s = 0x%s".formatted(flagVarName, Integer.toHexString(initialValue)));
       ffAnn.flags(sticky).forEach((idx, flag) -> cb.stmt("%s |= ((value >> %d) & 1) << %d"
           .formatted(flagVarName, idx, flag.qemuFlagOffset)));

--- a/vadl/main/vadl/iss/passes/tcg/lowering/TcgCtx.java
+++ b/vadl/main/vadl/iss/passes/tcg/lowering/TcgCtx.java
@@ -24,6 +24,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import vadl.iss.passes.TcgPassUtils;
+import vadl.iss.passes.extensions.RegInfo;
 import vadl.iss.passes.nodes.IssGvecOpNode;
 import vadl.iss.passes.nodes.IssMoveNode;
 import vadl.iss.passes.nodes.IssReadRegNode;
@@ -197,6 +198,11 @@ public class TcgCtx extends DefinitionExtension<Instruction> {
 
     @Handler
     List<TcgVRefNode> destOf(ReadRegTensorNode toHandle) {
+      var reg = toHandle.regTensor();
+      var info = reg.expectExtension(RegInfo.class);
+      if (info.isLazy()) {
+        return assignments.computeIfAbsent(toHandle, v -> createTempLazyRegVar(reg));
+      }
       if (toHandle instanceof IssReadRegNode issRead
           && issRead.windowKind() == IssReadRegNode.WindowKind.CHUNK) {
         return assignments.computeIfAbsent(toHandle, v -> createTempExprVar(toHandle));
@@ -302,6 +308,16 @@ public class TcgCtx extends DefinitionExtension<Instruction> {
               )
           ))
           .toList();
+    }
+
+    /**
+     * Creates a temporary variable for the given lazy register.
+     *
+     * @param reg The lazy register.
+     * @return The variable corresponding to the register.
+     */
+    private List<TcgVRefNode> createTempLazyRegVar(RegisterTensor reg) {
+      return List.of(toNode(TcgV.tmp("lazy_" + reg.simpleName().toLowerCase(), targetSize)));
     }
 
     /**

--- a/vadl/main/vadl/iss/passes/tcg/lowering/TcgOpLoweringPass.java
+++ b/vadl/main/vadl/iss/passes/tcg/lowering/TcgOpLoweringPass.java
@@ -39,6 +39,7 @@ import vadl.iss.passes.TcgPassUtils;
 import vadl.iss.passes.common.opDecomposition.nodes.IssMul2Node;
 import vadl.iss.passes.common.opDecomposition.nodes.IssMulhNode;
 import vadl.iss.passes.common.safeResourceRead.nodes.ExprSaveNode;
+import vadl.iss.passes.extensions.RegInfo;
 import vadl.iss.passes.nodes.IssConstExtractNode;
 import vadl.iss.passes.nodes.IssGhostCastNode;
 import vadl.iss.passes.nodes.IssGvecOpNode;
@@ -552,7 +553,7 @@ class TcgOpLoweringExecutor implements CfgTraverser {
   @Handler
   void handle(TruncateNode toHandle) {
     toHandle.fail(
-        "Shouldn't exist at this point. The ExtractNormalizationPass should have replaced it.");
+        "Shouldn't exist at this point. The IssNormalizationPass should have replaced it.");
   }
 
   /**
@@ -563,7 +564,7 @@ class TcgOpLoweringExecutor implements CfgTraverser {
   @Handler
   void handle(ZeroExtendNode toHandle) {
     toHandle.fail(
-        "Shouldn't exist at this point. The ExtractNormalizationPass should have replaced it.");
+        "Shouldn't exist at this point. The IssNormalizationPass should have replaced it.");
   }
 
   /**
@@ -574,7 +575,7 @@ class TcgOpLoweringExecutor implements CfgTraverser {
   @Handler
   void handle(SignExtendNode toHandle) {
     toHandle.fail(
-        "Shouldn't exist at this point. The ExtractNormalizationPass should have replaced it.");
+        "Shouldn't exist at this point. The IssNormalizationPass should have replaced it.");
   }
 
   /**
@@ -621,6 +622,14 @@ class TcgOpLoweringExecutor implements CfgTraverser {
 
   @Handler
   void handle(ReadRegTensorNode toHandle) {
+    var info = toHandle.regTensor().expectExtension(RegInfo.class);
+    if (info.isLazy()) {
+      var dest = singleDestOf(toHandle);
+      replaceCurrent(new TcgHelperCall(
+          dest, new NodeList<>(), true, "lazy_read_" + info.nameLower()
+      ));
+      return;
+    }
     if (toHandle instanceof IssReadRegNode issRead
         && issRead.windowKind() == IssReadRegNode.WindowKind.CHUNK) {
       var dest = singleDestOf(toHandle);
@@ -658,8 +667,15 @@ class TcgOpLoweringExecutor implements CfgTraverser {
       var isStatic = toHandle instanceof IssWriteRegNode issWrite && issWrite.isStatic();
       addBeforeCurrent(new TcgIsJmpTbStateWrite(isStatic));
     }
-    var destVar = singleDestOf(toHandle);
     var srcVar = singleDestOf(toHandle.value());
+    var info = toHandle.regTensor().expectExtension(RegInfo.class);
+    if (info.isLazy()) {
+      replaceCurrent(new TcgHelperCall(
+          null, new NodeList<>(srcVar), true, "lazy_write_" + info.nameLower()
+      ));
+      return;
+    }
+    var destVar = singleDestOf(toHandle);
     if (toHandle instanceof IssWriteRegNode issWrite
         && issWrite.windowKind() == IssWriteRegNode.WindowKind.CHUNK) {
       replaceCurrent(new TcgDepositNode(destVar, destVar, srcVar,

--- a/vadl/main/vadl/iss/template/IssTemplateRenderingPass.java
+++ b/vadl/main/vadl/iss/template/IssTemplateRenderingPass.java
@@ -47,6 +47,7 @@ import vadl.types.UIntType;
 import vadl.viam.Endianness;
 import vadl.viam.Memory;
 import vadl.viam.Specification;
+import vadl.viam.annotations.FloatFlagAnnotation;
 
 /**
  * The template rendering pass all ISS (QEMU) rendering passes extend from.
@@ -131,6 +132,10 @@ public abstract class IssTemplateRenderingPass extends AbstractTemplateRendering
   protected Map<String, Object> createVariables(PassResults passResults,
                                                 Specification specification) {
     var vars = new HashMap<String, Object>();
+    var floatBuiltinConfigs = passResults.lastResultOf(
+        IssFloatBuiltinCollectionPass.class,
+        IssFloatBuiltinCollectionPass.Output.class
+    );
     vars.put("gen_arch", configuration().targetName().toLowerCase());
     vars.put("gen_arch_upper", configuration().targetName().toUpperCase());
     vars.put("gen_arch_lower", configuration().targetName().toLowerCase());
@@ -138,11 +143,8 @@ public abstract class IssTemplateRenderingPass extends AbstractTemplateRendering
     vars.put("gen_machine_upper", configuration().machineName().toUpperCase());
     vars.put("gen_machine_lower", configuration().machineName().toLowerCase());
     vars.put("register_tensors", mapRegTensors(specification));
-    vars.put("float_builtins", getFloatBuiltins(passResults.lastResultOf(
-        IssFloatBuiltinCollectionPass.class,
-        IssFloatBuiltinCollectionPass.Output.class
-    )));
-    vars.put("float_formats", getFloatFormats(specification));
+    vars.put("float_builtins", getFloatBuiltins(floatBuiltinConfigs));
+    vars.put("float_facts", getFloatFacts(specification, floatBuiltinConfigs));
     vars.put("pc_info", getPcInfo(specification));
     vars.put("target_size", configuration().targetSize().width);
     vars.put("mem_regions", memRegions(specification));
@@ -189,11 +191,27 @@ public abstract class IssTemplateRenderingPass extends AbstractTemplateRendering
     }).toList()).toList();
   }
 
-  private List<Map<String, String>> getFloatFormats(Specification viam) {
-    return viam.isa().get().ownFloatFormats().stream().map(fmt -> Map.of(
-        "name", fmt.nameLower(),
-        "bit_size", Integer.toString(requireNonNull(fmt.encoding()).size)
-    )).toList();
+  private Map<String, Object> getFloatFacts(Specification viam,
+                                             IssFloatBuiltinCollectionPass.Output config) {
+    var hasFloatOps = !config.floatBuiltIns().isEmpty();
+    var hasStickyFlags = false;
+    var hasNonStickyFlags = false;
+    var annotations = viam.isa().get().registerTensors().stream()
+        .filter(r -> r.hasAnnotation(FloatFlagAnnotation.class))
+        .map(r -> r.expectAnnotation(FloatFlagAnnotation.class)).toList();
+    for (var ann : annotations) {
+      hasStickyFlags |= !ann.stickyFlags().isEmpty();
+      hasNonStickyFlags |= !ann.nonStickyFlags().isEmpty();
+    }
+    var stickyMask = FloatFlagAnnotation.qemuFlagMask(annotations, true);
+    var nonStickyMask = FloatFlagAnnotation.qemuFlagMask(annotations, false);
+    return Map.of(
+        "has_float_ops", hasFloatOps,
+        "has_sticky_flags", hasStickyFlags,
+        "has_non_sticky_flags", hasNonStickyFlags,
+        "sticky_mask", "0x" + Integer.toHexString(stickyMask),
+        "non_sticky_mask", "0x" + Integer.toHexString(nonStickyMask)
+    );
   }
 
   private String builtInName(BuiltInTable.BuiltIn builtin) {

--- a/vadl/main/vadl/iss/template/IssTemplateRenderingPass.java
+++ b/vadl/main/vadl/iss/template/IssTemplateRenderingPass.java
@@ -209,6 +209,7 @@ public abstract class IssTemplateRenderingPass extends AbstractTemplateRendering
         "has_float_ops", hasFloatOps,
         "has_sticky_flags", hasStickyFlags,
         "has_non_sticky_flags", hasNonStickyFlags,
+        "need_float_status", hasStickyFlags || hasNonStickyFlags || hasFloatOps,
         "sticky_mask", "0x" + Integer.toHexString(stickyMask),
         "non_sticky_mask", "0x" + Integer.toHexString(nonStickyMask)
     );

--- a/vadl/main/vadl/iss/template/target/BaseClearCpuAccessors.java
+++ b/vadl/main/vadl/iss/template/target/BaseClearCpuAccessors.java
@@ -47,9 +47,12 @@ final class BaseClearCpuAccessors {
     var signature = "void cpu_clear_" + regLower + "("
         + "CPU" + config.targetName().toUpperCase() + "State *env)";
 
-    var body = info.hasCpuStateArrayStorage()
-        ? "memset(env->" + regLower + ", 0, sizeof(env->" + regLower + "));"
-        : "env->" + regLower + " = 0;";
+    // Note: fully lazy registers have no field in env
+    var body = info.isFullyLazy()
+        ? ""
+        : info.hasCpuStateArrayStorage()
+          ? "memset(env->" + regLower + ", 0, sizeof(env->" + regLower + "));"
+          : "env->" + regLower + " = 0;";
 
     return Map.of(
         "name", "cpu_clear_" + regLower,

--- a/vadl/main/vadl/iss/template/target/EmitIssCpuSourcePass.java
+++ b/vadl/main/vadl/iss/template/target/EmitIssCpuSourcePass.java
@@ -49,7 +49,7 @@ public class EmitIssCpuSourcePass extends IssTemplateRenderingPass {
     var vars = super.createVariables(passResults, specification);
     var accessorRegistry = passResults.lastResultOf(IssRegisterAccessInfoRetrievalPass.class,
         IssAccessorRegistry.class);
-    vars.put("reg_dump_code", dumpRegsCode(specification));
+    vars.put("reg_dump_code", dumpRegsCode(specification, accessorRegistry));
     vars.put("reset", getResetCode(specification, accessorRegistry));
     vars.put("base_accessors", accessorRegistry.baseAccessors());
     vars.put("base_clear_cpu_accessors",
@@ -70,19 +70,20 @@ public class EmitIssCpuSourcePass extends IssTemplateRenderingPass {
     return new IssResetGen(proc.reset(), accessorRegistry).fetch();
   }
 
-  private String dumpRegsCode(Specification specification) {
+  private String dumpRegsCode(Specification specification, IssAccessorRegistry accessorRegistry) {
     var sb = new CStringBuilder();
     var isa = specification.processor().get().isa();
     sb.indent();
     isa.registerTensors().forEach(tensor -> {
-      dumpRegsCode(sb, tensor);
+      dumpRegsCode(sb, tensor, accessorRegistry);
       sb.append("\n");
     });
     return sb.toString();
   }
 
   @SuppressWarnings("LambdaParameterName")
-  private void dumpRegsCode(CCodeBuilder sb, RegisterTensor reg) {
+  private void dumpRegsCode(CCodeBuilder sb, RegisterTensor reg,
+                            IssAccessorRegistry accessorRegistry) {
     var regLower = reg.simpleName().toLowerCase();
     var target = configuration().targetName().toLowerCase();
     var names = target + "_cpu_" + regLower + "_names";
@@ -93,9 +94,14 @@ public class EmitIssCpuSourcePass extends IssTemplateRenderingPass {
     if (regInfo.execClass() == RegInfo.ExecClass.CPU_VECTOR) {
       dumpCpuVectorRegCode(sb, reg, regLower, names, dims.size());
     } else if (dims.isEmpty()) {
+      var accessor = regInfo.isLazy()
+          ? accessorRegistry.baseAccessors().stream()
+            .filter(a -> a.owner().reg() == reg && a.accessType() == RegInfo.AccessType.READ)
+            .findFirst().get().name() + "(env)"
+          : "env->" + regLower;
       sb.callStmt("qemu_fprintf", "f",
           "\" " + reg.simpleName() + ":    \" TARGET_FMT_lx \"\\n\"",
-          "env->" + regLower);
+          accessor);
     } else if (dims.size() == 1) {
       var flatSize = dims.getFirst().size();
       var isWideElement = reg.resultType().bitWidth() > 64;

--- a/vadl/main/vadl/iss/template/target/EmitIssGdbStubPass.java
+++ b/vadl/main/vadl/iss/template/target/EmitIssGdbStubPass.java
@@ -30,12 +30,12 @@ import vadl.utils.codegen.CCodeBuilder;
 import vadl.utils.codegen.CStringBuilder;
 import vadl.viam.RegisterTensor;
 import vadl.viam.Specification;
-import vadl.viam.annotations.FloatFlagAnnotation;
 
 /**
  * Emits the {@code target/gen-arch/gdbstub.c} file which implements target-specific callback
  * that are used by QEMU's generic gdbstub to read and modify the CPU state.
  * The minimal required callbacks are read/write of CPU registers.
+ * Stubs for lazy registers use CPU helpers.
  *
  * <p>The {@link vadl.iss.template.gdb_xml.EmitIssGdbXmlPass} emits the CPU register information
  * used by GDB to address certain registers.</p>
@@ -175,8 +175,7 @@ public class EmitIssGdbStubPass extends IssTemplateRenderingPass {
         emitReadChunkedScalar(builder, bitSize, callPrefix);
       }
     } else if (origin.isSingleRegister()) {
-      boolean useCpuGetter = origin.hasAnnotation(FloatFlagAnnotation.class);
-      var accessor = useCpuGetter
+      var accessor = origin.expectExtension(RegInfo.class).isLazy()
           ? accessorRegistry.baseAccessors().stream()
             .filter(a -> a.owner().reg() == origin && a.accessType() == RegInfo.AccessType.READ)
             .findFirst().get().name() + "(env)"
@@ -212,14 +211,13 @@ public class EmitIssGdbStubPass extends IssTemplateRenderingPass {
         emitWriteChunkedScalar(builder, bitSize, callPrefix);
       }
     } else if (origin.isSingleRegister()) {
-      boolean useCpuGetter = origin.hasAnnotation(FloatFlagAnnotation.class);
-      if (useCpuGetter) {
+      if (origin.expectExtension(RegInfo.class).laziness() == RegInfo.Laziness.NONE) {
+        builder.stmt("env->" + base + " = " + scalarLoader(bitSize) + "(mem_buf)");
+      } else {
         var accessorName = accessorRegistry.baseAccessors().stream()
             .filter(a -> a.owner().reg() == origin && a.accessType() == RegInfo.AccessType.WRITE)
             .findFirst().get().name();
         builder.stmt(accessorName + "(env, " + scalarLoader(bitSize) + "(mem_buf))");
-      } else {
-        builder.stmt("env->" + base + " = " + scalarLoader(bitSize) + "(mem_buf)");
       }
       builder.stmt("return " + wireSizeBytes(bitSize));
     } else {

--- a/vadl/main/vadl/iss/template/target/EmitIssGdbStubPass.java
+++ b/vadl/main/vadl/iss/template/target/EmitIssGdbStubPass.java
@@ -21,6 +21,8 @@ import java.util.List;
 import java.util.Map;
 import vadl.configuration.IssConfiguration;
 import vadl.iss.passes.common.IssGdbInfoExtractionPass;
+import vadl.iss.passes.common.IssRegisterAccessInfoRetrievalPass;
+import vadl.iss.passes.extensions.IssAccessorRegistry;
 import vadl.iss.passes.extensions.RegInfo;
 import vadl.iss.template.IssTemplateRenderingPass;
 import vadl.pass.PassResults;
@@ -28,6 +30,7 @@ import vadl.utils.codegen.CCodeBuilder;
 import vadl.utils.codegen.CStringBuilder;
 import vadl.viam.RegisterTensor;
 import vadl.viam.Specification;
+import vadl.viam.annotations.FloatFlagAnnotation;
 
 /**
  * Emits the {@code target/gen-arch/gdbstub.c} file which implements target-specific callback
@@ -64,20 +67,22 @@ public class EmitIssGdbStubPass extends IssTemplateRenderingPass {
     var vars = super.createVariables(passResults, specification);
     var gdbInfo = passResults.lastResultOf(IssGdbInfoExtractionPass.class,
         IssGdbInfoExtractionPass.Result.class);
+    var accessorRegistry = passResults.lastResultOf(IssRegisterAccessInfoRetrievalPass.class,
+        IssAccessorRegistry.class);
     var groups = groupRegs(gdbInfo.regs());
     vars.put("regs", gdbInfo.regs());
-    vars.put("gdb_helpers", createHelpers(groups));
+    vars.put("gdb_helpers", createHelpers(groups, accessorRegistry));
     vars.put("read_regs", createRead(groups));
     vars.put("write_regs", createWrite(groups));
     return vars;
   }
 
-  private String createHelpers(List<RegGroup> groups) {
+  private String createHelpers(List<RegGroup> groups, IssAccessorRegistry accessorRegistry) {
     var helpers = new CStringBuilder();
     for (var group : groups) {
-      emitReadHelper(helpers, group);
+      emitReadHelper(helpers, group, accessorRegistry);
       helpers.newLine();
-      emitWriteHelper(helpers, group);
+      emitWriteHelper(helpers, group, accessorRegistry);
       helpers.newLine();
     }
     return helpers.toString();
@@ -151,7 +156,8 @@ public class EmitIssGdbStubPass extends IssTemplateRenderingPass {
     return out.toString();
   }
 
-  private void emitReadHelper(CCodeBuilder builder, RegGroup group) {
+  private void emitReadHelper(CCodeBuilder builder, RegGroup group,
+                              IssAccessorRegistry accessorRegistry) {
     var sample = group.sample();
     var origin = sample.origin();
     var bitSize = sample.bitSize();
@@ -169,14 +175,21 @@ public class EmitIssGdbStubPass extends IssTemplateRenderingPass {
         emitReadChunkedScalar(builder, bitSize, callPrefix);
       }
     } else if (origin.isSingleRegister()) {
-      builder.stmt("return " + scalarGetter(bitSize) + "(mem_buf, env->" + base + ")");
+      boolean useCpuGetter = origin.hasAnnotation(FloatFlagAnnotation.class);
+      var accessor = useCpuGetter
+          ? accessorRegistry.baseAccessors().stream()
+            .filter(a -> a.owner().reg() == origin && a.accessType() == RegInfo.AccessType.READ)
+            .findFirst().get().name() + "(env)"
+          : "env->" + base;
+      builder.stmt("return " + scalarGetter(bitSize) + "(mem_buf, " + accessor + ")");
     } else {
       builder.stmt("return " + scalarGetter(bitSize) + "(mem_buf, env->" + base + "[idx])");
     }
     builder.unindent().appendLn("}");
   }
 
-  private void emitWriteHelper(CCodeBuilder builder, RegGroup group) {
+  private void emitWriteHelper(CCodeBuilder builder, RegGroup group,
+                               IssAccessorRegistry accessorRegistry) {
     var sample = group.sample();
     var origin = sample.origin();
     var bitSize = sample.bitSize();
@@ -199,8 +212,16 @@ public class EmitIssGdbStubPass extends IssTemplateRenderingPass {
         emitWriteChunkedScalar(builder, bitSize, callPrefix);
       }
     } else if (origin.isSingleRegister()) {
-      builder.stmt("env->" + base + " = " + scalarLoader(bitSize) + "(mem_buf)")
-          .stmt("return " + wireSizeBytes(bitSize));
+      boolean useCpuGetter = origin.hasAnnotation(FloatFlagAnnotation.class);
+      if (useCpuGetter) {
+        var accessorName = accessorRegistry.baseAccessors().stream()
+            .filter(a -> a.owner().reg() == origin && a.accessType() == RegInfo.AccessType.WRITE)
+            .findFirst().get().name();
+        builder.stmt(accessorName + "(env, " + scalarLoader(bitSize) + "(mem_buf))");
+      } else {
+        builder.stmt("env->" + base + " = " + scalarLoader(bitSize) + "(mem_buf)");
+      }
+      builder.stmt("return " + wireSizeBytes(bitSize));
     } else {
       builder.stmt("env->" + base + "[idx] = " + scalarLoader(bitSize) + "(mem_buf)")
           .stmt("return " + wireSizeBytes(bitSize));

--- a/vadl/main/vadl/iss/template/target/EmitIssTranslateCPass.java
+++ b/vadl/main/vadl/iss/template/target/EmitIssTranslateCPass.java
@@ -23,6 +23,7 @@ import static vadl.utils.GraphUtils.getSingleNode;
 import com.google.common.collect.Streams;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import vadl.configuration.IssConfiguration;
@@ -134,6 +135,7 @@ public class EmitIssTranslateCPass extends IssTemplateRenderingPass {
     sb.indent();
     isa.registerTensors().stream()
         .filter(IssUtils::isTcgReg)
+        .filter(Predicate.not(IssUtils::isLazyReg))
         .forEach(tensor -> {
           regInitCode(sb, tensor);
           sb.append("\n");

--- a/vadl/main/vadl/viam/Constant.java
+++ b/vadl/main/vadl/viam/Constant.java
@@ -1256,6 +1256,14 @@ public abstract class Constant {
       return other.stream().allMatch(i -> parts().anyMatch(p -> p.msb() >= i && p.lsb() <= i));
     }
 
+    /**
+     * Checks whether all bits in the slice {@code [0..width-1]} are contained in this
+     * slice.
+     */
+    public boolean covers(int width) {
+      return covers(Constant.BitSlice.of(width - 1, 0));
+    }
+
     private static List<Part> normalized(Part[] parts) {
       // flat map all parts to a single array of integers
       var flattened = Arrays.stream(parts)

--- a/vadl/main/vadl/viam/annotations/FloatFlagAnnotation.java
+++ b/vadl/main/vadl/viam/annotations/FloatFlagAnnotation.java
@@ -19,8 +19,10 @@ package vadl.viam.annotations;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import vadl.viam.Annotation;
+import vadl.viam.Constant;
 import vadl.viam.FloatExceptionFlag;
 import vadl.viam.RegisterTensor;
 
@@ -63,6 +65,19 @@ public class FloatFlagAnnotation extends Annotation<RegisterTensor> {
 
   public Map<Integer, FloatExceptionFlag> flags(boolean sticky) {
     return sticky ? stickyFlags() : nonStickyFlags();
+  }
+
+  /**
+   * Returns a bit slice containing all bits that contain a flag.
+   */
+  public Constant.BitSlice slice() {
+    return new Constant.BitSlice(
+        Stream.concat(
+            sticky.keySet().stream(),
+            nonSticky.keySet().stream()
+        ).distinct().map(i -> Constant.BitSlice.Part.of(i, i))
+            .toArray(Constant.BitSlice.Part[]::new)
+    );
   }
 
   /**

--- a/vadl/main/vadl/viam/annotations/FloatFlagAnnotation.java
+++ b/vadl/main/vadl/viam/annotations/FloatFlagAnnotation.java
@@ -16,6 +16,7 @@
 
 package vadl.viam.annotations;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -58,6 +59,50 @@ public class FloatFlagAnnotation extends Annotation<RegisterTensor> {
 
   public Map<Integer, FloatExceptionFlag> nonStickyFlags() {
     return nonSticky;
+  }
+
+  public Map<Integer, FloatExceptionFlag> flags(boolean sticky) {
+    return sticky ? stickyFlags() : nonStickyFlags();
+  }
+
+  /**
+   * Creates a binary mask for the float exception flags in the register this annotation
+   * is attached to, where all flags are set, which exists in the register.
+   *
+   * @param sticky     Whether to compute the mask for sticky flags (if {@code false}, then
+   *                   the mask is computed for the non-sticky flags)
+   * @return           The mask
+   */
+  public long flagMask(boolean sticky) {
+    return flags(sticky).keySet().stream().mapToLong(idx -> idx)
+        .reduce(0, (mask, idx) -> mask | (1L << idx));
+  }
+
+  /**
+   * Creates a binary mask for the QEMU float exception flags, where all flags are set,
+   * which exists in the given annotation.
+   *
+   * @param sticky      Whether to compute the mask for sticky flags (if {@code false}, then
+   *                    the mask is computed for the non-sticky flags)
+   * @return            The mask
+   */
+  public int qemuFlagMask(boolean sticky) {
+    return (short) flags(sticky).values().stream().mapToInt(f -> f.qemuFlagOffset)
+        .reduce(0, (mask, idx) -> mask | (1 << idx));
+  }
+
+  /**
+   * Creates a binary mask for the QEMU float exception flags, where all flags are set,
+   * which exists in any of the given annotations.
+   *
+   * @param annotations The float flags annotations to consider
+   * @param sticky      Whether to compute the mask for sticky flags (if {@code false}, then
+   *                    the mask is computed for the non-sticky flags)
+   * @return            The mask
+   */
+  public static int qemuFlagMask(Collection<FloatFlagAnnotation> annotations, boolean sticky) {
+    return annotations.stream().mapToInt(ann -> ann.qemuFlagMask(sticky))
+        .reduce(0, (a, b) -> a | b);
   }
 
 }


### PR DESCRIPTION
Adds lazy registers (could also be named "virtual registers"). Lazy registers contain parts, which are not stored or updated in the TCG global of the register. These parts are instead sourced from other parts of the CPU-state (e.g. the float_status). Reading/writing these registers must go through the C getters and setters in `cpu.c`. Thus, translation functions must emit helper calls to read/write. This is an optimization to avoid emitting costly logic for updating registers, which are often written inside helpers, but are rarely read.

Lazy registers are now used to speed up float exception flags. Instead of converting between QEMU's flag format to RISC-V's format after every float instruction, we now just store QEMU's format in the CPU-state. When the flags are read, the FCSR register is constructed from that.