### PR TITLE
iss: Enable AArch32 embench

### DIFF
--- a/vadl/main/vadl/iss/passes/common/IssSideEffectReorderingPass.java
+++ b/vadl/main/vadl/iss/passes/common/IssSideEffectReorderingPass.java
@@ -1,0 +1,305 @@
+// SPDX-FileCopyrightText : © 2026 TU Wien <vadl@tuwien.ac.at>
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package vadl.iss.passes.common;
+
+import static java.util.Objects.requireNonNull;
+import static vadl.utils.GraphUtils.getSingleNode;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import vadl.configuration.GeneralConfiguration;
+import vadl.pass.Pass;
+import vadl.pass.PassName;
+import vadl.pass.PassResults;
+import vadl.types.BuiltInTable;
+import vadl.utils.GraphUtils;
+import vadl.utils.ViamUtils;
+import vadl.viam.DefProp;
+import vadl.viam.Instruction;
+import vadl.viam.Procedure;
+import vadl.viam.Specification;
+import vadl.viam.Stage;
+import vadl.viam.graph.Graph;
+import vadl.viam.graph.control.AbstractBeginNode;
+import vadl.viam.graph.control.AbstractEndNode;
+import vadl.viam.graph.control.ControlNode;
+import vadl.viam.graph.control.DirectionalNode;
+import vadl.viam.graph.control.ForallNode;
+import vadl.viam.graph.control.IfNode;
+import vadl.viam.graph.control.InstrEndNode;
+import vadl.viam.graph.control.MergeNode;
+import vadl.viam.graph.control.ProcEndNode;
+import vadl.viam.graph.control.StageEndNode;
+import vadl.viam.graph.control.StartNode;
+import vadl.viam.graph.dependency.BuiltInCall;
+import vadl.viam.graph.dependency.ExpressionNode;
+import vadl.viam.graph.dependency.ProcCallNode;
+import vadl.viam.graph.dependency.ReadResourceNode;
+import vadl.viam.graph.dependency.SideEffectNode;
+import vadl.viam.graph.dependency.WriteRegTensorNode;
+import vadl.viam.passes.sideeffect_condition.SideEffectConditionResolver;
+
+/**
+ * Moves all side effects which cause an instruction exit to the end of the instruction, while
+ * preserving the condition under which the moved side effects are executed. It only executes
+ * on instruction and procedure behaviors.
+ *
+ * <p>The pass first traverses the graph and saves the conditions of the side effects. This is
+ * done in a similar way as {@link SideEffectConditionResolver} does it. The conditions are not
+ * combined using dis- and conjunctions however, but kept separate. This way, the original
+ * control flow structure can be reconstructed exactly.
+ *
+ * <p>The pass then inserts nested if-blocks just before the end of the graph. Disjunct conditions
+ * are translated to disjunct if-blocks. Conjunct conditions are grouped two groups: Static and
+ * dynamic. Inside the groups, the conditions are then conjoined and then used to emit at most
+ * two nested if-blocks (one static and one dynamic). Conjoining all conditions could hide static
+ * conditions, which would then be emitted as dynamic (TCG instructions).
+ *
+ * <p>TODO: In the future this pass should also move non-memory side effects behind memory
+ *     side effects, see Issue #1082.
+ *
+ * <p>TODO: Grouping conjunct conditions into static and dynamic preserves much optimization
+ *     potential. A thorough condition analysis pass could expose more potential by extracting
+ *     static parts out of otherwise dynamic conditions.
+ */
+public class IssSideEffectReorderingPass extends Pass {
+
+  public IssSideEffectReorderingPass(GeneralConfiguration configuration) {
+    super(configuration);
+  }
+
+  @Override
+  public PassName getName() {
+    return new PassName("Instruction Exit Scheduling Pass");
+  }
+
+  @Nullable
+  @Override
+  public Object execute(PassResults passResults, Specification viam) throws IOException {
+    var defs = ViamUtils.findDefinitionsByFilter(viam, def ->
+        def instanceof Instruction || def instanceof Procedure);
+    for (var def : defs) {
+      ((DefProp.WithBehavior) def).behaviors().forEach(this::moveInstrExitSideEffectsToInstrEnd);
+    }
+    return null;
+  }
+
+  /**
+   * Moves all side effects causing an instruction exit to the end of the instruction graph.
+   * Unconditional side effects are simply added to the instruction end node. Conditional
+   * side effect nodes are put in if-blocks.
+   *
+   * @param behaviour The graph to process.
+   */
+  private void moveInstrExitSideEffectsToInstrEnd(Graph behaviour) {
+    var sideEffectConditions = SideEffectConditionCollector.collectConditions(behaviour);
+    var instrEndNodeClass = switch (behaviour.parentDefinition()) {
+      case Instruction i -> InstrEndNode.class;
+      case Procedure p -> ProcEndNode.class;
+      case Stage s -> StageEndNode.class;
+      default -> throw new IllegalStateException("Unexpected graph parent");
+    };
+    var instrEnd = GraphUtils.getSingleNode(behaviour, instrEndNodeClass);
+    var instrExitSideEffects = behaviour.getNodes(SideEffectNode.class).filter(
+        s -> (s instanceof WriteRegTensorNode write && write.isPcAccess())
+            || (s instanceof ProcCallNode procCall && procCall.exceptionRaise())
+    ).toList();
+
+    for (var instrExit : instrExitSideEffects) {
+      // this is a list of all places the side effect is scheduled. for each place, it contains
+      // a list of all the conditions of the if-clauses containing the side effect
+      var conditions = requireNonNull(sideEffectConditions.get(instrExit));
+      instrExit.usages().filter(AbstractEndNode.class::isInstance).toList()
+          .forEach(user -> ((AbstractEndNode) user).removeSideEffect(instrExit));
+      // go through all scheduled instances of the side effect
+      for (var instanceCondition : conditions) {
+        if (instanceCondition.isEmpty()) {
+          instrEnd.addSideEffect(instrExit);
+        } else {
+          // For each, create nested if-blocks, with the conditions of the original if-blocks.
+          // We could use a conjunction of all the conditions, but that makes the simulation slower:
+          // Say we have a static and dynamic condition, then the conjunction is dynamic, and
+          // optimization potential is lost.
+          // TODO: In the future, we should make the branch lowering more intelligent: It should
+          //  be able to take apart conditions into their static and dynamic parts, which would
+          //  allow the translation function to evaluate parts of the condition at translation time.
+          var pred = requireNonNull(instrEnd.predecessor());
+          pred.unlinkNext();
+          var collapsedInstanceCondition = collapseConditions(instanceCondition);
+          pred.setNext(addInNestedIf(collapsedInstanceCondition, instrEnd, behaviour, instrExit));
+        }
+      }
+    }
+  }
+
+  /**
+   * Groups the conditions into static and dynamic. Creates a conjunction out of each group.
+   * Returns the conjunctions in a list. May return list of size 2, 1 or empty.
+   */
+  private static List<ExpressionNode> collapseConditions(List<ExpressionNode> conditions) {
+    return conditions.stream().collect(Collectors.partitioningBy(
+        c -> GraphUtils.hasDependencies(c, dep -> dep instanceof ReadResourceNode)
+    )).values().stream().flatMap(
+        c -> c.stream().reduce((a, b) -> BuiltInCall.of(BuiltInTable.AND, a, b)).stream()
+    ).toList();
+  }
+
+  /**
+   * Puts the given side effect into nested if-blocks. For each given condition in the list,
+   * an if-block is created.
+   */
+  private static ControlNode addInNestedIf(List<ExpressionNode> conditions, ControlNode next,
+                                           Graph graph, SideEffectNode se) {
+    if (conditions.isEmpty()) {
+      throw new IllegalStateException("Expected non-empty list of conditions");
+    }
+    if (conditions.size() == 1) {
+      return GraphUtils.ifElseSideEffect(
+          graph,
+          conditions.getFirst(),
+          List.of(se),
+          List.of(),
+          next,
+          se.location()
+      );
+    }
+    var pair = GraphUtils.insertIfElse(
+        graph,
+        conditions.getFirst(),
+        (g, end) -> addInNestedIf(
+            conditions.subList(1, conditions.size()),
+            end, graph, se
+        ),
+        (g, end) -> end,
+        se.location()
+    );
+    pair.right().setNext(next);
+    return pair.left();
+  }
+}
+
+class SideEffectConditionCollector {
+
+  private final HashMap<SideEffectNode, List<List<ExpressionNode>>> conditions = new HashMap<>();
+
+  /**
+   * Collect all side effect conditions. Each side effect gets a list of all instances, in
+   * which the side effect node is scheduled. Each instance is a list of all the conditions
+   * which must be met, such that that instance is reached.
+   *
+   * <p>For example:
+   * <pre>{@code
+   * if (a) { if (b) {} else { se_0 } }
+   * if (c) { se_0 }
+   * }</pre>
+   * yields:
+   * <pre>{@code
+   * { se_0: [ [a, -b], [c] ] }
+   * }</pre>
+   */
+  public static Map<SideEffectNode, List<List<ExpressionNode>>> collectConditions(
+      Graph behavior) {
+    var collector = new SideEffectConditionCollector();
+    collector.collect(behavior);
+    return collector.conditions;
+  }
+
+  private void collect(Graph behavior) {
+    var start = getSingleNode(behavior, StartNode.class);
+    resolveBranch(start, new ArrayList<>());
+  }
+
+  /**
+   * Recursively traverses the CFG. Jumps over regular directional nodes. When an if-block
+   * is encountered, its condition is added to branchCondition while traversing the true-branch
+   * and removed afterward. The same is done for the negation of the condition for the false-branch.
+   */
+  private @Nullable MergeNode resolveBranch(AbstractBeginNode beginNode,
+                                            List<ExpressionNode> branchCondition) {
+    // the current control node
+    ControlNode current = beginNode;
+
+    // loop is only terminated by return of AbstractEndNode
+    while (true) {
+
+      switch (current) {
+        case AbstractEndNode endNode -> {
+          return handleEndNode(endNode, branchCondition);
+        }
+        case IfNode ifNode -> current = handleIf(ifNode, branchCondition);
+        // forall as no special handling required, as it doesn't influence the condition
+        case ForallNode forallNode -> current = forallNode.beginNode();
+        // handle normal singled directed node by just skipping it and continue
+        case DirectionalNode directionalNode -> current = directionalNode.next();
+        // there should not be an other control node that was not handled yet
+        default -> //noinspection DataFlowIssue
+            current.ensure(false,
+                "Not an expected node in the SideEffectConditionCollector. "
+                    + "You want to implement it.");
+      }
+    }
+  }
+
+  @Nullable
+  private MergeNode handleEndNode(AbstractEndNode endNode, List<ExpressionNode> branchCondition) {
+    // handle the end of the current branch
+    var graph = endNode.graph();
+    endNode.ensure(graph != null,
+        "Node is not active, but control flow must be stable for SideEffectConditionResolver");
+
+    // add the condition to all side effects
+    for (var sideEffect : endNode.sideEffects()) {
+      conditions.computeIfAbsent(sideEffect, s -> new ArrayList<>())
+          .add(List.copyOf(branchCondition));
+    }
+
+    // find and return the merge node if available
+    // (only in case of an InstrEndNode the MergeNode is not available)
+    return endNode.usages()
+        .filter(user -> user instanceof MergeNode)
+        .map(MergeNode.class::cast)
+        .findAny()
+        .orElse(null);
+  }
+
+  @SuppressWarnings("checkstyle:VariableDeclarationUsageDistance")
+  private MergeNode handleIf(IfNode ifNode, List<ExpressionNode> branchCondition) {
+
+    branchCondition.addLast(ifNode.condition());
+    var trueMergeNode = resolveBranch(ifNode.trueBranch(), branchCondition);
+    branchCondition.removeLast();
+
+    branchCondition.addLast(BuiltInCall.of(BuiltInTable.NOT, ifNode.condition()));
+    var falseMergeNode = resolveBranch(ifNode.falseBranch(), branchCondition);
+    branchCondition.removeLast();
+
+    // MergeNode must be the same for all branches and not null
+    ifNode.ensure(trueMergeNode == falseMergeNode,
+        "Branches of node don't result in the same merge node");
+    ifNode.ensure(trueMergeNode != null,
+        "Couldn't find merge node for true branch");
+
+    // continue with the found mergeNode
+    return trueMergeNode;
+  }
+
+}

