### PR TITLE
gcb: Add explicit diagnostic for missing ABI

### DIFF
--- a/vadl/main/vadl/gcb/passes/GenerateCompilerRegistersPass.java
+++ b/vadl/main/vadl/gcb/passes/GenerateCompilerRegistersPass.java
@@ -37,6 +37,7 @@ import vadl.pass.PassName;
 import vadl.pass.PassResults;
 import vadl.types.BitsType;
 import vadl.utils.Pair;
+import vadl.utils.SourceLocation;
 import vadl.viam.Abi;
 import vadl.viam.ArtificialResource;
 import vadl.viam.Constant;
@@ -73,7 +74,14 @@ public class GenerateCompilerRegistersPass extends Pass {
   @Nullable
   @Override
   public Object execute(PassResults passResults, Specification viam) throws IOException {
-    var abi = (Abi) viam.definitions().filter(x -> x instanceof Abi).findFirst().get();
+    var abi = (Abi) viam
+        .definitions()
+        .filter(x -> x instanceof Abi)
+        .findFirst()
+        .orElseThrow(() -> Diagnostic.error(
+            "Missing ABI definition for compiler generation",
+            SourceLocation.INVALID_SOURCE_LOCATION).build()
+        );
 
     var generalRegisters =
         generalRegisters(viam.registerTensors().filter(RegisterTensor::isSingleRegister).toList());


### PR DESCRIPTION
Previously, when attempting to run gcb on a specification without ABI definition, it would attempt to `get()` an empty `Optional`. This commit still lets that operation fail, but now does so by throwing a proper `Diagnostic` - even if it does not include a source location, since it is reporting the absence of a definition.