### PR TITLE
util: Improve sourcelocation outermost expansion access

### DIFF
--- a/vadl-lsp/main/vadl/lsp/AstFinderByPosition.java
+++ b/vadl-lsp/main/vadl/lsp/AstFinderByPosition.java
@@ -99,7 +99,7 @@ public abstract class AstFinderByPosition<N extends Node> extends RecursiveAstVi
           vadl.utils.RopeList<SourceLocation.DirectLocation> expandedFrom
         )
       ) {
-        var outerLocation = expandedFrom.toList().getLast();
+        var outerLocation = expandedFrom.getLast();
         if (!primaryLocation.begin().isWithin(outerLocation)
             || !primaryLocation.end().isWithin(outerLocation)) {
           return false;

--- a/vadl/main/vadl/error/Diagnostic.java
+++ b/vadl/main/vadl/error/Diagnostic.java
@@ -208,7 +208,7 @@ public class Diagnostic extends RuntimeException {
     for (var diagnostic : diagnostics) {
 
       final var locationDiagnostics = structure.computeIfAbsent(
-          diagnostic.multiLocation.primaryLocation.location().asDirectLocation(),
+          diagnostic.multiLocation.primaryLocation.location().innermostDirectLocation(),
           k -> new ArrayList<>());
 
       var similar = locationDiagnostics.stream()

--- a/vadl/main/vadl/utils/RopeList.java
+++ b/vadl/main/vadl/utils/RopeList.java
@@ -92,6 +92,32 @@ public sealed interface RopeList<T> permits RopeList.ItemLeaf, RopeList.ListLeaf
   }
 
   /**
+   * Get the first element stored in the list.
+   *
+   * @return the element.
+   */
+  default T getFirst() {
+    return switch (this) {
+      case ItemLeaf<T> node -> node.element;
+      case Concat<T> node -> node.left.getFirst();
+      case ListLeaf<T> node -> node.elements.getFirst();
+    };
+  }
+
+  /**
+   * Get the last element stored in the list.
+   *
+   * @return the element.
+   */
+  default T getLast() {
+    return switch (this) {
+      case ItemLeaf<T> node -> node.element;
+      case Concat<T> node -> node.left.getLast();
+      case ListLeaf<T> node -> node.elements.getLast();
+    };
+  }
+
+  /**
    * Concatenates two lists in constant time and space.
    * Does not modify the original lists.
    *

--- a/vadl/main/vadl/utils/SourceLocation.java
+++ b/vadl/main/vadl/utils/SourceLocation.java
@@ -196,16 +196,59 @@ public sealed interface SourceLocation extends WithLocation, Comparable<SourceLo
   }
 
   /**
-   * Strips a location of all expandedFrom information and returns it as a direct location.
+   * Strips a location of all its macro expansion information and returns it as a
+   * {@link DirectLocation}.
+   *
+   * <p><pre>{@code
+   *  model inner(): Ex = {
+   *    42
+   *  }
+   *
+   *  model outer(): Ex = {
+   *    $inner
+   *  }
+   *
+   *  $outer()
+   * }</pre>
+   * In this example the {@code innermostDirectLocation} of the integer literal would be the one in
+   * the second line inside the inner model.
    *
    * @return the direct location.
    */
-  default DirectLocation asDirectLocation() {
+  default DirectLocation innermostDirectLocation() {
     return switch (this) {
       case DirectLocation direct -> direct;
       case ExpandedLocation expanded -> expanded.primaryLocation;
     };
   }
+
+  /**
+   * Gets the outer most macro invocation (the top-level call).
+   * If the location is not the result of a macro call this just returns the location itself.
+   *
+   * <p><pre>{@code
+   *  model inner(): Ex = {
+   *    42
+   *  }
+   *
+   *  model outer(): Ex = {
+   *    $inner
+   *  }
+   *
+   *  $outer()
+   * }</pre>
+   * In this example the {@code outermostDirectLocation} of the integer literal would be the one in
+   * last line.
+   *
+   * @return the outer direct location.
+   */
+  default DirectLocation outermostDirectLocation() {
+    return switch (this) {
+      case DirectLocation direct -> direct;
+      case ExpandedLocation expanded -> expanded.expandedFrom.getLast();
+    };
+  }
+
 
   /**
    * Create a new source location that is a copy of the current one with the provided expanded stack

--- a/vadl/main/vadl/viam/graph/dependency/ForIdxNode.java
+++ b/vadl/main/vadl/viam/graph/dependency/ForIdxNode.java
@@ -60,7 +60,7 @@ public class ForIdxNode extends ExpressionNode {
                     int toIdx) {
     super(normalizeType(type));
     this.bindingName = bindingName;
-    this.bindingLocation = bindingLocation.asDirectLocation();
+    this.bindingLocation = bindingLocation.innermostDirectLocation();
     this.fromIdx = fromIdx;
     this.toIdx = toIdx;
   }


### PR DESCRIPTION
A easier (and faster) way to access the outermost location (where the outermost macro was called)