--- a/vadl/main/vadl/iss/passes/tcg/IssSelectLoweringPass.java
+++ b/vadl/main/vadl/iss/passes/tcg/IssSelectLoweringPass.java
@@ -125,7 +125,7 @@ class IssSelectLowerer extends GraphProcessor<Void> {
     // determine the result TCG variable in the assignments.
     var selectResultTcgVar = assignments.singleDestOf(resultExprNode);
 
-    var ifElse = GraphUtils.insertIfElse(insertionPoint, select.condition(),
+    var ifElse = GraphUtils.insertIfElse(insertionPoint.ensureGraph(), select.condition(),
         (graph, end) -> graph.addWithInputs(
             new ScheduledNode(
                 // emit IssMoveNode that moves the true expression into the result variable
@@ -139,7 +139,7 @@ class IssSelectLowerer extends GraphProcessor<Void> {
                 new IssMoveNode(selectResultTcgVar, select.falseCase()),
                 end
             )
-        ));
+        ), select.location());
 
 
     // set the insertion node's next to the ifNode

--- a/vadl/main/vadl/iss/passes/tcg/lowering/TcgBranchLoweringPass.java
+++ b/vadl/main/vadl/iss/passes/tcg/lowering/TcgBranchLoweringPass.java
@@ -136,6 +136,8 @@ class TcgBranchLoweringExecutor implements CfgTraverser {
 
     var ifNode = (IfNode) splitNode;
 
+    // FIXME: if parts of the condition are tcg and others are not, we could separate them
+    //  and move some decision-making to translation time
     if (!isCondTcg(ifNode.condition())) {
       // if the condition is immediate, we emit C-If construct
       // and no TCG operations

--- a/vadl/main/vadl/iss/passes/tcg/lowering/TcgOpLoweringPass.java
+++ b/vadl/main/vadl/iss/passes/tcg/lowering/TcgOpLoweringPass.java
@@ -867,7 +867,7 @@ class TcgOpLoweringExecutor implements CfgTraverser {
     // TODO: Calling a helper function for performing complex slice
     //  operations might be more efficient.
     // constructed result
-    var res = tmp(0);
+    var res = constant(intU(0, toHandle.type().bitWidth()));
     // holds value that is deposit next
     var bit = tmp(1);
     var destOffset = 0;

--- a/vadl/main/vadl/pass/order/IssPassOrder.java
+++ b/vadl/main/vadl/pass/order/IssPassOrder.java
@@ -40,6 +40,7 @@ import vadl.iss.passes.common.IssNormalizationPass;
 import vadl.iss.passes.common.IssRegisterAccessInfoRetrievalPass;
 import vadl.iss.passes.common.IssRegisterAccessLoweringPass;
 import vadl.iss.passes.common.IssScheduleIndirectJumpsPass;
+import vadl.iss.passes.common.IssSideEffectReorderingPass;
 import vadl.iss.passes.common.IssTensorAssignmentToForallPass;
 import vadl.iss.passes.common.opDecomposition.IssOpDecompositionPass;
 import vadl.iss.passes.common.planning.IssExecStrategyPass;
@@ -125,6 +126,7 @@ public final class IssPassOrder {
     order.add(new IssInfoRetrievalPass(config))
         .add(new IssConfigurationPass(config))
         .add(new IssApplyMemoryEndiannessPass(config))
+        .add(new IssSideEffectReorderingPass(config))
         .add(new IssMemoryDetectionPass(config))
         .add(new IssRegisterAccessLoweringPass(config))
         .add(new IssBitfieldWriteLoweringPass(config))

--- a/vadl/main/vadl/utils/GraphUtils.java
+++ b/vadl/main/vadl/utils/GraphUtils.java
@@ -365,10 +365,9 @@ public class GraphUtils {
   }
 
   /**
-   * Inserts an if-else region into the graph at the specified position.
+   * Inserts an if-else region into the graph.
    *
-   * @param position          The node at which the if-else structure is inserted.
-   *                          Must be part of a valid graph.
+   * @param graph             The graph into which the if-else structure is inserted.
    * @param condition         The condition node that determines the branching
    *                          of the if-else structure.
    * @param createTrueBranch  A function that defines the true branch of the if-else structure,
@@ -382,18 +381,25 @@ public class GraphUtils {
    */
 
   public static Pair<IfNode, MergeNode> insertIfElse(
-      DirectionalNode position,
+      Graph graph,
       ExpressionNode condition,
       BiFunction<Graph, BranchEndNode, ControlNode> createTrueBranch,
-      BiFunction<Graph, BranchEndNode, ControlNode> createFalseBranch) {
-    var graph = position.ensureGraph();
+      BiFunction<Graph, BranchEndNode, ControlNode> createFalseBranch,
+      SourceLocation location) {
     var trueEnd = graph.addWithInputs(new BranchEndNode(new NodeList<>()));
+    trueEnd.setSourceLocationRecursively(location);
     var falseEnd = graph.addWithInputs(new BranchEndNode(new NodeList<>()));
+    falseEnd.setSourceLocationRecursively(location);
     var trueBranch = createTrueBranch.apply(graph, trueEnd);
+    trueBranch.setSourceLocationRecursively(location);
     var falseBranch = createFalseBranch.apply(graph, falseEnd);
+    falseBranch.setSourceLocationRecursively(location);
     var trueBegin = graph.addWithInputs(new BranchBeginNode(trueBranch));
+    trueBegin.setSourceLocationRecursively(location);
     var falseBegin = graph.addWithInputs(new BranchBeginNode(falseBranch));
+    falseBegin.setSourceLocationRecursively(location);
     var ifNode = graph.addWithInputs(new IfNode(condition, trueBegin, falseBegin));
+    ifNode.setSourceLocationRecursively(location);
 
     var mergeNode = graph.addWithInputs(new MergeNode(new NodeList<>(trueEnd, falseEnd)));
     return Pair.of(ifNode, mergeNode);

--- a/vadl/main/vadl/viam/graph/control/MergeNode.java
+++ b/vadl/main/vadl/viam/graph/control/MergeNode.java
@@ -69,7 +69,13 @@ public class MergeNode extends AbstractBeginNode {
     ControlNode curr = trueBranchEnd();
     while (!(curr instanceof ControlSplitNode controlSplitNode)) {
       ensure(curr != null, "Reached node with no predecessor, which should be impossible.");
-      curr = GraphUtils.predecessorSkippingMerges(curr);
+      if (curr instanceof MergeNode merge) {
+        // skip merge nodes by jumping straight to the node before the control split start
+        curr = merge.controlSplit().predecessor();
+      } else {
+        var pred = curr.predecessor();
+        curr = pred instanceof ControlNode cn ? cn : null;
+      }
     }
     return controlSplitNode;
   }

--- a/vadl/main/vadl/viam/graph/dependency/WriteRegTensorNode.java
+++ b/vadl/main/vadl/viam/graph/dependency/WriteRegTensorNode.java
@@ -124,13 +124,17 @@ public class WriteRegTensorNode extends WriteResourceNode implements WritesRegis
 
   @Override
   public WriteRegTensorNode copy() {
-    return new WriteRegTensorNode(regTensor, indices.copy(), value.copy(), staticCounterAccess(),
-        condition != null ? condition.copy() : null);
+    var copy = new WriteRegTensorNode(regTensor, indices.copy(), value.copy(),
+        staticCounterAccess(), condition != null ? condition.copy() : null);
+    copy.setSourceLocation(location());
+    return copy;
   }
 
   @Override
   public WriteRegTensorNode shallowCopy() {
-    return new WriteRegTensorNode(regTensor, indices, value, staticCounterAccess(), condition);
+    var copy = new WriteRegTensorNode(regTensor, indices, value, staticCounterAccess(), condition);
+    copy.setSourceLocation(location());
+    return copy;
   }
 
   @Override

--- a/vadl/main/vadl/viam/passes/sideEffectScheduling/SideEffectSchedulingPass.java
+++ b/vadl/main/vadl/viam/passes/sideEffectScheduling/SideEffectSchedulingPass.java
@@ -16,6 +16,7 @@
 
 package vadl.viam.passes.sideEffectScheduling;
 
+import static java.util.Objects.requireNonNull;
 import static vadl.utils.GraphUtils.getSingleNode;
 
 import com.google.common.collect.Lists;
@@ -27,8 +28,8 @@ import vadl.configuration.GeneralConfiguration;
 import vadl.pass.Pass;
 import vadl.pass.PassName;
 import vadl.pass.PassResults;
+import vadl.utils.GraphUtils;
 import vadl.utils.ViamUtils;
-import vadl.viam.Counter;
 import vadl.viam.DefProp;
 import vadl.viam.Instruction;
 import vadl.viam.Procedure;
@@ -39,13 +40,16 @@ import vadl.viam.graph.control.AbstractEndNode;
 import vadl.viam.graph.control.ControlNode;
 import vadl.viam.graph.control.ControlSplitNode;
 import vadl.viam.graph.control.DirectionalNode;
+import vadl.viam.graph.control.InstrEndNode;
 import vadl.viam.graph.control.MergeNode;
 import vadl.viam.graph.control.ScheduledNode;
 import vadl.viam.graph.control.StartNode;
 import vadl.viam.graph.dependency.ProcCallNode;
+import vadl.viam.graph.dependency.SideEffectNode;
 import vadl.viam.graph.dependency.WriteRegTensorNode;
 import vadl.viam.graph.dependency.WriteResourceNode;
 import vadl.viam.passes.sideEffectScheduling.nodes.InstrExitNode;
+import vadl.viam.passes.sideeffect_condition.SideEffectConditionResolver;
 
 /**
  * A pass that schedules side effects within the control flow graph (CFG) of instructions.
@@ -129,6 +133,14 @@ class SideEffectScheduler {
    * @param behavior The behavior to process.
    */
   public static void run(Graph behavior) {
+    if (behavior.parentDefinition() instanceof Instruction) {
+      // re-evaluate side effect conditions (have been removed by IssConfigurationPass)
+      SideEffectConditionResolver.run(behavior);
+      moveInstrExitSideEffectsToInstrEnd(behavior);
+      // delete side effect conditions, as they are not needed and break later passes
+      behavior.getNodes(SideEffectNode.class).forEach(n -> n.setCondition(null));
+      behavior.deleteUnusedDependencies();
+    }
     var startNode = getSingleNode(behavior, StartNode.class);
     var scheduler = new SideEffectScheduler();
     scheduler.processBranch(startNode);
@@ -155,16 +167,15 @@ class SideEffectScheduler {
         ));
 
     var nonPcUpdateEffects = partitionedEffects.getOrDefault(false, List.of());
-    var instrExitSideEffects = partitionedEffects.getOrDefault(true, List.of())
-        .stream().findFirst();
+    var instrExitSideEffects = partitionedEffects.getOrDefault(true, List.of());
 
     // All non-PC updates should be inserted directly at the beginning of the branch
     for (var effect : Lists.reverse(nonPcUpdateEffects)) {
       beginNode.addAfter(new ScheduledNode(effect));
     }
 
-    // Add PC update directly in front of branch end
-    instrExitSideEffects.ifPresent(exitCause -> {
+    // Add PC updates directly in front of branch end
+    instrExitSideEffects.forEach(exitCause -> {
           if (exitCause instanceof ProcCallNode procCall) {
             endNode.addBefore(new InstrExitNode.Raise(procCall));
           } else if (exitCause instanceof WriteResourceNode write) {
@@ -177,6 +188,42 @@ class SideEffectScheduler {
     );
 
     return endNode;
+  }
+
+  /**
+   * Moves all side effects causing an instruction exit to the end of the instruction graph.
+   * Unconditional side effects are simply added to the instruction end node. Conditional
+   * side effect nodes are put in an if-block.
+   *
+   * @param behaviour The graph to process.
+   */
+  private static void moveInstrExitSideEffectsToInstrEnd(Graph behaviour) {
+    var instrEnd = GraphUtils.getSingleNode(behaviour, InstrEndNode.class);
+    var instrExitSideEffects = behaviour.getNodes(SideEffectNode.class).filter(
+        s -> (s instanceof WriteRegTensorNode write && write.isPcAccess())
+            || (s instanceof ProcCallNode procCall && procCall.exceptionRaise())
+    ).toList();
+
+    for (var instrExit : instrExitSideEffects) {
+      var cond = instrExit.condition();
+      // the side effect may be scheduled multiple times, but the condition covers everything
+      instrExit.usages().filter(AbstractEndNode.class::isInstance).toList()
+          .forEach(user -> ((AbstractEndNode) user).removeSideEffect(instrExit));
+      if (cond == null) {
+        instrEnd.addSideEffect(instrExit);
+      } else {
+        var pred = requireNonNull(instrEnd.predecessor());
+        pred.unlinkNext();
+        pred.setNext(GraphUtils.ifElseSideEffect(
+            behaviour,
+            cond,
+            List.of(instrExit),
+            List.of(),
+            instrEnd,
+            instrExit.location()
+        ));
+      }
+    }
   }
 
   /**

--- a/vadl/main/vadl/viam/passes/sideEffectScheduling/SideEffectSchedulingPass.java
+++ b/vadl/main/vadl/viam/passes/sideEffectScheduling/SideEffectSchedulingPass.java
@@ -16,7 +16,6 @@
 
 package vadl.viam.passes.sideEffectScheduling;
 
-import static java.util.Objects.requireNonNull;
 import static vadl.utils.GraphUtils.getSingleNode;
 
 import com.google.common.collect.Lists;
@@ -28,7 +27,6 @@ import vadl.configuration.GeneralConfiguration;
 import vadl.pass.Pass;
 import vadl.pass.PassName;
 import vadl.pass.PassResults;
-import vadl.utils.GraphUtils;
 import vadl.utils.ViamUtils;
 import vadl.viam.DefProp;
 import vadl.viam.Instruction;
@@ -40,16 +38,13 @@ import vadl.viam.graph.control.AbstractEndNode;
 import vadl.viam.graph.control.ControlNode;
 import vadl.viam.graph.control.ControlSplitNode;
 import vadl.viam.graph.control.DirectionalNode;
-import vadl.viam.graph.control.InstrEndNode;
 import vadl.viam.graph.control.MergeNode;
 import vadl.viam.graph.control.ScheduledNode;
 import vadl.viam.graph.control.StartNode;
 import vadl.viam.graph.dependency.ProcCallNode;
-import vadl.viam.graph.dependency.SideEffectNode;
 import vadl.viam.graph.dependency.WriteRegTensorNode;
 import vadl.viam.graph.dependency.WriteResourceNode;
 import vadl.viam.passes.sideEffectScheduling.nodes.InstrExitNode;
-import vadl.viam.passes.sideeffect_condition.SideEffectConditionResolver;
 
 /**
  * A pass that schedules side effects within the control flow graph (CFG) of instructions.
@@ -133,14 +128,6 @@ class SideEffectScheduler {
    * @param behavior The behavior to process.
    */
   public static void run(Graph behavior) {
-    if (behavior.parentDefinition() instanceof Instruction) {
-      // re-evaluate side effect conditions (have been removed by IssConfigurationPass)
-      SideEffectConditionResolver.run(behavior);
-      moveInstrExitSideEffectsToInstrEnd(behavior);
-      // delete side effect conditions, as they are not needed and break later passes
-      behavior.getNodes(SideEffectNode.class).forEach(n -> n.setCondition(null));
-      behavior.deleteUnusedDependencies();
-    }
     var startNode = getSingleNode(behavior, StartNode.class);
     var scheduler = new SideEffectScheduler();
     scheduler.processBranch(startNode);
@@ -188,42 +175,6 @@ class SideEffectScheduler {
     );
 
     return endNode;
-  }
-
-  /**
-   * Moves all side effects causing an instruction exit to the end of the instruction graph.
-   * Unconditional side effects are simply added to the instruction end node. Conditional
-   * side effect nodes are put in an if-block.
-   *
-   * @param behaviour The graph to process.
-   */
-  private static void moveInstrExitSideEffectsToInstrEnd(Graph behaviour) {
-    var instrEnd = GraphUtils.getSingleNode(behaviour, InstrEndNode.class);
-    var instrExitSideEffects = behaviour.getNodes(SideEffectNode.class).filter(
-        s -> (s instanceof WriteRegTensorNode write && write.isPcAccess())
-            || (s instanceof ProcCallNode procCall && procCall.exceptionRaise())
-    ).toList();
-
-    for (var instrExit : instrExitSideEffects) {
-      var cond = instrExit.condition();
-      // the side effect may be scheduled multiple times, but the condition covers everything
-      instrExit.usages().filter(AbstractEndNode.class::isInstance).toList()
-          .forEach(user -> ((AbstractEndNode) user).removeSideEffect(instrExit));
-      if (cond == null) {
-        instrEnd.addSideEffect(instrExit);
-      } else {
-        var pred = requireNonNull(instrEnd.predecessor());
-        pred.unlinkNext();
-        pred.setNext(GraphUtils.ifElseSideEffect(
-            behaviour,
-            cond,
-            List.of(instrExit),
-            List.of(),
-            instrEnd,
-            instrExit.location()
-        ));
-      }
-    }
   }
 
   /**

--- a/vadl/test/vadl/iss/TestConstants.java
+++ b/vadl/test/vadl/iss/TestConstants.java
@@ -19,6 +19,6 @@ package vadl.iss;
 class TestConstants {
 
   static final String TEST_BASE_IMAGE =
-      "ghcr.io/openvadl/iss-test-base@sha256:b06d35aac32965ef48e1e6c8aced83af1bfc2253eccac44e079053f7021d5e3a";
+      "ghcr.io/openvadl/iss-test-base@sha256:a3edbf2541345ad0ef89caa2f1eea44cd9a01ac595284dc96d65091c809eb8c3";
 
 }

--- a/vadl/test/vadl/iss/aarch32/IssAarch32EmbenchBenchmarkTest.java
+++ b/vadl/test/vadl/iss/aarch32/IssAarch32EmbenchBenchmarkTest.java
@@ -19,6 +19,7 @@ package vadl.iss.aarch32;
 import java.io.IOException;
 import java.util.List;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import vadl.iss.IssEmbenchBenchmark;
 
 public class IssAarch32EmbenchBenchmarkTest extends IssEmbenchBenchmark {
@@ -28,7 +29,7 @@ public class IssAarch32EmbenchBenchmarkTest extends IssEmbenchBenchmark {
     return List.of("arm-softmmu");
   }
 
-  // @Test
+  @Test
   @Tag("BenchmarkTest")
   void a32BenchmarkTest() throws IOException {
     runBenchmark(benchmarkSpec(

--- a/vadl/test/vadl/iss/aarch32/IssAarch32EmbenchTest.java
+++ b/vadl/test/vadl/iss/aarch32/IssAarch32EmbenchTest.java
@@ -17,6 +17,7 @@
 package vadl.iss.aarch32;
 
 import java.io.IOException;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.utility.MountableFile;
@@ -27,7 +28,7 @@ public class IssAarch32EmbenchTest extends QemuIssTest {
 
   private static final Logger log = LoggerFactory.getLogger(IssAarch32EmbenchTest.class);
 
-  // @Test
+  @Test
   void a32EmbenchTest() throws IOException {
     runEmbenchTest("sys/aarch32/virt.vadl", "build_virt-iss-a32.sh", "qemu-system-a32");
   }

--- a/vadl/test/vadl/iss/codegen/IssTbChainExitTest.java
+++ b/vadl/test/vadl/iss/codegen/IssTbChainExitTest.java
@@ -136,15 +136,15 @@ public class IssTbChainExitTest extends QemuIssTest {
         /* dynamic write */
         testWith(cfg_all(12, false, false, 0, 0, Behavior.END_NO_CHAIN)),
         /* direct jump + dynamic write */
-        testWith(cfg_all(13, false, true,  0, 0, Behavior.CHAIN_1)),
-        testWith(cfg_all(13, false, true,  0, 1, Behavior.END_NO_CHAIN)),
+        testWith(cfg_all(13, false, false,  1, 0, Behavior.END_NO_CHAIN)),
+        testWith(cfg_all(13, false, false,  1, 1, Behavior.END_NO_CHAIN)),
         /* indirect jump + dynamic write */
         testWith(cfg_all(14, false, false, 1, 0, Behavior.END_NO_CHAIN)),
         testWith(cfg_all(14, false, false, 1, 1, Behavior.END_NO_CHAIN)),
         /* direct + indirect jump + dynamic write */
-        testWith(cfg_all(15, false, true,  1, 0, Behavior.CHAIN_1)),
-        testWith(cfg_all(15, false, true,  1, 1, Behavior.END_NO_CHAIN)),
-        testWith(cfg_all(15, false, true,  1, 2, Behavior.END_NO_CHAIN))
+        testWith(cfg_all(15, false, false,  2, 0, Behavior.END_NO_CHAIN)),
+        testWith(cfg_all(15, false, false,  2, 1, Behavior.END_NO_CHAIN)),
+        testWith(cfg_all(15, false, false,  2, 2, Behavior.END_NO_CHAIN))
     );
   }
 

--- a/vadl/test/vadl/iss/passes/IssTcgSchedulingPassTest.java
+++ b/vadl/test/vadl/iss/passes/IssTcgSchedulingPassTest.java
@@ -28,6 +28,7 @@ import vadl.AbstractTest;
 import vadl.configuration.DumpMode;
 import vadl.configuration.GeneralConfiguration;
 import vadl.configuration.IssConfiguration;
+import vadl.iss.passes.common.IssSideEffectReorderingPass;
 import vadl.pass.PassOrders;
 import vadl.pass.exception.DuplicatedPassKeyException;
 import vadl.types.BuiltInTable;
@@ -50,6 +51,7 @@ public class IssTcgSchedulingPassTest extends AbstractTest {
 
     var setup = setupPassManagerAndRunSpec("passes/issTcgScheduling/valid_branch_1.vadl",
         PassOrders.iss(config)
+            .skip(IssSideEffectReorderingPass.class)
             .untilFirst(SideEffectSchedulingPass.class)
     );
     var viam = setup.specification();


### PR DESCRIPTION
- Enables AArch32 embench
- Updates ISS test image to latest sha
- Fixes bug in reverse graph traversal (`MergeNode.controlSplit()`)
- Fixes instruction-exiting side-effect scheduling by adding the `IssSideEffectReorderingPass`
  - Before, if disjunct if-clauses existed on the same level/scope, side-effects were not scheduled correctly. Specifically, side-effects, which cause an instruction exit must be scheduled after all other side-effects. This is now achieved, by moving such side-effects to the instruction end, instead of the branch end. Side-effect conditions are preserved.

**Note:** The scheduling fix currently leaves empty if-blocks in the CFG, which are not removed by any later pass. This will be fixed, but does not affect correctness of the generated translation functions.

Closes #1101
Closes #1093 