### PR TITLE
iss: Enable risc-v float embench

### DIFF
--- a/docker/iss/riscv-toolchain/Dockerfile
+++ b/docker/iss/riscv-toolchain/Dockerfile
@@ -20,9 +20,11 @@ RUN ../configure --prefix=/opt/riscv  \
     rv32i-ilp32--;\
     rv32im-ilp32--;\
     rv32im_zicsr-ilp32--;\
+    rv32imf-ilp32f--;\
     rv64i-lp64--;\
     rv64im-lp64--;\
-    rv64im_zicsr-lp64--"
+    rv64im_zicsr-lp64--;\
+    rv64imfd-lp64d--"
 RUN make -j8
 
 # Separate final stages for different architectures

--- a/sys/risc-v/rv64d.vadl
+++ b/sys/risc-v/rv64d.vadl
@@ -1,10 +1,10 @@
 
-import rv64fd::{RV64IFD} with ("ExtensionFD=D")
+import rv64fd::{RV64IMFD} with ("ExtensionFD=D")
 
-instruction set architecture RV64ID extending RV64IFD = {}
+instruction set architecture RV64IMD extending RV64IMFD = {}
 
 [ htif ]
-processor Spike implements RV64ID = {
+processor Spike implements RV64IMD = {
     constant reset_vec_addr = 0x1000
 
     reset = {

--- a/sys/risc-v/rv64f.vadl
+++ b/sys/risc-v/rv64f.vadl
@@ -1,7 +1,7 @@
 
-import rv64fd::{RV64IFD}
+import rv64fd::{RV64IMFD}
 
-instruction set architecture RV64IF extending RV64IFD = {}
+instruction set architecture RV64IMF extending RV64IMFD = {}
 
 [ htif ]
 processor Spike implements RV64IF = {

--- a/sys/risc-v/rv64fd.vadl
+++ b/sys/risc-v/rv64fd.vadl
@@ -1,7 +1,7 @@
 
-import rv64csr::{RV64IZicsr}
+import rv64csr::{RV64IMZicsr}
 
-instruction set architecture RV64IFD extending RV64IZicsr = {
+instruction set architecture RV64IMFD extending RV64IMZicsr = {
 
   // TODO: generate illegal instruction exception when float is not enabled
 

--- a/vadl/test/resources/embench/benchmark-extras/run-benchmarks-rv64imd.sh
+++ b/vadl/test/resources/embench/benchmark-extras/run-benchmarks-rv64imd.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText : © 2025 TU Wien <vadl@tuwien.ac.at>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+set -e
+
+cd $(realpath $(dirname "$0"))
+
+CPU_MHZ="${EMBENCH_MHZ:-1000}"
+
+# QEMU
+../build_spike-rv64imd.sh --cpu-mhz "$CPU_MHZ"
+echo "Benchmarking open-vadl..."
+./run-benchmark.sh "rv64imd-open-vadl"  ./benchmark_qemu.sh       "qemu-system-rv64imd" -nographic -bios
+echo "Benchmarking qemu..."
+./run-benchmark.sh "rv64imd-qemu"       ./benchmark_qemu.sh       "qemu-system-riscv64" -nographic -M spike -bios
+echo "Done."
+
+# Normalize dtc timings
+python3 data-relative.py results-rv64imd-iss \
+        results/rv64imd-qemu/rv64imd-qemu.csv \
+        results/rv64imd-open-vadl/rv64imd-open-vadl.csv

--- a/vadl/test/resources/embench/build_spike-rv64imd.sh
+++ b/vadl/test/resources/embench/build_spike-rv64imd.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+cd $(realpath $(dirname "$0"))
+
+arch="rv64imd"
+abi="lp64d"
+
+cflags="-march=$arch -mabi=$abi"
+ldflags="-march=$arch -mabi=$abi"
+# non-float: aha-mont64,huffbench,md5sum,nettle-sha256,picojpeg,qrduino,slre,statemate,crc32,edn,matmult-int,nettle-aes,nsichneu,primecount,sglib-combined,tarfind,wikisort
+# float: cubic,nbody,minver,st,ud
+./build_all.py --arch riscv64 --chip generic --board spike --cflags="$cflags" --ldflags="$ldflags" --clean "$@"

--- a/vadl/test/vadl/iss/riscv/IssRiscvEmbenchBenchmarkTest.java
+++ b/vadl/test/vadl/iss/riscv/IssRiscvEmbenchBenchmarkTest.java
@@ -31,12 +31,12 @@ public class IssRiscvEmbenchBenchmarkTest extends IssEmbenchBenchmark {
 
   @Tag("BenchmarkTest")
   @Test
-  void rv64imBenchmarkTest() throws IOException {
+  void rv64imdBenchmarkTest() throws IOException {
     runBenchmark(benchmarkSpec(
-        "rv64im",
-        "sys/risc-v/rv64im.vadl",
-        "benchmark-extras/run-benchmarks-rv64im.sh",
-        "benchmark-extras/results-rv64im-iss"
+        "rv64imd",
+        "sys/risc-v/rv64d.vadl",
+        "benchmark-extras/run-benchmarks-rv64imd.sh",
+        "benchmark-extras/results-rv64imd-iss"
     ));
   }
 }

--- a/vadl/test/vadl/iss/riscv/IssRiscvEmbenchTest.java
+++ b/vadl/test/vadl/iss/riscv/IssRiscvEmbenchTest.java
@@ -36,11 +36,19 @@ public class IssRiscvEmbenchTest extends QemuIssTest {
 
   @Test
   void rv64imEmbenchTest() throws IOException {
+    // compiles for 64-bit riscv using soft-float
     runEmbenchTest("sys/risc-v/rv64v.vadl", "build_spike-rv64im.sh", "qemu-system-rv64imv");
   }
 
   @Test
+  void rv64dEmbenchTest() throws IOException {
+    // compiles for 64-bit riscv using hard-float
+    runEmbenchTest("sys/risc-v/rv64d.vadl", "build_spike-rv64imd.sh", "qemu-system-rv64imd");
+  }
+
+  @Test
   void rv32imEmbenchTest() throws IOException {
+    // compiles for 32-bit riscv using soft-float
     runEmbenchTest("sys/risc-v/rv32im.vadl", "build_spike-rv32im.sh", "qemu-system-rv32im");
   }
 


### PR DESCRIPTION
- Adds 32-bit float and 64-bit float config to risc-v toolchain
- Adds embench build scripts to compile for hard-float instead of soft-float
- Changes risc-v embench benchmarks to use hard-float instead of soft-float
- Adds M extension to all risc-v float specs

**Note:** The risc-v toolchain and iss-test-base containers need to be updated in the registry for embench to work again