### PR TITLE
frontend: Make `ConstantAnnotation`s resolve identifiers in their value

### DIFF
--- a/vadl-frontend/main/vadl/ast/Annotation.java
+++ b/vadl-frontend/main/vadl/ast/Annotation.java
@@ -53,38 +53,18 @@ public abstract class Annotation implements AnnotationDeclaration, WithLocation 
   /**
    * Called by the symbol resolver to resolve the subparts of the annotation.
    *
-   * <p>Can be overwritten by subclasses to specify additional
-   * annotation-specific behavior to execute during name-resolution.
-   *
-   * <p>In general, subclasses overwriting this method should call
-   * {@code super.resolveName} so that names in the annotation's values are
-   * resolved. If this is explicitly *not* desired, the {@code super} call must
-   * be omitted.
-   *
    * @param definition The `AnnotationDefinition` corresponding to this `Annotation`.
    * @param resolver The active name resolver.
    */
-  void resolveName(AnnotationDefinition definition, SymbolTable.SymbolResolver resolver) {
-    definition.values.forEach(value -> value.accept(resolver));
-  }
+  abstract void resolveName(AnnotationDefinition definition, SymbolTable.SymbolResolver resolver);
 
   /**
    * Called by the type checker to type check the annotation.
    *
-   * <p>Can be overwritten by subclasses to specify additional
-   * annotation-specific behavior to execute during typechecking.
-   *
-   * <p>In general, subclasses overwriting this method should call
-   * {@code super.typeCheck} so that the annotation's values are also
-   * typechecked. If this is explicitly *not* desired, the {@code super} call
-   * must be omitted.
-   *
    * @param definition The `AnnotationDefinition` corresponding to this `Annotation`.
    * @param typeChecker the active typechecker.
    */
-  void typeCheck(AnnotationDefinition definition, TypeChecker typeChecker) {
-    definition.values.forEach(typeChecker::check);
-  }
+  abstract void typeCheck(AnnotationDefinition definition, TypeChecker typeChecker);
 
   @Override
   public String name() {

--- a/vadl-frontend/main/vadl/ast/Annotation.java
+++ b/vadl-frontend/main/vadl/ast/Annotation.java
@@ -24,7 +24,7 @@ import vadl.utils.SourceLocation;
 import vadl.utils.WithLocation;
 
 /**
- * A Annotation in Vadl keeps state and knows how to resolve and type check itself. Further checks
+ * An Annotation in Vadl keeps state and knows how to resolve and type check itself. Further checks
  * can be defined on the {@link AnnotationGroupProvider} and who also knows how to apply the
  * annotation to the VIAM.
  *
@@ -51,20 +51,40 @@ public abstract class Annotation implements AnnotationDeclaration, WithLocation 
   }
 
   /**
-   * Called by the symbol resolver to resolve parts of the annotation.
+   * Called by the symbol resolver to resolve the subparts of the annotation.
    *
-   * @param definition to be resolved.
-   * @param resolver   who resolves the annotation.
+   * <p>Can be overwritten by subclasses to specify additional
+   * annotation-specific behavior to execute during name-resolution.
+   *
+   * <p>In general, subclasses overwriting this method should call
+   * {@code super.resolveName} so that names in the annotation's values are
+   * resolved. If this is explicitly *not* desired, the {@code super} call must
+   * be omitted.
+   *
+   * @param definition The `AnnotationDefinition` corresponding to this `Annotation`.
+   * @param resolver The active name resolver.
    */
-  abstract void resolveName(AnnotationDefinition definition, SymbolTable.SymbolResolver resolver);
+  void resolveName(AnnotationDefinition definition, SymbolTable.SymbolResolver resolver) {
+    definition.values.forEach(value -> value.accept(resolver));
+  }
 
   /**
    * Called by the type checker to type check the annotation.
    *
-   * @param definition  to be type checked.
-   * @param typeChecker who type checks the annotation.
+   * <p>Can be overwritten by subclasses to specify additional
+   * annotation-specific behavior to execute during typechecking.
+   *
+   * <p>In general, subclasses overwriting this method should call
+   * {@code super.typeCheck} so that the annotation's values are also
+   * typechecked. If this is explicitly *not* desired, the {@code super} call
+   * must be omitted.
+   *
+   * @param definition The `AnnotationDefinition` corresponding to this `Annotation`.
+   * @param typeChecker the active typechecker.
    */
-  abstract void typeCheck(AnnotationDefinition definition, TypeChecker typeChecker);
+  void typeCheck(AnnotationDefinition definition, TypeChecker typeChecker) {
+    definition.values.forEach(typeChecker::check);
+  }
 
   @Override
   public String name() {
@@ -76,7 +96,7 @@ public abstract class Annotation implements AnnotationDeclaration, WithLocation 
     return definition.location();
   }
 
-  protected void verifyValuesCntBetween(AnnotationDefinition definition, int min, int max) {
+  protected static void verifyValuesCntBetween(AnnotationDefinition definition, int min, int max) {
     if (definition.values.size() < min || definition.values.size() > max) {
       throw error("Invalid annotation arguments", definition)
           .locationDescription(definition, "Expected between %d and %d arguments but got %d", min,
@@ -86,7 +106,7 @@ public abstract class Annotation implements AnnotationDeclaration, WithLocation 
     }
   }
 
-  protected void verifyValuesCnt(AnnotationDefinition definition, int cnt) {
+  protected static void verifyValuesCnt(AnnotationDefinition definition, int cnt) {
     if (definition.values.size() != cnt) {
       throw error("Invalid annotation arguments", definition)
           .locationDescription(definition, "Expected %d arguments but got %d", cnt,
@@ -95,7 +115,7 @@ public abstract class Annotation implements AnnotationDeclaration, WithLocation 
     }
   }
 
-  protected void verifyValuesNonEmpty(AnnotationDefinition definition) {
+  protected static void verifyValuesNonEmpty(AnnotationDefinition definition) {
     if (definition.values.isEmpty()) {
       throw error("Invalid annotation arguments", definition)
           .locationDescription(definition, "Expected at leat one argument but got none")

--- a/vadl-frontend/main/vadl/ast/AnnotationTable.java
+++ b/vadl-frontend/main/vadl/ast/AnnotationTable.java
@@ -1354,6 +1354,7 @@ class ConstantAnnotation extends Annotation {
   @Override
   void resolveName(AnnotationDefinition definition, SymbolTable.SymbolResolver resolver) {
     verifyValuesCnt(definition, 1);
+    definition.values.getFirst().accept(resolver);
   }
 
   @Override

--- a/vadl-frontend/main/vadl/ast/AnnotationTable.java
+++ b/vadl-frontend/main/vadl/ast/AnnotationTable.java
@@ -1147,12 +1147,12 @@ class EnableAnnotation extends Annotation {
 
   @Override
   void typeCheck(AnnotationDefinition definition, TypeChecker typeChecker) {
-    definition.values.forEach(typeChecker::check);
 
     // Only eval the argument if there is one
     if (definition.values.size() == 1) {
       var valueExpr = definition.values.getFirst();
 
+      typeChecker.check(valueExpr);
       if (!valueExpr.type().equals(Type.bool())) {
         throw error("Enable annotation expects a boolean argument", valueExpr)
             .locationDescription(valueExpr, "Expected a boolean but got %s", valueExpr.type())
@@ -1362,14 +1362,15 @@ class ConstantAnnotation extends Annotation {
   void resolveName(AnnotationDefinition definition, SymbolTable.SymbolResolver resolver) {
     verifyValuesCnt(definition, 1);
 
-    definition.values.forEach(value -> value.accept(resolver));
+    definition.values.getFirst().accept(resolver);
   }
 
   @Override
   void typeCheck(AnnotationDefinition definition, TypeChecker typeChecker) {
-    definition.values.forEach(typeChecker::check);
+    var valueExpr = definition.values.getFirst();
+    typeChecker.check(valueExpr);
 
-    constant = typeChecker.constantEvaluator.eval(definition.values.getFirst());
+    constant = typeChecker.constantEvaluator.eval(valueExpr);
   }
 
   /**
@@ -1433,16 +1434,18 @@ class StringAnnotation extends Annotation {
           .locationDescription(
               firstValue,
               "Expected a string but got %s",
-              firstValue.nodeName())
-          .build();
+              firstValue.nodeName()
+          ).build();
     }
 
-    definition.values.forEach(value -> value.accept(resolver));
+    // Intentionally skip name resolution of values as they are guaranteed to
+    // be strings at this point, which do not need any resolution.
   }
 
   @Override
   void typeCheck(AnnotationDefinition definition, TypeChecker typeChecker) {
-    definition.values.forEach(typeChecker::check);
+    var valueExpr = definition.values.getFirst();
+    typeChecker.check(valueExpr);
   }
 
   @Override
@@ -1626,14 +1629,15 @@ class OptExprAnnotation extends Annotation {
 
     if (!definition.values.isEmpty()) {
       expr = definition.values.getFirst();
+      expr.accept(resolver);
     }
-
-    definition.values.forEach(value -> value.accept(resolver));
   }
 
   @Override
   void typeCheck(AnnotationDefinition definition, TypeChecker typeChecker) {
-    definition.values.forEach(typeChecker::check);
+    if (expr != null) {
+      expr.accept(typeChecker);
+    }
   }
 
   @Override
@@ -1679,13 +1683,12 @@ class ExprAnnotation extends Annotation {
   void resolveName(AnnotationDefinition definition, SymbolTable.SymbolResolver resolver) {
     verifyValuesCnt(definition, 1);
     expr = definition.values.getFirst();
-
-    definition.values.forEach(value -> value.accept(resolver));
+    expr.accept(resolver);
   }
 
   @Override
   void typeCheck(AnnotationDefinition definition, TypeChecker typeChecker) {
-    definition.values.forEach(typeChecker::check);
+    expr.accept(typeChecker);
   }
 
   @Override

--- a/vadl-frontend/main/vadl/ast/AnnotationTable.java
+++ b/vadl-frontend/main/vadl/ast/AnnotationTable.java
@@ -1111,6 +1111,11 @@ interface AnnotationDeclaration {
 
 }
 
+/**
+ * Marker interface for all annotations that set the {@link FloatTypeDefinition#encoding} field.
+ */
+interface FloatEncodingAnnotation {}
+
 
 // ---------- GENERAL ANNOTATION CLASSES ----------
 
@@ -1137,12 +1142,12 @@ class EnableAnnotation extends Annotation {
   void resolveName(AnnotationDefinition definition, SymbolTable.SymbolResolver resolver) {
     verifyValuesCntBetween(definition, 0, 1);
 
-    super.resolveName(definition, resolver);
+    definition.values.forEach(value -> value.accept(resolver));
   }
 
   @Override
   void typeCheck(AnnotationDefinition definition, TypeChecker typeChecker) {
-    super.typeCheck(definition, typeChecker);
+    definition.values.forEach(typeChecker::check);
 
     // Only eval the argument if there is one
     if (definition.values.size() == 1) {
@@ -1331,17 +1336,10 @@ abstract class FormatFieldAnnotation extends Annotation {
 }
 
 /**
- * Marker interface for all annotations that set the {@link FloatTypeDefinition#encoding} field.
- */
-interface FloatEncodingAnnotation {
-}
-
-/**
  * An annotation which makes a {@link FloatTypeDefinition} use IEEE-754 encoding with a given
  * size (32 or 64 bit).
  */
-class IEEEFloatFormatAnnotation extends ConstantAnnotation implements FloatEncodingAnnotation {
-}
+class IEEEFloatFormatAnnotation extends ConstantAnnotation implements FloatEncodingAnnotation {}
 
 /**
  * A simple annotation that stores and evaluates a constant argument.
@@ -1364,12 +1362,12 @@ class ConstantAnnotation extends Annotation {
   void resolveName(AnnotationDefinition definition, SymbolTable.SymbolResolver resolver) {
     verifyValuesCnt(definition, 1);
 
-    super.resolveName(definition, resolver);
+    definition.values.forEach(value -> value.accept(resolver));
   }
 
   @Override
   void typeCheck(AnnotationDefinition definition, TypeChecker typeChecker) {
-    super.typeCheck(definition, typeChecker);
+    definition.values.forEach(typeChecker::check);
 
     constant = typeChecker.constantEvaluator.eval(definition.values.getFirst());
   }
@@ -1439,7 +1437,12 @@ class StringAnnotation extends Annotation {
           .build();
     }
 
-    super.resolveName(definition, resolver);
+    definition.values.forEach(value -> value.accept(resolver));
+  }
+
+  @Override
+  void typeCheck(AnnotationDefinition definition, TypeChecker typeChecker) {
+    definition.values.forEach(typeChecker::check);
   }
 
   @Override
@@ -1590,7 +1593,7 @@ class IdentifersAnnotation extends Annotation {
   void typeCheck(AnnotationDefinition definition, TypeChecker typeChecker) {
     // Only typecheck expressions
     if (targetClass != null && Expr.class.isAssignableFrom(targetClass)) {
-      super.typeCheck(definition, typeChecker);
+      definition.values.forEach(typeChecker::check);
     }
   }
 
@@ -1625,7 +1628,12 @@ class OptExprAnnotation extends Annotation {
       expr = definition.values.getFirst();
     }
 
-    super.resolveName(definition, resolver);
+    definition.values.forEach(value -> value.accept(resolver));
+  }
+
+  @Override
+  void typeCheck(AnnotationDefinition definition, TypeChecker typeChecker) {
+    definition.values.forEach(typeChecker::check);
   }
 
   @Override
@@ -1672,7 +1680,12 @@ class ExprAnnotation extends Annotation {
     verifyValuesCnt(definition, 1);
     expr = definition.values.getFirst();
 
-    super.resolveName(definition, resolver);
+    definition.values.forEach(value -> value.accept(resolver));
+  }
+
+  @Override
+  void typeCheck(AnnotationDefinition definition, TypeChecker typeChecker) {
+    definition.values.forEach(typeChecker::check);
   }
 
   @Override

--- a/vadl-frontend/main/vadl/ast/AnnotationTable.java
+++ b/vadl-frontend/main/vadl/ast/AnnotationTable.java
@@ -1136,16 +1136,18 @@ class EnableAnnotation extends Annotation {
   @Override
   void resolveName(AnnotationDefinition definition, SymbolTable.SymbolResolver resolver) {
     verifyValuesCntBetween(definition, 0, 1);
+
+    super.resolveName(definition, resolver);
   }
 
   @Override
   void typeCheck(AnnotationDefinition definition, TypeChecker typeChecker) {
+    super.typeCheck(definition, typeChecker);
 
     // Only eval the argument if there is one
     if (definition.values.size() == 1) {
       var valueExpr = definition.values.getFirst();
 
-      typeChecker.check(valueExpr);
       if (!valueExpr.type().equals(Type.bool())) {
         throw error("Enable annotation expects a boolean argument", valueExpr)
             .locationDescription(valueExpr, "Expected a boolean but got %s", valueExpr.type())
@@ -1184,13 +1186,16 @@ class FloatFlagAnnotation extends FormatFieldAnnotation {
   @Override
   void typeCheck(AnnotationDefinition definition, TypeChecker typeChecker) {
     super.typeCheck(definition, typeChecker);
+
     verifyValuesCnt(definition, 1);
+
     field = (Identifier) definition.values.getFirst();
   }
 
   @Override
   void typeCheckTarget(TypedNode target) {
     super.typeCheckTarget(target);
+
     var format = ((FormatType) target.type()).format;
     var range = requireNonNull(format.getFieldRange(field.name));
     Diagnostic.ensure(range.from() == range.to(), () ->
@@ -1276,17 +1281,21 @@ abstract class FormatFieldAnnotation extends Annotation {
 
   @Override
   void resolveName(AnnotationDefinition definition, SymbolTable.SymbolResolver resolver) {
+    // Intentionally skip name resolution for values, since they are relative
+    // to the annotated value, and thus not available here.
   }
 
   @Override
   void typeCheck(AnnotationDefinition definition, TypeChecker typeChecker) {
-    definition.values.forEach(def -> {
+    // Intentionally skip typechecking as well.
+
+    fields = definition.values.stream().map(def -> {
       Diagnostic.ensure(def instanceof Identifier, () -> error("Invalid annotation value", def)
           .description("An identifier was expected.")
       );
-    });
 
-    fields = definition.values.stream().map(def -> (Identifier) def).toList();
+      return (Identifier) def;
+    }).toList();
   }
 
   void typeCheckTarget(TypedNode target) {
@@ -1354,15 +1363,15 @@ class ConstantAnnotation extends Annotation {
   @Override
   void resolveName(AnnotationDefinition definition, SymbolTable.SymbolResolver resolver) {
     verifyValuesCnt(definition, 1);
-    definition.values.getFirst().accept(resolver);
+
+    super.resolveName(definition, resolver);
   }
 
   @Override
   void typeCheck(AnnotationDefinition definition, TypeChecker typeChecker) {
-    var valueExpr = definition.values.getFirst();
-    typeChecker.check(valueExpr);
+    super.typeCheck(definition, typeChecker);
 
-    constant = typeChecker.constantEvaluator.eval(valueExpr);
+    constant = typeChecker.constantEvaluator.eval(definition.values.getFirst());
   }
 
   /**
@@ -1418,20 +1427,19 @@ class StringAnnotation extends Annotation {
   @Override
   void resolveName(AnnotationDefinition definition, SymbolTable.SymbolResolver resolver) {
     verifyValuesCnt(definition, 1);
+
     var firstValue = definition.values.getFirst();
 
     if (!(firstValue instanceof StringLiteral)) {
       throw error("Invalid Annotation Argument", firstValue)
-          .locationDescription(firstValue, "Expected a string but got %s",
+          .locationDescription(
+              firstValue,
+              "Expected a string but got %s",
               firstValue.nodeName())
           .build();
     }
-  }
 
-  @Override
-  void typeCheck(AnnotationDefinition definition, TypeChecker typeChecker) {
-    var valueExpr = definition.values.getFirst();
-    typeChecker.check(valueExpr);
+    super.resolveName(definition, resolver);
   }
 
   @Override
@@ -1483,13 +1491,13 @@ class EnumAnnotation extends Annotation {
           .build();
     }
 
-    // Do not symbol resolve on purpose as the identifiers here aren't pointing to anything in the
-    // AST.
+    // Skip resolving the annotation's values as the identifiers aren't
+    // pointing to anything in the AST.
   }
 
   @Override
   void typeCheck(AnnotationDefinition definition, TypeChecker typeChecker) {
-    // Do nothing on purpose as the identifiers don't need to be checked.
+    // Do nothing on purpose as the identifiers cannot be checked.
   }
 
   @Override
@@ -1564,6 +1572,7 @@ class IdentifersAnnotation extends Annotation {
                 value.nodeName())
             .build();
       }
+
       identifiers.add(identifier);
 
       if (targetClass != null) {
@@ -1572,13 +1581,16 @@ class IdentifersAnnotation extends Annotation {
         definition.symbolTable().requireAs(identifier, Node.class);
       }
     }
+
+    // Skip `super` call since the above loop already effectively performed
+    // name resolution via the `requireAs` calls.
   }
 
   @Override
   void typeCheck(AnnotationDefinition definition, TypeChecker typeChecker) {
     // Only typecheck expressions
     if (targetClass != null && Expr.class.isAssignableFrom(targetClass)) {
-      identifiers.forEach(typeChecker::check);
+      super.typeCheck(definition, typeChecker);
     }
   }
 
@@ -1608,17 +1620,12 @@ class OptExprAnnotation extends Annotation {
   @Override
   void resolveName(AnnotationDefinition definition, SymbolTable.SymbolResolver resolver) {
     verifyValuesCntBetween(definition, 0, 1);
+
     if (!definition.values.isEmpty()) {
       expr = definition.values.getFirst();
-      expr.accept(resolver);
     }
-  }
 
-  @Override
-  void typeCheck(AnnotationDefinition definition, TypeChecker typeChecker) {
-    if (expr != null) {
-      expr.accept(typeChecker);
-    }
+    super.resolveName(definition, resolver);
   }
 
   @Override
@@ -1664,12 +1671,8 @@ class ExprAnnotation extends Annotation {
   void resolveName(AnnotationDefinition definition, SymbolTable.SymbolResolver resolver) {
     verifyValuesCnt(definition, 1);
     expr = definition.values.getFirst();
-    expr.accept(resolver);
-  }
 
-  @Override
-  void typeCheck(AnnotationDefinition definition, TypeChecker typeChecker) {
-    expr.accept(typeChecker);
+    super.resolveName(definition, resolver);
   }
 
   @Override
@@ -1710,6 +1713,7 @@ class ZeroConstraintAnnotation extends ExprAnnotation {
   @Override
   void typeCheck(AnnotationDefinition definition, TypeChecker typeChecker) {
     super.typeCheck(definition, typeChecker);
+
     var def = definition.target;
 
     if (!(expr instanceof CallIndexExpr callExpr)) {
@@ -1748,7 +1752,6 @@ class ZeroConstraintAnnotation extends ExprAnnotation {
             .build();
       }
     }).toList();
-
   }
 
   @Override
@@ -1762,8 +1765,10 @@ class EncodingConstraintAnnotation extends ExprAnnotation {
   @Override
   void resolveName(AnnotationDefinition definition, SymbolTable.SymbolResolver resolver) {
     var format = requireNonNull(((EncodingDefinition) definition.target).formatNode);
+
     // Extend annotation's symbol table by the symbol table of the encoding's format.
     definition.symbolTable().extendBy(format.symbolTable());
+
     super.resolveName(definition, resolver);
   }
 }
@@ -1773,8 +1778,10 @@ class InstructionUndefinedAnnotation extends ExprAnnotation {
   @Override
   void resolveName(AnnotationDefinition definition, SymbolTable.SymbolResolver resolver) {
     var format = requireNonNull(((InstructionDefinition) definition.target).formatNode);
+
     // Extend annotation's symbol table by the symbol table of the encoding's format.
     definition.symbolTable().extendBy(format.symbolTable());
+
     super.resolveName(definition, resolver);
   }
 }

--- a/vadl-frontend/test/resources/frontend-snapshots/annotation/constantAnnotationValueNameResolution.vadl
+++ b/vadl-frontend/test/resources/frontend-snapshots/annotation/constantAnnotationValueNameResolution.vadl
@@ -1,0 +1,14 @@
+instruction set architecture ISA = {
+  constant N = 8
+
+  [alignment : N]
+  register X : Bits<32>
+}
+
+
+//  Reported Diagnostics:
+//
+//  No diagnostics were reported, the input was correctly parsed, typechecked and lowered.
+//
+//
+// Part of the class vadl.ast.FrontendSnapshotTests


### PR DESCRIPTION
Super-simple fix for the lack of name resolution in the values of annotations of type `ConstantAnnotation`.